### PR TITLE
stream logs to client

### DIFF
--- a/pkg/docker/builder.go
+++ b/pkg/docker/builder.go
@@ -1,5 +1,5 @@
 package docker
 
 type ImageBuilder interface {
-	BuildAndPush(dir string, dockerfilePath string, name string) (fullImageTag string, err error)
+	BuildAndPush(dir string, dockerfilePath string, name string, logWriter func(string)) (fullImageTag string, err error)
 }

--- a/pkg/docker/exists.go
+++ b/pkg/docker/exists.go
@@ -3,15 +3,13 @@ package docker
 import (
 	"os"
 	"os/exec"
-
-	log "github.com/sirupsen/logrus"
 )
 
-func Exists(tag string) bool {
+func Exists(tag string, logWriter func(string)) bool {
 	cmd := exec.Command("docker", "inspect", "--type=image", tag)
 	cmd.Env = os.Environ()
 
-	pipeToWithDockerChecks(cmd.StderrPipe, log.Debug)
+	pipeToWithDockerChecks(cmd.StderrPipe, logWriter)
 
 	err := cmd.Run()
 	return err == nil

--- a/pkg/docker/pull.go
+++ b/pkg/docker/pull.go
@@ -7,11 +7,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func Pull(tag string) error {
+func Pull(tag string, logWriter func(string)) error {
 	log.Info("Downloading image...")
 	cmd := exec.Command("docker", "pull", tag)
 
-	stderrDone, err := pipeToWithDockerChecks(cmd.StderrPipe, log.Debug)
+	stderrDone, err := pipeToWithDockerChecks(cmd.StderrPipe, logWriter)
 	if err != nil {
 		return err
 	}

--- a/pkg/logger/stream_logger.go
+++ b/pkg/logger/stream_logger.go
@@ -1,0 +1,76 @@
+package logger
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/replicate/cog/pkg/model"
+	log "github.com/sirupsen/logrus"
+)
+
+type MessageType string
+
+const (
+	MessageTypeLogLine MessageType = "log_line"
+	MessageTypeError   MessageType = "error"
+	MessageTypeStatus  MessageType = "status"
+	MessageTypeModel   MessageType = "model"
+)
+
+type Message struct {
+	Type  MessageType  `json:"type"`
+	Text  string       `json:"data"`
+	Model *model.Model `json:"model"`
+}
+
+type StreamLogger struct {
+	writer http.ResponseWriter
+}
+
+func NewStreamLogger(w http.ResponseWriter) *StreamLogger {
+	return &StreamLogger{writer: w}
+}
+
+func (logger *StreamLogger) logText(messageType MessageType, text string) {
+	msg := Message{Type: messageType, Text: text}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		log.Warnf("Failed to marshal log text: %s", text)
+	}
+	logger.write(data)
+}
+
+func (logger *StreamLogger) write(data []byte) {
+	data = append(data, '\n')
+	if _, err := logger.writer.Write(data); err != nil {
+		log.Warnf("HTTP response writer failed to write: %s", data)
+		return
+	}
+	if f, ok := logger.writer.(http.Flusher); ok {
+		f.Flush()
+	} else {
+		log.Warnf("HTTP response writer can not be flushed")
+	}
+}
+
+func (logger *StreamLogger) WriteLogLine(line string) {
+	logger.logText(MessageTypeLogLine, line)
+}
+
+func (logger *StreamLogger) WriteStatus(status string, args ...interface{}) {
+	logger.logText(MessageTypeStatus, fmt.Sprintf(status, args...))
+}
+
+func (logger *StreamLogger) WriteError(err error) {
+	logger.logText(MessageTypeError, err.Error())
+}
+
+func (logger *StreamLogger) WriteModel(mod *model.Model) {
+	msg := Message{Type: MessageTypeModel, Model: mod}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		log.Warnf("Failed to marshal model")
+	}
+	logger.write(data)
+}

--- a/pkg/serving/platform.go
+++ b/pkg/serving/platform.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Platform interface {
-	Deploy(mod *model.Model, target model.Target) (Deployment, error)
+	Deploy(mod *model.Model, target model.Target, logWriter func(string)) (Deployment, error)
 }
 
 type Deployment interface {


### PR DESCRIPTION
The upload endpoint now streams all logs as json lines. If the client receives the model as JSON the upload was successful. It's a little messy but it (mostly) works.