### PR TITLE
Caching zip reader/writer for faster builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519 // indirect
+	github.com/klauspost/compress v1.11.4 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/mattn/go-isatty v0.0.12

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -21,6 +21,7 @@ func newBuildCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 	addRepoFlag(cmd)
+	addProjectDirFlag(cmd)
 
 	return cmd
 }
@@ -31,7 +32,7 @@ func buildModel(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	projectDir, err := os.Getwd()
+	projectDir, err := getProjectDir()
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -14,6 +14,7 @@ import (
 )
 
 var repoFlag string
+var projectDirFlag string
 
 var repoRegex = regexp.MustCompile("^(?:([^/]*)/)?(?:([-_a-zA-Z0-9]+)/)([-_a-zA-Z0-9]+)$")
 
@@ -88,4 +89,15 @@ func parseRepo(repoString string) (*model.Repo, error) {
 		User: matches[2],
 		Name: matches[3],
 	}, nil
+}
+
+func addProjectDirFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&projectDirFlag, "project-dir", "D", "", "Projet directory, defaults to current working directory")
+}
+
+func getProjectDir() (string, error) {
+	if projectDirFlag == "" {
+		return os.Getwd()
+	}
+	return projectDirFlag, nil
 }

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -2,6 +2,7 @@ package files
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"golang.org/x/sys/unix"
@@ -27,4 +28,24 @@ func IsDir(path string) (bool, error) {
 
 func IsExecutable(path string) bool {
 	return unix.Access(path, unix.X_OK) == nil
+}
+
+func CopyFile(src string, dest string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("Failed to open %s while copying to %s: %w", src, dest, err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("Failed to create %s while copying %s: %w", dest, src, err)
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return fmt.Errorf("Failed to copy %s to %s: %w", src, dest, err)
+	}
+	return out.Close()
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -69,6 +69,9 @@ func (s *Server) Start() error {
 	router.Path("/v1/repos/{user}/{name}/models/{id}").
 		Methods(http.MethodDelete).
 		HandlerFunc(s.DeleteModel)
+	router.Path("/v1/repos/{user}/{name}/cache-hashes/").
+		Methods(http.MethodGet).
+		HandlerFunc(s.GetCacheHashes)
 	console.Infof("Server running on 0.0.0.0:%d", s.port)
 	return http.ListenAndServe(fmt.Sprintf(":%d", s.port), router)
 }

--- a/pkg/zip/fs.go
+++ b/pkg/zip/fs.go
@@ -1,0 +1,52 @@
+package zip
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/replicate/cog/pkg/files"
+)
+
+// TODO(andreas): garbage collection
+
+type CacheFileSystem struct {
+	dir string
+}
+
+func NewRepoCache(user string, repoName string) (*CacheFileSystem, error) {
+	return NewCacheFileSystem(fmt.Sprintf(".cog/zip-cache/%s/%s", user, repoName))
+}
+
+func NewCacheFileSystem(cacheDir string) (*CacheFileSystem, error) {
+	exists, err := files.Exists(cacheDir)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		if err := os.MkdirAll(cacheDir, 0755); err != nil {
+			return nil, err
+		}
+	}
+	return &CacheFileSystem{dir: cacheDir}, nil
+}
+
+func (c *CacheFileSystem) GetHashes() ([]string, error) {
+	f, err := os.Open(c.dir)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to open %s: %v", c.dir, err)
+	}
+	names, err := f.Readdirnames(0)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to list directory %s: %v", c.dir, err)
+	}
+	return names, nil
+}
+
+func (c *CacheFileSystem) load(hash string, path string) error {
+	return files.CopyFile(filepath.Join(c.dir, hash), path)
+}
+
+func (c *CacheFileSystem) save(hash string, path string) error {
+	return files.CopyFile(path, filepath.Join(c.dir, hash))
+}

--- a/pkg/zip/hash.go
+++ b/pkg/zip/hash.go
@@ -1,0 +1,23 @@
+package zip
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"fmt"
+)
+
+func getFileHash(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("Failed to open %s: %v", path, err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", fmt.Errorf("Failed to hash file %s: %v", path, err)
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}

--- a/pkg/zip/read.go
+++ b/pkg/zip/read.go
@@ -1,0 +1,55 @@
+package zip
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+func (z *CachingZip) ReaderUnarchive(source io.Reader, size int64, destination string, cacheFS *CacheFileSystem) error {
+	if err := z.zip.ReaderUnarchive(source, size, destination); err != nil {
+		return err
+	}
+
+	return filepath.Walk(destination, func(fpath string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		prefixBuf := make([]byte, len(cachePrefix))
+		file, err := os.Open(fpath)
+		if err != nil {
+			return fmt.Errorf("Failed to open %s: %v", fpath, err)
+		}
+		defer file.Close()
+		if _, err := file.Read(prefixBuf); err != nil {
+			return fmt.Errorf("Failed to read %s: %v", fpath, err)
+		}
+		if string(prefixBuf) == cachePrefix {
+			hashBuf := make([]byte, hashLength)
+			if _, err := file.Read(hashBuf); err != nil {
+				return fmt.Errorf("Failed to read hash from %s: %v", fpath, err)
+			}
+			hash := string(hashBuf)
+			if err := cacheFS.load(hash, fpath); err != nil {
+				return err
+			}
+		} else {
+			file.Close()
+			hash, err := getFileHash(fpath)
+			if err != nil {
+				return err
+			}
+			if err := cacheFS.save(hash, fpath); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}

--- a/pkg/zip/write.go
+++ b/pkg/zip/write.go
@@ -1,0 +1,103 @@
+package zip
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/mholt/archiver/v3"
+
+	"github.com/replicate/cog/pkg/console"
+)
+
+func (z *CachingZip) WriterArchive(source string, destination io.Writer, cachedHashes []string) error {
+	cachedHashSet := map[string]bool{}
+	for _, hash := range cachedHashes {
+		cachedHashSet[hash] = true
+	}
+
+	if err := z.zip.Create(destination); err != nil {
+		return fmt.Errorf("creating zip: %v", err)
+	}
+	defer z.zip.Close()
+
+	sourceInfo, err := os.Stat(source)
+	if err != nil {
+		return fmt.Errorf("%s: stat: %v", source, err)
+	}
+
+	return filepath.Walk(source, func(fpath string, info os.FileInfo, err error) error {
+		handleErr := func(err error) error {
+			if z.zip.ContinueOnError {
+				console.Infof("[ERROR] Walking %s: %v", fpath, err)
+				return nil
+			}
+			return err
+		}
+		if err != nil {
+			return handleErr(fmt.Errorf("traversing %s: %v", fpath, err))
+		}
+		if info == nil {
+			return handleErr(fmt.Errorf("%s: no file info", fpath))
+		}
+
+		// build the name to be used within the archive
+		nameInArchive, err := makeNameInArchive(sourceInfo, source, "", fpath)
+		if err != nil {
+			return handleErr(err)
+		}
+
+		var file io.ReadCloser
+		if info.Mode().IsRegular() {
+			hash, err := getFileHash(fpath)
+			if err != nil {
+				return handleErr(err)
+			}
+			if cachedHashSet[hash] {
+				file = io.NopCloser(bytes.NewReader([]byte(cachePrefix + hash)))
+			} else {
+				file, err = os.Open(fpath)
+				if err != nil {
+					return handleErr(fmt.Errorf("%s: opening: %v", fpath, err))
+				}
+				defer file.Close()
+			}
+		}
+
+		err = z.zip.Write(archiver.File{
+			FileInfo: archiver.FileInfo{
+				FileInfo:   info,
+				CustomName: nameInArchive,
+			},
+			ReadCloser: file,
+		})
+		if err != nil {
+			return handleErr(fmt.Errorf("%s: writing: %s", fpath, err))
+		}
+
+		return nil
+	})
+}
+
+// makeNameInArchive returns the filename for the file given by fpath to be used within
+// the archive. sourceInfo is the FileInfo obtained by calling os.Stat on source, and baseDir
+// is an optional base directory that becomes the root of the archive. fpath should be the
+// unaltered file path of the file given to a filepath.WalkFunc.
+func makeNameInArchive(sourceInfo os.FileInfo, source, baseDir, fpath string) (string, error) {
+	name := filepath.Base(fpath) // start with the file or dir name
+	if sourceInfo.IsDir() {
+		// preserve internal directory structure; that's the path components
+		// between the source directory's leaf and this file's leaf
+		dir, err := filepath.Rel(filepath.Dir(source), filepath.Dir(fpath))
+		if err != nil {
+			return "", err
+		}
+		// prepend the internal directory structure to the leaf name,
+		// and convert path separators to forward slashes as per spec
+		name = path.Join(filepath.ToSlash(dir), name)
+	}
+	return path.Join(baseDir, name), nil // prepend the base directory
+}

--- a/pkg/zip/zip.go
+++ b/pkg/zip/zip.go
@@ -1,0 +1,16 @@
+package zip
+
+import (
+	"github.com/mholt/archiver/v3"
+)
+
+const cachePrefix = "cogcache"
+const hashLength = 64
+
+type CachingZip struct {
+	zip *archiver.Zip
+}
+
+func NewCachingZip() *CachingZip {
+	return &CachingZip{zip: &archiver.Zip{ImplicitTopLevelFolder: false}}
+}

--- a/pkg/zip/zip_test.go
+++ b/pkg/zip/zip_test.go
@@ -1,0 +1,129 @@
+package zip
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mholt/archiver/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCachingZip(t *testing.T) {
+	cacheRootDir, err := os.MkdirTemp("/tmp", "cache")
+	require.NoError(t, err)
+	defer os.RemoveAll(cacheRootDir)
+	dataDir, err := os.MkdirTemp("/tmp", "data")
+	require.NoError(t, err)
+	defer os.RemoveAll(dataDir)
+	workDir, err := os.MkdirTemp("/tmp", "work")
+	require.NoError(t, err)
+	defer os.RemoveAll(workDir)
+	tempDir, err := os.MkdirTemp("/tmp", "temp")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+	unzipDir1, err := os.MkdirTemp("/tmp", "unzip1")
+	require.NoError(t, err)
+	defer os.RemoveAll(unzipDir1)
+	unzipDir2, err := os.MkdirTemp("/tmp", "unzip2")
+	require.NoError(t, err)
+	defer os.RemoveAll(unzipDir2)
+	unzipDir3, err := os.MkdirTemp("/tmp", "unzip3")
+	require.NoError(t, err)
+	defer os.RemoveAll(unzipDir3)
+	unzipDir4, err := os.MkdirTemp("/tmp", "unzip4")
+	require.NoError(t, err)
+	defer os.RemoveAll(unzipDir4)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dataDir, "my/dir"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dataDir, "anotherdir"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "foo.txt"), []byte("foo"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "my/dir/bar.txt"), []byte("bar"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "anotherdir/baz.txt"), []byte("baz"), 0644))
+
+	z := NewCachingZip()
+
+	outPath := filepath.Join(workDir, "myzip.zip")
+	out, err := os.Create(outPath)
+	require.NoError(t, err)
+
+	err = z.WriterArchive(dataDir + "/", out, []string{})
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+
+	err = new(archiver.Zip).Unarchive(outPath, unzipDir1)
+	require.NoError(t, err)
+	requireUnzippedCorrectly(t, unzipDir1, "foo", "bar", "baz")
+
+	cacheDir := filepath.Join(cacheRootDir, "my-repo")
+	fs, err := NewCacheFileSystem(cacheDir)
+	require.NoError(t, err)
+
+	hashes, err := fs.GetHashes()
+	require.NoError(t, err)
+	require.ElementsMatch(t, hashes, []string{})
+
+	file, err := os.Open(outPath)
+	require.NoError(t, err)
+	stat, err := file.Stat()
+	require.NoError(t, err)
+	err = z.ReaderUnarchive(file, stat.Size(), unzipDir2 + "/", fs)
+	require.NoError(t, err)
+	requireUnzippedCorrectly(t, unzipDir2, "foo", "bar", "baz")
+
+	fs, err = NewCacheFileSystem(cacheDir)
+	require.NoError(t, err)
+	hashes, err = fs.GetHashes()
+	require.NoError(t, err)
+	require.ElementsMatch(t, hashes, []string{
+		"fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9",
+		"baa5a0964d3320fbc0c6a922140453c8513ea24ab8fd0577034804a967248096",
+		"2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+	})
+
+	outPath2 := filepath.Join(workDir, "myzip2.zip")
+	out2, err := os.Create(outPath2)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "anotherdir/baz.txt"), []byte("changed-baz"), 0644))
+
+	err = z.WriterArchive(dataDir + "/", out2, hashes)
+
+	err = new(archiver.Zip).Unarchive(outPath2, unzipDir3)
+	require.NoError(t, err)
+	requireUnzippedCorrectly(t, unzipDir3, "cogcache2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae", "cogcachefcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9", "changed-baz")
+
+	fs, err = NewCacheFileSystem(cacheDir)
+	require.NoError(t, err)
+
+	file, err = os.Open(outPath2)
+	require.NoError(t, err)
+	stat, err = file.Stat()
+	require.NoError(t, err)
+	err = z.ReaderUnarchive(file, stat.Size(), unzipDir4 + "/", fs)
+	require.NoError(t, err)
+	requireUnzippedCorrectly(t, unzipDir4, "foo", "bar", "changed-baz")
+
+	fs, err = NewCacheFileSystem(cacheDir)
+	require.NoError(t, err)
+	hashes, err = fs.GetHashes()
+	require.NoError(t, err)
+	require.ElementsMatch(t, hashes, []string{
+		"fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9",
+		"baa5a0964d3320fbc0c6a922140453c8513ea24ab8fd0577034804a967248096",
+		"2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+		"59c1af9b47dd31426dd3dbdfa66869b5e5f0bcde4052d2d6d560976fa3291895",
+	})
+}
+
+func requireUnzippedCorrectly(t *testing.T, dir string, foo string, bar string, baz string) {
+	contents, err := os.ReadFile(filepath.Join(dir, "foo.txt"))
+	require.NoError(t, err)
+	require.Equal(t, foo, string(contents))
+	contents, err = os.ReadFile(filepath.Join(dir, "my/dir/bar.txt"))
+	require.NoError(t, err)
+	require.Equal(t, bar, string(contents))
+	contents, err = os.ReadFile(filepath.Join(dir, "anotherdir/baz.txt"))
+	require.NoError(t, err)
+	require.Equal(t, baz, string(contents))
+}


### PR DESCRIPTION
Caches all files by SHA256 on the server and only uploads files that
have changed. Currently missing garbage collection so every changed
file is saved forever.

Signed-off-by: andreasjansson <andreas@replicate.ai>