### PR TITLE
Make content-addressable IDs ignore timestamps

### DIFF
--- a/pkg/zip/hash.go
+++ b/pkg/zip/hash.go
@@ -3,9 +3,9 @@ package zip
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
-	"fmt"
 )
 
 func getFileHash(path string) (string, error) {

--- a/pkg/zip/read.go
+++ b/pkg/zip/read.go
@@ -24,11 +24,13 @@ func (z *CachingZip) ReaderUnarchive(source io.Reader, size int64, destination s
 		prefixBuf := make([]byte, len(cachePrefix))
 		file, err := os.Open(fpath)
 		if err != nil {
-			return fmt.Errorf("Failed to open %s: %v", fpath, err)
+			return fmt.Errorf("Failed to open in zip %s: %v", fpath, err)
 		}
 		defer file.Close()
 		if _, err := file.Read(prefixBuf); err != nil {
-			return fmt.Errorf("Failed to read %s: %v", fpath, err)
+			if err != io.EOF {
+				return fmt.Errorf("Failed to read in zip %s: %v", fpath, err)
+			}
 		}
 		if string(prefixBuf) == cachePrefix {
 			hashBuf := make([]byte, hashLength)

--- a/pkg/zip/zip_test.go
+++ b/pkg/zip/zip_test.go
@@ -47,7 +47,7 @@ func TestCachingZip(t *testing.T) {
 	out, err := os.Create(outPath)
 	require.NoError(t, err)
 
-	err = z.WriterArchive(dataDir + "/", out, []string{})
+	err = z.WriterArchive(dataDir+"/", out, []string{})
 	require.NoError(t, err)
 	require.NoError(t, out.Close())
 
@@ -67,7 +67,7 @@ func TestCachingZip(t *testing.T) {
 	require.NoError(t, err)
 	stat, err := file.Stat()
 	require.NoError(t, err)
-	err = z.ReaderUnarchive(file, stat.Size(), unzipDir2 + "/", fs)
+	err = z.ReaderUnarchive(file, stat.Size(), unzipDir2+"/", fs)
 	require.NoError(t, err)
 	requireUnzippedCorrectly(t, unzipDir2, "foo", "bar", "baz")
 
@@ -87,7 +87,7 @@ func TestCachingZip(t *testing.T) {
 
 	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "anotherdir/baz.txt"), []byte("changed-baz"), 0644))
 
-	err = z.WriterArchive(dataDir + "/", out2, hashes)
+	err = z.WriterArchive(dataDir+"/", out2, hashes)
 
 	err = new(archiver.Zip).Unarchive(outPath2, unzipDir3)
 	require.NoError(t, err)
@@ -100,7 +100,7 @@ func TestCachingZip(t *testing.T) {
 	require.NoError(t, err)
 	stat, err = file.Stat()
 	require.NoError(t, err)
-	err = z.ReaderUnarchive(file, stat.Size(), unzipDir4 + "/", fs)
+	err = z.ReaderUnarchive(file, stat.Size(), unzipDir4+"/", fs)
 	require.NoError(t, err)
 	requireUnzippedCorrectly(t, unzipDir4, "foo", "bar", "changed-baz")
 


### PR DESCRIPTION
Plus fix bug where IDs were generated before resolving cached content

Signed-off-by: andreasjansson <andreas@replicate.ai>