### PR TITLE
Batch inference on the CLI

### DIFF
--- a/pkg/cli/infer.go
+++ b/pkg/cli/infer.go
@@ -1,29 +1,38 @@
 package cli
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"mime"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/TylerBrock/colorjson"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 
-	"github.com/replicate/cog/pkg/util/console"
-
 	"github.com/replicate/cog/pkg/client"
 	"github.com/replicate/cog/pkg/logger"
 	"github.com/replicate/cog/pkg/model"
 	"github.com/replicate/cog/pkg/serving"
+	"github.com/replicate/cog/pkg/util/console"
+	"github.com/replicate/cog/pkg/util/mime"
+	"github.com/replicate/cog/pkg/util/slices"
 )
+
+type inferFileLine struct {
+	number int
+	fields []string
+}
 
 var (
 	inputs    []string
+	inputFile string
 	outPath   string
+	outputDir string
 	inferArch string
 )
 
@@ -36,13 +45,31 @@ func newInferCommand() *cobra.Command {
 	}
 	addModelFlag(cmd)
 	cmd.Flags().StringArrayVarP(&inputs, "input", "i", []string{}, "Inputs, in the form name=value. if value is prefixed with @, then it is read from a file on disk. E.g. -i path=@image.jpg")
+	cmd.Flags().StringVar(&inputFile, "file", "", "File containing inputs in the format key1=val1,key2=\"val2\", etc., one input per line. If value is prefixed with @, then it is read from a file on disk. E.g. key1=val1,key2=my-dir/image.jpg")
 	cmd.Flags().StringVarP(&outPath, "output", "o", "", "Output path")
+	cmd.Flags().StringVar(&outputDir, "output-dir", "", "Output directory for when --file is used. Output files are named output.XXXXXXX.EXT, where XXXXXXX corresponds to the line in the input file, starting with 0000001.")
 	cmd.Flags().StringVarP(&inferArch, "arch", "a", "cpu", "Architecture to run inference on (cpu/gpu)")
 
 	return cmd
 }
 
 func cmdInfer(cmd *cobra.Command, args []string) error {
+	if len(inputs) > 0 && inputFile != "" {
+		return fmt.Errorf("--input and --file are mutually exclusive. Please only use one or the other")
+	}
+	if outPath != "" && outputDir != "" {
+		return fmt.Errorf("--output and --output-dir are mutually exclusive. Please only use one or the other")
+	}
+	if len(inputs) > 0 && outputDir != "" {
+		return fmt.Errorf("--output-dir can only be used in conjunction with --file")
+	}
+	if inputFile != "" && outPath != "" {
+		return fmt.Errorf("--output can only be used in conjunction with --input")
+	}
+	if !slices.ContainsString([]string{"cpu", "gpu"}, inferArch) {
+		return fmt.Errorf("--arch must be either 'cpu' or 'gpu'")
+	}
+
 	mod, err := getModel()
 	if err != nil {
 		return err
@@ -67,8 +94,7 @@ func cmdInfer(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	logWriter := logger.NewConsoleLogger()
-	// TODO(andreas): GPU inference
-	useGPU := false
+	useGPU := inferArch == "gpu"
 	deployment, err := servingPlatform.Deploy(context.Background(), image.URI, useGPU, logWriter)
 	if err != nil {
 		return err
@@ -79,22 +105,14 @@ func cmdInfer(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	keyVals := map[string]string{}
-	for _, input := range inputs {
-		var name, value string
-
-		// Default input name is "input"
-		if !strings.Contains(input, "=") {
-			name = "input"
-			value = input
-		} else {
-			split := strings.SplitN(input, "=", 2)
-			name = split[0]
-			value = split[1]
-		}
-		keyVals[name] = value
+	if len(inputs) > 0 {
+		return inferIndividualInputs(deployment, inputs, outPath, logWriter)
 	}
-	example := serving.NewExample(keyVals)
+	return inferBatch(deployment, inputFile, outputDir, logWriter)
+}
+
+func inferIndividualInputs(deployment serving.Deployment, inputs []string, outputPath string, logWriter logger.Logger) error {
+	example := parseInferInputs(inputs)
 	result, err := deployment.RunInference(context.Background(), example, logWriter)
 	if err != nil {
 		return err
@@ -103,7 +121,7 @@ func cmdInfer(cmd *cobra.Command, args []string) error {
 	output := result.Values["output"]
 
 	// Write to stdout
-	if outPath == "" {
+	if outputPath == "" {
 		// Is it something we can sensibly write to stdout?
 		if output.MimeType == "plain/text" {
 			_, err := io.Copy(os.Stdout, output.Buffer)
@@ -121,23 +139,23 @@ func cmdInfer(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 		// Otherwise, fall back to writing file
-		outPath = "output"
-		extension, _ := mime.ExtensionsByType(output.MimeType)
-		if len(extension) > 0 {
-			outPath += extension[0]
+		outputPath = "output"
+		extension := mime.ExtensionByType(output.MimeType)
+		if extension != "" {
+			outputPath += extension
 		}
 	}
 
 	// Ignore @, to make it behave the same as -i
-	outPath = strings.TrimPrefix(outPath, "@")
+	outputPath = strings.TrimPrefix(outputPath, "@")
 
-	outPath, err := homedir.Expand(outPath)
+	outputPath, err = homedir.Expand(outputPath)
 	if err != nil {
 		return err
 	}
 
 	// Write to file
-	outFile, err := os.OpenFile(outPath, os.O_WRONLY|os.O_CREATE, 0755)
+	outFile, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE, 0755)
 	if err != nil {
 		return err
 	}
@@ -146,6 +164,95 @@ func cmdInfer(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Println("Written output to " + outPath)
+	fmt.Println("Written output to " + outputPath)
 	return nil
+}
+
+func inferBatch(deployment serving.Deployment, inputFile string, outputDir string, logWriter logger.Logger) error {
+	file, err := os.Open(inputFile)
+	if err != nil {
+		return fmt.Errorf("Failed to open %s: %w", inputFile, err)
+	}
+	defer file.Close()
+	for line := range iterateInferFileLines(file) {
+		example := parseInferInputs(line.fields)
+		result, err := deployment.RunInference(context.Background(), example, logWriter)
+		if err != nil {
+			console.Errorf("Failed to process line %d: %v", line.number, err)
+			continue
+		}
+		output := result.Values["output"]
+		outputFilename := fmt.Sprintf("output.%07d", line.number)
+		extension := mime.ExtensionByType(output.MimeType)
+		if extension != "" {
+			outputFilename += extension
+		}
+		outputPath := filepath.Join(outputDir, outputFilename)
+		outFile, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE, 0755)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(outFile, output.Buffer); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func iterateInferFileLines(reader io.Reader) <-chan *inferFileLine {
+	ch := make(chan *inferFileLine)
+	scanner := bufio.NewScanner(reader)
+	go func() {
+		defer close(ch)
+		for lineNumber := 1; scanner.Scan(); lineNumber++ {
+			fields := commaSplit(scanner.Text())
+			// allow empty lines
+			if len(fields) == 0 {
+				continue
+			}
+			// allow # prefix for comments
+			if strings.HasPrefix(fields[0], "#") {
+				continue
+			}
+			ch <- &inferFileLine{number: lineNumber, fields: fields}
+		}
+	}()
+	return ch
+}
+
+// split a line like `a, b ,"c,d"` into []{"a", "b", `"c,d"`}
+func commaSplit(line string) []string {
+	quoted := false
+	fields := strings.FieldsFunc(line, func(r rune) bool {
+		if r == '"' {
+			quoted = !quoted
+		}
+		return !quoted && r == ','
+	})
+	for i, field := range fields {
+		fields[i] = strings.TrimSpace(field)
+	}
+	return fields
+}
+
+func parseInferInputs(inputs []string) *serving.Example {
+	keyVals := map[string]string{}
+	for _, input := range inputs {
+		var name, value string
+
+		// Default input name is "input"
+		if !strings.Contains(input, "=") {
+			name = "input"
+			value = input
+		} else {
+			split := strings.SplitN(input, "=", 2)
+			name = split[0]
+			value = split[1]
+		}
+		if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
+			value = value[1 : len(value)-1]
+		}
+		keyVals[name] = value
+	}
+	return serving.NewExample(keyVals)
 }

--- a/pkg/cli/infer_test.go
+++ b/pkg/cli/infer_test.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIterateInferFileLines(t *testing.T) {
+	text := `foo=bar,baz=qux
+# comment, newline below
+
+value
+"# value"
+ foo ,  bar , qux
+foo="bar" , baz="qux"
+`
+	r := strings.NewReader(text)
+	ch := iterateInferFileLines(r)
+	require.Equal(t, &inferFileLine{1, []string{"foo=bar", "baz=qux"}}, <-ch)
+	require.Equal(t, &inferFileLine{4, []string{"value"}}, <-ch)
+	require.Equal(t, &inferFileLine{5, []string{`"# value"`}}, <-ch)
+	require.Equal(t, &inferFileLine{6, []string{"foo", "bar", "qux"}}, <-ch)
+	require.Equal(t, &inferFileLine{7, []string{`foo="bar"`, `baz="qux"`}}, <-ch)
+}

--- a/pkg/serving/test.go
+++ b/pkg/serving/test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"mime"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	"github.com/montanaflynn/stats"
 	"github.com/replicate/cog/pkg/logger"
 	"github.com/replicate/cog/pkg/model"
+	"github.com/replicate/cog/pkg/util/mime"
 )
 
 // TODO(andreas): put this somewhere else since it's used by server?
@@ -140,155 +140,6 @@ func validateServingExampleInput(args map[string]*model.RunArgument, input map[s
 	return nil
 }
 
-func extensionByType(mimeType string) string {
-	switch mimeType {
-	case "audio/aac":
-		return ".aac"
-	case "application/x-abiword":
-		return ".abw"
-	case "application/x-freearc":
-		return ".arc"
-	case "video/x-msvideo":
-		return ".avi"
-	case "application/vnd.amazon.ebook":
-		return ".azw"
-	case "application/octet-stream":
-		return ".bin"
-	case "image/bmp":
-		return ".bmp"
-	case "application/x-bzip":
-		return ".bz"
-	case "application/x-bzip2":
-		return ".bz2"
-	case "application/x-csh":
-		return ".csh"
-	case "text/css":
-		return ".css"
-	case "text/csv":
-		return ".csv"
-	case "application/msword":
-		return ".doc"
-	case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-		return ".docx"
-	case "application/vnd.ms-fontobject":
-		return ".eot"
-	case "application/epub+zip":
-		return ".epub"
-	case "application/gzip":
-		return ".gz"
-	case "image/gif":
-		return ".gif"
-	case "text/html":
-		return ".html"
-	case "image/vnd.microsoft.icon":
-		return ".ico"
-	case "text/calendar":
-		return ".ics"
-	case "application/java-archive":
-		return ".jar"
-	case "image/jpeg":
-		return ".jpg"
-	case "text/javascript":
-		return ".js"
-	case "application/json":
-		return ".json"
-	case "application/ld+json":
-		return ".jsonld"
-	case "audio/midi audio/x-midi":
-		return ".midi"
-	case "audio/mpeg":
-		return ".mp3"
-	case "application/x-cdf":
-		return ".cda"
-	case "video/mp4":
-		return ".mp4"
-	case "video/mpeg":
-		return ".mpeg"
-	case "application/vnd.apple.installer+xml":
-		return ".mpkg"
-	case "application/vnd.oasis.opendocument.presentation":
-		return ".odp"
-	case "application/vnd.oasis.opendocument.spreadsheet":
-		return ".ods"
-	case "application/vnd.oasis.opendocument.text":
-		return ".odt"
-	case "audio/ogg":
-		return ".oga"
-	case "video/ogg":
-		return ".ogv"
-	case "application/ogg":
-		return ".ogx"
-	case "audio/opus":
-		return ".opus"
-	case "font/otf":
-		return ".otf"
-	case "image/png":
-		return ".png"
-	case "application/pdf":
-		return ".pdf"
-	case "application/x-httpd-php":
-		return ".php"
-	case "application/vnd.ms-powerpoint":
-		return ".ppt"
-	case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
-		return ".pptx"
-	case "application/vnd.rar":
-		return ".rar"
-	case "application/rtf":
-		return ".rtf"
-	case "application/x-sh":
-		return ".sh"
-	case "image/svg+xml":
-		return ".svg"
-	case "application/x-shockwave-flash":
-		return ".swf"
-	case "application/x-tar":
-		return ".tar"
-	case "image/tiff":
-		return ".tiff"
-	case "video/mp2t":
-		return ".ts"
-	case "font/ttf":
-		return ".ttf"
-	case "text/plain":
-		return ".txt"
-	case "application/vnd.visio":
-		return ".vsd"
-	case "audio/wav":
-		return ".wav"
-	case "audio/webm":
-		return ".weba"
-	case "video/webm":
-		return ".webm"
-	case "image/webp":
-		return ".webp"
-	case "font/woff":
-		return ".woff"
-	case "font/woff2":
-		return ".woff2"
-	case "application/xhtml+xml":
-		return ".xhtml"
-	case "application/vnd.ms-excel":
-		return ".xls"
-	case "application/xml":
-		return ".xml"
-	case "application/zip":
-		return ".zip"
-	case "video/3gpp":
-		return ".3gp"
-	case "video/3gpp2":
-		return ".3gp2"
-	case "application/x-7z-compressed":
-		return ".7z"
-	default:
-		extensions, _ := mime.ExtensionsByType(mimeType)
-		if extensions == nil || len(extensions) == 0 {
-			return ""
-		}
-		return extensions[0]
-	}
-}
-
 func copyExamples(examples []*model.Example) []*model.Example {
 	copy := []*model.Example{}
 	for _, ex := range examples {
@@ -349,7 +200,7 @@ func setAggregateStats(modelStats *model.Stats, setupTimes []float64, runTimes [
 
 func updateExampleOutput(example *model.Example, newExampleOutputs map[string][]byte, outputBytes []byte, mimeType string, index int) {
 	filename := fmt.Sprintf("output.%02d", index)
-	if ext := extensionByType(mimeType); ext != "" {
+	if ext := mime.ExtensionByType(mimeType); ext != "" {
 		filename += ext
 	}
 	outputPath := filepath.Join(ExampleOutputDir, filename)

--- a/pkg/serving/test_test.go
+++ b/pkg/serving/test_test.go
@@ -150,14 +150,6 @@ func TestValidateServingExampleInput(t *testing.T) {
 	}))
 }
 
-func TestExtensionByType(t *testing.T) {
-	require.Equal(t, ".txt", extensionByType("text/plain"))
-	require.Equal(t, ".jpg", extensionByType("image/jpeg"))
-	require.Equal(t, ".png", extensionByType("image/png"))
-	require.Equal(t, ".json", extensionByType("application/json"))
-	require.Equal(t, "", extensionByType("asdfasdf"))
-}
-
 func TestOutputBytesFromExample(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "test")
 	require.NoError(t, err)

--- a/pkg/util/mime/mime.go
+++ b/pkg/util/mime/mime.go
@@ -1,0 +1,154 @@
+package mime
+
+import (
+	"mime"
+)
+
+func ExtensionByType(mimeType string) string {
+	switch mimeType {
+	case "audio/aac":
+		return ".aac"
+	case "application/x-abiword":
+		return ".abw"
+	case "application/x-freearc":
+		return ".arc"
+	case "video/x-msvideo":
+		return ".avi"
+	case "application/vnd.amazon.ebook":
+		return ".azw"
+	case "application/octet-stream":
+		return ".bin"
+	case "image/bmp":
+		return ".bmp"
+	case "application/x-bzip":
+		return ".bz"
+	case "application/x-bzip2":
+		return ".bz2"
+	case "application/x-csh":
+		return ".csh"
+	case "text/css":
+		return ".css"
+	case "text/csv":
+		return ".csv"
+	case "application/msword":
+		return ".doc"
+	case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+		return ".docx"
+	case "application/vnd.ms-fontobject":
+		return ".eot"
+	case "application/epub+zip":
+		return ".epub"
+	case "application/gzip":
+		return ".gz"
+	case "image/gif":
+		return ".gif"
+	case "text/html":
+		return ".html"
+	case "image/vnd.microsoft.icon":
+		return ".ico"
+	case "text/calendar":
+		return ".ics"
+	case "application/java-archive":
+		return ".jar"
+	case "image/jpeg":
+		return ".jpg"
+	case "text/javascript":
+		return ".js"
+	case "application/json":
+		return ".json"
+	case "application/ld+json":
+		return ".jsonld"
+	case "audio/midi audio/x-midi":
+		return ".midi"
+	case "audio/mpeg":
+		return ".mp3"
+	case "application/x-cdf":
+		return ".cda"
+	case "video/mp4":
+		return ".mp4"
+	case "video/mpeg":
+		return ".mpeg"
+	case "application/vnd.apple.installer+xml":
+		return ".mpkg"
+	case "application/vnd.oasis.opendocument.presentation":
+		return ".odp"
+	case "application/vnd.oasis.opendocument.spreadsheet":
+		return ".ods"
+	case "application/vnd.oasis.opendocument.text":
+		return ".odt"
+	case "audio/ogg":
+		return ".oga"
+	case "video/ogg":
+		return ".ogv"
+	case "application/ogg":
+		return ".ogx"
+	case "audio/opus":
+		return ".opus"
+	case "font/otf":
+		return ".otf"
+	case "image/png":
+		return ".png"
+	case "application/pdf":
+		return ".pdf"
+	case "application/x-httpd-php":
+		return ".php"
+	case "application/vnd.ms-powerpoint":
+		return ".ppt"
+	case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+		return ".pptx"
+	case "application/vnd.rar":
+		return ".rar"
+	case "application/rtf":
+		return ".rtf"
+	case "application/x-sh":
+		return ".sh"
+	case "image/svg+xml":
+		return ".svg"
+	case "application/x-shockwave-flash":
+		return ".swf"
+	case "application/x-tar":
+		return ".tar"
+	case "image/tiff":
+		return ".tiff"
+	case "video/mp2t":
+		return ".ts"
+	case "font/ttf":
+		return ".ttf"
+	case "text/plain":
+		return ".txt"
+	case "application/vnd.visio":
+		return ".vsd"
+	case "audio/wav":
+		return ".wav"
+	case "audio/webm":
+		return ".weba"
+	case "video/webm":
+		return ".webm"
+	case "image/webp":
+		return ".webp"
+	case "font/woff":
+		return ".woff"
+	case "font/woff2":
+		return ".woff2"
+	case "application/xhtml+xml":
+		return ".xhtml"
+	case "application/vnd.ms-excel":
+		return ".xls"
+	case "application/xml":
+		return ".xml"
+	case "application/zip":
+		return ".zip"
+	case "video/3gpp":
+		return ".3gp"
+	case "video/3gpp2":
+		return ".3gp2"
+	case "application/x-7z-compressed":
+		return ".7z"
+	default:
+		extensions, _ := mime.ExtensionsByType(mimeType)
+		if extensions == nil || len(extensions) == 0 {
+			return ""
+		}
+		return extensions[0]
+	}
+}

--- a/pkg/util/mime/mime_test.go
+++ b/pkg/util/mime/mime_test.go
@@ -1,0 +1,15 @@
+package mime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtensionByType(t *testing.T) {
+	require.Equal(t, ".txt", ExtensionByType("text/plain"))
+	require.Equal(t, ".jpg", ExtensionByType("image/jpeg"))
+	require.Equal(t, ".png", ExtensionByType("image/png"))
+	require.Equal(t, ".json", ExtensionByType("application/json"))
+	require.Equal(t, "", ExtensionByType("asdfasdf"))
+}


### PR DESCRIPTION
Adds --file and --output-dir arguments to cog infer.

## Example usage

Given the following infer.py script that prefixes file contents with "hello ":
```python
# infer.py
from pathlib import Path
import cog

class Model(cog.Model):
    def setup(self):
        self.prefix = "hello"

    @cog.input("file", type=Path, help="File containing text that will get prefixed by 'hello '")
    def run(self, file):
        with file.open() as f:
            return self.prefix + " " + f.read()
```

...you can process an arbitrary number of input files by creating a file containing the filenames process. In this case, we call the file "inputs.txt":

```
# inputs.txt
file=@inputs/file1.txt
file=@inputs/file2.txt
file=@inputs/file3.txt
# [...]
```

The input file contains one line per example, where each example is in the form `<key>=<value>[,<key>=<value>[, ...]]`. As in the single-example `cog infer --input ...` command, filenames are prefixed with `@`.

To process the files in inputs.txt, invoke cog infer with:

```
cog infer --file=inputs.txt --output-dir=outputs my-name/my-model:version
```

This will put outputs in a directory called `outputs`, and the files will be named `outputs/output.0000002.txt`, `outputs/output.0000003.txt`, `outputs/output.0000004.txt`, etc. The number (e.g. `0000002`) corresponds to the line number in inputs.txt. In this case the line number starts at 2 since line 1 is a comment.

Examples that fail to process will output a warning to stderr, but processing will continue.

---

_This PR doesn't add batch infer capabilities to the Python library._

Signed-off-by: andreasjansson <andreas@replicate.ai>

Closes #29