### PR TITLE
Only keep :latest tag for local images

### DIFF
--- a/end-to-end-test/end_to_end_test/conftest.py
+++ b/end-to-end-test/end_to_end_test/conftest.py
@@ -1,3 +1,5 @@
+from typing import Generator
+from dataclasses import dataclass
 import os
 import subprocess
 import tempfile
@@ -5,24 +7,46 @@ from waiting import wait
 import requests
 import pytest
 
-from .util import random_string, find_free_port, docker_run
+from .util import random_string, find_free_port, docker_run, get_local_ip, wait_for_port
+
+
+@dataclass
+class CogServer:
+    port: int
+    registry_host: str
 
 
 @pytest.fixture
-def cog_server_port():
+def registry_host():
+    container_name = "cog-test-registry-" + random_string(10)
+    port = find_free_port()
+    with docker_run(
+        "registry:2",
+        name=container_name,
+        publish=[{"host": port, "container": 5000}],
+        detach=True,
+    ):
+        wait_for_port("localhost", port)
+        yield f"localhost:{port}"
+
+
+@pytest.fixture
+def cog_server(registry_host) -> Generator[CogServer, None, None]:
     old_cwd = os.getcwd()
     with tempfile.TemporaryDirectory() as cog_dir:
         os.chdir(cog_dir)
-        port = str(find_free_port())
-        server_proc = subprocess.Popen(["cog", "server", "--port", port])
+        port = find_free_port()
+        server_proc = subprocess.Popen(
+            ["cog", "server", "--port", str(port), "--docker-registry", registry_host]
+        )
         resp = wait(
-            lambda: requests.get("http://localhost:" + port + "/ping"),
+            lambda: requests.get(f"http://localhost:{port}/ping"),
             timeout_seconds=60,
             expected_exceptions=(requests.exceptions.ConnectionError,),
         )
         assert resp.text == "pong"
 
-        yield port
+        yield CogServer(port=port, registry_host=registry_host)
 
     os.chdir(old_cwd)
     server_proc.kill()

--- a/end-to-end-test/end_to_end_test/test_queue_worker.py
+++ b/end-to-end-test/end_to_end_test/test_queue_worker.py
@@ -16,10 +16,10 @@ from .util import (
 )
 
 
-def test_queue_worker(cog_server_port, project_dir, redis_port, tmpdir_factory):
+def test_queue_worker(cog_server, project_dir, redis_port, tmpdir_factory):
     user = random_string(10)
     model_name = random_string(10)
-    model_url = f"http://localhost:{cog_server_port}/{user}/{model_name}"
+    model_url = f"http://localhost:{cog_server.port}/{user}/{model_name}"
 
     set_model_url(model_url, project_dir)
     version_id = push_with_log(project_dir)

--- a/pkg/docker/builder.go
+++ b/pkg/docker/builder.go
@@ -9,4 +9,5 @@ import (
 type ImageBuilder interface {
 	Build(ctx context.Context, dir string, dockerfileContents string, name string, useGPU bool, logWriter logger.Logger) (tag string, err error)
 	Push(ctx context.Context, tag string, logWriter logger.Logger) error
+	Cleanup(dockerTag string) error
 }

--- a/pkg/docker/mock.go
+++ b/pkg/docker/mock.go
@@ -23,3 +23,7 @@ func (m *MockImageBuilder) Build(ctx context.Context, dir string, dockerfileCont
 func (m *MockImageBuilder) Push(ctx context.Context, tag string, logWriter logger.Logger) error {
 	return nil
 }
+
+func (m *MockImageBuilder) Cleanup(imageURI string) error {
+	return nil
+}

--- a/pkg/server/queue.go
+++ b/pkg/server/queue.go
@@ -214,6 +214,11 @@ func (q *BuildQueue) handleJob(job *BuildJob) {
 		outChan <- &JobOutput{error: err}
 		return
 	}
+	defer func() {
+		if err := q.dockerImageBuilder.Cleanup(imageURI); err != nil {
+			console.Errorf("Failed to clean up %s: %v", imageURI, err)
+		}
+	}()
 
 	testResult, err := serving.TestVersion(ctx, q.servingPlatform, imageURI, job.config.Examples, job.dir, job.arch == "gpu", logWriter)
 	if err != nil {


### PR DESCRIPTION
Images are built, tagged with registry and content-addressable tag,
pushed, re-tagged as :latest, and the original tag is removed.

This prevents Cog from using a ton of disk space, but builds are still
fast since the cached layers from the last build are still kept around
thanks to the :latest tag.

ref #80 #18

Signed-off-by: andreasjansson <andreas@replicate.ai>