### PR TITLE
Make end to end tests parallel

### DIFF
--- a/end-to-end-test/Makefile
+++ b/end-to-end-test/Makefile
@@ -1,3 +1,3 @@
 .PHONY: test
 test:
-	pytest -s --tb=short
+	pytest --tb=short -n 10

--- a/end-to-end-test/requirements.txt
+++ b/end-to-end-test/requirements.txt
@@ -1,4 +1,5 @@
 pytest==6.1.1
+pytest-xdist==2.2.1
 waiting==1.4.1
 requests==2.25.1
 redis==3.5.3


### PR DESCRIPTION
In theory this should make end to end tests much faster. However -- `find_free_port()` has a race condition. When port is closed, another parallel process can take the port. Perhaps it can defer closing.