### PR TITLE
Cache preinstall

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -85,7 +85,7 @@ func getModel() (*model.Model, error) {
 		if projectSettings.Model != nil {
 			return projectSettings.Model, nil
 		}
-		return nil, fmt.Errorf("No model specified. You need to either run `cog model set <url>` to set a model for the current directory, or pass --model <url> to the command")
+		return nil, fmt.Errorf("No model set. You need to either run `cog model set <url>` to set a model for the current directory, or pass --model <url> to the command")
 	}
 }
 

--- a/pkg/docker/generate.go
+++ b/pkg/docker/generate.go
@@ -87,8 +87,8 @@ func (g *DockerfileGenerator) GenerateBase() (string, error) {
 		aptInstalls,
 		pythonRequirements,
 		pipInstalls,
-		installCog,
 		g.preInstall(),
+		installCog,
 		g.workdir(),
 	}), "\n"), nil
 }


### PR DESCRIPTION
Installing Cog busts the Docker cache, so do the pre-install before it.