### PR TITLE
refactor: re-usable config loading, and basic error definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ Untitled*.ipynb
 __pycache__
 .cog
 dist
+# Used by a vim plugin (projectionist)
+.projections.json
+.venv/

--- a/end-to-end-test/end_to_end_test/test_config.py
+++ b/end-to-end-test/end_to_end_test/test_config.py
@@ -1,0 +1,23 @@
+import os
+import subprocess
+
+
+def test_config(tmpdir_factory):
+    tmpdir = tmpdir_factory.mktemp("project")
+    with open(tmpdir / "cog.yaml", "w") as f:
+        cog_yaml = """
+environment:
+  python: "3.8"
+        """
+        f.write(cog_yaml)
+
+    subdir = tmpdir / "some/sub/dir"
+    os.makedirs(subdir)
+
+    result = subprocess.run(
+        ["cog", "run", "echo", "hello world"],
+        cwd=subdir,
+        check=True,
+        capture_output=True,
+    )
+    assert b"hello world" in result.stdout

--- a/end-to-end-test/end_to_end_test/test_queue_worker.py
+++ b/end-to-end-test/end_to_end_test/test_queue_worker.py
@@ -1,18 +1,19 @@
 import json
-import redis
-from contextlib import contextmanager
 import multiprocessing
-from flask import Flask, request, jsonify, Response
+from contextlib import contextmanager
+
+import redis
+from flask import Flask, Response, jsonify, request
 
 from .util import (
+    docker_run,
+    find_free_port,
+    get_bridge_ip,
+    push_with_log,
     random_string,
     set_model_url,
     show_version,
-    push_with_log,
-    find_free_port,
-    docker_run,
-    get_local_ip,
-    wait_for_port,
+    wait_for_port
 )
 
 
@@ -28,9 +29,9 @@ def test_queue_worker(cog_server, project_dir, redis_port, tmpdir_factory):
     input_queue = multiprocessing.Queue()
     output_queue = multiprocessing.Queue()
     controller_port = find_free_port()
-    local_ip = get_local_ip()
-    upload_url = f"http://{local_ip}:{controller_port}/upload"
-    redis_host = local_ip
+    bridge_ip = get_bridge_ip()
+    upload_url = f"http://{bridge_ip}:{controller_port}/upload"
+    redis_host = bridge_ip
     worker_name = "test-worker"
     predict_queue_name = "predict-queue"
     response_queue_name = "response-queue"
@@ -67,7 +68,7 @@ def test_queue_worker(cog_server, project_dir, redis_port, tmpdir_factory):
                             "path": {
                                 "file": {
                                     "name": "myinput.txt",
-                                    "url": f"http://{local_ip}:{controller_port}/download",
+                                    "url": f"http://{bridge_ip}:{controller_port}/download",
                                 }
                             },
                         },
@@ -93,7 +94,7 @@ def test_queue_worker(cog_server, project_dir, redis_port, tmpdir_factory):
                             "path": {
                                 "file": {
                                     "name": "myinput.txt",
-                                    "url": f"http://{local_ip}:{controller_port}/download",
+                                    "url": f"http://{bridge_ip}:{controller_port}/download",
                                 }
                             },
                         },

--- a/end-to-end-test/end_to_end_test/util.py
+++ b/end-to-end-test/end_to_end_test/util.py
@@ -114,4 +114,7 @@ def get_local_ip():
 
 def get_bridge_ip():
     """Return the IP address of the docker bridge network"""
-    return "172.17.0.1"
+    cmd = ["docker", "network", "inspect", "bridge", "--format='{{ json (index .IPAM.Config 0).Gateway }}'"]
+    out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE).communicate()
+
+    return out.decode().strip().replace('"', "").replace("'", "")

--- a/end-to-end-test/end_to_end_test/util.py
+++ b/end-to-end-test/end_to_end_test/util.py
@@ -1,13 +1,12 @@
-import time
-from contextlib import contextmanager
 import json
-import subprocess
 import random
 import re
-import string
 import socket
+import string
+import subprocess
+import time
+from contextlib import closing, contextmanager
 from typing import List, Optional
-from contextlib import closing
 
 
 def find_free_port():
@@ -112,3 +111,7 @@ def docker_run(
 
 def get_local_ip():
     return socket.gethostbyname(socket.gethostname())
+
+def get_bridge_ip():
+    """Return the IP address of the docker bridge network"""
+    return "172.17.0.1"

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/docker"
 	"github.com/replicate/cog/pkg/global"
-	"github.com/replicate/cog/pkg/util/config"
 	"github.com/replicate/cog/pkg/util/console"
 )
 

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/replicate/cog/pkg/docker"
 	"github.com/replicate/cog/pkg/global"
+	"github.com/replicate/cog/pkg/util/config"
 	"github.com/replicate/cog/pkg/util/console"
 )
 
@@ -30,7 +31,7 @@ func newDebugCommand() *cobra.Command {
 }
 
 func cmdDockerfile(cmd *cobra.Command, args []string) error {
-	config, projectDir, err := getConfig()
+	config, projectDir, err := config.GetConfig(projectDirFlag)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/model.go
+++ b/pkg/cli/model.go
@@ -3,15 +3,13 @@ package cli
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	"github.com/replicate/cog/pkg/client"
-	"github.com/replicate/cog/pkg/global"
 	"github.com/replicate/cog/pkg/settings"
+	"github.com/replicate/cog/pkg/util/config"
 	"github.com/replicate/cog/pkg/util/console"
-	"github.com/replicate/cog/pkg/util/files"
 )
 
 func newModelCommand() *cobra.Command {
@@ -53,16 +51,10 @@ func modelSet(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	exists, err := files.Exists(filepath.Join(cwd, global.ConfigFilename))
+
+	projectDir, err := config.GetProjectDir(projectDirFlag)
 	if err != nil {
 		console.Error(err.Error())
-	}
-	if !exists {
-		console.Warnf("%s does not exist in %s. Are you in the right directory?", global.ConfigFilename, cwd)
 	}
 
 	cli := client.NewClient()
@@ -70,7 +62,7 @@ func modelSet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	userSettings, err := settings.LoadProjectSettings(cwd)
+	userSettings, err := settings.LoadProjectSettings(projectDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/model.go
+++ b/pkg/cli/model.go
@@ -7,8 +7,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/replicate/cog/pkg/client"
+	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/settings"
-	"github.com/replicate/cog/pkg/util/config"
 	"github.com/replicate/cog/pkg/util/console"
 )
 

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/replicate/cog/pkg/client"
+	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/docker"
 	"github.com/replicate/cog/pkg/logger"
 	"github.com/replicate/cog/pkg/model"
@@ -64,7 +65,7 @@ func cmdPredict(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
 		// Local
 
-		config, projectDir, err := getConfig()
+		config, projectDir, err := config.GetConfig(projectDirFlag)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -7,9 +7,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/replicate/cog/pkg/client"
+	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/logger"
 	"github.com/replicate/cog/pkg/model"
-	"github.com/replicate/cog/pkg/util/config"
 	"github.com/replicate/cog/pkg/util/console"
 )
 

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -9,6 +9,7 @@ import (
 	"github.com/replicate/cog/pkg/client"
 	"github.com/replicate/cog/pkg/logger"
 	"github.com/replicate/cog/pkg/model"
+	"github.com/replicate/cog/pkg/util/config"
 	"github.com/replicate/cog/pkg/util/console"
 )
 
@@ -43,7 +44,7 @@ func push(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	config, projectDir, err := getConfig()
+	config, projectDir, err := config.GetConfig(projectDirFlag)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -2,9 +2,7 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path"
 	"regexp"
 
 	"github.com/spf13/cobra"
@@ -13,7 +11,6 @@ import (
 	"github.com/replicate/cog/pkg/model"
 	"github.com/replicate/cog/pkg/settings"
 	"github.com/replicate/cog/pkg/util/console"
-	"github.com/replicate/cog/pkg/util/files"
 )
 
 var modelFlag string
@@ -103,33 +100,4 @@ func parseModel(modelString string) (*model.Model, error) {
 
 func addProjectDirFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&projectDirFlag, "project-dir", "D", "", "Project directory, defaults to current working directory")
-}
-
-func getConfig() (*model.Config, string, error) {
-	projectDir, err := os.Getwd()
-	if err != nil {
-		return nil, "", err
-	}
-
-	configPath := path.Join(projectDir, global.ConfigFilename)
-
-	exists, err := files.Exists(configPath)
-	if err != nil {
-		return nil, "", err
-	}
-	if !exists {
-		return nil, "", fmt.Errorf("%s does not exist in %s. Are you in the right directory?", global.ConfigFilename, projectDir)
-	}
-
-	contents, err := ioutil.ReadFile(configPath)
-	if err != nil {
-		return nil, "", err
-	}
-
-	config, err := model.ConfigFromYAML(contents)
-	if err != nil {
-		return nil, "", err
-	}
-	err = config.ValidateAndCompleteConfig()
-	return config, projectDir, err
 }

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/mattn/go-isatty"
+	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/docker"
 	"github.com/replicate/cog/pkg/logger"
 	"github.com/replicate/cog/pkg/util/terminal"
@@ -36,7 +37,7 @@ func run(cmd *cobra.Command, args []string) error {
 	ui := terminal.ConsoleUI(context.Background())
 	defer ui.Close()
 
-	config, projectDir, err := getConfig()
+	config, projectDir, err := config.GetConfig(projectDirFlag)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/docker"
 	"github.com/replicate/cog/pkg/logger"
 	"github.com/replicate/cog/pkg/serving"
-	"github.com/replicate/cog/pkg/util/config"
 	"github.com/replicate/cog/pkg/util/console"
 )
 

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/replicate/cog/pkg/docker"
 	"github.com/replicate/cog/pkg/logger"
 	"github.com/replicate/cog/pkg/serving"
+	"github.com/replicate/cog/pkg/util/config"
 	"github.com/replicate/cog/pkg/util/console"
 )
 
@@ -30,7 +31,7 @@ func Test(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	config, projectDir, err := getConfig()
+	config, projectDir, err := config.GetConfig(projectDirFlag)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -35,6 +35,9 @@ func GetProjectDir(customDir string) (string, error) {
 func GetConfig(customDir string) (*model.Config, string, error) {
 	// Find the root project directory
 	rootDir, err := GetProjectDir(customDir)
+	if err != nil {
+		return nil, "", err
+	}
 	configPath := path.Join(rootDir, global.ConfigFilename)
 
 	// Then try to load the config file from there

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -34,7 +34,7 @@ func GetProjectDir(projectDirFlag string) (string, error) {
 // projectDir can be specified to override the default - current working directory
 func GetConfig(projectDir string) (*model.Config, string, error) {
 	var rootDir string
-	if projectDir != "" {
+	if projectDir == "" {
 		cwd, err := os.Getwd()
 		if err != nil {
 			return nil, "", err

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -81,7 +81,8 @@ func TestFindProjectRootDirShouldFindParentDir(t *testing.T) {
 	require.NoError(t, err)
 
 	subdir := path.Join(projectDir, "some/sub/dir")
-	os.MkdirAll(subdir, 0700)
+	err = os.MkdirAll(subdir, 0700)
+	require.NoError(t, err)
 
 	foundDir, err := findProjectRootDir(subdir)
 	require.NoError(t, err)
@@ -94,7 +95,8 @@ func TestFindProjectRootDirShouldReturnErrIfNoConfig(t *testing.T) {
 	defer os.RemoveAll(projectDir)
 
 	subdir := path.Join(projectDir, "some/sub/dir")
-	os.MkdirAll(subdir, 0700)
+	err = os.MkdirAll(subdir, 0700)
+	require.NoError(t, err)
 
 	_, err = findProjectRootDir(subdir)
 	require.Error(t, err)

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/replicate/cog/pkg/model"
+	"github.com/stretchr/testify/require"
+)
+
+const TEST_CONFIG = `model: "model.py:SomeModel"
+environment:
+  architectures:
+    - cpu
+  python_version: "3.8"
+  python_requirements: requirements.txt
+  system_packages:
+    - libgl1-mesa-glx
+    - libglib2.0-0
+examples:
+  - input:
+      input: "@example/foo.jpg"
+  - input:
+      input: "@example/bar.jpg"
+`
+
+func TestGetProjectDirWithFlagSet(t *testing.T) {
+	projectDirFlag := "foo"
+
+	projectDir, err := GetProjectDir(projectDirFlag)
+	require.NoError(t, err)
+	require.Equal(t, projectDir, projectDirFlag)
+}
+
+func TestGetConfigShouldLoadFromFile(t *testing.T) {
+	dir, err := ioutil.TempDir("/tmp/", "cog-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	err = ioutil.WriteFile(path.Join(dir, "cog.yaml"), []byte(TEST_CONFIG), 0644)
+	require.NoError(t, err)
+	t.Log(dir)
+	conf, _, err := GetConfig(dir)
+	require.NoError(t, err)
+	want := &model.Config{
+		Model: "model.py:SomeModel",
+		Environment: &model.Environment{
+			PythonVersion:      "3.8",
+			PythonRequirements: "requirements.txt",
+			Architectures: []string{
+				"cpu",
+			},
+			SystemPackages: []string{
+				"libgl1-mesa-glx",
+				"libglib2.0-0",
+			},
+		},
+		Examples: []*model.Example{
+			{
+				Input: map[string]string{
+					"input": "@example/foo.jpg",
+				},
+			},
+			{
+				Input: map[string]string{
+					"input": "@example/bar.jpg",
+				},
+			},
+		},
+	}
+	require.Equal(t, want, conf)
+}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,49 @@
+package errors
+
+const (
+	CodeConfigNotFound = "CONFIG_NOT_FOUND"
+)
+
+// Types ////////////////////////////////////////
+
+type CodedError interface {
+	Code() string
+}
+
+type codedError struct {
+	code string
+	msg  string
+}
+
+func (e *codedError) Error() string {
+	return e.msg
+}
+
+func (e *codedError) Code() string {
+	return e.code
+}
+
+// Error Creators ///////////////////////////////
+
+// The Cog config was not found
+func ConfigNotFound(msg string) error {
+	return &codedError{
+		code: CodeConfigNotFound,
+		msg:  msg + ``, // TODO: populate this
+	}
+}
+
+// Helpers //////////////////////////////////////
+
+func IsConfigNotFound(err error) bool {
+	return Code(err) == CodeConfigNotFound
+}
+
+// Return the error code, or the empty string
+func Code(err error) string {
+	if cerr, ok := err.(CodedError); ok {
+		return cerr.Code()
+	}
+
+	return ""
+}

--- a/pkg/server/build.go
+++ b/pkg/server/build.go
@@ -17,10 +17,10 @@ import (
 	"github.com/segmentio/ksuid"
 
 	"github.com/replicate/cog/pkg/database"
-	"github.com/replicate/cog/pkg/global"
 	"github.com/replicate/cog/pkg/logger"
 	"github.com/replicate/cog/pkg/model"
 	"github.com/replicate/cog/pkg/serving"
+	"github.com/replicate/cog/pkg/util/config"
 	"github.com/replicate/cog/pkg/util/console"
 	"github.com/replicate/cog/pkg/util/zip"
 )
@@ -212,18 +212,13 @@ func (s *Server) saveExamples(result *BuildResult, dir string, config *model.Con
 	return nil
 }
 
+// Load the Cog config
 func (s *Server) ReadConfig(dir string) (*model.Config, error) {
-	configRaw, err := os.ReadFile(filepath.Join(dir, global.ConfigFilename))
-	if err != nil {
-		return nil, fmt.Errorf("Failed to read %s: %w", global.ConfigFilename, err)
-	}
-	config, err := model.ConfigFromYAML(configRaw)
+	config, _, err := config.GetConfig("") // Read from cwd by default
 	if err != nil {
 		return nil, err
 	}
-	if err := config.ValidateAndCompleteConfig(); err != nil {
-		return nil, err
-	}
+
 	return config, nil
 }
 

--- a/pkg/server/build.go
+++ b/pkg/server/build.go
@@ -16,11 +16,11 @@ import (
 	"github.com/mholt/archiver/v3"
 	"github.com/segmentio/ksuid"
 
+	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/database"
 	"github.com/replicate/cog/pkg/logger"
 	"github.com/replicate/cog/pkg/model"
 	"github.com/replicate/cog/pkg/serving"
-	"github.com/replicate/cog/pkg/util/config"
 	"github.com/replicate/cog/pkg/util/console"
 	"github.com/replicate/cog/pkg/util/zip"
 )

--- a/pkg/server/build.go
+++ b/pkg/server/build.go
@@ -214,7 +214,7 @@ func (s *Server) saveExamples(result *BuildResult, dir string, config *model.Con
 
 // Load the Cog config
 func (s *Server) ReadConfig(dir string) (*model.Config, error) {
-	config, _, err := config.GetConfig("") // Read from cwd by default
+	config, _, err := config.GetConfig(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -1,0 +1,103 @@
+// Cog Config
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/replicate/cog/pkg/global"
+	"github.com/replicate/cog/pkg/model"
+	"github.com/replicate/cog/pkg/util/files"
+)
+
+// Returns the project's root directory, or the directory specified by the --project-dir flag
+func GetProjectDir(projectDirFlag string) (string, error) {
+	if projectDirFlag != "" {
+		return projectDirFlag, nil
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return findProjectRootDir(cwd)
+}
+
+// Loads the cog config
+func GetConfig(projectDir string) (*model.Config, string, error) {
+	var rootDir string
+	if projectDir != "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, "", err
+		}
+
+		// First find the project root directory
+		rootDir, err = findProjectRootDir(cwd)
+		if err != nil {
+			return nil, "", err
+		}
+	} else {
+		rootDir = projectDir
+	}
+	configPath := path.Join(rootDir, global.ConfigFilename)
+
+	// Then try to load the config file from there
+	config, err := loadConfigFromFile(configPath)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Finally, validate the loaded config
+	err = config.ValidateAndCompleteConfig()
+
+	return config, rootDir, err
+}
+
+// Given a file path, attempt to load a config from that file
+func loadConfigFromFile(file string) (*model.Config, error) {
+	exists, err := files.Exists(file)
+	if err != nil {
+		return nil, err
+	}
+
+	if !exists {
+		return nil, fmt.Errorf("%s does not exist in %s. Are you in the right directory?", global.ConfigFilename, filepath.Dir(file))
+	}
+
+	contents, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := model.ConfigFromYAML(contents)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+
+}
+
+// Walk up the directory tree to find the root of the project.
+// The project root is defined as the directory housing a `cog.yaml` file.
+func findProjectRootDir(dir string) (string, error) {
+	for dir != "." {
+		configPath := path.Join(dir, global.ConfigFilename)
+		configExists, err := files.Exists(configPath)
+		if err != nil {
+			return "", err
+		}
+		if configExists {
+			return dir, nil
+		}
+
+		dir = filepath.Dir(dir)
+	}
+
+	return "", errors.New("No cog.yaml found in parent directories.")
+}


### PR DESCRIPTION
#102 

### What does this PR do?
* Standardises config-related functionality in `utils/config.go`
* Eliminates some repetitious config loading code
* Adds a func to walk the parent directories in search of a `cog.yaml`
* Adds some basic error creation code in `pkg/errors/errors.go`

### Next Steps/Questions
* Is this a reasonable approach?
* ~~How do we want `cog run` to work - relative to `cwd` or relative to the root (see #102)?~~
* ~~What else needs to change to allow `cog` usage in subdirectories?~~
* What's the best way to test this? Unit tests (where?), some addition to the e2e tests?

(If you like the config-loading (`utils/config.go`) refactor, we could merge that as a separate PR first to keep PRs small and lean)