### PR TITLE
Attempt to delete :latest tag before tagging with :latest

### DIFF
--- a/end-to-end-test/end_to_end_test/test_docker_cleanup.py
+++ b/end-to-end-test/end_to_end_test/test_docker_cleanup.py
@@ -1,0 +1,48 @@
+import os
+import subprocess
+from typing import List
+
+from .util import random_string, set_model_url, push_with_log
+
+
+def test_docker_cleanup(cog_server, project_dir):
+    user = random_string(10)
+    model_name = random_string(10)
+    model_url = f"http://localhost:{cog_server.port}/{user}/{model_name}"
+
+    set_model_url(model_url, project_dir)
+
+    push_with_log(project_dir)
+
+    # check that only the :latest version remains locally
+    tags = list_docker_tags(cog_server.registry_host, model_name)
+    assert tags == ["latest"]
+
+    # push a new version
+    with open(project_dir / "newfile.txt", "w") as f:
+        f.write("i'm new here")
+
+    push_with_log(project_dir)
+
+    # check that only the :latest version remains locally, still
+    tags = list_docker_tags(cog_server.registry_host, model_name)
+    assert tags == ["latest"]
+
+
+def list_docker_tags(registry_host, model_name) -> List[str]:
+    return (
+        subprocess.Popen(
+            [
+                "docker",
+                "images",
+                f"{registry_host}/{model_name}",
+                "--format",
+                "{{.Tag}}",
+            ],
+            stdout=subprocess.PIPE,
+        )
+        .communicate()[0]
+        .decode()
+        .strip()
+        .splitlines()
+    )

--- a/end-to-end-test/end_to_end_test/test_server.py
+++ b/end-to-end-test/end_to_end_test/test_server.py
@@ -28,7 +28,7 @@ def test_server_end_to_end(cog_server, project_dir, tmpdir_factory):
 
     out = show_version(model_url, version_id)
     subprocess.Popen(
-        ["cog", "--model", model_url, "build", "log", "-f", out["build_ids"]["cpu"]]
+        ["cog", "--model", model_url, "build", "log", out["build_ids"]["cpu"]]
     ).communicate()
 
     out = show_version(model_url, version_id)
@@ -41,25 +41,6 @@ def test_server_end_to_end(cog_server, project_dir, tmpdir_factory):
         f"http://{cog_server.registry_host}/v2/{model_name}/tags/list"
     ).json()
     assert tags_response["tags"][0] == image_tag
-
-    # check that only the :latest version remains locally
-    local_tags = (
-        subprocess.Popen(
-            [
-                "docker",
-                "images",
-                f"{cog_server.registry_host}/{model_name}",
-                "--format",
-                "{{.Tag}}",
-            ],
-            stdout=subprocess.PIPE,
-        )
-        .communicate()[0]
-        .decode()
-        .strip()
-        .splitlines()
-    )
-    assert local_tags == ["latest"]
 
     # show without --model
     out, _ = subprocess.Popen(


### PR DESCRIPTION
Following up from https://github.com/replicate/cog/pull/88, this will
keep Cog from leaving dangling Docker images that take lots of disk
space.

Fixes #18

Signed-off-by: andreasjansson <andreas@replicate.ai>