### PR TITLE
Make inline terminal taller

### DIFF
--- a/pkg/util/terminal/glint_step_group.go
+++ b/pkg/util/terminal/glint_step_group.go
@@ -84,7 +84,7 @@ func (f *glintStep) TermOutput() io.Writer {
 	defer f.mu.Unlock()
 
 	if f.term == nil {
-		t, err := newGlintTerm(f.ctx, 10, 80)
+		t, err := newGlintTerm(f.ctx, 20, 80)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Makes build output easier to read.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>