### PR TITLE
Send logs to queue

### DIFF
--- a/end-to-end-test/end_to_end_test/conftest.py
+++ b/end-to-end-test/end_to_end_test/conftest.py
@@ -58,20 +58,21 @@ def project_dir(tmpdir_factory):
     with open(tmpdir / "predict.py", "w") as f:
         f.write(
             """
-import time
+import sys
 import tempfile
 from pathlib import Path
 import cog
 
 class Model(cog.Model):
     def setup(self):
+        print("setting up model")
         self.foo = "foo"
 
     @cog.input("text", type=str)
     @cog.input("path", type=Path)
     @cog.input("output_file", type=bool, default=False)
     def predict(self, text, path, output_file):
-        time.sleep(1)
+        sys.stderr.write("processing " + text + "\\n")
         with open(path) as f:
             output = self.foo + text + f.read()
         if output_file:
@@ -80,7 +81,9 @@ class Model(cog.Model):
             tmp_path = Path(tmp.name)
             with tmp_path.open("w") as f:
                 f.write(output)
+                print("successfully processed file " + text)
                 return tmp_path
+        print("successfully processed " + text)
         return output
         """
         )

--- a/pkg/docker/cog.py
+++ b/pkg/docker/cog.py
@@ -439,6 +439,7 @@ class RedisQueueWorker:
         """
 
         class QueueLogger:
+        # TODO(bfirsh): maybe this should be a subclass of io.TextIOWrapper?
             def __init__(self, redis, queue, old_out):
                 self.redis = redis
                 self.queue = queue

--- a/pkg/docker/generate.go
+++ b/pkg/docker/generate.go
@@ -235,7 +235,7 @@ import os
 os.chdir("` + g.getWorkdir() + `")
 sys.path.append("` + g.getWorkdir() + `")
 from ` + module + ` import ` + class + `
-cog.RedisQueueWorker(` + class + `(), redis_host=sys.argv[1], redis_port=sys.argv[2], input_queue=sys.argv[3], upload_url=sys.argv[4], consumer_id=sys.argv[5]).start()`
+cog.RedisQueueWorker(` + class + `(), redis_host=sys.argv[1], redis_port=sys.argv[2], input_queue=sys.argv[3], upload_url=sys.argv[4], consumer_id=sys.argv[5], model_id=sys.argv[6], log_queue=sys.argv[7]).start()`
 	scriptString := strings.ReplaceAll(script, "\n", "\\n")
 	return `
 RUN echo '` + scriptString + `' > ` + scriptPath + `

--- a/pkg/docker/generate_test.go
+++ b/pkg/docker/generate_test.go
@@ -167,6 +167,6 @@ RUN echo '#!/usr/bin/env python\nimport sys\nimport cog\nimport os\nos.chdir("/c
 RUN chmod +x /usr/bin/cog-http-server
 RUN echo '#!/usr/bin/env python\nimport sys\nimport cog\nimport os\nos.chdir("/code")\nsys.path.append("/code")\nfrom predict import Model\ncog.AIPlatformPredictionServer(Model()).start_server()' > /usr/bin/cog-ai-platform-prediction-server
 RUN chmod +x /usr/bin/cog-ai-platform-prediction-server
-RUN echo '#!/usr/bin/env python\nimport sys\nimport cog\nimport os\nos.chdir("/code")\nsys.path.append("/code")\nfrom predict import Model\ncog.RedisQueueWorker(Model(), redis_host=sys.argv[1], redis_port=sys.argv[2], input_queue=sys.argv[3], upload_url=sys.argv[4], consumer_id=sys.argv[5]).start()' > /usr/bin/cog-redis-queue-worker
+RUN echo '#!/usr/bin/env python\nimport sys\nimport cog\nimport os\nos.chdir("/code")\nsys.path.append("/code")\nfrom predict import Model\ncog.RedisQueueWorker(Model(), redis_host=sys.argv[1], redis_port=sys.argv[2], input_queue=sys.argv[3], upload_url=sys.argv[4], consumer_id=sys.argv[5], model_id=sys.argv[6], log_queue=sys.argv[7]).start()' > /usr/bin/cog-redis-queue-worker
 RUN chmod +x /usr/bin/cog-redis-queue-worker`
 }


### PR DESCRIPTION
Queue worker "tees" stdout/stderr to a Redis queue, such that each log
line becomes a message on the queue. The ID is the model URL during
setup, and the prediction ID during the run stage.

Signed-off-by: andreasjansson <andreas@replicate.ai>