### PR TITLE
Redirect build stdout to stderr

### DIFF
--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -28,7 +28,7 @@ func Build(dir, dockerfile, imageName string, progressOutput string) error {
 	cmd := exec.Command("docker", args...)
 	cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
 	cmd.Dir = dir
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = os.Stderr // redirect stdout to stderr - build output is all messaging
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = strings.NewReader(dockerfile)
 

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -30,7 +30,8 @@ predict: "predict.py:Predictor"
     result = subprocess.run(
         ["cog", "predict", "-i", "world"], cwd=tmpdir, check=True, capture_output=True
     )
-    assert b"hello world" in result.stdout
+    # stdout should be clean without any log messages so it can be piped to other commands
+    assert result.stdout == b"hello world\n"
 
 
 def test_predict_with_existing_image(tmpdir_factory):
@@ -73,6 +74,6 @@ predict: "predict.py:Predictor"
             check=True,
             capture_output=True,
         )
-        assert b"hello world" in result.stdout
+        assert result.stdout == b"hello world\n"
     finally:
         subprocess.run(["docker", "rmi", image_name], check=True)


### PR DESCRIPTION
So predict output is clean and can be piped.