### PR TITLE
Implement expected file methods on Cog's queue logger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LDFLAGS := -ldflags "-X github.com/replicate/cog/pkg/global.Version=$(VERSION) -
 
 default: build
 
-pkg/dockerfile/embed/cog.whl: python/* python/cog/*
+pkg/dockerfile/embed/cog.whl: python/* python/cog/* python/cog/server/* python/cog/command/*
 	@echo "Building Python library"
 	rm -rf python/dist
 	cd python && python setup.py bdist_wheel

--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -237,13 +237,13 @@ class RedisQueueWorker:
         existing output stream.
         """
 
-        class QueueLogger:
+        class QueueLogger(io.IOBase):
             # TODO(bfirsh): maybe this should be a subclass of io.TextIOWrapper?
             def __init__(self, redis, queue, old_out):
+                super().__init__()
                 self.redis = redis
                 self.queue = queue
                 self.old_out = old_out
-                self.linebuf = ""
 
             def write(self, buf):
                 for line in buf.rstrip().splitlines():
@@ -263,44 +263,6 @@ class RedisQueueWorker:
                         "timestamp_sec": timestamp_sec,
                     }
                 )
-
-            # standard IOBase methods implemented with noops
-            def flush(self):
-                pass
-
-            def readable(self):
-                return False
-
-            def close(self):
-                self.write("WARNING: stream close() attempted")
-
-            def fileno(self):
-                raise OSError()
-
-            def isatty(self):
-                return False
-
-            def readline(self):
-                raise io.UnsupportedOperation("not readable")
-
-            def readlines(self):
-                raise io.UnsupportedOperation("not readable")
-
-            def seek(self):
-                raise io.UnsupportedOperation("not seekable")
-
-            def seekable(self):
-                return OSError()
-
-            def tell(self):
-                return 0
-
-            def writeable(self):
-                return True
-
-            def writelines(self, lines):
-                for line in lines:
-                    self.write_line(line)
 
         if self.log_queue is None:
             yield

--- a/test-integration/test_integration/conftest.py
+++ b/test-integration/test_integration/conftest.py
@@ -73,6 +73,7 @@ class Predictor(cog.Predictor):
     @cog.input("output_file", type=bool, default=False)
     def predict(self, text, path, output_file):
         sys.stderr.write("processing " + text + "\\n")
+        sys.stderr.flush()
         with open(path) as f:
             output = self.foo + text + f.read()
         if output_file:


### PR DESCRIPTION
Since we're overwriting sys.std{out,err} with our custom logger, it
needs to implement the file methods present on the overwritten objects.

Signed-off-by: andreasjansson <andreas@replicate.ai>