### PR TITLE
Use buildkit caching for pip and apt

### DIFF
--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -26,6 +26,7 @@ func Build(dir, dockerfile, imageName string, progressOutput string) error {
 		".",
 	)
 	cmd := exec.Command("docker", args...)
+	cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
 	cmd.Dir = dir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
This dramatically speeds up `pip install` when adding/changing pip packages, because tensorflow/torch are so goddamn huge.