### PR TITLE
Enable GPUs when fetching type signature

### DIFF
--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -34,7 +34,7 @@ func Build(cfg *config.Config, dir, imageName string, progressOutput string) err
 	}
 
 	console.Info("Adding labels to image...")
-	signature, err := GetTypeSignature(imageName)
+	signature, err := GetTypeSignature(imageName, cfg.Build.GPU)
 	if err != nil {
 		return fmt.Errorf("Failed to get type signature: %w", err)
 	}

--- a/pkg/image/type_signature.go
+++ b/pkg/image/type_signature.go
@@ -32,14 +32,22 @@ type TypeSignature struct {
 	Inputs []Input `json:"inputs,omitempty"`
 }
 
-func GetTypeSignature(imageName string) (*TypeSignature, error) {
+func GetTypeSignature(imageName string, enableGPU bool) (*TypeSignature, error) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
+
+	// FIXME(bfirsh): we could detect this by reading the config label on the image
+	gpus := ""
+	if enableGPU {
+		gpus = "all"
+	}
+
 	if err := docker.RunWithIO(docker.RunOptions{
 		Image: imageName,
 		Args: []string{
 			"python", "-m", "cog.command.type_signature",
 		},
+		GPUs: gpus,
 	}, nil, &stdout, &stderr); err != nil {
 		console.Info(stdout.String())
 		console.Info(stderr.String())


### PR DESCRIPTION
GPU models might expect GPUs to exist to even be able to import.

The downside of this approach is that it is now impossible to build
GPU models on a CPU. Perhaps something we need to explain.

See also #199 