### PR TITLE
Set all labels after build

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -1,9 +1,7 @@
 package dockerfile
 
 import (
-	"bytes"
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/replicate/cog/pkg/config"
-	"github.com/replicate/cog/pkg/global"
 )
 
 //go:embed embed/cog.whl
@@ -69,11 +66,6 @@ func (g *DockerfileGenerator) GenerateBase() (string, error) {
 		return "", err
 	}
 
-	configJson, err := json.Marshal(g.Config)
-	if err != nil {
-		return "", err
-	}
-
 	return strings.Join(filterEmpty([]string{
 		"# syntax = docker/dockerfile:1.2",
 		"FROM " + baseImage,
@@ -86,9 +78,6 @@ func (g *DockerfileGenerator) GenerateBase() (string, error) {
 		g.preInstall(),
 		g.workdir(),
 		g.command(),
-		// Add labels at end so cache isn't busted
-		label(global.LabelNamespace+"cog_version", global.Version),
-		label(global.LabelNamespace+"config", string(bytes.TrimSpace(configJson))),
 	}), "\n"), nil
 }
 
@@ -235,10 +224,6 @@ func (g *DockerfileGenerator) preInstall() string {
 		lines = append(lines, "RUN "+run)
 	}
 	return strings.Join(lines, "\n")
-}
-
-func label(name, value string) string {
-	return fmt.Sprintf(`LABEL %s="%s"`, name, strings.Replace(value, `"`, `\"`, -1))
 }
 
 func filterEmpty(list []string) []string {

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -69,8 +69,6 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia
 ` + testInstallCog(gen.generatedPaths) + `
 WORKDIR /src
 CMD ["python", "-m", "cog.server.http"]
-LABEL org.cogmodel.cog_version="dev"
-LABEL org.cogmodel.config="{\"build\":{\"python_version\":\"3.8\"},\"predict\":\"predict.py:Predictor\"}"
 COPY . /src`
 
 	require.Equal(t, expected, actual)
@@ -99,8 +97,6 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia
 ` + testInstallPython("3.8") + testInstallCog(gen.generatedPaths) + `
 WORKDIR /src
 CMD ["python", "-m", "cog.server.http"]
-LABEL org.cogmodel.cog_version="dev"
-LABEL org.cogmodel.config="{\"build\":{\"gpu\":true,\"python_version\":\"3.8\",\"cuda\":\"11.0\",\"cudnn\":\"8\"},\"predict\":\"predict.py:Predictor\"}"
 COPY . /src`
 
 	require.Equal(t, expected, actual)
@@ -141,8 +137,6 @@ RUN --mount=type=cache,target=/root/.cache/pip pip install -r /tmp/requirements.
 RUN --mount=type=cache,target=/root/.cache/pip pip install -f https://download.pytorch.org/whl/torch_stable.html   torch==1.5.1+cpu pandas==1.2.0.12
 WORKDIR /src
 CMD ["python", "-m", "cog.server.http"]
-LABEL org.cogmodel.cog_version="dev"
-LABEL org.cogmodel.config="{\"build\":{\"python_version\":\"3.8\",\"python_requirements\":\"my-requirements.txt\",\"python_packages\":[\"torch==1.5.1\",\"pandas==1.2.0.12\"],\"system_packages\":[\"ffmpeg\",\"cowsay\"]},\"predict\":\"predict.py:Predictor\"}"
 COPY . /src`
 	require.Equal(t, expected, actual)
 }
@@ -183,8 +177,6 @@ RUN --mount=type=cache,target=/root/.cache/pip pip install -r /tmp/requirements.
 RUN --mount=type=cache,target=/root/.cache/pip pip install   torch==1.5.1 pandas==1.2.0.12
 WORKDIR /src
 CMD ["python", "-m", "cog.server.http"]
-LABEL org.cogmodel.cog_version="dev"
-LABEL org.cogmodel.config="{\"build\":{\"gpu\":true,\"python_version\":\"3.8\",\"python_requirements\":\"my-requirements.txt\",\"python_packages\":[\"torch==1.5.1\",\"pandas==1.2.0.12\"],\"system_packages\":[\"ffmpeg\",\"cowsay\"],\"cuda\":\"10.2\",\"cudnn\":\"8\"},\"predict\":\"predict.py:Predictor\"}"
 COPY . /src`
 
 	require.Equal(t, expected, actual)


### PR DESCRIPTION
A quote in a `pre_install` step was being escaped incorrectly.
Unsurprisingly -- we were putting a shell script inside an argument
inside a string, inside a JSON document, inside a string, inside a
Dockerfile instruction.

By doing this in the post-build labelling step this works properly
(shrug). We should be really be using proper APIs as much as we can
or we're going to be endlessly battling typing/escaping problems
like this.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>