### PR TITLE
Add `run` build option to `cog.yaml`

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -58,6 +58,21 @@ build:
   python_version: "3.8.1"
 ```
 
+### `run`
+
+A list of commands to run to run in the environment to set it up. They are run last, after your system packages and Python packages have been installed. If you've used Docker, it's just like a `RUN` instruction in your `Dockerfile`.
+
+Your code is _not_ available to commands in `run`. This is so we can build your image efficiently when running locally.
+
+For example:
+
+```yaml
+build:
+  run:
+    - curl -L https://github.com/cowsay-org/cowsay/archive/refs/tags/v3.7.0.tar.gz | tar -xzf -
+    - cd cowsay-3.7.0 && make install
+```
+
 ### `system_packages`
 
 A list of Ubuntu APT packages to install. For example:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,8 +22,9 @@ type Build struct {
 	PythonExtraIndexURLs []string `json:"python_extra_index_urls,omitempty" yaml:"python_extra_index_urls"`
 	PythonFindLinks      []string `json:"python_find_links,omitempty" yaml:"python_find_links"`
 	PythonPackages       []string `json:"python_packages,omitempty" yaml:"python_packages"`
+	Run                  []string `json:"run,omitempty" yaml:"run"`
 	SystemPackages       []string `json:"system_packages,omitempty" yaml:"system_packages"`
-	PreInstall           []string `json:"pre_install,omitempty" yaml:"pre_install"`
+	PreInstall           []string `json:"pre_install,omitempty" yaml:"pre_install"` // Deprecated, but included for backwards compatibility
 	CUDA                 string   `json:"cuda,omitempty" yaml:"cuda"`
 	CuDNN                string   `json:"cudnn,omitempty" yaml:"cudnn"`
 }


### PR DESCRIPTION
The existing `pre_install` was intentionally left undocumented
because the name was not ideal. (What is it "pre"? What's
"install"?)

"run" seems apt, because it maps directly to the Dockerfile
instruction and it's "running" these things, not "installing" them.

Known issues:
- This does not work with multiple lines.
- There should be some method of getting files in that works
  efficiently even when building base images. Maybe a run command
  could say what files it needs copied?

I will create separate issues for these when this is merged.

Closes #159