### PR TITLE
Allow installing any PyTorch CPU version

### DIFF
--- a/pkg/config/compatibility.go
+++ b/pkg/config/compatibility.go
@@ -231,15 +231,6 @@ func CUDABaseImageFor(cuda string, cuDNN string) (string, error) {
 	return "", fmt.Errorf("No matching base image for CUDA %s and CuDNN %s", cuda, cuDNN)
 }
 
-// func tfCPUPackage(ver string) (name string, cpuVersion string, err error) {
-// 	for _, compat := range TFCompatibilityMatrix {
-// 		if compat.TF == ver {
-// 			return splitPythonPackage(compat.TFCPUPackage)
-// 		}
-// 	}
-// 	return "", "", fmt.Errorf("No matching tensorflow CPU package for version %s", ver)
-// }
-
 func tfGPUPackage(ver string, cuda string) (name string, cpuVersion string, err error) {
 	for _, compat := range TFCompatibilityMatrix {
 		if compat.TF == ver && compat.CUDA == cuda {

--- a/pkg/config/compatibility.go
+++ b/pkg/config/compatibility.go
@@ -256,7 +256,8 @@ func torchCPUPackage(ver string, goos string, goarch string) (name string, cpuVe
 		}
 	}
 
-	return "", "", "", fmt.Errorf("No matching Torch CPU package for version %s", ver)
+	// Fall back to just installing default version. For older pytorch versions, they don't have any CPU versions.
+	return "torch", ver, "", nil
 }
 
 func torchGPUPackage(ver string, cuda string) (name string, cpuVersion string, indexURL string, err error) {
@@ -302,7 +303,8 @@ func torchvisionCPUPackage(ver string, goos string, goarch string) (name string,
 			return "torchvision", torchStripCPUSuffixForM1(compat.Torchvision, goos, goarch), compat.IndexURL, nil
 		}
 	}
-	return "", "", "", fmt.Errorf("No matching torchvision CPU package for version %s", ver)
+	// Fall back to just installing default version. For older torchvision versions, they don't have any CPU versions.
+	return "torchvision", ver, "", nil
 }
 
 func torchvisionGPUPackage(ver string, cuda string) (name string, cpuVersion string, indexURL string, err error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -161,13 +161,8 @@ func (c *Config) pythonPackageForArch(pkg string, goos string, goarch string) (a
 			if err != nil {
 				return "", "", err
 			}
-			// HACK: disable for CPU
-			// } else {
-			// name, version, err = tfCPUPackage(version)
-			// if err != nil {
-			// 	return "", "", err
-			// }
 		}
+		// There is no CPU case for tensorflow because the default package is just the CPU package, so no transformation of version is needed
 	} else if name == "torch" {
 		if c.Build.GPU {
 			name, version, indexURL, err = torchGPUPackage(version, c.Build.CUDA)


### PR DESCRIPTION
If it's not in the compatibility matrix, we don't need to stop users from installing it. It's not like GPU where we need to know the correct CUDA version.

Historically, we needed this because Cog has to support CPU and GPU _simultaneously_. But we don't do that any longer, so just let users install whatever the heck packages they like.

See also #220 