### PR TITLE
Better build temp directory

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/replicate/cog/pkg/config"
@@ -33,7 +35,10 @@ func cmdDockerfile(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	generator := dockerfile.NewGenerator(config, projectDir)
+	generator, err := dockerfile.NewGenerator(config, projectDir)
+	if err != nil {
+		return fmt.Errorf("Error creating Dockerfile generator: %w", err)
+	}
 	defer func() {
 		if err := generator.Cleanup(); err != nil {
 			console.Warnf("Error cleaning up after build: %v", err)

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -18,7 +18,10 @@ import (
 func Build(cfg *config.Config, dir, imageName string, progressOutput string) error {
 	console.Infof("Building Docker image from environment in cog.yaml as %s...", imageName)
 
-	generator := dockerfile.NewGenerator(cfg, dir)
+	generator, err := dockerfile.NewGenerator(cfg, dir)
+	if err != nil {
+		return fmt.Errorf("Error creating Dockerfile generator: %w", err)
+	}
 	defer func() {
 		if err := generator.Cleanup(); err != nil {
 			console.Warnf("Error cleaning up Dockerfile generator: %s", err)
@@ -67,7 +70,10 @@ func BuildBase(cfg *config.Config, dir string, progressOutput string) (string, e
 	imageName := config.BaseDockerImageName(dir)
 
 	console.Info("Building Docker image from environment in cog.yaml...")
-	generator := dockerfile.NewGenerator(cfg, dir)
+	generator, err := dockerfile.NewGenerator(cfg, dir)
+	if err != nil {
+		return "", fmt.Errorf("Error creating Dockerfile generator: %w", err)
+	}
 	defer func() {
 		if err := generator.Cleanup(); err != nil {
 			console.Warnf("Error cleaning up Dockerfile generator: %s", err)


### PR DESCRIPTION
Use a single, randomly generated tempdir when building. This
means more than one build can run concurrently without colliding,
and neatens up the cleanup process.

This was a WIP implementation of #222 that I abandoned, but this
is useful separately.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>