### PR TITLE
More sensible pytest output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test-integration: install
 
 .PHONY: test-python
 test-python:
-	cd python/ && pytest
+	cd python/ && pytest -vv
 
 .PHONY: test
 test: test-go test-python test-integration

--- a/test-integration/Makefile
+++ b/test-integration/Makefile
@@ -1,3 +1,3 @@
 .PHONY: test
 test:
-	pytest -s --tb=short
+	pytest -vv


### PR DESCRIPTION
1) -vv displays full diff output so you can see what failure is
2) Enabled output capturing again, so output isn't a big mess
   and failure is associated with output.

Not sure why it was this way to start with.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>