### PR TITLE
Allow PyTorch GPU versions not known by Cog

### DIFF
--- a/pkg/config/compatibility.go
+++ b/pkg/config/compatibility.go
@@ -128,9 +128,6 @@ func cudasFromTorch(ver string) ([]string, error) {
 			cudas = append(cudas, *compat.CUDA)
 		}
 	}
-	if len(cudas) == 0 {
-		return nil, fmt.Errorf("torch==%s doesn't have any compatible CUDA versions", ver)
-	}
 	return cudas, nil
 }
 
@@ -282,7 +279,8 @@ func torchGPUPackage(ver string, cuda string) (name string, cpuVersion string, i
 		}
 	}
 	if latest == nil {
-		return "", "", "", fmt.Errorf("No torch GPU package for version %s that's lower or equal to CUDA %s", ver, cuda)
+		// We've already warned user if they're doing something stupid in validateAndCompleteCUDA()
+		return "torch", ver, "", nil
 	}
 
 	return "torch", latest.Torch, latest.IndexURL, nil


### PR DESCRIPTION
This is the GPU partner of https://github.com/replicate/cog/pull/221.

Lets you do stuff like this:

```
build:
  gpu: true
  cuda: "9.2"
  python_version: "3.6.3"
  python_packages:
    - "torch==0.4.1"
```

Even though Torch 0.4.1 is not known by Cog. If you do this, it will display a warning saying things might not work correctly if you don't know what you're doing. If you don't supply `cuda`, it will fail hard.

Part of the way towards #181 and #220.