### PR TITLE
Use hostname for integration tests instead of IP

### DIFF
--- a/test-integration/test_integration/conftest.py
+++ b/test-integration/test_integration/conftest.py
@@ -7,7 +7,13 @@ from waiting import wait
 import requests
 import pytest
 
-from .util import random_string, find_free_port, docker_run, get_local_ip, wait_for_port
+from .util import (
+    random_string,
+    find_free_port,
+    docker_run,
+    get_local_host,
+    wait_for_port,
+)
 
 
 @dataclass
@@ -111,7 +117,7 @@ def redis_port():
         publish=[{"host": port, "container": 6379}],
         detach=True,
     ):
-        wait_for_port(get_local_ip(), port)
+        wait_for_port(get_local_host(), port)
         yield port
 
 

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -13,7 +13,7 @@ from .util import (
     docker_run,
     find_free_port,
     get_bridge_ip,
-    get_local_ip,
+    get_local_host,
     random_string,
     wait_for_port,
 )
@@ -26,7 +26,7 @@ def test_queue_worker_yielding(docker_image, redis_port, request):
     input_queue = multiprocessing.Queue()
     output_queue = multiprocessing.Queue()
     controller_port = find_free_port()
-    local_ip = get_local_ip()
+    local_ip = get_local_host()
     upload_url = f"http://{local_ip}:{controller_port}/upload"
     redis_host = local_ip
     worker_name = "test-worker"
@@ -93,7 +93,7 @@ def test_queue_worker_error(docker_image, redis_port, request):
     input_queue = multiprocessing.Queue()
     output_queue = multiprocessing.Queue()
     controller_port = find_free_port()
-    local_ip = get_local_ip()
+    local_ip = get_local_host()
     upload_url = f"http://{local_ip}:{controller_port}/upload"
     redis_host = local_ip
     worker_name = "test-worker"
@@ -153,7 +153,7 @@ def test_queue_worker(project_dir, docker_image, redis_port, request):
     input_queue = multiprocessing.Queue()
     output_queue = multiprocessing.Queue()
     controller_port = find_free_port()
-    local_ip = get_local_ip()
+    local_ip = get_local_host()
     upload_url = f"http://{local_ip}:{controller_port}/upload"
     redis_host = local_ip
     worker_name = "test-worker"

--- a/test-integration/test_integration/util.py
+++ b/test-integration/test_integration/util.py
@@ -70,8 +70,9 @@ def docker_run(
         subprocess.Popen(["docker", "rm", "--force", name]).wait()
 
 
-def get_local_ip():
-    return socket.gethostbyname(socket.gethostname())
+def get_local_host():
+    # FIXME: this is fragile https://github.com/replicate/cog/issues/262
+    return socket.gethostname()
 
 
 def get_bridge_ip():


### PR DESCRIPTION
This seemed to be relying on some very subtle behavior. It seems that
the IP returned as the reverse of the local hostname was a local IP that
was just on the host but not inside the container (maybe 127.0.1.1
instead of 127.0.0.1 or something?).

Either way this wasn't working due to something about my local network
setup and my hostname resolved to 127.0.0.1. This is actually localhost
inside the container, hence it couldn't connect to redis.

This is a bodge to get this working. Instead of relying on IP addresses,
use the hostname which will instead defer to DNS to figure out what the
right IP address based on where it is being accessed.

But this is still fragile and I spent laods of time debugging! See also: #262

Signed-off-by: Ben Firshman <ben@firshman.co.uk>