### PR TITLE
Add prediction timeouts to redis worker

### DIFF
--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -21,6 +21,26 @@ from ..json import to_json
 from ..predictor import Predictor, run_prediction, load_predictor
 
 
+class timeout:
+    """A context manager that times out after a given number of seconds."""
+
+    def __init__(self, seconds=1, error_message="Prediction timed out"):
+        self.seconds = seconds
+        self.error_message = error_message
+
+    def handle_timeout(self, signum, frame):
+        raise TimeoutError(self.error_message)
+
+    def __enter__(self):
+        if self.seconds is not None:
+            signal.signal(signal.SIGALRM, self.handle_timeout)
+            signal.alarm(self.seconds)
+
+    def __exit__(self, type, value, traceback):
+        if self.seconds is not None:
+            signal.alarm(0)
+
+
 class RedisQueueWorker:
     SETUP_TIME_QUEUE_SUFFIX = "-setup-time"
     RUN_TIME_QUEUE_SUFFIX = "-run-time"
@@ -33,20 +53,22 @@ class RedisQueueWorker:
         redis_host: str,
         redis_port: int,
         input_queue: str,
-        consumer_id: str,
         upload_url: str,
+        consumer_id: str,
         model_id: Optional[str] = None,
         log_queue: Optional[str] = None,
+        predict_timeout: Optional[int] = None,
         redis_db: int = 0,
     ):
         self.predictor = predictor
-        self.model_id = model_id
         self.redis_host = redis_host
         self.redis_port = redis_port
         self.input_queue = input_queue
-        self.log_queue = log_queue
-        self.consumer_id = consumer_id
         self.upload_url = upload_url
+        self.consumer_id = consumer_id
+        self.model_id = model_id
+        self.log_queue = log_queue
+        self.predict_timeout = predict_timeout
         self.redis_db = redis_db
         # TODO: respect max_processing_time in message handling
         self.max_processing_time = 10 * 60  # timeout after 10 minutes
@@ -103,6 +125,7 @@ class RedisQueueWorker:
         signal.signal(signal.SIGTERM, self.signal_exit)
         start_time = time.time()
 
+        # TODO(bfirsh): setup should time out too, but we don't display these logs to the user, so don't timeout to avoid confusion
         with self.capture_log(self.STAGE_SETUP, self.model_id):
             self.predictor.setup()
 
@@ -186,7 +209,9 @@ class RedisQueueWorker:
             self.push_error(response_queue, e)
             return
 
-        with self.capture_log(self.STAGE_RUN, prediction_id):
+        with self.capture_log(self.STAGE_RUN, prediction_id), timeout(
+            seconds=self.predict_timeout
+        ):
             return_value = self.predictor.predict(**inputs)
         if isinstance(return_value, types.GeneratorType):
             last_result = None
@@ -194,7 +219,9 @@ class RedisQueueWorker:
             while True:
                 # we consume iterator manually to capture log
                 try:
-                    with self.capture_log(self.STAGE_RUN, prediction_id):
+                    with self.capture_log(self.STAGE_RUN, prediction_id), timeout(
+                        seconds=self.predict_timeout
+                    ):
                         result = next(return_value)
                 except StopIteration:
                     break
@@ -308,16 +335,39 @@ class RedisQueueWorker:
                 sys.stderr = old_stderr
 
 
+def _queue_worker_from_argv(
+    predictor,
+    redis_host,
+    redis_port,
+    input_queue,
+    upload_url,
+    comsumer_id,
+    model_id,
+    log_queue,
+    predict_timeout=None,
+):
+    """
+    Construct a RedisQueueWorker object from sys.argv, taking into account optional arguments and types.
+
+    This is intensely fragile. This should be kwargs or JSON or something like that.
+    """
+    if predict_timeout is not None:
+        predict_timeout = int(predict_timeout)
+    return RedisQueueWorker(
+        predictor,
+        redis_host,
+        redis_port,
+        input_queue,
+        upload_url,
+        comsumer_id,
+        model_id,
+        log_queue,
+        predict_timeout,
+    )
+
+
 if __name__ == "__main__":
     predictor = load_predictor()
-    worker = RedisQueueWorker(
-        predictor,
-        redis_host=sys.argv[1],
-        redis_port=sys.argv[2],
-        input_queue=sys.argv[3],
-        upload_url=sys.argv[4],
-        consumer_id=sys.argv[5],
-        model_id=sys.argv[6],
-        log_queue=sys.argv[7],
-    )
+
+    worker = _queue_worker_from_argv(predictor, *sys.argv[1:])
     worker.start()

--- a/test-integration/test_integration/fixtures/timeout-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/timeout-project/cog.yaml
@@ -1,0 +1,3 @@
+predict: "predict.py:Predictor"
+build:
+  python_version: "3.8"

--- a/test-integration/test_integration/fixtures/timeout-project/predict.py
+++ b/test-integration/test_integration/fixtures/timeout-project/predict.py
@@ -1,0 +1,12 @@
+import cog
+import time
+
+
+class Predictor(cog.Predictor):
+    def setup(self):
+        pass
+
+    @cog.input("sleep_time", type=float)
+    def predict(self, sleep_time):
+        time.sleep(sleep_time)
+        return "it worked!"

--- a/test-integration/test_integration/fixtures/yielding-timeout-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/yielding-timeout-project/cog.yaml
@@ -1,0 +1,3 @@
+predict: "predict.py:Predictor"
+build:
+  python_version: "3.8"

--- a/test-integration/test_integration/fixtures/yielding-timeout-project/predict.py
+++ b/test-integration/test_integration/fixtures/yielding-timeout-project/predict.py
@@ -1,0 +1,14 @@
+import cog
+import time
+
+
+class Predictor(cog.Predictor):
+    def setup(self):
+        pass
+
+    @cog.input("sleep_time", type=float)
+    @cog.input("n_iterations", type=int)
+    def predict(self, sleep_time, n_iterations):
+        for i in range(n_iterations):
+            time.sleep(sleep_time)
+            yield f"yield {i}"

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -264,6 +264,84 @@ def test_queue_worker(project_dir, docker_image, redis_port, request):
         ]
 
 
+def test_queue_worker_timeout(docker_image, redis_port, request):
+    project_dir = Path(__file__).parent / "fixtures/timeout-project"
+    subprocess.run(["cog", "build", "-t", docker_image], check=True, cwd=project_dir)
+
+    input_queue = multiprocessing.Queue()
+    output_queue = multiprocessing.Queue()
+    controller_port = find_free_port()
+    local_ip = get_local_ip()
+    upload_url = f"http://{local_ip}:{controller_port}/upload"
+    redis_host = local_ip
+    worker_name = "test-worker"
+    predict_queue_name = "predict-queue"
+    response_queue_name = "response-queue"
+
+    redis_client = redis.Redis(host=redis_host, port=redis_port, db=0)
+
+    with queue_controller(
+        input_queue, output_queue, controller_port, request
+    ), docker_run(
+        image=docker_image,
+        interactive=True,
+        command=[
+            "python",
+            "-m",
+            "cog.server.redis_queue",
+            redis_host,
+            str(redis_port),
+            predict_queue_name,
+            upload_url,
+            worker_name,
+            "model_id",
+            "logs",
+            "1",  # timeout
+        ],
+    ):
+        redis_client.xgroup_create(
+            mkstream=True, groupname=predict_queue_name, name=predict_queue_name, id="$"
+        )
+
+        predict_id = random_string(10)
+        redis_client.xadd(
+            name=predict_queue_name,
+            fields={
+                "value": json.dumps(
+                    {
+                        "id": predict_id,
+                        "inputs": {
+                            "sleep_time": {"value": 0.5},
+                        },
+                        "response_queue": response_queue_name,
+                    }
+                ),
+            },
+        )
+
+        response = json.loads(redis_client.brpop(response_queue_name, timeout=10)[1])
+        assert response == {"status": "success", "value": "it worked!"}
+
+        predict_id = random_string(10)
+        redis_client.xadd(
+            name=predict_queue_name,
+            fields={
+                "value": json.dumps(
+                    {
+                        "id": predict_id,
+                        "inputs": {
+                            "sleep_time": {"value": 5.0},
+                        },
+                        "response_queue": response_queue_name,
+                    }
+                ),
+            },
+        )
+
+        response = json.loads(redis_client.brpop(response_queue_name, timeout=10)[1])
+        assert response == {"status": "failed", "error": "Prediction timed out"}
+
+
 @contextmanager
 def queue_controller(input_queue, output_queue, controller_port, request):
     controller = QueueController(input_queue, output_queue, controller_port)

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -342,6 +342,89 @@ def test_queue_worker_timeout(docker_image, redis_port, request):
         assert response == {"status": "failed", "error": "Prediction timed out"}
 
 
+def test_queue_worker_yielding_timeout(docker_image, redis_port, request):
+    project_dir = Path(__file__).parent / "fixtures/yielding-timeout-project"
+    subprocess.run(["cog", "build", "-t", docker_image], check=True, cwd=project_dir)
+
+    input_queue = multiprocessing.Queue()
+    output_queue = multiprocessing.Queue()
+    controller_port = find_free_port()
+    local_ip = get_local_ip()
+    upload_url = f"http://{local_ip}:{controller_port}/upload"
+    redis_host = local_ip
+    worker_name = "test-worker"
+    predict_queue_name = "predict-queue"
+    response_queue_name = "response-queue"
+
+    redis_client = redis.Redis(host=redis_host, port=redis_port, db=0)
+
+    with queue_controller(
+        input_queue, output_queue, controller_port, request
+    ), docker_run(
+        image=docker_image,
+        interactive=True,
+        command=[
+            "python",
+            "-m",
+            "cog.server.redis_queue",
+            redis_host,
+            str(redis_port),
+            predict_queue_name,
+            upload_url,
+            worker_name,
+            "model_id",
+            "logs",
+            "1",  # timeout
+        ],
+    ):
+        redis_client.xgroup_create(
+            mkstream=True, groupname=predict_queue_name, name=predict_queue_name, id="$"
+        )
+
+        predict_id = random_string(10)
+        redis_client.xadd(
+            name=predict_queue_name,
+            fields={
+                "value": json.dumps(
+                    {
+                        "id": predict_id,
+                        "inputs": {
+                            "sleep_time": {"value": 0.5},
+                            "n_iterations": {"value": 1},
+                        },
+                        "response_queue": response_queue_name,
+                    }
+                ),
+            },
+        )
+
+        response = json.loads(redis_client.brpop(response_queue_name, timeout=10)[1])
+        assert response == {"status": "success", "value": "yield 0"}
+
+        predict_id = random_string(10)
+        redis_client.xadd(
+            name=predict_queue_name,
+            fields={
+                "value": json.dumps(
+                    {
+                        "id": predict_id,
+                        "inputs": {
+                            "sleep_time": {"value": 0.7},
+                            "n_iterations": {"value": 10},
+                        },
+                        "response_queue": response_queue_name,
+                    }
+                ),
+            },
+        )
+
+        response = json.loads(redis_client.brpop(response_queue_name, timeout=10)[1])
+        assert response == {"value": "yield 0", "status": "processing"}
+
+        response = json.loads(redis_client.brpop(response_queue_name, timeout=10)[1])
+        assert response == {"status": "failed", "error": "Prediction timed out"}
+
+
 @contextmanager
 def queue_controller(input_queue, output_queue, controller_port, request):
     controller = QueueController(input_queue, output_queue, controller_port)

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -418,6 +418,7 @@ def test_queue_worker_yielding_timeout(docker_image, redis_port, request):
             },
         )
 
+        # TODO(andreas): revisit this test design if it starts being flakey
         response = json.loads(redis_client.brpop(response_queue_name, timeout=10)[1])
         assert response == {"value": "yield 0", "status": "processing"}
 


### PR DESCRIPTION
Timeouts are passed as seconds to the somewhat unwieldy list of
arguments. It is optional, so it remains backwards compatible with
models.

I have made a little helper to use Python's argument handling to parse
the argument string and set types. This should really be kwargs, or
JSON, or something.

One thought about this: timeouts using signals might happen anywhere and
might leave Predictors in unpredictable (lol) states. We might have to
see whether this is a problem in reality. If so, then we might want to
just reboot the whole worker on timeout.

@andreasjansson Can you think of any reasons off the top of your head why GPUs/Tensorflow/Torch might get left in weird states?

An additional caveat of this: if a model has a bare `except:` in it, the timeout won't work, because the signal is raised as an exception. But this won't be a problem in Replicate once we have an additional timeout on Replicate's side that kills naughty pods that aren't timing out.