### PR TITLE
Relax torchvision version check

### DIFF
--- a/pkg/config/compatibility.go
+++ b/pkg/config/compatibility.go
@@ -327,7 +327,9 @@ func torchvisionGPUPackage(ver string, cuda string) (name string, cpuVersion str
 		}
 	}
 	if latest == nil {
-		return "", "", "", fmt.Errorf("No torchvision GPU package for version %s that's lower or equal to CUDA %s", ver, cuda)
+		// TODO: can we suggest a CUDA version known to be compatible?
+		console.Warnf("Cog doesn't know if CUDA %s is compatible with torchvision %s. This might cause CUDA problems.", cuda, ver)
+		return "torchvision", ver, "", nil
 	}
 
 	return "torchvision", latest.Torchvision, latest.IndexURL, nil


### PR DESCRIPTION
Let the user manually specify things like `torchvision==0.10.0+cu111`.
Or, shoot themselves in the foot. But we told them, right?

Related to #181

Signed-off-by: Ben Firshman <ben@firshman.co.uk>