### PR TITLE
use curl instead of wget to download weights

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,9 +41,9 @@ Inside this environment you can do anything – run a Jupyter notebook, your tr
 
 Let's pretend we've trained a model. With Cog, we can define how to run predictions on it in a standard way, so other people can easily run predictions on it without having to hunt around for a prediction script.
 
-First, run this get some pre-trained model weights:
+First, run this to get some pre-trained model weights:
 
-    wget https://storage.googleapis.com/tensorflow/keras-applications/resnet/resnet50_weights_tf_dim_ordering_tf_kernels.h5
+    curl -O -J https://storage.googleapis.com/tensorflow/keras-applications/resnet/resnet50_weights_tf_dim_ordering_tf_kernels.h5
 
 Then, we need to write some code to describe how predictions are run on the model. Save this to `predict.py`:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,7 @@ Let's pretend we've trained a model. With Cog, we can define how to run predicti
 
 First, run this to get some pre-trained model weights:
 
-    curl -O -J https://storage.googleapis.com/tensorflow/keras-applications/resnet/resnet50_weights_tf_dim_ordering_tf_kernels.h5
+    curl -O https://storage.googleapis.com/tensorflow/keras-applications/resnet/resnet50_weights_tf_dim_ordering_tf_kernels.h5
 
 Then, we need to write some code to describe how predictions are run on the model. Save this to `predict.py`:
 


### PR DESCRIPTION
`wget` is not installed by default on macOS. It's easy to `brew install wget`, but then we're assuming the user has homebrew, and would have to add some macOS-specific clause in the docs.

This PR updates the getting started to use `curl` instead of `wget`, as most users will have this command in their environment.

```
 -O, --remote-name   Write output to a file named as the remote file
```