### PR TITLE
document how to Upgrade cog versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/lat
 sudo chmod +x /usr/local/bin/cog
 ```
 
+## Upgrade
+
+If you're already got Cog installed and want to update to a newer version:
+
+```
+sudo rm $(which cog)
+sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
+sudo chmod +x /usr/local/bin/cog
+```
+
 ## Next steps
 
 - [Get started with an example model](docs/getting-started.md)


### PR DESCRIPTION
This PR adds a section to the README describing how to upgrade Cog. I wouldn't expect this to be necessary, but for some reason on my machine if I already have cog installed and run the documented install commands, I end up with a broken binary:

```sh
$ sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`

$ sudo chmod +x /usr/local/bin/cog

$ which cog
/usr/local/bin/cog                                                                        

$ cog
zsh: killed     cog

$ cog --version
zsh: killed     cog --version
```

Starting a new shell doesn't seem to help. 🤔 

Resolves https://github.com/replicate/cog/issues/315