### PR TITLE
Support for returning multiple outputs

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -52,3 +52,8 @@ func setPersistentFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().Bool("version", false, "Show version of Cog")
 	_ = cmd.PersistentFlags().MarkHidden("profile")
 }
+
+func addProjectDirFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&projectDirFlag, "project-dir", "", "Project directory, defaults to current directory")
+	_ = cmd.Flags().MarkHidden("project-dir") // this flag is not fully tested, but useful in development
+}

--- a/python/cog/input.py
+++ b/python/cog/input.py
@@ -105,7 +105,7 @@ def _is_numeric_type(typ: Type) -> bool:
 def validate_and_convert_inputs(
     predictor: Predictor, raw_inputs: Dict[str, Any], cleanup_functions: List[Callable]
 ) -> Dict[str, Any]:
-    input_specs = predictor.predict._inputs
+    input_specs = getattr(predictor.predict, "_inputs", [])
     inputs = {}
 
     for input_spec in input_specs:

--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -273,6 +273,23 @@ class RedisQueueWorker:
             message = {
                 "value": result,
             }
+        elif isinstance(result, dict):
+            multi_values = []
+            for key, value in result.items():
+                multi_value = {"name": key}
+                if isinstance(value, Path):
+                    multi_value["file"] = {
+                        "url": self.upload_to_temp(value),
+                        "name": value.name,
+                    }
+                elif isinstance(value, str):
+                    multi_value["value"] = value
+                else:
+                    multi_value["value"] = to_json(value)
+                multi_values.append(multi_value)
+            message = {
+                "multi_values": multi_values,
+            }
         else:
             message = {
                 "value": to_json(result),

--- a/python/cog_test.py
+++ b/python/cog_test.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 from flask.testing import FlaskClient
+from requests_toolbelt.multipart.decoder import MultipartDecoder
 import numpy as np
 from PIL import Image
 
@@ -352,6 +353,7 @@ def test_default_path_input():
     assert resp.status_code == 200
     assert resp.data == b"noneee"
 
+
 def test_path_output_str():
     class Predictor(cog.Predictor):
         def setup(self):
@@ -392,19 +394,19 @@ def test_path_output_image():
     assert resp.content_length == 195894
 
 
-def test_json_output_numpy():
+def test_output_numpy():
     class Predictor(cog.Predictor):
         def setup(self):
             pass
 
         def predict(self):
-            return {"foo": np.float32(1.0)}
+            return np.array([1.0, 2.0])
 
     client = make_client(Predictor())
     resp = client.post("/predict")
     assert resp.status_code == 200
     assert resp.content_type == "application/json"
-    assert resp.data == b'{"foo": 1.0}'
+    assert resp.data == b"[1.0, 2.0]"
 
 
 def test_multiple_arguments():
@@ -475,6 +477,7 @@ def test_type_signature():
         ]
     }
 
+
 def test_yielding_strings_from_generator_predictors():
     class Predictor(cog.Predictor):
         def setup(self):
@@ -491,6 +494,7 @@ def test_yielding_strings_from_generator_predictors():
     assert resp.content_type == "text/plain; charset=utf-8"
     assert resp.data == b"baz"
 
+
 def test_yielding_json_from_generator_predictors():
     class Predictor(cog.Predictor):
         def setup(self):
@@ -498,9 +502,9 @@ def test_yielding_json_from_generator_predictors():
 
         def predict(self):
             predictions = [
-                {"meaning_of_life": 40}, 
-                {"meaning_of_life": 41},
-                {"meaning_of_life": 42}
+                "meaning_of_life: 40",
+                "meaning_of_life: 41",
+                "meaning_of_life: 42",
             ]
             for prediction in predictions:
                 yield prediction
@@ -508,8 +512,8 @@ def test_yielding_json_from_generator_predictors():
     client = make_client(Predictor())
     resp = client.post("/predict")
     assert resp.status_code == 200
-    assert resp.content_type == "application/json"
-    assert resp.data == b'{"meaning_of_life": 42}'
+    assert resp.content_type == "text/plain; charset=utf-8"
+    assert resp.data == b"meaning_of_life: 42"
 
 
 def test_yielding_files_from_generator_predictors():
@@ -528,13 +532,14 @@ def test_yielding_files_from_generator_predictors():
 
     client = make_client(Predictor())
     resp = client.post("/predict")
-    
+
     assert resp.status_code == 200
     # need both image/bmp and image/x-ms-bmp until https://bugs.python.org/issue44211 is fixed
     assert resp.content_type in ["image/bmp", "image/x-ms-bmp"]
     image = Image.open(io.BytesIO(resp.data))
     image_color = Image.Image.getcolors(image)[0][1]
-    assert image_color == (255, 255, 0) # yellow
+    assert image_color == (255, 255, 0)  # yellow
+
 
 def test_timing():
     class PredictorSlow(cog.Predictor):
@@ -563,3 +568,29 @@ def test_timing():
     assert resp.status_code == 200
     assert float(resp.headers["X-Setup-Time"]) < 0.5
     assert float(resp.headers["X-Run-Time"]) < 0.5
+
+
+def test_multiple_outputs():
+    class Predictor(cog.Predictor):
+        def setup(self):
+            self.foo = "foo"
+
+        @cog.input("text", type=str)
+        def predict(self, text):
+            temp_dir = tempfile.mkdtemp()
+            temp_path = os.path.join(temp_dir, "my_file.txt")
+            with open(temp_path, "w") as f:
+                f.write(self.foo + text)
+            return {"output1": Path(temp_path), "output2": "qux"}
+
+    client = make_client(Predictor())
+    resp = client.post("/predict", data={"text": "baz"})
+    assert resp.status_code == 200
+    assert resp.content_type.startswith("multipart/form-data; boundary=")
+    parts = MultipartDecoder(resp.data, resp.content_type).parts
+    assert parts[0].headers[b"Content-Disposition"] == b'form-data; name="output1"; filename="my_file.txt"'
+    assert parts[0].headers[b"Content-Type"] == b'text/plain'
+    assert parts[0].content == b"foobaz"
+    assert parts[1].headers[b"Content-Disposition"] == b'form-data; name="output2"; filename="output-output2.txt"'
+    assert parts[1].headers[b"Content-Type"] == b'text/plain'
+    assert parts[1].content == b"qux"

--- a/python/setup.py
+++ b/python/setup.py
@@ -19,6 +19,7 @@ setuptools.setup(
         "flask>=2,<3",
         "redis>=3,<4",
         "requests>=2,<3",
+        "requests_toolbelt>=0.9.0,<1",
         "PyYAML",
     ],
     packages=setuptools.find_packages(),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,6 @@ pytest==6.2.4
 PyYAML==5.4.1
 redis==3.5.3
 requests==2.25.1
+requests_toolbelt==0.9.1
 waiting==1.4.1
 wheel==0.36.2

--- a/test-integration/test_integration/fixtures/multi-output-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/multi-output-project/cog.yaml
@@ -1,0 +1,3 @@
+predict: "predict.py:Predictor"
+build:
+  python_version: "3.8"

--- a/test-integration/test_integration/fixtures/multi-output-project/predict.py
+++ b/test-integration/test_integration/fixtures/multi-output-project/predict.py
@@ -1,0 +1,13 @@
+import cog
+import time
+
+
+class Predictor(cog.Predictor):
+    def setup(self):
+        pass
+
+    def predict(self):
+        return {
+            "output1": "it worked!",
+            "output2": [1, 2, 3, 4],
+        }

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -97,3 +97,51 @@ def test_predict_with_remote_image(tmpdir_factory):
     # lots of docker pull logs are written to stdout before writing the actual output
     # TODO: clean up docker output so cog predict is always clean
     assert out.strip().endswith("hello world")
+
+
+def test_predict_multiple_outputs(tmpdir_factory):
+    tmpdir = tmpdir_factory.mktemp("project")
+    with open(tmpdir / "predict.py", "w") as f:
+        f.write(
+            """
+import cog
+import tempfile
+from pathlib import Path
+
+class Predictor(cog.Predictor):
+    def setup(self):
+        pass
+
+    @cog.input("input", type=str)
+    def predict(self, input):
+        out_dir = Path(tempfile.mkdtemp())
+        out_path1 = out_dir / "first.txt"
+        out_path2 = out_dir / "second.txt"
+        with open(out_path1, "w") as f:
+            f.write(f"one {input}")
+        with open(out_path2, "w") as f:
+            f.write(f"two {input}")
+        
+        return {"first": out_path1, "second": out_path2, "third": "just text"}
+        """
+        )
+    with open(tmpdir / "cog.yaml", "w") as f:
+        cog_yaml = """
+build:
+  python_version: "3.8"
+predict: "predict.py:Predictor"
+        """
+        f.write(cog_yaml)
+
+    result = subprocess.run(
+        ["cog", "predict", "-i", "hello"], cwd=tmpdir, check=True, capture_output=True
+    )
+    stdout = result.stdout.decode()
+
+    # multi-output case is less clean than single-output, and
+    # outputs can be printed in any order
+    expected_strings = ["first:\none hello\n", "second:\ntwo hello\n", "third:\njust text\n"]
+    for expected_string in expected_strings:
+        assert expected_string in stdout
+
+    assert len(stdout) == sum([len(s) for s in expected_strings])


### PR DESCRIPTION
This PR makes it possible to return more than one output from Cog, without having to wrap the outputs in a zip file.

# Python API changes

The `predict()` function treats dict outputs as multiple outputs. This is a change in behavior from before, when dicts were returned as json.

You can mix `pathlib.Path`s and other non-Path types. The following is a valid response:
```python
def predict(self):
    return {
        "file-output1": Path(path1),
        "file-output2": Path(path2),
        "text-output": "foobar",
        "list-output": [1, 2, 3],
    }
```

# Server changes

The built-in HTTP server returns multiple outputs as `multipart/form-data`.

The Redis queue worker returns multiple outputs as a new `multi_values` field in the response struct. The response struct now is:
```go
type InferResponse struct {
	Error       string        `json:"error"`
	File        *InferFile    `json:"file"`
	Value       string        `json:"value"`
	MultiValues []*MultiValue `json:"multi_values"`
	Status      string        `json:"status"`
}

type MultiValue struct {
	Name  string     `json:"name"`
	File  *InferFile `json:"file"`
	Value string     `json:"value"`
}

type InferFile struct {
	URL  string `json:"url"`
	Name string `json:"name"`
}
```

# UI changes

`cog predict` can write multiple outputs to stdout if the outputs are non-Path or textual Path outputs.

For example, given the following predict.py:
```python
    @cog.input("input", type=str)
    def predict(self, input):
        out_dir = Path(tempfile.mkdtemp())
        out_path1 = out_dir / "first.txt"
        out_path2 = out_dir / "second.txt"
        with open(out_path1, "w") as f:
            f.write(f"one {input}")
        with open(out_path2, "w") as f:
            f.write(f"two {input}")
        
        return {"first": out_path1, "second": out_path2, "third": "just text"}
```

`cog predict -i input=hello` outputs:

```
first:
one hello
second:
two hello
third:
just text
```

Non-textual Path outputs are written to files named after the key in the response dict.

If the user passes the `-o` flag to `cog predict`, the outputs get named `<output-name>.<dict-key>.<extension>`.

---

Signed-off-by: andreasjansson <andreas@replicate.ai>