### PR TITLE
Capture _all_ stdout/stderr in Redis worker

### DIFF
--- a/python/cog/server/redis_log_capture.py
+++ b/python/cog/server/redis_log_capture.py
@@ -1,0 +1,161 @@
+import time
+import json
+import sys
+import uuid
+import multiprocessing
+import os
+import contextlib
+
+import redis
+
+
+@contextlib.contextmanager
+def capture_log(redis_host, redis_port, redis_db, log_queue, stage, prediction_id):
+    """
+    Send each log line to a redis RPUSH queue in addition to an
+    existing output stream.
+    """
+
+    # if we don't have a log queue, this is a no-op
+    if log_queue is None:
+        yield
+
+    # if we have a log queue, tee stdout and stderr to redis via a logging subprocess
+    else:
+        outs = {
+            "stdout": sys.stdout,
+            "stderr": sys.stderr,
+        }
+        pipe_readers = {}
+        pipe_writers = {}
+        old_fds = {}
+        procs = {}
+
+        # done_token is sent to the logging subprocess as a sentinel signal to break
+        # its infinite loop
+        done_token = str(uuid.uuid4())
+
+        for out_name, out_file in outs.items():
+
+            # create a pipe that we'll send to the logging subprocess
+            pipe_readers[out_name], pipe_writers[out_name] = multiprocessing.Pipe(
+                duplex=False
+            )
+
+            # get a handle to the original stdout/stderr file descriptor
+            old_fds[out_name] = os.dup(out_file.fileno())
+
+            # redirect stdout/stderr to the pipe
+            os.dup2(pipe_writers[out_name].fileno(), out_file.fileno())
+
+            # start the logging subprocess as a daemon
+            procs[out_name] = LogProcess(
+                redis_host=redis_host,
+                redis_port=redis_port,
+                redis_db=redis_db,
+                queue=log_queue,
+                prediction_id=prediction_id,
+                stage=stage,
+                pipe_reader=pipe_readers[out_name],
+                old_out_fd=old_fds[out_name],
+                done_token=done_token,
+            )
+            procs[out_name].daemon = True
+            procs[out_name].start()
+
+        try:
+            # do the work
+            yield
+
+        finally:
+
+            # write done token to exit the logging loop
+            for out_file in outs.values():
+                out_file.write(done_token + "\n")
+
+            for out_name, out_file in outs.items():
+
+                # exit the logging process as gracefully as possible
+                procs[out_name].join(timeout=1.0)
+                procs[out_name].close()
+
+                # clean up pipe
+                pipe_readers[out_name].close()
+                pipe_writers[out_name].close()
+
+                # reset stdout/stderr to original file descriptor
+                os.dup2(old_fds[out_name], out_file.fileno())
+
+                # close the reference to the original file descriptor
+                os.close(old_fds[out_name])
+
+
+class LogProcess(multiprocessing.Process):
+    def __init__(
+        self,
+        redis_host,
+        redis_port,
+        redis_db,
+        queue,
+        prediction_id,
+        stage,
+        pipe_reader,
+        old_out_fd,
+        done_token,
+    ):
+        super(LogProcess, self).__init__()
+        self.redis_host = redis_host
+        self.redis_port = redis_port
+        self.redis_db = redis_db
+        self.queue = queue
+        self.pipe_reader = pipe_reader
+        self.prediction_id = prediction_id
+        self.stage = stage
+        self.old_out_fd = old_out_fd
+        self.done_token = done_token
+
+    def run(self):
+        # create a new redis client in the subprocess
+        self.redis = redis.Redis(
+            host=self.redis_host, port=self.redis_port, db=self.redis_db
+        )
+
+        # open the original stdout/stderr. we "tee" to both the original
+        # stdout/stderr as well as the redis queue
+        self.old_out = os.fdopen(self.old_out_fd, "w")
+
+        # open pipe reader
+        read_file = os.fdopen(self.pipe_reader.fileno(), "r", 1)
+
+        # infinite loop until we get the done token
+        while True:
+
+            # read a line from the pipe, stripping the newline
+            line = read_file.readline().rstrip()
+
+            # did we get the done token?
+            if line.strip() == self.done_token:
+                break
+
+            # write line to the queue
+            self.write_line(line)
+
+        # clean up open files
+        self.old_out.close()
+        self.pipe_reader.close()
+
+    def write_line(self, line):
+        # format the log line as json and push it to the queue
+        self.redis.rpush(self.queue, self.log_message(line))
+        self.old_out.write(line + "\n")
+
+    def log_message(self, line):
+        timestamp_sec = time.time()
+        return json.dumps(
+            {
+                "stage": self.stage,
+                "id": self.prediction_id,
+                "line": line,
+                "timestamp_sec": timestamp_sec,
+            }
+        )

--- a/test-integration/test_integration/conftest.py
+++ b/test-integration/test_integration/conftest.py
@@ -58,10 +58,15 @@ def project_dir(tmpdir_factory):
     with open(tmpdir / "predict.py", "w") as f:
         f.write(
             """
+import logging
+import ctypes
 import sys
 import tempfile
 from pathlib import Path
 import cog
+import time
+
+libc = ctypes.CDLL(None)
 
 class Predictor(cog.Predictor):
     def setup(self):
@@ -72,8 +77,14 @@ class Predictor(cog.Predictor):
     @cog.input("path", type=Path)
     @cog.input("output_file", type=bool, default=False)
     def predict(self, text, path, output_file):
+        logging.warn("writing log message")
+        time.sleep(.1)
+        libc.puts(b"writing from C")
+        time.sleep(.1)
         sys.stderr.write("processing " + text + "\\n")
+        time.sleep(.1)
         sys.stderr.flush()
+        time.sleep(.1)
         with open(path) as f:
             output = self.foo + text + f.read()
         if output_file:

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -257,8 +257,13 @@ def test_queue_worker(project_dir, docker_image, redis_port, request):
 
         assert setup_log_lines == ["setting up predictor"]
         assert run_log_lines == [
+            "WARNING:root:writing log message",
+            "writing from C",
             "processing bar",
             "successfully processed bar",
+
+            "WARNING:root:writing log message",
+            "writing from C",
             "processing baz",
             "successfully processed file baz",
         ]


### PR DESCRIPTION
We previously missed output printed from C modules, notably TensorFlow's GPU logs that are really helpful for debugging CUDA issues.

This PR uses os.dup2() to tee stdout/stderr to a subprocess that sends log messages to the log queue. It's fiddly low-level stuff so I've added lots of comments inline.

Signed-off-by: andreasjansson <andreas@replicate.ai>