### PR TITLE
Add full example of cog.yaml to getting started

### DIFF
--- a/docs/getting-started-own-model.md
+++ b/docs/getting-started-own-model.md
@@ -99,9 +99,13 @@ You also need to define the inputs to your model using the `@cog.input()` decora
 
 For more details about writing your model interface, [take a look at the prediction interface documentation](python.md).
 
-Next, be sure that the `predict` value in your `cog.yaml` file matches that filename and classname of your Python prediction function:
+Next, add the line `predict: "predict.py:Predictor"` to your `cog.yaml`, so it looks something like this:
 
 ```yaml
+build:
+  python_version: "3.8"
+  python_packages:
+    - "torch==1.7.0"
 predict: "predict.py:Predictor"
 ```
 


### PR DESCRIPTION
I was finding it hard to find an example of `cog.yaml` and `predict.py`
the other day when showing someone Replicate. This is the documentation
that is linked to from replicate.ai/docs.

This also makes it a bit clearer what is going on, I think.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>