### PR TITLE
Don't use threads or processes for HTTP server

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -72,14 +72,14 @@ class HTTPServer:
 
     def start_server(self):
         app = self.make_app()
-        app.run(host="0.0.0.0", port=5000)
+        app.run(host="0.0.0.0", port=5000, threaded=False, processes=1)
 
     def create_response(self, result, setup_time, run_time):
         # loop over generator function to get the last result
         if isinstance(result, types.GeneratorType):
             last_result = None
             for iteration in enumerate(result):
-                last_result = iteration        
+                last_result = iteration
             # last result is a tuple with (index, value)
             result = last_result[1]
 


### PR DESCRIPTION
Predictions will be run serially and get queued up if one is already running. This is a quick fix to get GPU models serving correctly.

The real fix is being incorporated into #259 and #343.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>