### PR TITLE
recognize all contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,96 @@
+{
+  "projectName": "cog",
+  "projectOwner": "replicate",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "none",
+  "contributors": [
+    {
+      "login": "bfirsh",
+      "name": "Ben Firshman",
+      "avatar_url": "https://avatars.githubusercontent.com/u/40906?v=4",
+      "profile": "https://fir.sh/",
+      "contributions": [
+        "code",
+        "doc"
+      ]
+    },
+    {
+      "login": "andreasjansson",
+      "name": "Andreas Jansson",
+      "avatar_url": "https://avatars.githubusercontent.com/u/713993?v=4",
+      "profile": "https://replicate.ai/",
+      "contributions": [
+        "code",
+        "doc"
+      ]
+    },
+    {
+      "login": "zeke",
+      "name": "Zeke Sikelianos",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2289?v=4",
+      "profile": "http://zeke.sikelianos.com/",
+      "contributions": [
+        "code",
+        "doc"
+      ]
+    },
+    {
+      "login": "synek",
+      "name": "Rory Byrne",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9436784?v=4",
+      "profile": "https://rory.bio/",
+      "contributions": [
+        "code",
+        "doc"
+      ]
+    },
+    {
+      "login": "hangtwenty",
+      "name": "Michael Floering",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2420688?v=4",
+      "profile": "https://github.com/hangtwenty",
+      "contributions": [
+        "code",
+        "doc",
+        "ideas"
+      ]
+    },
+    {
+      "login": "bencevans",
+      "name": "Ben Evans",
+      "avatar_url": "https://avatars.githubusercontent.com/u/638535?v=4",
+      "profile": "https://bencevans.io/",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "imshashank",
+      "name": "shashank agarwal",
+      "avatar_url": "https://avatars.githubusercontent.com/u/778870?v=4",
+      "profile": "https://shashank.pw/",
+      "contributions": [
+        "code",
+        "doc"
+      ]
+    },
+    {
+      "login": "VictorXLR",
+      "name": "VictorXLR",
+      "avatar_url": "https://avatars.githubusercontent.com/u/22397950?v=4",
+      "profile": "https://victorxlr.me/",
+      "contributions": [
+        "code",
+        "doc",
+        "test"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,21 @@ git interpret-trailers --if-exists doNothing --trailer \
     --in-place "$1"
 ```
 
+### Acknowledging contributions
+
+We welcome contributions from everyone, and consider all forms of contribution equally valuable. This includes code, bug reports, feature requests, and documentation. We use [All Contributors](https://allcontributors.org/) to maintain a list of all the people who have contributed to Cog.
+
+To acknowledge a contribution, add a comment to an issue or pull request in the following format:
+
+```
+@allcontributors please add @username for doc,code,ideas
+```
+
+A bot will automatically open a pull requests to add the contributor to the project README.
+
+Common contribution types include: `doc`, `code`, `bug`, and `ideas`. See the full list at [allcontributors.org/docs/en/emoji-key](https://allcontributors.org/docs/en/emoji-key)
+
+
 ## Development environment
 
 You'll need to [install Go 1.16](https://golang.org/doc/install). If you're using a newer Mac with an M1 chip, be sure to download the `darwin-arm64` installer package. Alternatively you can run `brew install go` which will automatically detect and use the appropriate installer for your system architecture.

--- a/README.md
+++ b/README.md
@@ -134,3 +134,32 @@ sudo chmod +x /usr/local/bin/cog
 ## Need help?
  
 [Join us in #cog on Discord.](https://discord.gg/QmzJApGjyE)
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://fir.sh/"><img src="https://avatars.githubusercontent.com/u/40906?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ben Firshman</b></sub></a><br /><a href="https://github.com/replicate/cog/commits?author=bfirsh" title="Code">💻</a> <a href="https://github.com/replicate/cog/commits?author=bfirsh" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://replicate.ai/"><img src="https://avatars.githubusercontent.com/u/713993?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Andreas Jansson</b></sub></a><br /><a href="https://github.com/replicate/cog/commits?author=andreasjansson" title="Code">💻</a> <a href="https://github.com/replicate/cog/commits?author=andreasjansson" title="Documentation">📖</a></td>
+    <td align="center"><a href="http://zeke.sikelianos.com/"><img src="https://avatars.githubusercontent.com/u/2289?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Zeke Sikelianos</b></sub></a><br /><a href="https://github.com/replicate/cog/commits?author=zeke" title="Code">💻</a> <a href="https://github.com/replicate/cog/commits?author=zeke" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://rory.bio/"><img src="https://avatars.githubusercontent.com/u/9436784?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Rory Byrne</b></sub></a><br /><a href="https://github.com/replicate/cog/commits?author=synek" title="Code">💻</a> <a href="https://github.com/replicate/cog/commits?author=synek" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/hangtwenty"><img src="https://avatars.githubusercontent.com/u/2420688?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Michael Floering</b></sub></a><br /><a href="https://github.com/replicate/cog/commits?author=hangtwenty" title="Code">💻</a> <a href="https://github.com/replicate/cog/commits?author=hangtwenty" title="Documentation">📖</a> <a href="#ideas-hangtwenty" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://bencevans.io/"><img src="https://avatars.githubusercontent.com/u/638535?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ben Evans</b></sub></a><br /><a href="https://github.com/replicate/cog/commits?author=bencevans" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://shashank.pw/"><img src="https://avatars.githubusercontent.com/u/778870?v=4?s=100" width="100px;" alt=""/><br /><sub><b>shashank agarwal</b></sub></a><br /><a href="https://github.com/replicate/cog/commits?author=imshashank" title="Code">💻</a> <a href="https://github.com/replicate/cog/commits?author=imshashank" title="Documentation">📖</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://victorxlr.me/"><img src="https://avatars.githubusercontent.com/u/22397950?v=4?s=100" width="100px;" alt=""/><br /><sub><b>VictorXLR</b></sub></a><br /><a href="https://github.com/replicate/cog/commits?author=VictorXLR" title="Code">💻</a> <a href="https://github.com/replicate/cog/commits?author=VictorXLR" title="Documentation">📖</a> <a href="https://github.com/replicate/cog/commits?author=VictorXLR" title="Tests">⚠️</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!


### PR DESCRIPTION
This PR sets up [All Contributors](https://allcontributors.org/) on the project so we can recognize contributions in all their various forms, not just commits.

- Added the @allcontributors bot which we can use to add contributors directly from Issue and PR comments.
- Added docs on how and we acknowledge contributions.
- Added the folks from GitHub's [Contributors](https://github.com/replicate/cog/graphs/contributors) page. There are more folks not on that list that we can add manually after this lands.
- There's a CLI for adding contributors but we probably need it since we have the GitHub bot. We can add it later if needed.

---

Here's what it look like in the rendered README:

<img width="882" alt="Screen Shot 2021-12-27 at 1 00 20 PM" src="https://user-images.githubusercontent.com/2289/147506887-b069c00d-81be-4b36-b8ae-efa1d49deb29.png">

