### PR TITLE
Upgrade to redis-py 4

### DIFF
--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -94,7 +94,7 @@ class RedisQueueWorker:
 
     def receive_message(self):
         # first, try to autoclaim old messages from pending queue
-        _, raw_messages = self.redis.execute_command(
+        raw_messages = self.redis.execute_command(
             "XAUTOCLAIM",
             self.input_queue,
             self.input_queue,

--- a/python/setup.py
+++ b/python/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     install_requires=[
         # intionally loose. perhaps these should be vendored to not collide with user code?
         "flask>=2,<3",
-        "redis>=3,<4",
+        "redis>=4,<5",
         "requests>=2,<3",
         "PyYAML",
     ],

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ numpy==1.21.1
 pillow==8.3.2
 pytest==6.2.4
 PyYAML==5.4.1
-redis==3.5.3
+redis==4.1.0
 requests==2.25.1
 waiting==1.4.1
 wheel==0.36.2


### PR DESCRIPTION
Fixes a deprecation warning. Looks like there was one undocumented
internal API change that affects us.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>