### PR TITLE
Run integration tests in Docker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,29 +72,7 @@ jobs:
     name: "Test integration"
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-go@v2
-        with:
-          go-version: 1.16
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            go-${{ secrets.CACHE_VERSION }}-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ hashFiles('**/requirements-dev.txt') }}
-          restore-keys: |
-            pip-${{ secrets.CACHE_VERSION }}-
-      - name: Install Python dependencies
-        run: |
-          pip install -r requirements-dev.txt
+      - uses: actions/checkout@v2
       - name: Test
         run: make test-integration
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# syntax = docker/dockerfile:1.2
+
+# Use Python base image because installing specific Python versions is slow and hard
+FROM python:3.10.1-bullseye
+
+# Install Go
+RUN curl -L https://go.dev/dl/go1.16.3.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+ENV GOPATH /go
+ENV PATH=/usr/local/go/bin:$GOPATH/bin:$PATH
+RUN go install std
+
+# Install Docker client
+RUN curl -L https://download.docker.com/linux/static/stable/x86_64/docker-20.10.9.tgz | tar -C /usr/local/bin -xzf - --strip-components=1 && \
+    docker --version
+
+RUN mkdir /src
+WORKDIR /src
+
+# Install Python development dependencies
+COPY requirements-dev.txt /src
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements-dev.txt
+
+# Install Go dependencies
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
+
+# Build Python package
+COPY python /src/python
+COPY README.md /src
+RUN cd python && python setup.py bdist_wheel
+
+
+# Compile and install Cog
+COPY . /src
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go install cmd/cog/cog.go

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ test-go: build-dependencies check-fmt vet lint
 	go get gotest.tools/gotestsum
 	go run gotest.tools/gotestsum -- -timeout 1200s -parallel 5 ./... $(ARGS)
 
-# TODO(bfirsh): use local copy of cog so we don't have to install globally
 .PHONY: test-integration
-test-integration: install
-	cd test-integration/ && $(MAKE)
+test-integration:
+	docker build --platform linux/x86_64 -t cog .
+	docker run --rm --init -it -v /var/run/docker.sock:/var/run/docker.sock -v $(PWD):/$(PWD) --workdir $(PWD)/test-integration cog pytest -vvv 
 
 .PHONY: test-python
 test-python:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 flask==2.0.1
-numpy==1.21.1
+numpy==1.22.0
 pillow==8.3.2
 pytest==6.2.4
 PyYAML==5.4.1


### PR DESCRIPTION
This doesn't work because Cog assumes the prediction server is running on `localhost` and makes lots of temporary files which aren't on the host machine.

Putting this here to remind us why this doesn't work, and to potentially get this working in the future.