### PR TITLE
Run Python tests on multiple Python versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,8 +45,12 @@ jobs:
         run: make test-go
 
   test-python:
-    name: "Test Python"
+    name: "Test Python ${{ matrix.python-version }}"
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     defaults:
       run:
         shell: bash
@@ -55,7 +59,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip


### PR DESCRIPTION
This would have caught a bug we found in new Cog on Python 3.7.

Ref #196. This is implicitly defining some of the Python versions we
support, but they are not enforced in Cog yet.

/cc @preeth1 