### PR TITLE
Install wheel with pyenv Python

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -176,7 +176,8 @@ RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get insta
 ` + fmt.Sprintf(`RUN curl https://pyenv.run | bash && \
 	git clone https://github.com/momo-lab/pyenv-install-latest.git "$(pyenv root)"/plugins/pyenv-install-latest && \
 	pyenv install-latest "%s" && \
-	pyenv global $(pyenv install-latest --print "%s")`, py, py), nil
+	pyenv global $(pyenv install-latest --print "%s") && \
+	pip install "wheel<1"`, py, py), nil
 }
 
 func (g *Generator) installCog() (string, error) {

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -41,7 +41,8 @@ RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get insta
 RUN curl https://pyenv.run | bash && \
 	git clone https://github.com/momo-lab/pyenv-install-latest.git "$(pyenv root)"/plugins/pyenv-install-latest && \
 	pyenv install-latest "%s" && \
-	pyenv global $(pyenv install-latest --print "%s")
+	pyenv global $(pyenv install-latest --print "%s") && \
+	pip install "wheel<1"
 `, version, version)
 }
 


### PR DESCRIPTION
Not having wheel installed makes installing some packages very slow. We
noticed dlib particularly.

Docker's Python base image already installs the wheel package, but it is
not installed when we install Python ourselves with pyenv.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>