### PR TITLE
Add minimal pyproject.toml

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+


### PR DESCRIPTION
See #386.

Does not replace setup.py (unless an alternative build backend like
poetry or flit is used), but just lets installers like pip know what is
required and how to run setup.py.