### PR TITLE
Upgrade numpy to 1.21.5

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 fastapi==0.70.1
-numpy==1.21.1
+numpy==1.21.5
 pillow==9.0.0
 pydantic==1.8.2
 pytest==6.2.4


### PR DESCRIPTION
Installing 1.21.1 failed locally because the binary is only available for older versions of Python.

Although the latest version of numpy is 1.22.2, the latest version that includes support for Python 3.7 is 1.21.5.

Signed-off-by: Dominic Baggott <dominic.baggott@gmail.com>