### PR TITLE
Document supported Python versions and display prerequisites in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,20 @@
 
 Use Docker for machine learning, without all the pain.
 
-Cog gives you a consistent environment to run your model in – for developing on your laptop, training on GPU machines, and for other people working on the model. Then, when the model is trained and you want to share or deploy it, you can bake the model into a Docker image that serves a standard HTTP API.
+- [What is Cog?](#what-is-cog)
+- [Develop and train in a consistent environment](#develop-and-train-in-a-consistent-environment)
+- [Put a trained model in a Docker image](#put-a-trained-model-in-a-docker-image)
+- [Why are we building this?](#why-are-we-building-this)
+- [Prerequisites](#prerequisites)
+- [Install](#install)
+- [Upgrade](#upgrade)
+- [Next steps](#next-steps)
+- [Need help?](#need-help)
+- [Contributors ✨](#contributors-%E2%9C%A8)
+
+## What is Cog?
+
+Cog is an open-source command-line tool that gives you a consistent environment to run your model in – for developing on your laptop, training on GPU machines, and for other people working on the model. Once you've trained your model and you want to share or deploy it, you can bake the model into a Docker image that serves a standard HTTP API and can be deployed anywhere.
 
 Cog does a few handy things beyond normal Docker:
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ We realized that, in addition to Spotify, other companies were also using Docker
 
 Hit us up if you're interested in using it or want to collaborate with us. [We're on Discord](https://discord.gg/QmzJApGjyE) or email us at [team@replicate.com](mailto:team@replicate.com).
 
+## Prerequisites
+
+- **macOS or Linux**. Cog works on macOS and Linux, but does not currently support Windows.
+- **Docker**. Cog uses Docker to create a container for your model. You'll need to [install Docker](https://docs.docker.com/get-docker/) before you can run Cog.
+- **Python 3.7 or greater**. Cog currently supports all active branches of Python: 3.7, 3.8, 3.9, 3.10.
+
 ## Install
 
 First, [install Docker if you haven't already](https://docs.docker.com/get-docker/). Then, run this in a terminal:

--- a/docs/getting-started-own-model.md
+++ b/docs/getting-started-own-model.md
@@ -6,6 +6,7 @@ This guide will show you how to put your own machine learning model in a Docker 
 
 - **macOS or Linux**. Cog works on macOS and Linux, but does not currently support Windows.
 - **Docker**. Cog uses Docker to create a container for your model. You'll need to [install Docker](https://docs.docker.com/get-docker/) before you can run Cog.
+- **Python 3.7 or greater**. Cog currently supports all active branches of Python: 3.7, 3.8, 3.9, 3.10.
 
 ## Initialization
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,6 +6,7 @@ This guide will walk you through what you can do with Cog by using an example mo
 
 - **macOS or Linux**. Cog works on macOS and Linux, but does not currently support Windows.
 - **Docker**. Cog uses Docker to create a container for your model. You'll need to [install Docker](https://docs.docker.com/get-docker/) before you can run Cog.
+- **Python 3.7 or greater**. Cog currently supports all active branches of Python: 3.7, 3.8, 3.9, 3.10.
 
 ## Install Cog
 


### PR DESCRIPTION
This PR:

- documents the Python versions we support
- adds a Prerequisites section to the README
- adds a TOC to the top of the README so you can see its contents at a glance.

Partially fixes https://github.com/replicate/cog/issues/196
