### PR TITLE
Display better error when output type is undefined

### DIFF
--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -133,7 +133,20 @@ def get_output_type(predictor: BasePredictor):
 
     signature = inspect.signature(predictor.predict)
     if signature.return_annotation is inspect.Signature.empty:
-        OutputType = Literal[None]
+        raise TypeError(
+            """You must set an output type. If your model can return multiple output types, you can explicitly set `Any` as the output type.
+
+For example:
+
+    from typing import Any
+
+    def predict(
+        self,
+        image: Path = Input(description="Input image"),
+    ) -> Any:
+        ...
+"""
+        )
     else:
         OutputType = signature.return_annotation
 

--- a/python/tests/server/test_http_input.py
+++ b/python/tests/server/test_http_input.py
@@ -191,7 +191,7 @@ def test_extranous_input_keys():
         text: str
 
     class Predictor(BasePredictor):
-        def predict(self, input: Input):
+        def predict(self, input: Input) -> str:
             return input.text
 
     client = make_client(Predictor())

--- a/test-integration/test_integration/fixtures/failing-project/predict.py
+++ b/test-integration/test_integration/fixtures/failing-project/predict.py
@@ -2,5 +2,5 @@ from cog import BasePredictor
 
 
 class Predictor(BasePredictor):
-    def predict(self, text: str):
+    def predict(self, text: str) -> str:
         raise Exception("over budget")


### PR DESCRIPTION
If an output type isn't specified, Pydantic expects the model to return nothing. When the model returns an output and it's compared to `None`, an error is logged and a 500 error is returned.

This change explicitly raises an error when the output type is undefined and raises an error message, rather than defaulting to `None`. The error message provides explanation of how to fix the issue more clearly than the original behaviour.

## Before

<img width="1012" alt="Screenshot 2022-02-10 at 14 29 03" src="https://user-images.githubusercontent.com/74812/153431468-0195dd9b-2e64-4512-b0d1-9c014374eba4.png">

## After

<img width="1101" alt="Screenshot 2022-02-10 at 14 48 12" src="https://user-images.githubusercontent.com/74812/153432102-5e16c7a2-1e06-470b-b4e8-4db831ae9e69.png">