### PR TITLE
Strictly limit the allowed model input types

### DIFF
--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -403,3 +403,24 @@ def test_timing(time_mock):
     assert resp.status_code == 200
     assert float(resp.headers["X-Setup-Time"]) == 1.0
     assert float(resp.headers["X-Run-Time"]) == 2.0
+
+
+def test_untyped_inputs():
+    class Predictor(BasePredictor):
+        def predict(self, input) -> str:
+            return input
+
+    with pytest.raises(TypeError):
+        client = make_client(Predictor())
+
+
+def test_input_with_unsupported_type():
+    class Input(BaseModel):
+        text: str
+
+    class Predictor(BasePredictor):
+        def predict(self, input: Input) -> str:
+            return input.text
+
+    with pytest.raises(TypeError):
+        client = make_client(Predictor())

--- a/python/tests/server/test_http_input.py
+++ b/python/tests/server/test_http_input.py
@@ -186,19 +186,6 @@ def test_path_output_file():
     assert len(base64.b64decode(b64data)) == 195894
 
 
-def test_extranous_input_keys():
-    class Input(BaseModel):
-        text: str
-
-    class Predictor(BasePredictor):
-        def predict(self, input: Input) -> str:
-            return input.text
-
-    client = make_client(Predictor())
-    resp = client.post("/predictions", json={"input": {"text": "baz", "text2": "qux"}})
-    assert resp.status_code == 422
-
-
 def test_multiple_arguments():
     class Predictor(BasePredictor):
         def predict(


### PR DESCRIPTION
Allow only a short list of types for model inputs. We can extend this list in the future much more easily than restricting it.

Add a test to assert an error is raised when starting the server. Remove the test for extraneous keys, because the server won't start any more with that predictor definition.

There's a minor weirdness for the Cog types: within Cog, `Path` and `File` are available in the module `cog.types`, but when Cog is imported into another project they're in the module `cog`. We've written some special case code to handle that, but don't know enough about Python packaging to understand why there's a difference, and whether there's a better way to handle this.