### PR TITLE
support and document prereleases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,7 +35,7 @@ changelog:
       - "^test:"
 release:
   # If set to auto, will mark the release as not ready for production
-  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
+  # in case there is an indicator for this in the tag e.g. v1.0.0-alpha
   # If set to true, will mark the release as not ready for production.
   # Default is false.
   prerelease: auto

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,3 +33,9 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+release:
+  # If set to auto, will mark the release as not ready for production
+  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
+  # If set to true, will mark the release as not ready for production.
+  # Default is false.
+  prerelease: auto

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,8 @@ Then visit [github.com/replicate/cog/actions](https://github.com/replicate/cog/a
 
 ### Publishing a prerelease
 
+Prereleases are a useful way to give testers a way to try out new versions of Cog without affecting the documented `latest` download URL which people normally use to install Cog.
+
 To publish a prerelease version, append a [SemVer prerelease identifer](https://semver.org/#spec-item-9) like `-alpha` or `-beta` to the git tag name. Goreleaser will detect this and mark it as a prerelease in GitHub Releases.
 
     git checkout some-prerelease-branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,15 @@ To publish a new release, run the following in your local checkout of cog:
 
 Then visit [github.com/replicate/cog/actions](https://github.com/replicate/cog/actions) to monitor the release process.
 
+### Publishing a prerelease
+
+To publish a **prerelease** version, use the same process as a above but append a hyphen and an identifer like `-alpha` or `-beta` to the git tag name. Goreleaser will detect this and mark it as a prerelease in GitHub Releases.
+
+    git checkout some-prerelease-branch
+    git fetch --all --tags
+    git tag -a v0.1.0-alpha -m "Prerelease v0.1.0"
+    git push --tags
+
 ## Troubleshooting
 
 ### `invalid command 'bdist_wheel'`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ Then visit [github.com/replicate/cog/actions](https://github.com/replicate/cog/a
 
 ### Publishing a prerelease
 
-To publish a **prerelease** version, use the same process as a above but append a hyphen and an identifer like `-alpha` or `-beta` to the git tag name. Goreleaser will detect this and mark it as a prerelease in GitHub Releases.
+To publish a prerelease version, append a [SemVer prerelease identifer](https://semver.org/#spec-item-9) like `-alpha` or `-beta` to the git tag name. Goreleaser will detect this and mark it as a prerelease in GitHub Releases.
 
     git checkout some-prerelease-branch
     git fetch --all --tags


### PR DESCRIPTION
This updates the goreleaser config to support prereleases, and updates the CONTRIBUTING guide with instructions on how to create a prerelease.

https://goreleaser.com/customization/release/#github