### PR TITLE
Show a replicate.com link after pushing to r8.im

### DIFF
--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -2,11 +2,13 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/docker"
+	"github.com/replicate/cog/pkg/global"
 	"github.com/replicate/cog/pkg/image"
 	"github.com/replicate/cog/pkg/util/console"
 )
@@ -46,5 +48,14 @@ func push(cmd *cobra.Command, args []string) error {
 
 	console.Infof("\nPushing image '%s'...", imageName)
 
-	return docker.Push(imageName)
+	exitStatus := docker.Push(imageName)
+	if exitStatus == nil {
+		console.Infof("Image '%s' pushed", imageName)
+		replicatePrefix := fmt.Sprintf("%s/", global.ReplicateRegistryHost)
+		if strings.HasPrefix(imageName, replicatePrefix) {
+			replicatePage := fmt.Sprintf("https://%s", strings.Replace(imageName, global.ReplicateRegistryHost, global.ReplicateWebsiteHost, 1))
+			console.Infof("\nRun your model on Replicate:\n    %s", replicatePage)
+		}
+	}
+	return exitStatus
 }

--- a/pkg/global/global.go
+++ b/pkg/global/global.go
@@ -13,5 +13,6 @@ var (
 	StartupTimeout        = 5 * time.Minute
 	ConfigFilename        = "cog.yaml"
 	ReplicateRegistryHost = "r8.im"
+	ReplicateWebsiteHost  = "replicate.com"
 	LabelNamespace        = "org.cogmodel."
 )


### PR DESCRIPTION
Show a message after a successful push. If the push was to the Replicate registry then also show a link to the model page on replicate.com.

<img width="800" alt="Screenshot 2022-02-28 at 17 51 48" src="https://user-images.githubusercontent.com/74812/156033643-afbddaaa-1eff-4da0-89f0-f6cba56f078f.png">

(It's using `localhost:8100` as the replicate registry in development – in the wild that'd be matching against and replacing `r8.im`)

## The path not taken

I talked to @bfirsh about displaying a message from replicate.com rather than hardcoding this into Cog. Unfortunately, there's no existing call made to replicate.com after the `docker push` command has completed, and there's no way I know of to make `docker push` display more info by feeding it a suitable response from the server.

So, although it's much harder to update this when it's in Cog (because rolling out new code changes requires people to update their version), this seems like the right place to have it for now.

Fixes #210 