### PR TITLE
Remove `lt` and `gt` as `cog.Input` options

### DIFF
--- a/docs/getting-started-own-model.md
+++ b/docs/getting-started-own-model.md
@@ -100,9 +100,7 @@ You can provide more information about the input with the `Input()` function, as
 
 - `description`: A description of what to pass to this input for users of the model
 - `default`: A default value to set the input to. If this argument is not passed, the input is required. If it is explicitly set to `None`, the input is optional.
-- `gt`: For `int` or `float` types, the value should be greater than this number.
 - `ge`: For `int` or `float` types, the value should be greater than or equal to this number.
-- `lt`: For `int` or `float` types, the value should be less than this number.
 - `le`: For `int` or `float` types, the value should be less than or equal to this number.
 - `choices`: A list of possible values for this input.
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -78,7 +78,7 @@ Use cog's `Input()` function to define each of the parameters in your `predict()
 class Predictor(BasePredictor):
     def predict(self,
             image: Path = Input(description="Image to enlarge"),
-            scale: float = Input(description="Factor to scale image by", default=1.5, gt=0, lt=10)
+            scale: float = Input(description="Factor to scale image by", default=1.5, ge=1.0, le=10.0)
     ) -> Path:
 ```
 
@@ -86,9 +86,7 @@ The `Input()` function takes these keyword arguments:
 
 - `description`: A description of what to pass to this input for users of the model.
 - `default`: A default value to set the input to. If this argument is not passed, the input is required. If it is explicitly set to `None`, the input is optional.
-- `gt`: For `int` or `float` types, the value must be greater than this number.
 - `ge`: For `int` or `float` types, the value must be greater than or equal to this number.
-- `lt`: For `int` or `float` types, the value must be less than this number.
 - `le`: For `int` or `float` types, the value must be less than or equal to this number.
 - `min_length`: For `str` types, the minimum length of the string.
 - `max_length`: For `str` types, the maximum length of the string.

--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -16,9 +16,7 @@ from pydantic.typing import NoArgAnyCallable
 def Input(
     default=...,
     description: str = None,
-    gt: float = None,
     ge: float = None,
-    lt: float = None,
     le: float = None,
     min_length: int = None,
     max_length: int = None,
@@ -29,9 +27,7 @@ def Input(
     return Field(
         default,
         description=description,
-        gt=gt,
         ge=ge,
-        lt=lt,
         le=le,
         min_length=min_length,
         max_length=max_length,

--- a/python/tests/server/test_http_input.py
+++ b/python/tests/server/test_http_input.py
@@ -216,7 +216,7 @@ def test_multiple_arguments():
 
 def test_gt_lt():
     class Predictor(BasePredictor):
-        def predict(self, num: float = Input(gt=3, lt=10.5)) -> float:
+        def predict(self, num: float = Input(ge=3.01, le=10.5)) -> float:
             return num
 
     client = make_client(Predictor())
@@ -224,10 +224,10 @@ def test_gt_lt():
     assert resp.json() == {
         "detail": [
             {
-                "ctx": {"limit_value": 3},
+                "ctx": {"limit_value": 3.01},
                 "loc": ["body", "input", "num"],
-                "msg": "ensure this value is greater than 3",
-                "type": "value_error.number.not_gt",
+                "msg": "ensure this value is greater than or equal to 3.01",
+                "type": "value_error.number.not_ge",
             }
         ]
     }


### PR DESCRIPTION
Due to [this pydantic bug](https://github.com/tiangolo/fastapi/issues/240), the `gt` and `lt` options for `cog.Input` do not work and cause the schema parsing to fail. This PR removes them and fixes the tests / documentation to not use them.