### PR TITLE
Clean up temporary input files

### DIFF
--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -215,7 +215,10 @@ class RedisQueueWorker:
         with self.capture_log(self.STAGE_RUN, prediction_id), timeout(
             seconds=self.predict_timeout
         ):
-            return_value = self.predictor.predict(**input_obj.dict())
+            try:
+                return_value = self.predictor.predict(**input_obj.dict())
+            finally:
+                input_obj.cleanup()
         if isinstance(return_value, types.GeneratorType):
             last_result = None
 

--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -97,12 +97,8 @@ class Path(pathlib.PosixPath):
             return value
 
         src = File.validate(value)
-        # TODO: cleanup!
-        temp_dir = tempfile.mkdtemp()
-        temp_path = os.path.join(temp_dir, get_filename(value))
-        with open(temp_path, "wb") as dest:
-            shutil.copyfileobj(src, dest)
-
+        dest = tempfile.NamedTemporaryFile(suffix=get_filename(value), delete=False)
+        shutil.copyfileobj(src, dest)
         return cls(dest.name)
 
     @classmethod

--- a/python/tests/server/test_http_input.py
+++ b/python/tests/server/test_http_input.py
@@ -137,6 +137,25 @@ def test_path_input_data_url():
     assert resp.status_code == 200
 
 
+def test_path_temporary_files_are_removed():
+    class Predictor(BasePredictor):
+        def predict(self, path: Path) -> str:
+            return str(path)
+
+    client = make_client(Predictor())
+    resp = client.post(
+        "/predictions",
+        json={
+            "input": {
+                "path": "data:text/plain;base64,"
+                + base64.b64encode(b"bar").decode("utf-8")
+            }
+        },
+    )
+    temporary_path = resp.json()["output"]
+    assert not os.path.exists(temporary_path)
+
+
 @responses.activate
 def test_file_input_with_http_url():
     class Predictor(BasePredictor):


### PR DESCRIPTION
This is a todo item in #407. This was much easier than expected. In short, we're adding a `cleanup()` method to the dynamically generated `Input` method that can be called to remove all of its files. It gets called after a prediction is run -- inside a try/finally so it is _always_ run.

Output files in the Redis queue were already cleaned up, it was just input files that were not. Output files are not cleaned up for the HTTP server, but it is not designed to be production-ready yet so this can be a piece of follow-up work.

@evilstreak I did a bit of exploratory work to see how complex this would be, and in the end the exploratory work just turned into the implementation. Sorry. 😂