### PR TITLE
Only set custom Output object if it's not already called Output

### DIFF
--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -178,11 +178,14 @@ For example:
     if get_origin(OutputType) is Generator:
         OutputType = get_args(OutputType)[0]
 
-    # Wrap the type in a model so Pydantic can document it in component schema
-    class Output(BaseModel):
-        __root__: OutputType
+    if OutputType.__name__ != "Output":
+        # Wrap the type in a model called "Output" so it is a consistent name in the OpenAPI schema
+        class Output(BaseModel):
+            __root__: OutputType
 
-    return Output
+        OutputType = Output
+
+    return OutputType
 
 
 def human_readable_type_name(t):


### PR DESCRIPTION
If you call your custom output object `Output`, then FastAPI cleverly tries to dedupe and called it `modulename_Output`. This isn't particularly helpful because the whole point is we're trying to make it consistently called `Output`.

This feels a bit fragile, and could break `Input` too. I've expressed the problem here for future fixing: https://github.com/replicate/cog/issues/453