### PR TITLE
Make progressive output a list

### DIFF
--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from collections.abc import Generator
+from collections.abc import Iterator
 import enum
 import importlib
 import inspect
@@ -7,9 +7,10 @@ import os.path
 from pathlib import Path
 from pydantic import create_model, BaseModel
 from pydantic.fields import FieldInfo
+from typing import List
 
 # Added in Python 3.8. Can be from typing if we drop support for <3.8.
-from typing_extensions import Literal, get_origin, get_args
+from typing_extensions import get_origin, get_args
 import yaml
 
 from .errors import ConfigDoesNotExist, PredictorNotSet
@@ -174,11 +175,11 @@ For example:
     else:
         OutputType = signature.return_annotation
 
-    # The type that goes in the response is the type that is yielded
-    if get_origin(OutputType) is Generator:
-        OutputType = get_args(OutputType)[0]
+    # The type that goes in the response is a list of the yielded type
+    if get_origin(OutputType) is Iterator:
+        OutputType = List[get_args(OutputType)[0]]
 
-    if OutputType.__name__ != "Output":
+    if not hasattr(OutputType, "__name__") or OutputType.__name__ != "Output":
         # Wrap the type in a model called "Output" so it is a consistent name in the OpenAPI schema
         class Output(BaseModel):
             __root__: OutputType

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -65,15 +65,6 @@ def create_app(predictor: BasePredictor) -> FastAPI:
         if request:
             output_file_prefix = request.output_file_prefix
 
-        # loop over generator function to get the last result
-        if isinstance(output, types.GeneratorType):
-            last_result = None
-            for iteration in enumerate(output):
-                last_result = iteration
-                # TODO: clean up output files
-            # last result is a tuple with (index, value)
-            output = last_result[1]
-
         OutputType = get_output_type(predictor)
         Response = get_response_type(OutputType)
 

--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -220,8 +220,6 @@ class RedisQueueWorker:
             finally:
                 input_obj.cleanup()
         if isinstance(return_value, types.GeneratorType):
-            last_result = None
-
             while True:
                 # we consume iterator manually to capture log
                 try:
@@ -232,14 +230,12 @@ class RedisQueueWorker:
                 except StopIteration:
                     break
                 # push the previous result, so we can eventually detect the last iteration
-                if last_result is not None:
-                    self.push_result(response_queue, last_result, status="processing")
+                self.push_result(response_queue, result, status="processing")
                 if isinstance(result, Path):
                     cleanup_functions.append(result.unlink)
-                last_result = result
 
             # push the last result
-            self.push_result(response_queue, last_result, status="success")
+            self.push_result(response_queue, result, status="success")
         else:
             if isinstance(return_value, Path):
                 cleanup_functions.append(return_value.unlink)

--- a/test-integration/test_integration/fixtures/yielding-project/predict.py
+++ b/test-integration/test_integration/fixtures/yielding-project/predict.py
@@ -1,10 +1,10 @@
-from typing import Generator
+from typing import Iterator
 
 from cog import BasePredictor
 
 
 class Predictor(BasePredictor):
-    def predict(self, text: str) -> Generator[str, None, None]:
+    def predict(self, text: str) -> Iterator[str]:
         predictions = ["foo", "bar", "baz"]
         for prediction in predictions:
             yield prediction

--- a/test-integration/test_integration/fixtures/yielding-timeout-project/predict.py
+++ b/test-integration/test_integration/fixtures/yielding-timeout-project/predict.py
@@ -1,13 +1,11 @@
 import time
-from typing import Generator
+from typing import Iterator
 
 from cog import BasePredictor
 
 
 class Predictor(BasePredictor):
-    def predict(
-        self, sleep_time: float, n_iterations: int
-    ) -> Generator[str, None, None]:
+    def predict(self, sleep_time: float, n_iterations: int) -> Iterator[str]:
         for i in range(n_iterations):
             time.sleep(sleep_time)
             yield f"yield {i}"

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -112,6 +112,9 @@ def test_queue_worker_yielding(docker_network, docker_image, redis_client):
         assert response == {"value": "bar", "status": "processing"}
 
         response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        assert response == {"value": "baz", "status": "processing"}
+
+        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
         assert response == {"value": "baz", "status": "success"}
 
         response = redis_client.rpop("response-queue")
@@ -388,6 +391,9 @@ def test_queue_worker_yielding_timeout(docker_image, docker_network, redis_clien
         )
 
         response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        assert response == {"status": "processing", "value": "yield 0"}
+
+        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
         assert response == {"status": "success", "value": "yield 0"}
 
         predict_id = random_string(10)
@@ -410,6 +416,9 @@ def test_queue_worker_yielding_timeout(docker_image, docker_network, redis_clien
         # TODO(andreas): revisit this test design if it starts being flakey
         response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
         assert response == {"value": "yield 0", "status": "processing"}
+
+        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        assert response == {"value": "yield 1", "status": "processing"}
 
         response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
         assert response == {"status": "failed", "error": "Prediction timed out"}

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -106,16 +106,16 @@ def test_queue_worker_yielding(docker_network, docker_image, redis_client):
         )
 
         response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
-        assert response == {"value": "foo", "status": "processing"}
+        assert response == {"value": ["foo"], "status": "processing"}
 
         response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
-        assert response == {"value": "bar", "status": "processing"}
+        assert response == {"value": ["foo", "bar"], "status": "processing"}
 
         response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
-        assert response == {"value": "baz", "status": "processing"}
+        assert response == {"value": ["foo", "bar", "baz"], "status": "processing"}
 
         response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
-        assert response == {"value": "baz", "status": "success"}
+        assert response == {"value": ["foo", "bar", "baz"], "status": "success"}
 
         response = redis_client.rpop("response-queue")
         assert response == None
@@ -391,10 +391,10 @@ def test_queue_worker_yielding_timeout(docker_image, docker_network, redis_clien
         )
 
         response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
-        assert response == {"status": "processing", "value": "yield 0"}
+        assert response == {"status": "processing", "value": ["yield 0"]}
 
         response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
-        assert response == {"status": "success", "value": "yield 0"}
+        assert response == {"status": "success", "value": ["yield 0"]}
 
         predict_id = random_string(10)
         redis_client.xadd(
@@ -415,10 +415,10 @@ def test_queue_worker_yielding_timeout(docker_image, docker_network, redis_clien
 
         # TODO(andreas): revisit this test design if it starts being flakey
         response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
-        assert response == {"value": "yield 0", "status": "processing"}
+        assert response == {"value": ["yield 0"], "status": "processing"}
 
         response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
-        assert response == {"value": "yield 1", "status": "processing"}
+        assert response == {"value": ["yield 0", "yield 1"], "status": "processing"}
 
         response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
         assert response == {"status": "failed", "error": "Prediction timed out"}


### PR DESCRIPTION
An implementation of #462. This is a precursor to supporting progressive output for Pydantic Cog models on Replicate.

It's not documented, but it wasn't documented before, so I think we can defer that. #435

There is another bug fix in here with a little semantic change to the progressive output response. Details in the commit.

Closes #462