### PR TITLE
Remove cog.Predictor

### DIFF
--- a/python/cog/__init__.py
+++ b/python/cog/__init__.py
@@ -3,14 +3,10 @@ from pydantic import BaseModel
 from .predictor import BasePredictor
 from .types import File, Input, Path
 
-# Backwards compatibility. Will be deprecated before 1.0.0.
-Predictor = BasePredictor
-
 __all__ = [
     "BaseModel",
     "BasePredictor",
     "File",
     "Input",
     "Path",
-    "Predictor",
 ]


### PR DESCRIPTION
We're doing a backwards incompatible change anyway, and this is actually
a neat bit of forced compatibility. If you try to use a old Cog model
with new Cog it will just fail because it can't import `Predictor`,
instead of failing somewhere deeper in the stack.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>