### PR TITLE
Add types to enums in the schema

### DIFF
--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -144,7 +144,11 @@ def get_input_type(predictor: BasePredictor):
                 raise TypeError(
                     f"The input {name} uses the option choices. Choices can only be used with str types."
                 )
-            InputType = enum.Enum(name, {value: value for value in choices})
+
+            class InputTypeEnum(InputType, enum.Enum):
+                pass
+
+            InputType = InputTypeEnum(name, {value: value for value in choices})
 
         create_model_kwargs[name] = (InputType, default)
 

--- a/python/cog/response.py
+++ b/python/cog/response.py
@@ -4,7 +4,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 
-class Status(enum.Enum):
+class Status(str, enum.Enum):
     PROCESSING = "processing"
     SUCCESS = "success"
     FAILED = "failed"  # FIXME: "failure"?

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -202,6 +202,7 @@ def test_openapi_specification():
                     "title": "choices",
                     "enum": ["foo", "bar"],
                     "description": "An enumeration.",
+                    "type": "string",
                 },
             }
         },

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -182,6 +182,7 @@ def test_openapi_specification():
                     "title": "Status",
                     "enum": ["processing", "success", "failed"],
                     "description": "An enumeration.",
+                    "type": "string",
                 },
                 "ValidationError": {
                     "title": "ValidationError",
@@ -332,6 +333,7 @@ def test_openapi_specification_with_custom_user_defined_output_type():
                     "title": "Status",
                     "enum": ["processing", "success", "failed"],
                     "description": "An enumeration.",
+                    "type": "string",
                 },
                 "ValidationError": {
                     "title": "ValidationError",


### PR DESCRIPTION
This is stopping `choices` work on `Input`.

This is what the pydantic docs tell us to do: https://pydantic-docs.helpmanual.io/usage/types/#enums-and-choices

We need to do multiple inheritance to make the types work. It's always
a string, but may as well use InputType in case we support other things
in the future.

Also included a related fix to add a type to Response.status.

h/t @dashstander for the report!