### PR TITLE
Fix yielding predictor cleanup bug

### DIFF
--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -211,14 +211,13 @@ class RedisQueueWorker:
             self.push_error(response_queue, e)
             return
 
+        cleanup_functions.append(input_obj.cleanup)
+
         start_time = time.time()
         with self.capture_log(self.STAGE_RUN, prediction_id), timeout(
             seconds=self.predict_timeout
         ):
-            try:
-                return_value = self.predictor.predict(**input_obj.dict())
-            finally:
-                input_obj.cleanup()
+            return_value = self.predictor.predict(**input_obj.dict())
         if isinstance(return_value, types.GeneratorType):
             output = []
 

--- a/test-integration/test_integration/fixtures/yielding-file-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/yielding-file-project/cog.yaml
@@ -1,0 +1,3 @@
+predict: "predict.py:Predictor"
+build:
+  python_version: "3.8"

--- a/test-integration/test_integration/fixtures/yielding-file-project/predict.py
+++ b/test-integration/test_integration/fixtures/yielding-file-project/predict.py
@@ -1,0 +1,16 @@
+from typing import Iterator
+
+from cog import BasePredictor, Path
+
+
+class Predictor(BasePredictor):
+    def predict(self, path: Path) -> Iterator[Path]:
+        with open(path) as f:
+            prefix = f.read()
+
+        predictions = ["foo", "bar", "baz"]
+        for i, prediction in enumerate(predictions):
+            out_path = Path(f"/tmp/out-{i}.txt")
+            with out_path.open("w") as f:
+                f.write(prefix + " " + prediction)
+            yield out_path


### PR DESCRIPTION
Inputs were being cleaned up prematurely for progressive predictors. This caused all progressive output models that take files as input to throw errors.

This fix moves input cleanup to the cleanup_functions that are run after the prediction has finished.