### PR TITLE
document `cog debug dockerfile`

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,6 +139,12 @@ Building Docker image...
 Built resnet:latest
 ```
 
+Once you've built the image, you can optionally view the generated dockerfile to get a sense of what Cog is doing under the hood:
+
+```
+$ cog debug dockerfile
+```
+
 You can run this image with `cog predict` by passing the image name as an argument:
 
 ```


### PR DESCRIPTION
This PR updates the getting started guide with a note about how to view the dockerfile generated by Cog. A better long-term home for this information would be Cog's CLI docs, but those don't exist yet. See https://github.com/replicate/cog/issues/433

Resolves https://github.com/replicate/cog/issues/265