### PR TITLE
Design & document HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ sudo chmod +x /usr/local/bin/cog
 - [Take a look at some examples of using Cog](https://github.com/replicate/cog-examples)
 - [`cog.yaml` reference](docs/yaml.md) to learn how to define your model's environment
 - [Prediction interface reference](docs/python.md) to learn how the `Predictor` interface works
+- [HTTP API reference](docs/http.md) to learn how to use the HTTP API that models serve
 
 ## Need help?
 

--- a/docs/http.md
+++ b/docs/http.md
@@ -1,0 +1,61 @@
+# HTTP API
+
+When a Cog Docker image is run, it serves an HTTP API for making predictions.
+
+First, build your model:
+
+    cog build -t my-model
+
+Then, start the Docker container:
+
+    docker run -d -p 5000:5000 my-model
+
+    # If your model uses a GPU:
+    docker run -d -p 5000:5000 --gpus all my-model
+
+    # if you're on an M1 Mac:
+    docker run -d -p 5000:5000 --platform=linux/amd64 my-model
+
+Port 5000 is now serving the API:
+
+    curl http://localhost:5000
+
+To view the API documentation in browser for the model that is running, open [http://localhost:5000/docs](http://localhost:5000/docs).
+
+## `GET /openapi.json`
+
+The [OpenAPI](https://swagger.io/specification/) specification of the API, which is derived from the input and output types specified in your model's [Predictor](python.md) object.
+
+## `POST /predictions`
+
+Make a single prediction. The request body should be a JSON object with the following fields:
+
+- `input`: a JSON object with the same keys as the [arguments to the `predict()` function](python.md). Any `File` or `Path` inputs are passed as URLs.
+- `output_file_prefix`: A base URL to upload output files to. <!-- link to file handling documentation -->
+
+The response is a JSON object with the following fields:
+
+- `status`: Either `success` or `failed`.
+- `output`: The return value of the `predict()` function.
+- `error`: If `status` is `failed`, the error message.
+
+For example:
+
+    POST /predictions
+    {
+        "input": {
+            "image": "https://example.com/image.jpg",
+            "text": "Hello world!"
+        }
+    }
+
+Responds with:
+
+    {
+        "status": "success",
+        "output": "data:image/png;base64,..."
+    }
+
+Or, with curl:
+
+    curl -X POST -H "Content-Type: application/json" -d '{"input": {"image": "https://example.com/image.jpg", "text": "Hello world!"}}' http://localhost:5000/predictions


### PR DESCRIPTION
This is a work-in-progress implementation of #413. I was considering creating an issue to discuss the design of the HTTP API, but I figure a pull request and some documentation might be the most productive medium for doing this.

The text of the documentation is incomplete and might be partial sentences. Mainly looking here for feedback on the API, then we can complete all the sentences.

I think it is mostly there, but a few design questions:

1. Do we like our request and response objects?
2. Do we like our status names? (Maybe `failure` instead of `failed`? Is there some prior art here we can build upon instead of inventing something new?)
3. #428
4. Is this compatible with #437 and #443?
5. File handling is a work in progress and I will create a separate piece of documentation about that.
6. Is this compatible with a potential future async version?
7. Do we want to version it? #94 