### PR TITLE
Handle return statements in yielding generator functions

### DIFF
--- a/test-integration/test_integration/fixtures/yielding-returning-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/yielding-returning-project/cog.yaml
@@ -1,0 +1,3 @@
+predict: "predict.py:Predictor"
+build:
+  python_version: "3.8"

--- a/test-integration/test_integration/fixtures/yielding-returning-project/predict.py
+++ b/test-integration/test_integration/fixtures/yielding-returning-project/predict.py
@@ -1,0 +1,12 @@
+from typing import Iterator
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def predict(self, text: str) -> Iterator[str]:
+        predictions = ["foo", "bar", "baz"]
+        for prediction in predictions:
+            yield prediction
+
+        return "qux"


### PR DESCRIPTION
Returning from generators is a bit of an anti-pattern, but it is
nonetheless supported in Python >=3.3.

We've already seen users return in yielding functions, so it's likely
more people will do that (even if we document that it's not allowed).