### PR TITLE
fix invalid empty lists from `cog init`

### DIFF
--- a/pkg/cli/init-templates/cog.yaml
+++ b/pkg/cli/init-templates/cog.yaml
@@ -6,7 +6,7 @@ build:
   gpu: false
 
   # a list of ubuntu apt packages to install
-  system_packages:
+  # system_packages:
     # - "libgl1-mesa-glx"
     # - "libglib2.0-0"
 
@@ -14,13 +14,13 @@ build:
   python_version: "3.8"
 
   # a list of packages in the format <package-name>==<version>
-  python_packages:
+  # python_packages:
     # - "numpy==1.19.4"
     # - "torch==1.8.0"
     # - "torchvision==0.9.0"
   
   # commands run after the environment is setup
-  run:
+  # run:
     # - "echo env is ready!"
     # - "echo another command if needed"
 

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -121,7 +121,7 @@ build:
 
 
 def test_build_with_cog_init_templates(tmpdir_factory, docker_image):
-    tmpdir = tmpdir_factory.mktemp("projectz")
+    tmpdir = tmpdir_factory.mktemp("project")
 
     subprocess.run(
         ["cog", "init"],

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -29,8 +29,7 @@ def test_build_without_predictor(docker_image):
     assert "org.cogmodel.openapi_schema" not in labels
 
 
-def test_build_names_uses_image_option_in_cog_yaml(tmpdir_factory, docker_image):
-    tmpdir = tmpdir_factory.mktemp("project")
+def test_build_names_uses_image_option_in_cog_yaml(tmpdir, docker_image):
     with open(tmpdir / "cog.yaml", "w") as f:
         cog_yaml = f"""
 image: {docker_image}
@@ -82,8 +81,7 @@ def test_build_with_model(docker_image):
     }
 
 
-def test_build_gpu_model_on_cpu(tmpdir_factory, docker_image):
-    tmpdir = tmpdir_factory.mktemp("project")
+def test_build_gpu_model_on_cpu(tmpdir, docker_image):
     with open(tmpdir / "cog.yaml", "w") as f:
         cog_yaml = """
 build:
@@ -120,9 +118,7 @@ build:
     assert "org.cogmodel.openapi_schema" not in labels
 
 
-def test_build_with_cog_init_templates(tmpdir_factory, docker_image):
-    tmpdir = tmpdir_factory.mktemp("project")
-
+def test_build_with_cog_init_templates(tmpdir, docker_image):
     subprocess.run(
         ["cog", "init"],
         cwd=tmpdir,

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -118,3 +118,24 @@ build:
         }
     }
     assert "org.cogmodel.openapi_schema" not in labels
+
+
+def test_build_with_cog_init_templates(tmpdir_factory, docker_image):
+    tmpdir = tmpdir_factory.mktemp("projectz")
+
+    subprocess.run(
+        ["cog", "init"],
+        cwd=tmpdir,
+        capture_output=True,
+        check=True,
+    )
+
+    build_process = subprocess.run(
+        ["cog", "build", "-t", docker_image],
+        cwd=tmpdir,
+        capture_output=True,
+        check=True,
+    )
+
+    assert build_process.returncode == 0
+    assert "Image built as cog-" in build_process.stderr.decode()


### PR DESCRIPTION
The `cog init` command generates a boilerplate `cog.yaml` file with commented-out stanzas. This default output includes empty lists, which are not actually valid YAML.

```yaml
# this is not valid because it's an empty list
foo:
  # - "bar"
  # - "baz"
```

This PR resolves that issue by commenting out the entire stanza, leaving it up to the user to selectively uncomment or remove the default config as needed.

Resolves https://github.com/replicate/cog/issues/468