### PR TITLE
use `ge` and `le` options in predictor template

### DIFF
--- a/pkg/cli/init-templates/predict.py
+++ b/pkg/cli/init-templates/predict.py
@@ -13,7 +13,7 @@ class Predictor(BasePredictor):
         self,
         input: Path = Input(description="Grayscale input image"),
         scale: float = Input(
-            description="Factor to scale image by", gt=0, lt=10, default=1.5
+            description="Factor to scale image by", ge=0, le=10, default=1.5
         ),
     ) -> Path:
         """Run a single prediction on the model"""


### PR DESCRIPTION
The `lt` and `gt` options to the cog `Input` object are no longer supported: https://github.com/replicate/cog/pull/448

This PR updates the `predict.py` template generated by `cog init` to use the `ge` and `le` options instead.