### PR TITLE
Fix int enums

### DIFF
--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -140,15 +140,17 @@ def get_input_type(predictor: BasePredictor):
             choices = default.extra["choices"]
             # It will be passed automatically as 'enum' in the schema, so remove it as an extra field.
             del default.extra["choices"]
-            if InputType not in [str, int]:
+            if InputType == str:
+                class StringEnum(str, enum.Enum):
+                    pass
+                InputType = StringEnum(name, {value: value for value in choices})
+            elif InputType == int:
+                InputType = enum.IntEnum(name, {str(value): value for value in choices})
+            else:
                 raise TypeError(
                     f"The input {name} uses the option choices. Choices can only be used with str or int types."
                 )
 
-            class InputTypeEnum(InputType, enum.Enum):
-                pass
-
-            InputType = InputTypeEnum(name, {str(value): value for value in choices})
 
         create_model_kwargs[name] = (InputType, default)
 

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -45,6 +45,7 @@ def test_openapi_specification():
             path: Path = Input(description="Some path"),
             image: File = Input(description="Some path"),
             choices: str = Input(choices=["foo", "bar"]),
+            int_choices: int = Input(choices=[3, 4, 5]),
         ) -> str:
             pass
 
@@ -118,7 +119,13 @@ def test_openapi_specification():
                 },
                 "Input": {
                     "title": "Input",
-                    "required": ["no_default", "path", "image", "choices"],
+                    "required": [
+                        "no_default",
+                        "path",
+                        "image",
+                        "choices",
+                        "int_choices",
+                    ],
                     "type": "object",
                     "properties": {
                         "no_default": {
@@ -153,6 +160,7 @@ def test_openapi_specification():
                             "x-order": 4,
                         },
                         "choices": {"$ref": "#/components/schemas/choices"},
+                        "int_choices": {"$ref": "#/components/schemas/int_choices"},
                     },
                 },
                 "Output": {"title": "Output", "type": "string"},
@@ -203,6 +211,12 @@ def test_openapi_specification():
                     "enum": ["foo", "bar"],
                     "description": "An enumeration.",
                     "type": "string",
+                },
+                "int_choices": {
+                    "description": "An enumeration.",
+                    "enum": [3, 4, 5],
+                    "title": "int_choices",
+                    "type": "integer",
                 },
             }
         },

--- a/test-integration/test_integration/fixtures/many-inputs-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/many-inputs-project/cog.yaml
@@ -1,0 +1,3 @@
+build:
+  python_version: "3.8"
+predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/many-inputs-project/predict.py
+++ b/test-integration/test_integration/fixtures/many-inputs-project/predict.py
@@ -1,0 +1,34 @@
+from typing import List
+
+from cog import BaseModel, BasePredictor, Path, Input
+
+
+class Predictor(BasePredictor):
+    def predict(
+        self,
+        no_default: str,
+        default_without_input: str = "default",
+        input_with_default: int = Input(default=10),
+        path: Path = Input(description="Some path"),
+        image: Path = Input(description="Some path"),
+        choices: str = Input(choices=["foo", "bar"]),
+        int_choices: int = Input(description="hello", choices=[3, 4, 5]),
+    ) -> str:
+        with path.open() as f:
+            path_contents = f.read()
+        image_extension = str(image).split(".")[-1]
+        return (
+            no_default
+            + " "
+            + default_without_input
+            + " "
+            + str(input_with_default * 2)
+            + " "
+            + path_contents
+            + " "
+            + image_extension
+            + " "
+            + choices
+            + " "
+            + str(int_choices * 2)
+        )

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -132,3 +132,31 @@ def test_predict_in_subdirectory_with_imports(tmpdir_factory):
     )
     # stdout should be clean without any log messages so it can be piped to other commands
     assert result.stdout == b"hello world\n"
+
+
+def test_predict_many_inputs(tmpdir_factory):
+    project_dir = Path(__file__).parent / "fixtures/many-inputs-project"
+    out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
+    shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
+    inputs = {
+        "no_default": "hello",
+        "path": "@path.txt",
+        "image": "@image.jpg",
+        "choices": "foo",
+        "int_choices": 3,
+    }
+    with open(out_dir / "path.txt", "w") as fh:
+        fh.write("world")
+    with open(out_dir / "image.jpg", "w") as fh:
+        fh.write("")
+    cmd = ["cog", "predict"]
+    for k, v in inputs.items():
+        cmd += ["-i", f"{k}={v}"]
+
+    result = subprocess.run(
+        cmd,
+        cwd=out_dir,
+        check=True,
+        capture_output=True,
+    )
+    assert result.stdout.decode() == "hello default 20 world jpg foo 6\n"


### PR DESCRIPTION
Subclassing InputTypeEnum from `(int, enum.Enum)` caused validation
error in both the HTTP and Redis workers. Interestingly, this wasn't
caught by the existing `test_choices_int` test in test_http_input.py.

<img width="1377" alt="image" src="https://user-images.githubusercontent.com/713993/158479252-935d110b-5eb1-4b04-b8ce-8e172390a6d4.png">
