### PR TITLE
make the description consistent in Request and Response schemas

### DIFF
--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -29,7 +29,7 @@ class BasePredictor(ABC):
     @abstractmethod
     def predict(self, **kwargs):
         """
-        Run a single prediction on the model.
+        Run a single prediction on the model
         """
 
 
@@ -141,8 +141,10 @@ def get_input_type(predictor: BasePredictor):
             # It will be passed automatically as 'enum' in the schema, so remove it as an extra field.
             del default.extra["choices"]
             if InputType == str:
+
                 class StringEnum(str, enum.Enum):
                     pass
+
                 InputType = StringEnum(name, {value: value for value in choices})
             elif InputType == int:
                 InputType = enum.IntEnum(name, {str(value): value for value in choices})
@@ -150,7 +152,6 @@ def get_input_type(predictor: BasePredictor):
                 raise TypeError(
                     f"The input {name} uses the option choices. Choices can only be used with str or int types."
                 )
-
 
         create_model_kwargs[name] = (InputType, default)
 

--- a/python/cog/response.py
+++ b/python/cog/response.py
@@ -12,7 +12,7 @@ class Status(str, enum.Enum):
 
 def get_response_type(OutputType: Any):
     class Response(BaseModel):
-        """The status of a prediction."""
+        """The response body for a prediction"""
 
         status: Status = Field(...)
         output: OutputType = None

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -34,6 +34,8 @@ def create_app(predictor: BasePredictor) -> FastAPI:
     InputType = get_input_type(predictor)
 
     class Request(BaseModel):
+        """The request body for a prediction"""
+
         input: InputType = None
         output_file_prefix: str = None
 

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -54,7 +54,7 @@ def create_app(predictor: BasePredictor) -> FastAPI:
     # The function body is not used to generate the schema.
     def predict(request: Request = Body(default=None)):
         """
-        Run a single prediction on the model.
+        Run a single prediction on the model
         """
         has_input = request is not None and request.input is not None
         try:

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -72,7 +72,7 @@ def test_openapi_specification():
             "/predictions": {
                 "post": {
                     "summary": "Predict",
-                    "description": "Run a single prediction on the model.",
+                    "description": "Run a single prediction on the model",
                     "operationId": "predict_predictions_post",
                     "requestBody": {
                         "content": {
@@ -260,7 +260,7 @@ def test_openapi_specification_with_custom_user_defined_output_type():
             "/predictions": {
                 "post": {
                     "summary": "Predict",
-                    "description": "Run a single prediction on the model.",
+                    "description": "Run a single prediction on the model",
                     "operationId": "predict_predictions_post",
                     "requestBody": {
                         "content": {

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -174,6 +174,7 @@ def test_openapi_specification():
                             "type": "string",
                         },
                     },
+                    "description": "The request body for a prediction",
                 },
                 "Response": {
                     "title": "Response",
@@ -184,7 +185,7 @@ def test_openapi_specification():
                         "output": {"$ref": "#/components/schemas/Output"},
                         "error": {"title": "Error", "type": "string"},
                     },
-                    "description": "The status of a prediction.",
+                    "description": "The response body for a prediction",
                 },
                 "Status": {
                     "title": "Status",
@@ -332,6 +333,7 @@ def test_openapi_specification_with_custom_user_defined_output_type():
                             "type": "string",
                         },
                     },
+                    "description": "The request body for a prediction",
                 },
                 "Response": {
                     "title": "Response",
@@ -342,7 +344,7 @@ def test_openapi_specification_with_custom_user_defined_output_type():
                         "output": {"$ref": "#/components/schemas/Output"},
                         "error": {"title": "Error", "type": "string"},
                     },
-                    "description": "The status of a prediction.",
+                    "description": "The response body for a prediction",
                 },
                 "Status": {
                     "title": "Status",


### PR DESCRIPTION
The multi-line `"""heredocs"""` we define in the Request and Response objects become the `description` values in the OpenAPI schema. This updates those descriptions for consistency.

Toward #413 and #475 

---

<img width="470" alt="Screen Shot 2022-03-16 at 11 38 42 AM" src="https://user-images.githubusercontent.com/2289/158663277-5dadfc50-942a-4702-af54-ba5164e496d6.png">

