### PR TITLE
s/build, ship, run/package/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cog: Containers for machine learning
 
-Cog is an open-source tool that lets you build, ship, and run machine learning models in a standard, production-ready container.
+Cog is an open-source tool that lets you package machine learning models in a standard, production-ready container.
 
 You can deploy your packaged model to your own infrastructure, or to [Replicate](https://replicate.com/).
 


### PR DESCRIPTION
1. "Package" is clearer and more evocative than "build"
2. It does run models, but "run" makes you think of a cluster or deployment system
3. "Build, ship, run" is Docker's thing