### PR TITLE
document how to use notebooks with cog

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ sudo chmod +x /usr/local/bin/cog
 
 - [Get started with an example model](docs/getting-started.md)
 - [Get started with your own model](docs/getting-started-own-model.md)
+- [Using Cog with notebooks](docs/notebooks.md)
 - [Take a look at some examples of using Cog](https://github.com/replicate/cog-examples)
 - [`cog.yaml` reference](docs/yaml.md) to learn how to define your model's environment
 - [Prediction interface reference](docs/python.md) to learn how the `Predictor` interface works

--- a/README.md
+++ b/README.md
@@ -86,13 +86,11 @@ $ cog run python train.py
 ...
 ``` -->
 
-<!-- TODO: this doesn't work yet (needs ports etc)
-Or, spin up a Jupyter notebook:
+Or, [spin up a Jupyter notebook](docs/notebooks.md):
 
 ```
-$ cog run jupyter notebook
+$ cog run -p 8000 jupyter notebook ...
 ```
--->
 
 ## Why are we building this?
 

--- a/README.md
+++ b/README.md
@@ -79,18 +79,21 @@ $ curl http://localhost:5000/predictions -X POST \
    --data '{"input": "https://.../input.jpg"}'
 ```
 
-<!-- In development, you can also run arbitrary commands inside the Docker environment:
+<!-- NOTE (bfirsh): Development environment instructions intentionally left out of readme for now, so as not to confuse the "ship a model to production" message.
+ 
+In development, you can also run arbitrary commands inside the Docker environment:
 
 ```
 $ cog run python train.py
 ...
-``` -->
+```
 
 Or, [spin up a Jupyter notebook](docs/notebooks.md):
 
 ```
-$ cog run -p 8000 jupyter notebook --allow-root --ip=0.0.0.0
+$ cog run -p 8888 jupyter notebook --allow-root --ip=0.0.0.0
 ```
+ -->
 
 ## Why are we building this?
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ cog run python train.py
 Or, [spin up a Jupyter notebook](docs/notebooks.md):
 
 ```
-$ cog run -p 8000 jupyter notebook ...
+$ cog run -p 8000 jupyter notebook --allow-root --ip=0.0.0.0
 ```
 
 ## Why are we building this?

--- a/notebooks.md
+++ b/notebooks.md
@@ -1,6 +1,6 @@
 # Notebooks
 
-Cog plays nicely with Juptyer notebooks.
+Cog plays nicely with Jupyter notebooks.
 
 ## Run a notebook
 

--- a/notebooks.md
+++ b/notebooks.md
@@ -1,0 +1,34 @@
+# Notebooks
+
+Cog plays nicely with Juptyer notebooks.
+
+## Run a notebook
+
+Cog can run notebooks with the following command:
+
+```sh
+cog run -p 8888 jupyter notebook --allow-root --ip=0.0.0.0
+```
+
+## Use notebook code in your predictor
+
+You can also import a notebook into your Cog [Predictor](python.md) file.
+
+First, export your notebook to a Python file:
+
+```sh
+jupyter nbconvert --to script my_notebook.ipynb # create my_notebook.py
+```
+
+Then import the exported Python script into your `predict.py` file. Any functions or variables defined in your notebook will be available to your predictor:
+
+```python
+from cog import BasePredictor, Input
+
+import my_notebook
+
+class Predictor(BasePredictor):
+    def predict(self, prompt: str = Input(description="string prompt")) -> str:
+      output = my_notebook.do_stuff(prompt)
+      return output
+```

--- a/notebooks.md
+++ b/notebooks.md
@@ -4,7 +4,7 @@ Cog plays nicely with Jupyter notebooks.
 
 ## Run a notebook
 
-Cog can run notebooks with the following command:
+Cog can run notebooks in the environment you've defined in [`cog.yaml`](yaml.md) with the following command:
 
 ```sh
 cog run -p 8888 jupyter notebook --allow-root --ip=0.0.0.0


### PR DESCRIPTION
This PR adds a new file `docs/notebooks.md` which describes how to run a notebook server with Cog, and how to import a notebook into a Cog predictor.