### PR TITLE
Switch to cog.run labels

### DIFF
--- a/pkg/global/global.go
+++ b/pkg/global/global.go
@@ -14,5 +14,5 @@ var (
 	ConfigFilename        = "cog.yaml"
 	ReplicateRegistryHost = "r8.im"
 	ReplicateWebsiteHost  = "replicate.com"
-	LabelNamespace        = "org.cogmodel."
+	LabelNamespace        = "run.cog."
 )

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -52,6 +52,10 @@ func Build(cfg *config.Config, dir, imageName string, progressOutput string) err
 	labels := map[string]string{
 		global.LabelNamespace + "cog_version": global.Version,
 		global.LabelNamespace + "config":      string(bytes.TrimSpace(configJSON)),
+		// Backwards compatibility. Remove for 1.0.
+		"org.cogmodel.deprecated":  "The org.cogmodel labels are deprecated. Use run.cog.",
+		"org.cogmodel.cog_version": global.Version,
+		"org.cogmodel.config":      string(bytes.TrimSpace(configJSON)),
 	}
 
 	// OpenAPI schema is not set if there is no predictor.
@@ -61,6 +65,7 @@ func Build(cfg *config.Config, dir, imageName string, progressOutput string) err
 			return fmt.Errorf("Failed to convert type signature to JSON: %w", err)
 		}
 		labels[global.LabelNamespace+"openapi_schema"] = string(schemaJSON)
+		labels["org.cogmodel.openapi_schema"] = string(schemaJSON)
 	}
 
 	if err := docker.BuildAddLabelsToImage(imageName, labels); err != nil {

--- a/pkg/image/config.go
+++ b/pkg/image/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/docker"
+	"github.com/replicate/cog/pkg/global"
 )
 
 func GetConfig(imageName string) (*config.Config, error) {
@@ -13,7 +14,11 @@ func GetConfig(imageName string) (*config.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to inspect %s: %w", imageName, err)
 	}
-	configString := image.Config.Labels["org.cogmodel.config"]
+	configString := image.Config.Labels[global.LabelNamespace+"config"]
+	if configString == "" {
+		// Deprecated. Remove for 1.0.
+		configString = image.Config.Labels["org.cogmodel.config"]
+	}
 	if configString == "" {
 		return nil, fmt.Errorf("Image %s does not appear to be a Cog model", imageName)
 	}

--- a/pkg/image/openapi_schema.go
+++ b/pkg/image/openapi_schema.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/replicate/cog/pkg/docker"
+	"github.com/replicate/cog/pkg/global"
 	"github.com/replicate/cog/pkg/util/console"
 )
 
@@ -58,7 +59,11 @@ func GetOpenAPISchema(imageName string) (*openapi3.T, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to inspect %s: %w", imageName, err)
 	}
-	schemaString := image.Config.Labels["org.cogmodel.openapi_schema"]
+	schemaString := image.Config.Labels[global.LabelNamespace+"openapi_schema"]
+	if schemaString == "" {
+		// Deprecated. Remove for 1.0.
+		schemaString = image.Config.Labels["org.cogmodel.openapi_schema"]
+	}
 	if schemaString == "" {
 		return nil, fmt.Errorf("Image %s does not appear to be a Cog model", imageName)
 	}

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -22,6 +22,11 @@ def test_build_without_predictor(docker_image):
         ).stdout
     )
     labels = image[0]["Config"]["Labels"]
+    assert len(labels["run.cog.cog_version"]) > 0
+    assert json.loads(labels["run.cog.config"]) == {"build": {"python_version": "3.8"}}
+    assert "run.cog.openapi_schema" not in labels
+
+    # Deprecated. Remove for 1.0.
     assert len(labels["org.cogmodel.cog_version"]) > 0
     assert json.loads(labels["org.cogmodel.config"]) == {
         "build": {"python_version": "3.8"}
@@ -63,7 +68,10 @@ def test_build_with_model(docker_image):
         ).stdout
     )
     labels = image[0]["Config"]["Labels"]
-    schema = json.loads(labels["org.cogmodel.openapi_schema"])
+    schema = json.loads(labels["run.cog.openapi_schema"])
+
+    # Backwards compatibility
+    assert "org.cogmodel.openapi_schema" in labels
 
     assert schema["components"]["schemas"]["Input"] == {
         "title": "Input",
@@ -106,6 +114,19 @@ build:
         ).stdout
     )
     labels = image[0]["Config"]["Labels"]
+
+    assert len(labels["run.cog.cog_version"]) > 0
+    assert json.loads(labels["run.cog.config"]) == {
+        "build": {
+            "python_version": "3.8",
+            "gpu": True,
+            "cuda": "11.2",
+            "cudnn": "8",
+        }
+    }
+    assert "run.cog.openapi_schema" not in labels
+
+    # Deprecated. Remove for 1.0.
     assert len(labels["org.cogmodel.cog_version"]) > 0
     assert json.loads(labels["org.cogmodel.config"]) == {
         "build": {


### PR DESCRIPTION
Once we've added support for run.cog labels to Replicate, it should be
pretty safe to remove generating the old ones. Users will have to update
their Cog client to run new models.

We should leave in support for the old labels for running models --
there are lots on Replicate.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>