### PR TITLE
Rename run.cog.cog_version label to run.cog.version

### DIFF
--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -50,8 +50,8 @@ func Build(cfg *config.Config, dir, imageName string, progressOutput string) err
 	// built image to get those. But, the escaping of JSON inside a label inside a Dockerfile was gnarly, and
 	// doesn't seem to be a problem here, so do it here instead.
 	labels := map[string]string{
-		global.LabelNamespace + "cog_version": global.Version,
-		global.LabelNamespace + "config":      string(bytes.TrimSpace(configJSON)),
+		global.LabelNamespace + "version": global.Version,
+		global.LabelNamespace + "config":  string(bytes.TrimSpace(configJSON)),
 		// Backwards compatibility. Remove for 1.0.
 		"org.cogmodel.deprecated":  "The org.cogmodel labels are deprecated. Use run.cog.",
 		"org.cogmodel.cog_version": global.Version,

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -22,7 +22,7 @@ def test_build_without_predictor(docker_image):
         ).stdout
     )
     labels = image[0]["Config"]["Labels"]
-    assert len(labels["run.cog.cog_version"]) > 0
+    assert len(labels["run.cog.version"]) > 0
     assert json.loads(labels["run.cog.config"]) == {"build": {"python_version": "3.8"}}
     assert "run.cog.openapi_schema" not in labels
 
@@ -115,7 +115,7 @@ build:
     )
     labels = image[0]["Config"]["Labels"]
 
-    assert len(labels["run.cog.cog_version"]) > 0
+    assert len(labels["run.cog.version"]) > 0
     assert json.loads(labels["run.cog.config"]) == {
         "build": {
             "python_version": "3.8",


### PR DESCRIPTION
Looking at them in `docker inspect` output the former just looks really
clumsy. Now that "cog" and "version" are next to each other, it's pretty
obvious that it refers to Cog.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>