### PR TITLE
Only allow one of python_packages or python_requirements to be set

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,6 +135,11 @@ func (c *Config) ValidateAndCompleteConfig() error {
 			return err
 		}
 	}
+
+	if len(c.Build.PythonPackages) > 0 && c.Build.PythonRequirements != "" {
+		return fmt.Errorf("Only one of python_packages or python_requirements can be set in your cog.yaml, not both")
+	}
+
 	return nil
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPythonPackagesAndRequirementsCantBeUsedTogether(t *testing.T) {
+	config := &Config{
+		Build: &Build{
+			PythonVersion: "3.8",
+			PythonPackages: []string{
+				"replicate==1.0.0",
+			},
+			PythonRequirements: "requirements.txt",
+		},
+	}
+	err := config.ValidateAndCompleteConfig()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Only one of python_packages or python_requirements can be set in your cog.yaml, not both")
+}
+
 func TestValidateAndCompleteCUDAForAllTF(t *testing.T) {
 	for _, compat := range TFCompatibilityMatrix {
 		config := &Config{


### PR DESCRIPTION
A little bit of preparatory work for #157 I did last week. We want to use the same codepath for backwards compatibility for `python_packages`, and this'll be much simpler if only one of them is set.