### PR TITLE
Add support for numpy arrays as input/output

### DIFF
--- a/python/tests/server/fixtures/input_ndarray.py
+++ b/python/tests/server/fixtures/input_ndarray.py
@@ -1,0 +1,7 @@
+from cog import BasePredictor
+import numpy as np
+
+
+class Predictor(BasePredictor):
+    def predict(self, array: np.ndarray):
+        assert array == np.array([[1, 2], [3, 4]])

--- a/python/tests/server/test_http_input.py
+++ b/python/tests/server/test_http_input.py
@@ -252,6 +252,23 @@ def test_secret_str(client, match):
     assert resp.status_code == 422
 
 
+@uses_predictor("input_secret")
+def test_secret_str(client, match):
+    resp = client.post("/predictions", json={"input": {"secret": "foo"}})
+    assert resp.status_code == 200
+    assert resp.json() == match({"output": "foo", "status": "succeeded"})
+
+    resp = client.post("/predictions", json={"input": {"secret": {}}})
+    assert resp.status_code == 422
+
+
+@uses_predictor("input_ndarray")
+def test_numpy_ndarray_input(client):
+    resp = client.post("/predictions", json={"input": [[1, 2], [3, 4]]})
+    assert resp.status_code == 200
+    assert resp.json() == {"output": None, "status": "success"}
+
+
 def test_untyped_inputs():
     config = {"predict": _fixture_path("input_untyped")}
     app = create_app(

--- a/python/tests/server/test_http_output.py
+++ b/python/tests/server/test_http_output.py
@@ -1,6 +1,7 @@
 import base64
 import io
 
+import numpy as np
 import responses
 from responses.matchers import multipart_matcher
 
@@ -111,6 +112,17 @@ def test_json_output_numpy(client, match):
     resp = client.post("/predictions")
     assert resp.status_code == 200
     assert resp.json() == match({"output": 1.0, "status": "succeeded"})
+
+
+def test_numpy_ndarray_output():
+    class Predictor(BasePredictor):
+        def predict(self) -> np.ndarray:
+            return np.array([[1, 2], [3, 4]])
+
+    client = make_client(Predictor())
+    resp = client.post("/predictions")
+    assert resp.status_code == 200
+    assert resp.json() == {"output": [[1, 2], [3, 4]], "status": "success"}
 
 
 @uses_predictor("output_complex")


### PR DESCRIPTION
This does not work, but here are the failing test cases demonstrating what should work.

Some wrangling of Pydantic validators and encoders is needed. We created a custom `encode_json()` method to make it easier to convert custom outputs to JSON. I wonder if we can get inputs to work without doing some custom wrapper like this.

Some guidance if anyone wants to grab this:
- We'd probably want to set `arbitrary_types_allowed` on the output object. (See Pydantic docs for it.)
- https://github.com/samuelcolvin/pydantic/issues/951 for ideas.