### PR TITLE
Recursively encode tuple outputs

### DIFF
--- a/python/cog/json.py
+++ b/python/cog/json.py
@@ -1,5 +1,6 @@
 from enum import Enum
 import io
+from types import GeneratorType
 from typing import Any
 
 from pydantic import BaseModel
@@ -26,7 +27,7 @@ def encode_json(obj: Any, upload_file) -> Any:
         return encode_json(obj.dict(exclude_unset=True), upload_file)
     if isinstance(obj, dict):
         return {key: encode_json(value, upload_file) for key, value in obj.items()}
-    if isinstance(obj, list):
+    if isinstance(obj, (list, set, frozenset, GeneratorType, tuple)):
         return [encode_json(value, upload_file) for value in obj]
     if isinstance(obj, Enum):
         return obj.value

--- a/python/tests/test_json.py
+++ b/python/tests/test_json.py
@@ -9,6 +9,11 @@ import numpy as np
 from pydantic import BaseModel
 
 
+def test_encode_json_recursively_encodes_tuples():
+    result = encode_json((np.float32(0.1), np.float32(0.2)), None)
+    assert type(result[0]) == float
+
+
 def test_encode_json_encodes_pydantic_models():
     class Model(BaseModel):
         text: str


### PR DESCRIPTION
Fixes the getting started guide, which returns numpy floats in tuples.

Based on FastAPI's json_encodable:
https://github.com/tiangolo/fastapi/blob/26f725d259c5dbe3654f221e608b14412c6b40da/fastapi/encoders.py#L111

Signed-off-by: Ben Firshman <ben@firshman.co.uk>

Ref #541
Closes #499