### PR TITLE
Fix enums being passed to predict() when using `choices`

### DIFF
--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -77,6 +77,11 @@ def load_predictor():
 # Base class for inputs, constructed dynamically in get_input_type().
 # (This can't be a docstring or it gets passed through to the schema.)
 class BaseInput(BaseModel):
+    class Config:
+        # When using `choices`, the type is converted into an enum to validate
+        # But, after validation, we want to pass the actual value to predict(), not the enum object
+        use_enum_values = True
+
     def cleanup(self):
         """
         Cleanup any temporary files created by the input.

--- a/python/tests/server/test_http_input.py
+++ b/python/tests/server/test_http_input.py
@@ -259,7 +259,8 @@ def test_gt_lt():
 def test_choices_str():
     class Predictor(BasePredictor):
         def predict(self, text: str = Input(choices=["foo", "bar"])) -> str:
-            return str(text)
+            assert type(text) == str
+            return text
 
     client = make_client(Predictor())
     resp = client.post("/predictions", json={"input": {"text": "foo"}})


### PR DESCRIPTION
Fixes #513

Signed-off-by: Ben Firshman <ben@firshman.co.uk>