### PR TITLE
update notebook docs to mention installing jupyterlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,13 @@ In development, you can also run arbitrary commands inside the Docker environmen
 $ cog run python train.py
 ...
 ```
- -->
-
 
 Or, [spin up a Jupyter notebook](docs/notebooks.md):
 
 ```
 $ cog run -p 8888 jupyter notebook --allow-root --ip=0.0.0.0
 ```
+-->
 
 ## Why are we building this?
 

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -2,7 +2,7 @@
 
 Cog plays nicely with Jupyter notebooks.
 
-## Install the jupyterlab python package
+## Install the jupyterlab Python package
 
 First, add `jupyterlab` to the `python_packages` array in your [`cog.yaml`](yaml.md) file:
 

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -12,7 +12,6 @@ build:
     - "jupyterlab==3.3.4"
 ```
 
-Then run `cog build` to install dependencies and build the Docker image.
 
 ## Run a notebook
 

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -2,9 +2,21 @@
 
 Cog plays nicely with Jupyter notebooks.
 
+## Install the jupyterlab python package
+
+First, add `jupyterlab` to the `python_packages` array in your [`cog.yaml`](yaml.md) file:
+
+```yaml
+build:
+  python_packages:
+    - "jupyterlab==3.3.4"
+```
+
+Then run `cog build` to install dependencies and build the Docker image.
+
 ## Run a notebook
 
-Cog can run notebooks in the environment you've defined in [`cog.yaml`](yaml.md) with the following command:
+Cog can run notebooks in the environment you've defined in `cog.yaml` with the following command:
 
 ```sh
 cog run -p 8888 jupyter notebook --allow-root --ip=0.0.0.0
@@ -17,7 +29,7 @@ You can also import a notebook into your Cog [Predictor](python.md) file.
 First, export your notebook to a Python file:
 
 ```sh
-jupyter nbconvert --to script my_notebook.ipynb # create my_notebook.py
+jupyter nbconvert --to script my_notebook.ipynb # creates my_notebook.py
 ```
 
 Then import the exported Python script into your `predict.py` file. Any functions or variables defined in your notebook will be available to your predictor:


### PR DESCRIPTION
### The problem

The README currently gives the impression that users can run `$ cog run ... jupyter notebook ...` on a Cog model. This is true, but only works if that model has the `jupyterlab` python package installed. That package is not mentioned in the README, nor is it included in the default `cog.yaml` generated by `$ cog init`.

### The fix

This PR removes the misleading `$ cog run` command from the README, and updates the notebook docs to mention that `jupyterlab` must first be installed.

### Other ideas

A few other things we could do to make this a smoother experience for users:

- Include `jupyterlab` in the default list of deps created by `$cog init`
- Bake notebook support into every model by updating Cog to automatically install `jupyterlab` as part of the base image.

---

Resolves #560

Hat tip to @iperdomo for opening an issue about this.