### PR TITLE
[#567] Use pinned versions for `apt-get` packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Define the Docker environment your model runs in with `cog.yaml`:
 build:
   gpu: true
   system_packages:
-    - "libgl1-mesa-glx"
-    - "libglib2.0-0"
+    - "libgl1-mesa-glx=20.3.5-1"
+    - "libglib2.0-0=2.66.8-1"
   python_version: "3.8"
   python_packages:
     - "torch==1.8.1"

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -10,8 +10,8 @@ build:
   python_packages:
     - pytorch==1.4.0
   system_packages:
-    - "ffmpeg"
-    - "libavcodec-dev"
+    - "ffmpeg=7:4.3.3-0+deb11u1"
+    - "libavcodec-dev=7:4.3.3-0+deb11u1"
 predict: "predict.py:Predictor"
 ```
 
@@ -86,8 +86,19 @@ A list of Ubuntu APT packages to install. For example:
 ```yaml
 build:
   system_packages:
-    - "ffmpeg"
-    - "libavcodec-dev"
+    - "ffmpeg=7:4.3.3-0+deb11u1"
+    - "libavcodec-dev=7:4.3.3-0+deb11u1"
+```
+
+It's a good practice to _pin_ the version of your package installed with `apt-get`.
+See: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get
+
+To know the package available version you can execute, `apt-cache show <package-name>`, e.g.
+
+```bash
+# docker run --rm <image> bash -c "apt-get update -qq && apt-cache show <package-name> | grep Version"
+$ docker run --rm python:3.8 bash -c "apt-get update -qq && apt-cache show libgl1-mesa-glx | grep Version"
+Version: 20.3.5-1
 ```
 
 ## `image`

--- a/pkg/cli/init-templates/cog.yaml
+++ b/pkg/cli/init-templates/cog.yaml
@@ -7,8 +7,8 @@ build:
 
   # a list of ubuntu apt packages to install
   # system_packages:
-    # - "libgl1-mesa-glx"
-    # - "libglib2.0-0"
+    # - "libgl1-mesa-glx=20.3.5-1"
+    # - "libglib2.0-0=2.66.8-1"
 
   # python version in the form '3.8' or '3.8.12'
   python_version: "3.8"
@@ -18,7 +18,7 @@ build:
     # - "numpy==1.19.4"
     # - "torch==1.8.0"
     # - "torchvision==0.9.0"
-  
+
   # commands run after the environment is setup
   # run:
     # - "echo env is ready!"


### PR DESCRIPTION
Based on Dockerfile best practices:

> Version pinning forces the build to retrieve a particular version
> regardless of what’s in the cache. This technique can also reduce
> failures due to unanticipated changes in required packages.
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get

Signed-off-by: Iván Perdomo <ivan@perdomo.me>