### PR TITLE
Use multiprocessing spawn method to support CUDA

### DIFF
--- a/python/cog/server/log_capture.py
+++ b/python/cog/server/log_capture.py
@@ -75,7 +75,13 @@ def capture_log(logs_dest):
             os.close(old_fds[out_name])
 
 
-class LogProcess(multiprocessing.Process):
+# `multiprocessing.get_context("fork")` returns the same API as
+# `multiprocessing`, but will use the fork method when creating any subprocess.
+# Although fork is the default, we need this here because the log process gets
+# created from the predictor subprocess, which is set to use the spawn method.
+# As currently written, this log process relies on shared state in a way that
+# doesn't work with the spawn method.
+class LogProcess(multiprocessing.get_context("fork").Process):
     def __init__(
         self,
         logs_dest,

--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -64,7 +64,7 @@ class RedisQueueWorker:
         predict_timeout: Optional[int] = None,
         redis_db: int = 0,
     ):
-        self.runner = PredictionRunner(predictor)
+        self.runner = PredictionRunner()
         self.redis_host = redis_host
         self.redis_port = redis_port
         self.input_queue = input_queue

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -502,7 +502,7 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client):
             "test-worker",
             "model_id",
             "logs",
-            "1",  # timeout
+            "2",  # timeout
         ],
     ):
         redis_client.xgroup_create(
@@ -517,7 +517,7 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client):
                     {
                         "id": predict_id,
                         "input": {
-                            "sleep_time": 0.5,
+                            "sleep_time": 0.1,
                         },
                         "response_queue": "response-queue",
                     }
@@ -567,7 +567,7 @@ def test_queue_worker_yielding_timeout(docker_image, docker_network, redis_clien
             "test-worker",
             "model_id",
             "logs",
-            "1",  # timeout
+            "2",  # timeout
         ],
     ):
         redis_client.xgroup_create(
@@ -582,7 +582,7 @@ def test_queue_worker_yielding_timeout(docker_image, docker_network, redis_clien
                     {
                         "id": predict_id,
                         "input": {
-                            "sleep_time": 0.5,
+                            "sleep_time": 0.1,
                             "n_iterations": 1,
                         },
                         "response_queue": "response-queue",
@@ -605,7 +605,7 @@ def test_queue_worker_yielding_timeout(docker_image, docker_network, redis_clien
                     {
                         "id": predict_id,
                         "input": {
-                            "sleep_time": 0.4,
+                            "sleep_time": 0.8,
                             "n_iterations": 10,
                         },
                         "response_queue": "response-queue",


### PR DESCRIPTION
## The problem

If you try to fork a new process after CUDA has been initialized, it raises an error. From [the PyTorch docs](https://pytorch.org/docs/stable/notes/multiprocessing.html#cuda-in-multiprocessing):

> The CUDA runtime does not support the fork start method; either the spawn or forkserver start method are required to use CUDA in subprocesses.

We're already doing setup within the subprocess, but it seems that some imports will start initialization of CUDA, and we're loading the predictor outside of the subprocess.

## The fix

This PR moves the loading into the subprocess and switches to using spawn to start the subprocess. Doing the former without the latter is possibly enough, but we'd need to spend more time testing that.

We should release this promptly as 0.3.1 as (some?) CUDA models won't with the queue API with Cog 0.3.0.

## Side effects

Some of the timings in the timeout tests have changed. I'm not entirely sure why the process of running a prediction is slower, but it is. If we can test it thoroughly with fork instead of spawn, we might be able to go back to the old (faster) timings.