### PR TITLE
Base version for make install on latest release tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-COG_VERSION ?= dev
+COG_VERSION ?= $(shell git describe --tags --match 'v*' --abbrev=0)+dev
 RELEASE_DIR := release
 GOOS := $(shell go env GOOS)
 GOARCH := $(shell go env GOARCH)


### PR DESCRIPTION
When doing a local install from a dev environment using `make install` you get a binary with a version of `dev`.

In order to support breaking changes in Cog's APIs, we're building systems that switch based on the version of Cog that was used to build and push a model. For that to work for locally modified and installed versions, we need a more useful version number.

As we're using something similar to semantic versioning (and will actually use semantic versioning from 1.0.0 onwards), this uses the `+suffix` syntax for denoting build metadata:

> Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers immediately following the patch or pre-release version. Identifiers MUST comprise only ASCII alphanumerics and hyphens [0-9A-Za-z-]. Identifiers MUST NOT be empty. Build metadata MUST be ignored when determining version precedence. Thus two versions that differ only in the build metadata, have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85, 1.0.0+21AF26D3—-117B344092BD.

Signed-off-by: Dominic Baggott <dominic.baggott@gmail.com>

Closes #556 