### PR TITLE
Revert "Remove NVIDIA apt sources/key"

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -135,8 +135,8 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia
 	if g.Config.Build.GPU {
 		// Temporary hack until base images are updated
 		// https://github.com/NVIDIA/nvidia-docker/issues/1631
-		lines = append(lines, `RUN rm -f /etc/apt/sources.list.d/cuda.list && \
-    rm -f /etc/apt/sources.list.d/nvidia-ml.list && \
+		lines = append(lines, `RUN rm /etc/apt/sources.list.d/cuda.list && \
+    rm /etc/apt/sources.list.d/nvidia-ml.list && \
     apt-key del 7fa2af80`)
 	}
 

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -127,20 +127,9 @@ func (g *Generator) baseImage() (string, error) {
 }
 
 func (g *Generator) preamble() string {
-	lines := []string{
-		`ENV DEBIAN_FRONTEND=noninteractive
+	return `ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin`,
-	}
-	if g.Config.Build.GPU {
-		// Temporary hack until base images are updated
-		// https://github.com/NVIDIA/nvidia-docker/issues/1631
-		lines = append(lines, `RUN rm /etc/apt/sources.list.d/cuda.list && \
-    rm /etc/apt/sources.list.d/nvidia-ml.list && \
-    apt-key del 7fa2af80`)
-	}
-
-	return strings.Join(lines, "\n")
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin`
 }
 
 func (g *Generator) installTini() string {

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -109,9 +109,6 @@ FROM nvidia/cuda:11.2.0-cudnn8-devel-ubuntu20.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
-RUN rm /etc/apt/sources.list.d/cuda.list && \
-    rm /etc/apt/sources.list.d/nvidia-ml.list && \
-    apt-key del 7fa2af80
 ` + testTini() + testInstallPython("3.8") + testInstallCog(gen.relativeTmpDir) + `
 WORKDIR /src
 EXPOSE 5000
@@ -198,9 +195,6 @@ FROM nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
-RUN rm /etc/apt/sources.list.d/cuda.list && \
-    rm /etc/apt/sources.list.d/nvidia-ml.list && \
-    apt-key del 7fa2af80
 ` + testTini() +
 		testInstallPython("3.8") +
 		testInstallCog(gen.relativeTmpDir) + `

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -109,8 +109,8 @@ FROM nvidia/cuda:11.2.0-cudnn8-devel-ubuntu20.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
-RUN rm -f /etc/apt/sources.list.d/cuda.list && \
-    rm -f /etc/apt/sources.list.d/nvidia-ml.list && \
+RUN rm /etc/apt/sources.list.d/cuda.list && \
+    rm /etc/apt/sources.list.d/nvidia-ml.list && \
     apt-key del 7fa2af80
 ` + testTini() + testInstallPython("3.8") + testInstallCog(gen.relativeTmpDir) + `
 WORKDIR /src
@@ -198,8 +198,8 @@ FROM nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
-RUN rm -f /etc/apt/sources.list.d/cuda.list && \
-    rm -f /etc/apt/sources.list.d/nvidia-ml.list && \
+RUN rm /etc/apt/sources.list.d/cuda.list && \
+    rm /etc/apt/sources.list.d/nvidia-ml.list && \
     apt-key del 7fa2af80
 ` + testTini() +
 		testInstallPython("3.8") +


### PR DESCRIPTION
This reverts commit 67c5b31a143d6601df58ddd705bd707680359d6b.

#579 removed the nvidia apt sources because they were broken upstream. When CI passes here, they have been fixed and we can merge this.

See also https://github.com/NVIDIA/nvidia-docker/issues/1631