### PR TITLE
Require typing-extensions>=4.1.0

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
         "PyYAML",
         "redis>=4,<5",
         "requests>=2,<3",
-        "typing_extensions>=3.7.4",
+        "typing_extensions>=4.1.0",
         "uvicorn[standard]>=0.12,<1",
     ],
     packages=setuptools.find_packages(),


### PR DESCRIPTION
See https://github.com/replicate/cog/pull/593#issuecomment-1122004077

This will be properly fixed by
https://github.com/replicate/cog/issues/409

Signed-off-by: Ben Firshman <ben@firshman.co.uk>