### PR TITLE
Include timestamps in Redis responses

### DIFF
--- a/docs/redis.md
+++ b/docs/redis.md
@@ -100,6 +100,14 @@ Alternatively, to get the latest state whilst clearing the queue you can use the
 
     redis:6379> RPOP my-response-queue 1000
 
+### Experimental properties
+
+The response may also include experimental properties, prefixed with `x-experimental-`. Experimental properties may change or be removed in any version, not just major versions that would ordinarily be used to indicate a breaking change. Any such change will be documented in release notes.
+
+Current experimental properties are:
+
+- `x-experimental-timestamps`: the time the prediction started and finished.
+
 ## Telemetry
 
 Cog's queue worker is instrumented using [OpenTelemetry](https://opentelemetry.io). For setup it sends:


### PR DESCRIPTION
Timestamps are useful for calculating how long a prediction has taken to run. There are other ways we could get this data (using HTTP streams instead of queueing, and doing accurate timing from the outside), but this is probably the simplest to get started with and arguably the simplest for all sorts of users in the future.

Signed-off-by: Dominic Baggott <dominic.baggott@gmail.com>

Resolves #589 