### PR TITLE
Better next steps in `cog init`

### DIFF
--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -78,7 +78,7 @@ func initCommand(args []string) error {
 	}
 	console.Infof("✅ Created %s", predictPyPath)
 
-	console.Infof("\nDone! For next steps, check out the docs at https://github.com/replicate/cog/tree/main/docs")
+	console.Infof("\nDone! For next steps, check out the docs at https://cog.run/docs/getting-started")
 
 	return nil
 }


### PR DESCRIPTION
This just dumps you in a directory on GitHub, which is not particularly
helpful. Instead use a URL we can redirect anywhere. Right now it goes
to the getting started with your own model docs, but we might also want
to add some Replicate docs in there.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>