### PR TITLE
Make number of threads configurable

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -4,6 +4,8 @@ Cog containers are Docker containers that serve an HTTP server for running predi
 
 This guide assumes you have a model packaged with Cog. If you don't, [follow our getting started guide](getting-started-own-model.md), or use [an example model](https://github.com/replicate/cog-examples).
 
+## Getting started
+
 First, build your model:
 
     cog build -t my-model
@@ -30,3 +32,17 @@ To run a prediction on the model, call the `/predictions` endpoint, passing inpu
 To view the API documentation in browser for the model that is running, open [http://localhost:5000/docs](http://localhost:5000/docs).
 
 For more details about the HTTP API, see the [HTTP API reference documentation](http.md).
+
+## Options
+
+Cog Docker images have `python -m cog.server.http` set as the default command, which gets overridden if you pass a command to `docker run`. When you use command-line options, you need to pass in the full command before the options.
+
+### `--threads`
+
+This controls how many threads are used by Cog, which determines how many requests Cog serves in parallel. If your model uses a CPU, this is the number of CPUs on your machine. If your model uses a GPU, this is 1, because typically a GPU can only be used by one process.
+
+You might need to adjust this if you want to control how much memory your model uses, or other similar constraints. To do this, you can use the `--threads` option.
+
+For example:
+
+    docker run -d -p 5000:5000 my-model python -m cog.server.http --threads=10

--- a/python/cog/command/openapi_schema.py
+++ b/python/cog/command/openapi_schema.py
@@ -8,14 +8,15 @@ import json
 from ..errors import ConfigDoesNotExist, PredictorNotSet
 from ..suppress_output import suppress_output
 
-from ..predictor import load_predictor
+from ..predictor import load_predictor, load_config
 from ..server.http import create_app
 
 if __name__ == "__main__":
     schema = {}
     try:
         with suppress_output():
-            predictor = load_predictor()
+            config = load_config()
+            predictor = load_predictor(config)
     except (ConfigDoesNotExist, PredictorNotSet):
         # If there is no cog.yaml or 'predict' has not been set, then there is no type signature.
         # Not an error, there just isn't anything.

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -46,11 +46,11 @@ def run_prediction(
     return result
 
 
-def load_predictor() -> BasePredictor:
+# TODO: make config a TypedDict
+def load_config() -> Dict[str, Any]:
     """
-    Reads cog.yaml and constructs an instance of the user-defined Predictor class.
+    Reads cog.yaml and returns it as a dict.
     """
-
     # Assumes the working directory is /src
     config_path = os.path.abspath("cog.yaml")
     try:
@@ -60,6 +60,13 @@ def load_predictor() -> BasePredictor:
         raise ConfigDoesNotExist(
             f"Could not find {config_path}",
         )
+    return config
+
+
+def load_predictor(config: Dict[str, Any]) -> BasePredictor:
+    """
+    Constructs an instance of the user-defined Predictor class from a config.
+    """
 
     if "predict" not in config:
         raise PredictorNotSet(
@@ -225,7 +232,7 @@ def human_readable_type_name(t: Type) -> str:
         return t.__qualname__
     elif module.split(".")[0] == "cog":
         module = "cog"
-    
+
     try:
         return module + "." + t.__qualname__
     except AttributeError:

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -98,7 +98,8 @@ Check that your predict function is in this form, where `output_type` is the sam
 
 
 if __name__ == "__main__":
-    predictor = load_predictor()
+    config = load_config()
+    predictor = load_predictor(config)
     app = create_app(predictor)
     uvicorn.run(
         app,

--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -13,7 +13,7 @@ from pydantic import ValidationError
 import redis
 import requests
 
-from ..predictor import BasePredictor, get_input_type, load_predictor
+from ..predictor import BasePredictor, get_input_type, load_predictor, load_config
 from ..json import encode_json
 from ..response import Status
 from .runner import PredictionRunner
@@ -345,7 +345,8 @@ def _queue_worker_from_argv(
 
 
 if __name__ == "__main__":
-    predictor = load_predictor()
+    config = load_config()
+    predictor = load_predictor(config)
 
     worker = _queue_worker_from_argv(predictor, *sys.argv[1:])
     worker.start()

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
-from ..predictor import load_predictor
+from ..predictor import load_config, load_predictor
 from .log_capture import capture_log
 
 
@@ -54,7 +54,8 @@ class PredictionRunner:
         self.predictor_process.start()
 
     def _start_predictor_process(self) -> None:
-        self.predictor = load_predictor()
+        config = load_config()
+        self.predictor = load_predictor(config)
         self.predictor.setup()
 
         while True:


### PR DESCRIPTION
FastAPI uses threads for concurrency when the view function is synchronous, which is the case for `POST /predictions`. By default, the thread pool is 40. This won't work for GPU models which usually need to be run serially, and is too high for CPU models which are usually CPU bound. This may also be causing it to run out of memory (see #521).

This pull request sets the number of threads to be the number of CPUs, or just 1 if it's a GPU model. It is also configurable with the `--threads` option.

This is hard to test with an automated test, but open to ideas.

I tested locally with a simple model that sleeps:

```python
from cog import BasePredictor, Input
import time


class Predictor(BasePredictor):
    def setup(self):
        self.prefix = "hello"

    def predict(self, text: str = Input(description="Text to prefix with 'hello '")) -> str:
        time.sleep(5)
        return self.prefix + " " + text
```

Then ran this in several shells:

```
curl http://localhost:5000/predictions -X POST -H "Content-Type: application/json" \                                    !10139
  -d '{"input": {
    "text": "..."
  }}'
```

When `--threads=1` then they run one after another. With `--threads=5` or not passed at all they run at the same time.

Closes #633.