### PR TITLE
Check for new versions

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/replicate/cog/pkg/global"
+	"github.com/replicate/cog/pkg/update"
 	"github.com/replicate/cog/pkg/util/console"
 )
 
@@ -28,6 +29,9 @@ https://github.com/replicate/cog`,
 				console.SetLevel(console.DebugLevel)
 			}
 			cmd.SilenceUsage = true
+			if err := update.DisplayAndCheckForRelease(); err != nil {
+				console.Debugf("%s", err)
+			}
 		},
 		SilenceErrors: true,
 	}

--- a/pkg/update/state.go
+++ b/pkg/update/state.go
@@ -1,0 +1,84 @@
+package update
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/mitchellh/go-homedir"
+
+	"github.com/replicate/cog/pkg/util/console"
+	"github.com/replicate/cog/pkg/util/files"
+)
+
+type state struct {
+	Message     string    `json:"message"`
+	LastChecked time.Time `json:"lastChecked"`
+}
+
+// loadState loads the update check state from disk, returning defaults if it does not exist
+func loadState() (*state, error) {
+	state := state{}
+
+	p, err := statePath()
+	if err != nil {
+		return nil, err
+	}
+
+	exists, err := files.Exists(p)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return &state, nil
+	}
+	text, err := ioutil.ReadFile(p)
+	if err != nil {
+		console.Debugf("Failed to read %s: %s", p, err)
+		return &state, nil
+	}
+
+	err = json.Unmarshal(text, &state)
+	if err != nil {
+		return nil, err
+	}
+
+	return &state, nil
+}
+
+// writeState saves analytics state to disk
+func writeState(s *state) error {
+	statePath, err := statePath()
+	if err != nil {
+		return err
+	}
+
+	bytes, err := json.MarshalIndent(s, "", " ")
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(statePath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(statePath, bytes, 0o600)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func userDir() (string, error) {
+	return homedir.Expand("~/.config/cog")
+}
+
+func statePath() (string, error) {
+	dir, err := userDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "update-state.json"), nil
+}

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -1,0 +1,95 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/replicate/cog/pkg/global"
+	"github.com/replicate/cog/pkg/util/console"
+)
+
+func isUpdateEnabled() bool {
+	return os.Getenv("COG_NO_UPDATE_CHECK") == ""
+}
+
+// DisplayAndCheckForRelease will display an update message if an update is available and will check for a new update in the background
+// The result of that check will then be displayed the next time the user runs Cog
+// Returns errors which the caller is assumed to ignore so as not to break the client
+func DisplayAndCheckForRelease() error {
+	if !isUpdateEnabled() {
+		return fmt.Errorf("update check disabled")
+	}
+
+	state, err := loadState()
+	if err != nil {
+		return err
+	}
+	if time.Since(state.LastChecked) > time.Hour {
+		startCheckingForRelease()
+	}
+	if state.Message != "" {
+		console.Info(state.Message)
+		console.Info("")
+	}
+	return nil
+}
+
+func startCheckingForRelease() {
+	go func() {
+		console.Debugf("Checking for updates...")
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		switch r, err := checkForRelease(ctx); {
+		case err == nil:
+			if r == nil {
+				break
+			}
+			if err := writeState(&state{Message: r.Message, LastChecked: time.Now()}); err != nil {
+				console.Debugf("Failed to write state: %s", err)
+			}
+
+			console.Debugf("result of update check: %v", r.Message)
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			break
+		default:
+			console.Debugf("failed querying for new release: %v", err)
+		}
+	}()
+}
+
+type updateCheckResponse struct {
+	Message string `json:"message"`
+}
+
+func checkForRelease(ctx context.Context) (*updateCheckResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://update.cog.run/v1/check", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	q := req.URL.Query()
+	q.Add("version", global.Version)
+	q.Add("commit", global.Commit)
+	q.Add("os", runtime.GOOS)
+	q.Add("arch", runtime.GOARCH)
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var response updateCheckResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return &response, err
+	}
+
+	return &response, nil
+}

--- a/test-integration/test_integration/conftest.py
+++ b/test-integration/test_integration/conftest.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 import subprocess
 import pytest
@@ -5,6 +6,10 @@ import pytest
 import redis
 
 from .util import random_string, find_free_port, docker_run, wait_for_port
+
+
+def pytest_sessionstart(session):
+    os.environ["COG_NO_UPDATE_CHECK"] = "1"
 
 
 @pytest.fixture


### PR DESCRIPTION
Super simple thing to get this working. It works a bit like this:

- In the background, it hits `https://update.cog.run/v1/check?version=1.2.3` (easily cacheable on a CDN!)
- That endpoint responds with `{"message": "..."}` which gets stored in `~/.config/cog/update-check.json` along with a timestamp. 
- On subsequent runs, that message gets displayed before any Cog command. "A new version of Cog is available! Go to https://cog.run/docs/upgrade to upgrade."
- After an hour, it hits that endpoint again.

Any errors are swallowed and sent to debug logging so anything broken in here shouldn't break anything for the user.

### Alternative solutions & future

I considered encoding versions in the API somehow, but this seemed like the simplest, most flexible solution. You could imagine a future where `cog update` existed and this API had some smarts to inform how that worked.

### Backend

https://update.cog.run is currently running as a simple Cloudflare Worker, which runs on the edge to reduce latency, but this could be anything.

### Testing

Edit the Cloudflare Worker to return `{"message": "hello!"}` and Cog will say hello.

Closes #605