### PR TITLE
Make queue worker wait for setup before taking jobs

### DIFF
--- a/test-integration/test_integration/fixtures/long-setup-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/long-setup-project/cog.yaml
@@ -1,0 +1,3 @@
+build:
+  python_version: "3.8"
+predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/long-setup-project/predict.py
+++ b/test-integration/test_integration/fixtures/long-setup-project/predict.py
@@ -1,0 +1,12 @@
+from time import sleep
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def setup(self):
+        sleep(5)
+
+    def predict(self) -> str:
+        sleep(15)
+        return "done"

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -682,3 +682,88 @@ def test_queue_worker_complex_output(docker_network, docker_image, redis_client)
 
         response = redis_client.rpop("response-queue")
         assert response == None
+
+
+# the worker shouldn't start taking jobs until the runner has finished setup
+def test_queue_worker_setup(docker_network, docker_image, redis_client):
+    project_dir = Path(__file__).parent / "fixtures/long-setup-project"
+    subprocess.run(["cog", "build", "-t", docker_image], check=True, cwd=project_dir)
+
+    with docker_run(
+        image=docker_image,
+        interactive=True,
+        network=docker_network,
+        command=[
+            "python",
+            "-m",
+            "cog.server.redis_queue",
+            "redis",
+            "6379",
+            "predict-queue",
+            "",
+            "test-worker",
+            "model_id",
+            "logs",
+        ],
+    ):
+        redis_client.xgroup_create(
+            mkstream=True, groupname="predict-queue", name="predict-queue", id="$"
+        )
+
+        predict_id = random_string(10)
+        redis_client.xadd(
+            name="predict-queue",
+            fields={
+                "value": json.dumps(
+                    {
+                        "id": predict_id,
+                        "input": {},
+                        "response_queue": "response-queue",
+                    }
+                ),
+            },
+        )
+
+        predict_id = random_string(10)
+        redis_client.xadd(
+            name="predict-queue",
+            fields={
+                "value": json.dumps(
+                    {
+                        "id": predict_id,
+                        "input": {},
+                        "response_queue": "response-queue",
+                    }
+                ),
+            },
+        )
+
+        predict_id = random_string(10)
+        redis_client.xadd(
+            name="predict-queue",
+            fields={
+                "value": json.dumps(
+                    {
+                        "id": predict_id,
+                        "input": {},
+                        "response_queue": "response-queue",
+                    }
+                ),
+            },
+        )
+
+        import time
+
+        # give it about five seconds to get properly into setup
+        time.sleep(5)
+        predictions_in_progress = redis_client.xpending(
+            name="predict-queue", groupname="predict-queue"
+        )["pending"]
+        assert predictions_in_progress == 0
+
+        # give it another 10s to finish setup
+        time.sleep(10)
+        predictions_in_progress = redis_client.xpending(
+            name="predict-queue", groupname="predict-queue"
+        )["pending"]
+        assert predictions_in_progress == 1


### PR DESCRIPTION
When we moved the predictor into a subprocess, the call to `setup()` stopped blocking because the work isn't happening in the main thread.

Reuse the "prediction finished" communication channel to indicate that the setup is finished. Rename `PREDICTION_DONE` to `PROCESSING_DONE` to make it a little more generic.

I'm reluctant to add a test that has a minimum run time of 15s, but the timing on setup has a slightly non-deterministic amount of delay because of getting the docker container booted.