### PR TITLE
Add OpenTelemetry instrumentation to queue worker

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,5 @@
 [mypy]
 disallow_untyped_defs = True
+
+[mypy-opentelemetry.*]
+ignore_missing_imports = True

--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -215,7 +215,7 @@ class RedisQueueWorker:
                                 sys.stderr.write(f"Cleanup function caught error: {e}")
             except Exception as e:
                 tb = traceback.format_exc()
-                sys.stderr.write(f"Failed to handle message {message_id}: {tb}\n")
+                sys.stderr.write(f"Failed to handle message: {tb}\n")
 
     def handle_message(
         self,

--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -207,8 +207,6 @@ class RedisQueueWorker:
 
         cleanup_functions.append(input_obj.cleanup)
 
-        start_time = time.time()
-
         with timeout(seconds=self.predict_timeout):
             self.runner.run(**input_obj.dict())
 

--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -20,9 +20,9 @@ from ..response import Status
 from .runner import PredictionRunner
 
 from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter  # type: ignore
+from opentelemetry.sdk.trace import TracerProvider  # type: ignore
+from opentelemetry.sdk.trace.export import BatchSpanProcessor  # type: ignore
 from opentelemetry.trace import Status as TraceStatus, StatusCode
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -11,9 +11,9 @@ from ..predictor import load_config, load_predictor
 from .log_capture import capture_log
 
 from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter  # type: ignore
+from opentelemetry.sdk.trace import TracerProvider  # type: ignore
+from opentelemetry.sdk.trace.export import BatchSpanProcessor  # type: ignore
 from opentelemetry.trace import NonRecordingSpan, SpanContext
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -17,6 +17,8 @@ setuptools.setup(
     install_requires=[
         # intentionally loose. perhaps these should be vendored to not collide with user code?
         "fastapi>=0.6,<1",
+        "opentelemetry-exporter-otlp>=1.11.1,<2",
+        "opentelemetry-sdk>=1.11.1,<2",
         "pydantic>=1,<2",
         "PyYAML",
         "redis>=4,<5",


### PR DESCRIPTION
This adds some basic spans to setup and to predictions when running the predictor via the Redis queue worker.

Telemetry is enabled when the `OTEL_SERVICE_NAME` environment variable is set. The OTLP exporter also needs to be [configured via environment variables][1].

[1]: https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html

If a `traceparent` parameter is provided with the prediction request, Cog will use that value as the parent for the prediction spans. This allows spans from Cog to show up in distributed traces.

This PR includes a lot of whitespace churn due to the new `with …:` blocks, so is probably best reviewed with [?w=1](646/files?w=1)