### PR TITLE
Support lists of complex outputs in queue worker

### DIFF
--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -248,5 +248,7 @@ def make_pickleable(obj: Any) -> Any:
     """
     if isinstance(obj, BaseModel):
         return obj.dict(exclude_unset=True)
+    elif isinstance(obj, List):
+        return [make_pickleable(item) for item in obj]
     else:
         return obj


### PR DESCRIPTION
An output type of `List[Output]` would break because of the problems that `make_pickleable` works around. This change makes that work, by making pickleable each item in the list.

This is still a bandaid.

Fixes #652 