### PR TITLE
Annotate iterators so we can differentiate from lists

### DIFF
--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -2,7 +2,7 @@ import base64
 import io
 import os
 import tempfile
-from typing import Iterator
+from typing import Iterator, List
 from unittest import mock
 
 from fastapi.testclient import TestClient
@@ -406,6 +406,27 @@ def test_openapi_specification_with_yield():
         def predict(
             self,
         ) -> Iterator[str]:
+            pass
+
+    client = make_client(Predictor())
+    resp = client.get("/openapi.json")
+    assert resp.status_code == 200
+
+    assert resp.json()["components"]["schemas"]["Output"] == {
+        "title": "Output",
+        "type": "array",
+        "items": {
+            "type": "string",
+        },
+        "x-cog-array-type": "iterator",
+    }
+
+
+def test_openapi_specification_with_list():
+    class Predictor(BasePredictor):
+        def predict(
+            self,
+        ) -> List[str]:
             pass
 
     client = make_client(Predictor())


### PR DESCRIPTION
Iterators represent progressive output, lists just represent several
outputs. On Replicate, we want to be able to differentiate between these
two so iterators have a slider and lists are displayed as a grid.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>
