### PR TITLE
Send response when queue worker starts predict

### DIFF
--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -250,6 +250,8 @@ class RedisQueueWorker:
                 "logs": logs,
             }
 
+            self.redis.rpush(response_queue, json.dumps(response))
+
             # just send logs until output starts
             while self.runner.is_processing() and not self.runner.has_output_waiting():
                 if self.runner.has_logs_waiting():

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -49,7 +49,7 @@ def test_queue_worker_files(docker_image, docker_network, redis_client, upload_s
                 ),
             },
         )
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "succeeded",
             "output": "http://upload-server:5000/download/output.txt",
@@ -106,7 +106,7 @@ def test_queue_worker_yielding_file(
             },
         )
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "processing",
             "output": ["http://upload-server:5000/download/out-0.txt"],
@@ -116,7 +116,7 @@ def test_queue_worker_yielding_file(
         with open(upload_server / "out-0.txt") as f:
             assert f.read() == "test foo"
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "processing",
             "output": [
@@ -129,7 +129,7 @@ def test_queue_worker_yielding_file(
         with open(upload_server / "out-1.txt") as f:
             assert f.read() == "test bar"
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "processing",
             "output": [
@@ -143,7 +143,7 @@ def test_queue_worker_yielding_file(
         with open(upload_server / "out-2.txt") as f:
             assert f.read() == "test baz"
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "succeeded",
             "output": [
@@ -199,14 +199,14 @@ def test_queue_worker_yielding(docker_network, docker_image, redis_client):
             },
         )
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "processing",
             "output": ["foo", "bar", "baz"],
             "logs": [],
         }
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "succeeded",
             "output": ["foo", "bar", "baz"],
@@ -258,7 +258,7 @@ def test_queue_worker_error(docker_network, docker_image, redis_client):
             },
         )
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "failed",
             "output": None,
@@ -311,21 +311,21 @@ def test_queue_worker_error_after_output(docker_network, docker_image, redis_cli
             },
         )
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "processing",
             "output": ["hello bar"],
             "logs": [],
         }
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "processing",
             "output": ["hello bar"],
             "logs": ["a printed log message"],
         }
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "failed",
             "output": ["hello bar"],
@@ -378,7 +378,7 @@ def test_queue_worker_invalid_input(docker_network, docker_image, redis_client):
             },
         )
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert "status" in response
         assert response["status"] == "failed"
 
@@ -425,7 +425,7 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client):
             },
         )
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "processing",
             "output": None,
@@ -434,7 +434,7 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client):
             ],
         }
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "processing",
             "output": None,
@@ -444,7 +444,7 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client):
             ],
         }
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "processing",
             "output": None,
@@ -455,7 +455,7 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client):
             ],
         }
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "processing",
             "output": None,
@@ -467,7 +467,7 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client):
             ],
         }
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "succeeded",
             "output": "output",
@@ -525,7 +525,7 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client):
             },
         )
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {"status": "succeeded", "output": "it worked!", "logs": []}
 
         predict_id = random_string(10)
@@ -544,7 +544,7 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client):
             },
         )
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {"status": "failed", "error": "Prediction timed out"}
 
 
@@ -591,10 +591,10 @@ def test_queue_worker_yielding_timeout(docker_image, docker_network, redis_clien
             },
         )
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {"status": "processing", "output": ["yield 0"], "logs": []}
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {"status": "succeeded", "output": ["yield 0"], "logs": []}
 
         predict_id = random_string(10)
@@ -615,17 +615,17 @@ def test_queue_worker_yielding_timeout(docker_image, docker_network, redis_clien
         )
 
         # TODO(andreas): revisit this test design if it starts being flakey
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {"status": "processing", "output": ["yield 0"], "logs": []}
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "processing",
             "output": ["yield 0", "yield 1"],
             "logs": [],
         }
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {"status": "failed", "error": "Prediction timed out"}
 
 
@@ -670,7 +670,7 @@ def test_queue_worker_complex_output(docker_network, docker_image, redis_client)
             },
         )
 
-        response = json.loads(redis_client.brpop("response-queue", timeout=10)[1])
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "succeeded",
             "output": {

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -49,6 +49,14 @@ def test_queue_worker_files(docker_image, docker_network, redis_client, upload_s
                 ),
             },
         )
+
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
+        assert response == {
+            "status": "processing",
+            "output": None,
+            "logs": [],
+        }
+
         response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "succeeded",
@@ -105,6 +113,13 @@ def test_queue_worker_yielding_file(
                 ),
             },
         )
+
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
+        assert response == {
+            "status": "processing",
+            "output": None,
+            "logs": [],
+        }
 
         response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
@@ -202,6 +217,13 @@ def test_queue_worker_yielding(docker_network, docker_image, redis_client):
         response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
             "status": "processing",
+            "output": None,
+            "logs": [],
+        }
+
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
+        assert response == {
+            "status": "processing",
             "output": ["foo", "bar", "baz"],
             "logs": [],
         }
@@ -260,6 +282,13 @@ def test_queue_worker_error(docker_network, docker_image, redis_client):
 
         response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
+            "status": "processing",
+            "output": None,
+            "logs": [],
+        }
+
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
+        assert response == {
             "status": "failed",
             "output": None,
             "logs": [],
@@ -310,6 +339,13 @@ def test_queue_worker_error_after_output(docker_network, docker_image, redis_cli
                 ),
             },
         )
+
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
+        assert response == {
+            "status": "processing",
+            "output": None,
+            "logs": [],
+        }
 
         response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {
@@ -429,6 +465,13 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client):
         assert response == {
             "status": "processing",
             "output": None,
+            "logs": [],
+        }
+
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
+        assert response == {
+            "status": "processing",
+            "output": None,
             "logs": [
                 "WARNING:root:writing log message",
             ],
@@ -526,6 +569,13 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client):
         )
 
         response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
+        assert response == {
+            "status": "processing",
+            "output": None,
+            "logs": [],
+        }
+
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {"status": "succeeded", "output": "it worked!", "logs": []}
 
         predict_id = random_string(10)
@@ -543,6 +593,13 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client):
                 ),
             },
         )
+
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
+        assert response == {
+            "status": "processing",
+            "output": None,
+            "logs": [],
+        }
 
         response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {"status": "failed", "error": "Prediction timed out"}
@@ -592,6 +649,13 @@ def test_queue_worker_yielding_timeout(docker_image, docker_network, redis_clien
         )
 
         response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
+        assert response == {
+            "status": "processing",
+            "output": None,
+            "logs": [],
+        }
+
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {"status": "processing", "output": ["yield 0"], "logs": []}
 
         response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
@@ -613,6 +677,13 @@ def test_queue_worker_yielding_timeout(docker_image, docker_network, redis_clien
                 ),
             },
         )
+
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
+        assert response == {
+            "status": "processing",
+            "output": None,
+            "logs": [],
+        }
 
         # TODO(andreas): revisit this test design if it starts being flakey
         response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
@@ -669,6 +740,13 @@ def test_queue_worker_complex_output(docker_network, docker_image, redis_client)
                 ),
             },
         )
+
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
+        assert response == {
+            "status": "processing",
+            "output": None,
+            "logs": [],
+        }
 
         response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
         assert response == {


### PR DESCRIPTION
Currently the only way to know whether Cog has picked up a request is to watch for jobs to be claimed from the request queue. Sending an empty processing message is a much cleaner way to handle that, and will be picked up by whatever system folks are using to listen to non terminal responses.

PR also includes a commit to swap `brpop` to `blpop`, to fix a timing issue which was exposed by this change.