### PR TITLE
Pin protobuf to make opentelemetry work

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -19,6 +19,7 @@ setuptools.setup(
         "fastapi>=0.6,<1",
         "opentelemetry-exporter-otlp>=1.11.1,<2",
         "opentelemetry-sdk>=1.11.1,<2",
+        "protobuf<=3.20",
         "pydantic>=1,<2",
         "PyYAML",
         "redis>=4,<5",


### PR DESCRIPTION
Seeing this:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.8/site-packages/cog/server/redis_queue.py", line 20, in <module>
    from .runner import PredictionRunner
  File "/usr/local/lib/python3.8/site-packages/cog/server/runner.py", line 14, in <module>
    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter  # type: ignore
  File "/usr/local/lib/python3.8/site-packages/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py", line 22, in <module>
    from opentelemetry.exporter.otlp.proto.grpc.exporter import (
  File "/usr/local/lib/python3.8/site-packages/opentelemetry/exporter/otlp/proto/grpc/exporter.py", line 39, in <module>
    from opentelemetry.proto.common.v1.common_pb2 import (
  File "/usr/local/lib/python3.8/site-packages/opentelemetry/proto/common/v1/common_pb2.py", line 36, in <module>
    _descriptor.FieldDescriptor(
  File "/usr/local/lib/python3.8/site-packages/google/protobuf/descriptor.py", line 560, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```

See also #409 