### PR TITLE
Reset upgrade state when upgraded

### DIFF
--- a/pkg/update/state.go
+++ b/pkg/update/state.go
@@ -16,6 +16,7 @@ import (
 type state struct {
 	Message     string    `json:"message"`
 	LastChecked time.Time `json:"lastChecked"`
+	Version     string    `json:"version"`
 }
 
 // loadState loads the update check state from disk, returning defaults if it does not exist


### PR DESCRIPTION
I made the update check display a message for #672 but the message
doesn't reset when people upgrade.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>
