### PR TITLE
Websockets worker

### DIFF
--- a/python/cog/server/websocket_queue.py
+++ b/python/cog/server/websocket_queue.py
@@ -1,0 +1,384 @@
+import datetime
+import io
+import json
+import os
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+import signal
+import sys
+import traceback
+import time
+import types
+import contextlib
+
+from pydantic import ValidationError
+import websocket, rel
+import requests
+
+from ..predictor import BasePredictor, get_input_type, load_predictor, load_config
+from ..json import upload_files
+from ..response import Status
+from .runner import PredictionRunner
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter  # type: ignore
+from opentelemetry.sdk.trace import TracerProvider  # type: ignore
+from opentelemetry.sdk.trace.export import BatchSpanProcessor  # type: ignore
+from opentelemetry.trace import Status as TraceStatus, StatusCode
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+
+class timeout:
+    """A context manager that times out after a given number of seconds."""
+
+    def __init__(
+        self,
+        seconds: Optional[int],
+        elapsed: Optional[int] = None,
+        error_message: str = "Prediction timed out",
+    ) -> None:
+        if elapsed is None or seconds is None:
+            self.seconds = seconds
+        else:
+            self.seconds = seconds - int(elapsed)
+        self.error_message = error_message
+
+    def handle_timeout(self, signum: Any, frame: Any) -> None:
+        raise TimeoutError(self.error_message)
+
+    def __enter__(self) -> None:
+        if self.seconds is not None:
+            if self.seconds <= 0:
+                self.handle_timeout(None, None)
+            else:
+                signal.signal(signal.SIGALRM, self.handle_timeout)
+                signal.alarm(self.seconds)
+
+    def __exit__(self, type: Any, value: Any, traceback: Any) -> None:
+        if self.seconds is not None:
+            signal.alarm(0)
+
+
+class WebsocketQueueWorker:
+    STAGE_SETUP = "setup"
+    STAGE_RUN = "run"
+
+    def __init__(
+        self,
+        predictor: BasePredictor,
+        websocket_url: str,
+        websocket_auth: str,
+        model_id: Optional[str] = None,        
+        predict_timeout: Optional[int] = None,        
+    ):
+        self.runner = PredictionRunner()
+        self.websocket_url = websocket_url,
+        self.websocket_auth = websocket_auth,
+        self.model_id = model_id
+        self.predict_timeout = predict_timeout
+        # TODO: respect max_processing_time in message handling
+        self.max_processing_time = 10 * 60  # timeout after 10 minutes
+
+        # Set up types
+        self.InputType = get_input_type(predictor)
+
+        self.should_exit = False
+        self.tracer = trace.get_tracer("cog")
+
+    def signal_exit(self, signum: Any, frame: Any) -> None:
+        self.should_exit = True
+        sys.stderr.write("Caught SIGTERM, exiting...\n")
+
+    def start(self) -> None:
+        with self.tracer.start_as_current_span(name="websocket_queue.setup") as span:
+            signal.signal(signal.SIGTERM, self.signal_exit)
+            start_time = time.time()
+
+            # TODO(bfirsh): setup should time out too, but we don't display these logs to the user, so don't timeout to avoid confusion
+            self.runner.setup()
+
+            setup_time = time.time() - start_time
+            sys.stderr.write(f"Setup time: {setup_time:.2f}\n")        
+
+            websocket.enableTrace(True)
+            self.ws = websocket.WebSocketApp(
+                self.websocket_url,
+                on_open=self.on_open,
+                on_message=self.on_message,
+                on_error=self.on_error,
+                on_close=self.on_close,
+                cookie=self.websocket_auth
+            )
+        
+        self.ws.run_forever(dispatcher=rel)
+        rel.signal(2, rel.abort)
+        rel.dispatch()
+        
+
+    def on_open(self, ws, message_json):
+      sys.stderr.write(f"Waiting for message on {self.websocket_url}\n")
+
+    def on_close(self, ws, cloe_status_code, close_msg):
+      sys.stderr.write(f"Websocket connection closed")
+      # Todo - reconnect
+      sys.stderr.write("Closing runner, bye bye!\n")
+      self.runner.close()
+      
+
+    def on_error(self, ws, error):
+      sys.stderror.write(f"Websocket error: {error}")
+
+    def on_message(self, ws, message_json):
+        if message_json is None:            
+            return
+
+        time_in_queue = calculate_time_in_queue(message_id)  # type: ignore
+        message = json.loads(message_json)
+        message_id = message.id
+        # Check whether the incoming message includes details of an
+        # OpenTelemetry trace, to make distributed tracing work. The
+        # value should look like:
+        #
+        #     00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+        if "traceparent" in message:
+            context = TraceContextTextMapPropagator().extract(
+                {"traceparent": message["traceparent"]}
+            )
+        else:
+            context = None
+
+        with self.tracer.start_as_current_span(
+            name="websocket_queue.process_message",
+            context=context,
+            attributes={"time_in_queue": time_in_queue},
+        ) as span:            
+            sys.stderr.write(
+                f"Received message {message_id} on {self.websocket_url}\n"
+            )
+            # create this here so it's available during exception handling
+            response: Dict[str, Any] = {
+                "status": Status.PROCESSING,
+                "output": None,
+                "logs": [],
+                "id": message_id
+            }
+            cleanup_functions: List[Callable] = []
+            try:
+                start_time = time.time()
+                self.handle_message(
+                    response, message, cleanup_functions
+                )
+                run_time = time.time() - start_time
+                sys.stderr.write(f"Run time for {message_id}: {run_time:.2f}\n")
+            except Exception as e:
+                response["status"] = Status.FAILED
+                response["error"] = str(e)
+                response["x-experimental-timestamps"][
+                    "completed_at"
+                ] = datetime.datetime.now().isoformat()
+                self.push_message(json.dumps(response))
+            finally:
+                for cleanup_function in cleanup_functions:
+                    try:
+                        cleanup_function()
+                    except Exception as e:
+                        sys.stderr.write(f"Cleanup function caught error: {e}")
+
+    def handle_message(
+        self,        
+        response: Dict[str, Any],
+        message: Dict[str, Any],
+        cleanup_functions: List[Callable],
+    ) -> None:
+        span = trace.get_current_span()
+
+        try:
+            input_obj = self.InputType(**message["input"])
+        except ValidationError as e:
+            tb = traceback.format_exc()
+            sys.stderr.write(tb)
+            response["status"] = Status.FAILED
+            response["error"] = str(e)
+            self.push_message(response)
+            span.record_exception(e)
+            span.set_status(TraceStatus(status_code=StatusCode.ERROR))
+            return
+
+        cleanup_functions.append(input_obj.cleanup)
+
+        with timeout(seconds=self.predict_timeout):
+            self.runner.run(**input_obj.dict())
+
+            response["x-experimental-timestamps"] = {
+                "started_at": datetime.datetime.now().isoformat()
+            }
+
+            logs: List[str] = []
+            response["logs"] = logs
+
+            self.push_message(response)
+
+            # just send logs until output starts
+            while self.runner.is_processing() and not self.runner.has_output_waiting():
+                if self.runner.has_logs_waiting():
+                    logs.extend(self.runner.read_logs())
+                    self.push_message(response)
+
+            if self.runner.error() is not None:
+                response["status"] = Status.FAILED
+                response["error"] = str(self.runner.error())  # type: ignore
+                response["x-experimental-timestamps"][
+                    "completed_at"
+                ] = datetime.datetime.now().isoformat()
+                self.push_message(response)
+                span.record_exception(self.runner.error())
+                span.set_status(TraceStatus(status_code=StatusCode.ERROR))
+                return
+
+            span.add_event("received first output")
+
+            if self.runner.is_output_generator():
+                output = response["output"] = []
+
+                while self.runner.is_processing():
+                    # TODO: restructure this to avoid the tight CPU-eating loop
+                    if (
+                        self.runner.has_output_waiting()
+                        or self.runner.has_logs_waiting()
+                    ):
+                        # Object has already passed through `make_encodeable()` in the Runner, so all we need to do here is upload the files
+                        new_output = [
+                            self.upload_files(o) for o in self.runner.read_output()
+                        ]
+                        new_logs = self.runner.read_logs()
+
+                        # sometimes it'll say there's output when there's none
+                        if new_output == [] and new_logs == []:
+                            continue
+
+                        output.extend(new_output)
+                        logs.extend(new_logs)
+
+                        # we could `time.sleep(0.1)` and check `is_processing()`
+                        # here to give the predictor subprocess a chance to exit
+                        # so we don't send a double message for final output, at
+                        # the cost of extra latency
+                        self.push_message(response)
+
+                if self.runner.error() is not None:
+                    response["status"] = Status.FAILED
+                    response["error"] = str(self.runner.error())  # type: ignore
+                    response["x-experimental-timestamps"][
+                        "completed_at"
+                    ] = datetime.datetime.now().isoformat()
+                    self.push_message(response)
+                    span.record_exception(self.runner.error())
+                    span.set_status(TraceStatus(status_code=StatusCode.ERROR))
+                    return
+
+                span.add_event("received final output")
+
+                response["status"] = Status.SUCCEEDED
+                response["x-experimental-timestamps"][
+                    "completed_at"
+                ] = datetime.datetime.now().isoformat()
+                output.extend(self.upload_files(o) for o in self.runner.read_output())
+                logs.extend(self.runner.read_logs())
+                self.push_message(response)
+
+            else:
+                # just send logs until output ends
+                while self.runner.is_processing():
+                    if self.runner.has_logs_waiting():
+                        logs.extend(self.runner.read_logs())
+                        self.push_message(response)
+
+                if self.runner.error() is not None:
+                    response["status"] = Status.FAILED
+                    response["error"] = str(self.runner.error())  # type: ignore
+                    response["x-experimental-timestamps"][
+                        "completed_at"
+                    ] = datetime.datetime.now().isoformat()
+                    self.push_message(response)
+                    span.record_exception(self.runner.error())
+                    span.set_status(TraceStatus(status_code=StatusCode.ERROR))
+                    return
+
+                output = self.runner.read_output()
+                assert len(output) == 1
+
+                response["status"] = Status.SUCCEEDED
+                response["x-experimental-timestamps"][
+                    "completed_at"
+                ] = datetime.datetime.now().isoformat()
+                response["output"] = self.upload_files(output[0])
+                logs.extend(self.runner.read_logs())
+                self.push_message(response)
+
+    def download(self, url: str) -> bytes:
+        resp = requests.get(url)
+        resp.raise_for_status()
+        return resp.content
+
+    def push_message(self, response: Any) -> None:
+        self.ws.send(json.dumps(response))
+
+    def upload_files(self, obj: Any) -> Any:
+        def upload_file(fh: io.IOBase) -> str:
+            resp = requests.put(self.upload_url, files={"file": fh})
+            resp.raise_for_status()
+            return resp.json()["url"]
+
+        return upload_files(obj, upload_file)
+
+
+def calculate_time_in_queue(message_id: str) -> float:
+    """
+    Calculate how long a message spent in the queue based on the timestamp in
+    the message ID.
+    """
+    now = time.time()
+    queue_time = int(message_id[:13]) / 1000.0
+    return now - queue_time
+
+
+def _queue_worker_from_argv(
+    predictor: BasePredictor,
+    websocket_url: str,
+    websocket_auth: str,
+    upload_url: str,
+    model_id: str,
+    predict_timeout: Optional[str] = None,
+) -> WebsocketQueueWorker:
+    """
+    Construct a WebsocketQueueWorker object from sys.argv, taking into account optional arguments and types.
+
+    This is intensely fragile. This should be kwargs or JSON or something like that.
+    """
+    if predict_timeout is not None:
+        predict_timeout_int = int(predict_timeout)
+    else:
+        predict_timeout_int = None
+    return WebsocketQueueWorker(
+        predictor,
+        websocket_url,
+        websocket_auth,        
+        upload_url,        
+        model_id,        
+        predict_timeout_int,
+    )
+
+
+if __name__ == "__main__":
+    # Enable OpenTelemetry if the env vars are present. If this block isn't
+    # run, all the opentelemetry calls are no-ops.
+    if "OTEL_SERVICE_NAME" in os.environ:
+        trace.set_tracer_provider(TracerProvider())
+        span_processor = BatchSpanProcessor(OTLPSpanExporter())
+        trace.get_tracer_provider().add_span_processor(span_processor)
+
+    config = load_config()
+    predictor = load_predictor(config)
+
+    worker = _queue_worker_from_argv(predictor, *sys.argv[1:])
+    worker.start()

--- a/python/cog/server/websocket_queue.py
+++ b/python/cog/server/websocket_queue.py
@@ -74,7 +74,7 @@ class WebsocketQueueWorker:
     ):
         self.runner = PredictionRunner()
         self.websocket_url = websocket_url
-        self.websocket_auth = websocket_auth
+        self.websocket_auth = os.getenv("REPLICATE_WEBSOCKET_AUTH")
         self.upload_url = upload_url
         self.model_id = model_id
         self.predict_timeout = predict_timeout
@@ -110,8 +110,9 @@ class WebsocketQueueWorker:
                 on_message=self.on_message,
                 on_error=self.on_error,
                 on_close=self.on_close,
-                cookie=self.websocket_auth,
             )
+            if self.websocket_auth:
+                self.ws.cookie = self.websocket_auth
 
         self.ws.run_forever(dispatcher=rel)
         rel.signal(2, rel.abort)
@@ -316,7 +317,6 @@ def calculate_time_in_queue(message_id: str) -> float:
 def _queue_worker_from_argv(
     predictor: BasePredictor,
     websocket_url: str,
-    websocket_auth: str,
     upload_url: str,
     model_id: str,
     predict_timeout: Optional[str] = None,
@@ -333,7 +333,6 @@ def _queue_worker_from_argv(
     return WebsocketQueueWorker(
         predictor,
         websocket_url,
-        websocket_auth,
         upload_url,
         model_id,
         predict_timeout_int,

--- a/python/cog/server/websocket_queue.py
+++ b/python/cog/server/websocket_queue.py
@@ -67,7 +67,6 @@ class WebsocketQueueWorker:
         self,
         predictor: BasePredictor,
         websocket_url: str,
-        websocket_auth: str,
         upload_url: str,
         model_id: Optional[str] = None,
         predict_timeout: Optional[int] = None,

--- a/python/cog/server/websocket_queue.py
+++ b/python/cog/server/websocket_queue.py
@@ -101,7 +101,6 @@ class WebsocketQueueWorker:
             setup_time = time.time() - start_time
             sys.stderr.write(f"Setup time: {setup_time:.2f}\n")
 
-            websocket.enableTrace(True)
             sys.stderr.write(f"Connecting to {self.websocket_url}\n")
             self.ws = websocket.WebSocketApp(
                 self.websocket_url,

--- a/python/cog/server/websockets.py
+++ b/python/cog/server/websockets.py
@@ -160,9 +160,7 @@ class WebsocketWorker:
                 start_time = time.time()
                 await self.handle_message(websocket, response, message, cleanup_functions)
                 run_time = time.time() - start_time
-                if not response["metrics"]:
-                    response["metrics"] = {}
-                response["metrics"]["predict_time"] = run_time
+                response["metrics"] = {"predict_time": run_time}
                 sys.stderr.write(f"Run time for {message_id}: {run_time:.2f}\n")
                 await self.push_message(websocket, response)
             except Exception as e:

--- a/python/cog/server/websockets.py
+++ b/python/cog/server/websockets.py
@@ -158,7 +158,7 @@ class WebsocketWorker:
             self.running = True
             try:
                 start_time = time.time()
-                await self.handle_message(response, websocket, message, cleanup_functions)
+                await self.handle_message(websocket, response, message, cleanup_functions)
                 run_time = time.time() - start_time
                 if not response["metrics"]:
                     response["metrics"] = {}

--- a/python/cog/server/websockets.py
+++ b/python/cog/server/websockets.py
@@ -111,11 +111,11 @@ class WebsocketWorker:
             try:
                 sys.stderr.write(f"Connected\n")
                 async for message in websocket:
-                    if message is str:
+                    if isinstance(message, str):
                         sys.stderr.write("processing job")
                         await self.process_message(websocket, str(message))
                     else:
-                        sys.stderr.write(f"Ignoring binary payload")
+                        sys.stderr.write("Ignoring binary payload")
             except:
                 sys.stderr.write("Websocket error, will reconnect")
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -23,11 +23,10 @@ setuptools.setup(
         "pydantic>=1,<2",
         "PyYAML",
         "redis>=4,<5",
-        "rel>=0.4.7",
         "requests>=2,<3",
         "typing_extensions>=4.1.0",
         "uvicorn[standard]>=0.12,<1",
-        "websocket-client>=1.3.3",
+        "websockets>=10.3",
     ],
     packages=setuptools.find_packages(),
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -23,9 +23,11 @@ setuptools.setup(
         "pydantic>=1,<2",
         "PyYAML",
         "redis>=4,<5",
+        "rel>=0.4.7",
         "requests>=2,<3",
         "typing_extensions>=4.1.0",
         "uvicorn[standard]>=0.12,<1",
+        "websocket-client>=1.3.3",
     ],
     packages=setuptools.find_packages(),
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -17,6 +17,7 @@ setuptools.setup(
     install_requires=[
         # intentionally loose. perhaps these should be vendored to not collide with user code?
         "fastapi>=0.6,<1",
+        "hyperlink>=21.0.0",
         "opentelemetry-exporter-otlp>=1.11.1,<2",
         "opentelemetry-sdk>=1.11.1,<2",
         "protobuf<=3.20",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,12 +6,11 @@ pydantic==1.8.2
 pytest==6.2.4
 PyYAML==5.4.1
 redis==4.1.0
-rel==0.4.7
 requests==2.25.1
 responses==0.16.0
 types-requests==2.25.1
 types-PyYAML==5.4.1
 types-redis==4.1.0
 uvicorn[standard]==0.16.0
-websocket-client==1.3.3
+websockets==10.3
 wheel==0.36.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 fastapi==0.70.1
+hyperlink==21.0.0
 mypy==0.950
 numpy==1.21.5
 pillow==9.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,10 +6,12 @@ pydantic==1.8.2
 pytest==6.2.4
 PyYAML==5.4.1
 redis==4.1.0
+rel==0.4.7
 requests==2.25.1
 responses==0.16.0
 types-requests==2.25.1
 types-PyYAML==5.4.1
 types-redis==4.1.0
 uvicorn[standard]==0.16.0
+websocket-client==1.3.3
 wheel==0.36.2


### PR DESCRIPTION
This adds a websocket queue worker based heavily on the existing Redis queue worker - they share so much code that it's likely they could and should be refactored to use a base class, but I'm not really a python dev so I didn't attempt it. 

The worker takes 3 positional arguments: websocket queue URL, upload URL, and model ID. It will connect to the websocket and wait for a message to be sent; it simply expects a raw JSON payload that includes an ID and input, any other messages sent over the socket would throw an error at the moment - I'm not sure if it should really be designed otherwise. Responses are streamed back over the websocket connection live, with the ID included for correlation if multithreading is used. I have not done exhaustive testing as my server is still in the early stages, but it seems functional at a basic level.