### PR TITLE
Fix timeout behaviour

### DIFF
--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import os
+import signal
 import traceback
 import types
 from enum import Enum
@@ -20,6 +21,37 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor  # type: ignore
 from opentelemetry.trace import NonRecordingSpan, SpanContext
 
 
+class timeout:
+    """A context manager that times out after a given number of seconds."""
+
+    def __init__(
+        self,
+        seconds: Optional[int],
+        elapsed: Optional[int] = None,
+        error_message: str = "Prediction timed out",
+    ) -> None:
+        if elapsed is None or seconds is None:
+            self.seconds = seconds
+        else:
+            self.seconds = seconds - int(elapsed)
+        self.error_message = error_message
+
+    def handle_timeout(self, signum: Any, frame: Any) -> None:
+        raise TimeoutError(self.error_message)
+
+    def __enter__(self) -> None:
+        if self.seconds is not None:
+            if self.seconds <= 0:
+                self.handle_timeout(None, None)
+            else:
+                signal.signal(signal.SIGALRM, self.handle_timeout)
+                signal.alarm(self.seconds)
+
+    def __exit__(self, type: Any, value: Any, traceback: Any) -> None:
+        if self.seconds is not None:
+            signal.alarm(0)
+
+
 class PredictionRunner:
     PROCESSING_DONE = 1
     EXIT_SENTINEL = "exit"
@@ -29,7 +61,7 @@ class PredictionRunner:
         SINGLE = 1
         GENERATOR = 2
 
-    def __init__(self) -> None:
+    def __init__(self, predict_timeout: Optional[int] = None) -> None:
         self.logs_pipe_reader, self.logs_pipe_writer = multiprocessing.Pipe(
             duplex=False
         )
@@ -46,6 +78,7 @@ class PredictionRunner:
         self.done_pipe_reader, self.done_pipe_writer = multiprocessing.Pipe(
             duplex=False
         )
+        self.predict_timeout = predict_timeout
 
     def setup(self) -> None:
         """
@@ -228,22 +261,25 @@ class PredictionRunner:
                 context=trace.set_span_in_context(NonRecordingSpan(span_context)),
             ) as span:
                 try:
-                    output = self.predictor.predict(**prediction_input)
+                    with timeout(seconds=self.predict_timeout):
+                        output = self.predictor.predict(**prediction_input)
 
-                    if isinstance(output, types.GeneratorType):
-                        self.predictor_pipe_writer.send(self.OutputType.GENERATOR)
-                        while True:
-                            try:
-                                self.predictor_pipe_writer.send(
-                                    make_encodeable(next(output))
-                                )
-                            except StopIteration:
-                                break
-                    else:
-                        self.predictor_pipe_writer.send(self.OutputType.SINGLE)
-                        self.predictor_pipe_writer.send(make_encodeable(output))
+                        if isinstance(output, types.GeneratorType):
+                            self.predictor_pipe_writer.send(self.OutputType.GENERATOR)
+                            while True:
+                                try:
+                                    self.predictor_pipe_writer.send(
+                                        make_encodeable(next(output))
+                                    )
+                                except StopIteration:
+                                    break
+                        else:
+                            self.predictor_pipe_writer.send(self.OutputType.SINGLE)
+                            self.predictor_pipe_writer.send(make_encodeable(output))
                 except Exception as e:
-                    traceback.print_exc()
+                    # if it timed out there's no stack trace
+                    if type(e) != TimeoutError:
+                        traceback.print_exc()
                     self.error_pipe_writer.send(e)
 
         self.done_pipe_writer.send(self.PROCESSING_DONE)

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import os
+import traceback
 import types
 from enum import Enum
 from multiprocessing.connection import Connection
@@ -242,6 +243,7 @@ class PredictionRunner:
                         self.predictor_pipe_writer.send(self.OutputType.SINGLE)
                         self.predictor_pipe_writer.send(make_encodeable(output))
                 except Exception as e:
+                    traceback.print_exc()
                     self.error_pipe_writer.send(e)
 
         self.done_pipe_writer.send(self.PROCESSING_DONE)

--- a/test-integration/test_integration/fixtures/timeout-project/predict.py
+++ b/test-integration/test_integration/fixtures/timeout-project/predict.py
@@ -6,4 +6,4 @@ from cog import BasePredictor
 class Predictor(BasePredictor):
     def predict(self, sleep_time: float) -> str:
         time.sleep(sleep_time)
-        return "it worked!"
+        return f"it worked after {sleep_time} seconds!"

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -338,11 +338,22 @@ def test_queue_worker_error(docker_network, docker_image, redis_client):
         assert response == {
             "x-experimental-timestamps": {
                 "started_at": mock.ANY,
+            },
+            "status": "processing",
+            "output": None,
+            "logs": mock.ANY,  # includes a stack trace
+        }
+        assert "Traceback (most recent call last):" in response["logs"]
+
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
+        assert response == {
+            "x-experimental-timestamps": {
+                "started_at": mock.ANY,
                 "completed_at": mock.ANY,
             },
             "status": "failed",
             "output": None,
-            "logs": [],
+            "logs": mock.ANY,  # includes a stack trace
             "error": "over budget",
         }
 
@@ -425,11 +436,22 @@ def test_queue_worker_error_after_output(docker_network, docker_image, redis_cli
         assert response == {
             "x-experimental-timestamps": {
                 "started_at": mock.ANY,
+            },
+            "status": "processing",
+            "output": ["hello bar"],
+            "logs": mock.ANY,  # includes a stack trace
+        }
+        assert "Traceback (most recent call last):" in response["logs"]
+
+        response = json.loads(redis_client.blpop("response-queue", timeout=10)[1])
+        assert response == {
+            "x-experimental-timestamps": {
+                "started_at": mock.ANY,
                 "completed_at": mock.ANY,
             },
             "status": "failed",
             "output": ["hello bar"],
-            "logs": ["a printed log message"],
+            "logs": mock.ANY,  # includes a stack trace
             "error": "mid run error",
         }
 


### PR DESCRIPTION
When the Redis queue worker is responsible for handling timeouts, the predictor process continues running after the queue worker sends the timeout message. If another job gets picked up before the queue worker is finished, it'll send back outputs from the previous job.

Moving it into the runner means the predictor itself is timed out and stops running. Expand the test case to demonstrate the issue and prevent regression.

Contains a couple of the preliminary fixes from #678, and a semi-related fix to timeout logic. Best viewed commit-by-commit with whitespace diffs turned off.