### PR TITLE
Use a string key for responses instead of a list

### DIFF
--- a/docs/redis.md
+++ b/docs/redis.md
@@ -92,13 +92,15 @@ If the model yields [progressive output](python.md#progressive-output) then a mi
         ]
     }
 
-Because each message is a complete snapshot of the current state, you can use the `LRANGE` command to get the latest state from the end of the queue:
+The response is written to a string key using `SET`. Because each message is a complete snapshot of the current state, the previous snapshots are not needed. You can read the values using the `GET` command:
 
-    redis:6379> LRANGE my-response-queue -1 -1
+    redis:6379> GET my-response-queue
 
-Alternatively, to get the latest state whilst clearing the queue you can use the `RPOP` command with a count:
+To get notified of updates to the value, you can `SUBSCRIBE` to [keyspace notifications] for the key:
 
-    redis:6379> RPOP my-response-queue 1000
+    redis:6379> SUBSCRIBE __keyspace@0__:my-response-queue
+
+[keyspace notifications]: https://redis.io/docs/manual/keyspace-notifications/
 
 ### Experimental properties
 

--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -345,7 +345,7 @@ class RedisQueueWorker:
         return resp.content
 
     def push_message(self, response_queue: str, response: Any) -> None:
-        self.redis.rpush(response_queue, json.dumps(response))
+        self.redis.set(response_queue, json.dumps(response))
 
     def upload_files(self, obj: Any) -> Any:
         def upload_file(fh: io.IOBase) -> str:

--- a/test-integration/test_integration/fixtures/failing-after-output-project/predict.py
+++ b/test-integration/test_integration/fixtures/failing-after-output-project/predict.py
@@ -1,12 +1,13 @@
-import time
+from time import sleep
 
 from cog import BasePredictor
 
 
 class Predictor(BasePredictor):
     def predict(self, text: str) -> str:
+        sleep(0.2)  # sleep to help test timing
         yield f"hello {text}"
-        time.sleep(0.5)
+        sleep(0.2)  # sleep to help test timing
         print("a printed log message")
-        time.sleep(0.5)
+        sleep(0.2)  # sleep to help test timing
         raise Exception("mid run error")

--- a/test-integration/test_integration/fixtures/logging-project/predict.py
+++ b/test-integration/test_integration/fixtures/logging-project/predict.py
@@ -20,6 +20,7 @@ class Predictor(BasePredictor):
         self.foo = "foo"
 
     def predict(self, text: str = "") -> str:
+        time.sleep(0.1)
         logging.warn("writing log message")
         time.sleep(0.1)
         libc.puts(b"writing from C")
@@ -29,4 +30,5 @@ class Predictor(BasePredictor):
         sys.stderr.flush()
         time.sleep(0.1)
         print("writing with print")
+        time.sleep(0.1)
         return "output"

--- a/test-integration/test_integration/fixtures/yielding-file-project/predict.py
+++ b/test-integration/test_integration/fixtures/yielding-file-project/predict.py
@@ -11,7 +11,7 @@ class Predictor(BasePredictor):
 
         predictions = ["foo", "bar", "baz"]
         for i, prediction in enumerate(predictions):
-            sleep(0.5)
+            sleep(0.2)  # sleep to help test timing
             out_path = Path(f"/tmp/out-{i}.txt")
             with out_path.open("w") as f:
                 f.write(prefix + " " + prediction)

--- a/test-integration/test_integration/fixtures/yielding-list-of-complex-output-project/predict.py
+++ b/test-integration/test_integration/fixtures/yielding-list-of-complex-output-project/predict.py
@@ -1,4 +1,5 @@
 import io
+from time import sleep
 from typing import Iterator, List
 
 from cog import BasePredictor, File
@@ -13,3 +14,4 @@ class Output(BaseModel):
 class Predictor(BasePredictor):
     def predict(self) -> Iterator[List[Output]]:
         yield [Output(text="hello", file=io.StringIO("hello"))]
+        sleep(0.2)  # sleep to help test timing

--- a/test-integration/test_integration/fixtures/yielding-project/predict.py
+++ b/test-integration/test_integration/fixtures/yielding-project/predict.py
@@ -1,3 +1,4 @@
+from time import sleep
 from typing import Iterator
 
 from cog import BasePredictor
@@ -5,6 +6,10 @@ from cog import BasePredictor
 
 class Predictor(BasePredictor):
     def predict(self, text: str) -> Iterator[str]:
+        sleep(0.2)  # sleep to help test timing
+
         predictions = ["foo", "bar", "baz"]
         for prediction in predictions:
             yield prediction
+
+        sleep(0.2)  # sleep to help test timing


### PR DESCRIPTION
We're sending complete snapshots, so we don't need to keep intermediate states. The downside of putting the complete states onto a regular list is that we're adding monotonically increasing snapshots to it. In extreme cases, the size and number of those items can overwhelm the Redis server.

Using a string key should also be slightly more resilient than popping off a list, as we don't lose the latest state if something goes wrong.

## TODO

- [x] Add tests
- [x] Update documentation
- [x] Finish serving support for Replicate