### PR TITLE
Update macos test version from 10.15 to 12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
-        platform: [ubuntu-20.04, macos-10.15]
+        platform: [ubuntu-20.04, macos-12]
     runs-on: ${{ matrix.platform }}
     defaults:
       run:


### PR DESCRIPTION
The 10.15 test runner is being deprecated: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/