### PR TITLE
Output multiple files

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -12,7 +12,8 @@ Tip: Run [`cog init`](getting-started-own-model#initialization) to generate an a
     - [Progressive output](#progressive-output)
 - [`Input(**kwargs)`](#inputkwargs)
 - [Output](#output)
-    - [Optional properties](#optional-output-properties)
+    - [Returning an object](#returning-an-object)
+    - [Returning a list](#returning-a-list)
 - [Input and output types](#input-and-output-types)
 - [`File()`](#file)
 - [`Path()`](#path)
@@ -79,6 +80,8 @@ class Predictor(BasePredictor):
             yield Path(output_path)
 ```
 
+
+
 ## `Input(**kwargs)`
 
 Use cog's `Input()` function to define each of the parameters in your `predict()` method:
@@ -129,7 +132,9 @@ class Predictor(BasePredictor):
         return "hello"
 ```
 
-To return a complex object with multiple values, you can define an `Output` object with multiple fields to return from your `predict()` method:
+### Returning an object
+
+To return a complex object with multiple values, define an `Output` object with multiple fields to return from your `predict()` method:
 
 ```py
 from cog import BasePredictor, BaseModel, File
@@ -144,6 +149,27 @@ class Predictor(BasePredictor):
 ```
 
 Each of the output object's properties must be one of the supported output types. For the full list, see [Input and output types](#input-and-output-types).
+
+### Returning a list
+
+The `predict()` method can return a list of any of the supported output types. Here's an example that outputs multiple files:
+
+```py
+from cog import BasePredictor, Path
+
+class Predictor(BasePredictor):
+    def predict(self) -> List[Path]:
+        predictions = ["foo", "bar", "baz"]
+        output = []
+        for i, prediction in enumerate(predictions):
+            out_path = Path(f"/tmp/out-{i}.txt")
+            with out_path.open("w") as f:
+                f.write(prediction)
+            output.append(out_path)
+        return output
+```
+
+Files are named in the format `output.<index>.<extension>`, e.g. `output.0.txt`, `output.1.txt`, and `output.2.txt` from the example above.
 
 ### Optional properties
 

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -145,10 +145,12 @@ func predictIndividualInputs(predictor predict.Predictor, inputFlags []string, o
 			return fmt.Errorf("Failed to decode dataurl: %w", err)
 		}
 		out = dataurlObj.Data
-		outputPath = "output"
-		extension := mime.ExtensionByType(dataurlObj.ContentType())
-		if extension != "" {
-			outputPath += extension
+		if outputPath == "" {
+			outputPath = "output"
+			extension := mime.ExtensionByType(dataurlObj.ContentType())
+			if extension != "" {
+				outputPath += extension
+			}
 		}
 	} else if outputSchema.Type == "string" {
 		// Handle strings separately because if we encode it to JSON it will be surrounded by quotes.

--- a/test-integration/test_integration/fixtures/file-list-output-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/file-list-output-project/cog.yaml
@@ -1,0 +1,3 @@
+build:
+  python_version: "3.8"
+predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/file-list-output-project/predict.py
+++ b/test-integration/test_integration/fixtures/file-list-output-project/predict.py
@@ -1,0 +1,15 @@
+from typing import List
+
+from cog import BasePredictor, Path
+
+
+class Predictor(BasePredictor):
+    def predict(self) -> List[Path]:
+        predictions = ["foo", "bar", "baz"]
+        output = []
+        for i, prediction in enumerate(predictions):
+            out_path = Path(f"/tmp/out-{i}.txt")
+            with out_path.open("w") as f:
+                f.write(prediction)
+            output.append(out_path)
+        return output

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -51,13 +51,28 @@ def test_predict_writes_files_to_files(tmpdir_factory):
     out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
     shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
     result = subprocess.run(
-        ["cog", "predict", "-o", out_dir / "out.txt"],
+        ["cog", "predict"],
         cwd=out_dir,
         check=True,
         capture_output=True,
     )
     assert result.stdout == b""
     with open(out_dir / "output.bmp", "rb") as f:
+        assert len(f.read()) == 195894
+
+
+def test_predict_writes_files_to_files_with_custom_name(tmpdir_factory):
+    project_dir = Path(__file__).parent / "fixtures/file-output-project"
+    out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
+    shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
+    result = subprocess.run(
+        ["cog", "predict", "-o", out_dir / "myoutput.bmp"],
+        cwd=out_dir,
+        check=True,
+        capture_output=True,
+    )
+    assert result.stdout == b""
+    with open(out_dir / "myoutput.bmp", "rb") as f:
         assert len(f.read()) == 195894
 
 

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -76,6 +76,28 @@ def test_predict_writes_files_to_files_with_custom_name(tmpdir_factory):
         assert len(f.read()) == 195894
 
 
+def test_predict_writes_multiple_files_to_files(tmpdir_factory):
+    project_dir = Path(__file__).parent / "fixtures/file-list-output-project"
+    out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
+    shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
+    result = subprocess.run(
+        [
+            "cog",
+            "predict",
+        ],
+        cwd=out_dir,
+        check=True,
+        capture_output=True,
+    )
+    assert result.stdout == b""
+    with open(out_dir / "output.0.txt", "r") as f:
+        assert f.read() == "foo"
+    with open(out_dir / "output.1.txt", "r") as f:
+        assert f.read() == "bar"
+    with open(out_dir / "output.2.txt", "r") as f:
+        assert f.read() == "baz"
+
+
 def test_predict_writes_strings_to_files(tmpdir_factory):
     project_dir = Path(__file__).parent / "fixtures/string-project"
     out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))


### PR DESCRIPTION
Lots of models output multiple files -- either progressive output or batches of files.

This pull request makes `cog predict` output them as `output.0.png`, `output.1.png`, etc. The test is pretty illustrative.