### PR TITLE
Report the reason for the Internal Server Error, if an Exception is thrown by predict()

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -95,6 +95,8 @@ Check that your predict function is in this form, where `output_type` is the sam
 """
             )
             raise HTTPException(status_code=500)
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
         finally:
             if request is not None and request.input is not None:
                 request.input.cleanup()


### PR DESCRIPTION
Hi,

This is a minor change for reporting the reason for an Internal Server Error, if an Exception is thrown by predict(). This is really helpful for REST API users to understand what failed, especially when using models created by others.

make test-python passed successfully.

Also tested this works correctly with a local docker container running the Stable Diffusion model from replicate, by triggering a scenario where it's supposed to throw an Exception.

I tested by modifying the docker container with this PR, created a docker image and container from that, and tested that it no longer threw an opaque "Internal Server Error" message, but instead described the error correctly.

Thanks

Signed-off-by: cmdr2 <secondary.cmdr2@gmail.com>