### PR TITLE
Resolve dependencies in `python_requirements`

### DIFF
--- a/pkg/config/compatibility.go
+++ b/pkg/config/compatibility.go
@@ -253,7 +253,7 @@ func CUDABaseImageFor(cuda string, cuDNN string) (string, error) {
 func tfGPUPackage(ver string, cuda string) (name string, cpuVersion string, err error) {
 	for _, compat := range TFCompatibilityMatrix {
 		if compat.TF == ver && version.Equal(compat.CUDA, cuda) {
-			return splitPythonPackage(compat.TFGPUPackage)
+			return splitPinnedPythonRequirement(compat.TFGPUPackage)
 		}
 	}
 	// We've already warned user if they're doing something stupid in validateAndCompleteCUDA(), so fail silently

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -163,7 +163,8 @@ func (c *Config) ValidateAndComplete(projectDir string) error {
 	return nil
 }
 
-func (c *Config) PythonPackagesForArch(goos string, goarch string) (packages []string, indexURLs []string, err error) {
+// PythonRequirementsForArch returns a requirements.txt file with all the GPU packages resolved for given OS and architecture.
+func (c *Config) PythonRequirementsForArch(goos string, goarch string) (packages []string, indexURLs []string, err error) {
 	packages = []string{}
 	indexURLSet := map[string]bool{}
 	for _, pkg := range c.Build.pythonRequirementsContent {
@@ -183,6 +184,8 @@ func (c *Config) PythonPackagesForArch(goos string, goarch string) (packages []s
 	return packages, indexURLs, nil
 }
 
+// pythonPackageForArch takes a package==version line and
+// returns a package==version and index URL resolved to the correct GPU package for the given OS and architecture
 func (c *Config) pythonPackageForArch(pkg string, goos string, goarch string) (actualPackage string, indexURL string, err error) {
 	name, version, err := splitPythonPackage(pkg)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -164,13 +164,13 @@ func (c *Config) ValidateAndComplete(projectDir string) error {
 }
 
 // PythonRequirementsForArch returns a requirements.txt file with all the GPU packages resolved for given OS and architecture.
-func (c *Config) PythonRequirementsForArch(goos string, goarch string) ([]string, error) {
+func (c *Config) PythonRequirementsForArch(goos string, goarch string) (string, error) {
 	packages := []string{}
 	indexURLSet := map[string]bool{}
 	for _, pkg := range c.Build.pythonRequirementsContent {
 		archPkg, indexURL, err := c.pythonPackageForArch(pkg, goos, goarch)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 		packages = append(packages, archPkg)
 		if indexURL != "" {
@@ -188,7 +188,7 @@ func (c *Config) PythonRequirementsForArch(goos string, goarch string) ([]string
 	// Then, everything else
 	lines = append(lines, packages...)
 
-	return lines, nil
+	return strings.Join(lines, "\n"), nil
 }
 
 // pythonPackageForArch takes a package==version line and

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -110,7 +110,7 @@ func (c *Config) pythonPackageVersion(name string) (version string, ok bool) {
 	return "", false
 }
 
-func (c *Config) ValidateAndCompleteConfig(projectDir string) error {
+func (c *Config) ValidateAndComplete(projectDir string) error {
 	// TODO(andreas): return all errors at once, rather than
 	// whack-a-mole one at a time with errs := []error{}, etc.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,7 +1,10 @@
 package config
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"path"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -13,19 +16,20 @@ import (
 // TODO(andreas): support conda packages
 // TODO(andreas): support dockerfiles
 // TODO(andreas): custom cpu/gpu installs
-// TODO(andreas): validate python_requirements
 // TODO(andreas): suggest valid torchvision versions (e.g. if the user wants to use 0.8.0, suggest 0.8.1)
 
 type Build struct {
 	GPU                bool     `json:"gpu,omitempty" yaml:"gpu"`
 	PythonVersion      string   `json:"python_version,omitempty" yaml:"python_version"`
 	PythonRequirements string   `json:"python_requirements,omitempty" yaml:"python_requirements"`
-	PythonPackages     []string `json:"python_packages,omitempty" yaml:"python_packages"`
+	PythonPackages     []string `json:"python_packages,omitempty" yaml:"python_packages"` // Deprecated, but included for backwards compatibility
 	Run                []string `json:"run,omitempty" yaml:"run"`
 	SystemPackages     []string `json:"system_packages,omitempty" yaml:"system_packages"`
 	PreInstall         []string `json:"pre_install,omitempty" yaml:"pre_install"` // Deprecated, but included for backwards compatibility
 	CUDA               string   `json:"cuda,omitempty" yaml:"cuda"`
 	CuDNN              string   `json:"cudnn,omitempty" yaml:"cudnn"`
+
+	pythonRequirementsContent []string
 }
 
 type Example struct {
@@ -92,7 +96,7 @@ func (c *Config) cudaFromTF() (tfVersion string, tfCUDA string, tfCuDNN string, 
 }
 
 func (c *Config) pythonPackageVersion(name string) (version string, ok bool) {
-	for _, pkg := range c.Build.PythonPackages {
+	for _, pkg := range c.Build.pythonRequirementsContent {
 		pkgName, version, err := splitPythonPackage(pkg)
 		if err != nil {
 			// this should be caught by validation earlier
@@ -106,7 +110,7 @@ func (c *Config) pythonPackageVersion(name string) (version string, ok bool) {
 	return "", false
 }
 
-func (c *Config) ValidateAndCompleteConfig() error {
+func (c *Config) ValidateAndCompleteConfig(projectDir string) error {
 	// TODO(andreas): return all errors at once, rather than
 	// whack-a-mole one at a time with errs := []error{}, etc.
 
@@ -124,6 +128,28 @@ func (c *Config) ValidateAndCompleteConfig() error {
 		}
 	}
 
+	if len(c.Build.PythonPackages) > 0 && c.Build.PythonRequirements != "" {
+		return fmt.Errorf("Only one of python_packages or python_requirements can be set in your cog.yaml, not both")
+	}
+
+	// Load python_requirements into memory to simplify reading it multiple times
+	if c.Build.PythonRequirements != "" {
+		fh, err := os.Open(path.Join(projectDir, c.Build.PythonRequirements))
+		if err != nil {
+			return err
+		}
+		// Use scanner to handle CRLF endings
+		scanner := bufio.NewScanner(fh)
+		for scanner.Scan() {
+			c.Build.pythonRequirementsContent = append(c.Build.pythonRequirementsContent, scanner.Text())
+		}
+	}
+
+	// Backwards compatibility
+	if len(c.Build.PythonPackages) > 0 {
+		c.Build.pythonRequirementsContent = c.Build.PythonPackages
+	}
+
 	if err := c.validatePythonPackagesHaveVersions(); err != nil {
 		return err
 	}
@@ -134,17 +160,13 @@ func (c *Config) ValidateAndCompleteConfig() error {
 		}
 	}
 
-	if len(c.Build.PythonPackages) > 0 && c.Build.PythonRequirements != "" {
-		return fmt.Errorf("Only one of python_packages or python_requirements can be set in your cog.yaml, not both")
-	}
-
 	return nil
 }
 
 func (c *Config) PythonPackagesForArch(goos string, goarch string) (packages []string, indexURLs []string, err error) {
 	packages = []string{}
 	indexURLSet := map[string]bool{}
-	for _, pkg := range c.Build.PythonPackages {
+	for _, pkg := range c.Build.pythonRequirementsContent {
 		archPkg, indexURL, err := c.pythonPackageForArch(pkg, goos, goarch)
 		if err != nil {
 			return nil, nil, err
@@ -294,7 +316,7 @@ Compatible cuDNN version is: %s`,
 
 func (c *Config) validatePythonPackagesHaveVersions() error {
 	packagesWithoutVersions := []string{}
-	for _, pkg := range c.Build.PythonPackages {
+	for _, pkg := range c.Build.pythonRequirementsContent {
 		_, _, err := splitPythonPackage(pkg)
 		if err != nil {
 			packagesWithoutVersions = append(packagesWithoutVersions, pkg)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -44,17 +44,16 @@ foo==1.0.0`), 0o644)
 	require.Equal(t, "11.0.3", config.Build.CUDA)
 	require.Equal(t, "8", config.Build.CuDNN)
 
-	packages, indexURLs, err := config.PythonRequirementsForArch("", "")
+	requirements, err := config.PythonRequirementsForArch("", "")
 	require.NoError(t, err)
-	expectedPackages := []string{
+	expected := []string{
+		"--find-links https://download.pytorch.org/whl/torch_stable.html",
 		"torch==1.7.1+cu110",
 		"torchvision==0.8.2+cu110",
 		"torchaudio==0.7.2",
 		"foo==1.0.0",
 	}
-	expectedIndexURLs := []string{"https://download.pytorch.org/whl/torch_stable.html"}
-	require.Equal(t, expectedPackages, packages)
-	require.Equal(t, expectedIndexURLs, indexURLs)
+	require.Equal(t, expected, requirements)
 }
 
 func TestValidateAndCompleteCUDAForAllTF(t *testing.T) {
@@ -215,17 +214,16 @@ func TestPythonPackagesForArchTorchGPU(t *testing.T) {
 	require.Equal(t, "10.1", config.Build.CUDA)
 	require.Equal(t, "8", config.Build.CuDNN)
 
-	packages, indexURLs, err := config.PythonRequirementsForArch("", "")
+	requirements, err := config.PythonRequirementsForArch("", "")
 	require.NoError(t, err)
-	expectedPackages := []string{
+	expected := []string{
+		"--find-links https://download.pytorch.org/whl/torch_stable.html",
 		"torch==1.7.1+cu101",
 		"torchvision==0.8.2+cu101",
 		"torchaudio==0.7.2",
 		"foo==1.0.0",
 	}
-	expectedIndexURLs := []string{"https://download.pytorch.org/whl/torch_stable.html"}
-	require.Equal(t, expectedPackages, packages)
-	require.Equal(t, expectedIndexURLs, indexURLs)
+	require.Equal(t, expected, requirements)
 }
 
 func TestPythonPackagesForArchTorchCPU(t *testing.T) {
@@ -245,17 +243,16 @@ func TestPythonPackagesForArchTorchCPU(t *testing.T) {
 	err := config.ValidateAndComplete("")
 	require.NoError(t, err)
 
-	packages, indexURLs, err := config.PythonRequirementsForArch("", "")
+	requirements, err := config.PythonRequirementsForArch("", "")
 	require.NoError(t, err)
-	expectedPackages := []string{
+	expected := []string{
+		"--find-links https://download.pytorch.org/whl/torch_stable.html",
 		"torch==1.7.1+cpu",
 		"torchvision==0.8.2+cpu",
 		"torchaudio==0.7.2",
 		"foo==1.0.0",
 	}
-	expectedIndexURLs := []string{"https://download.pytorch.org/whl/torch_stable.html"}
-	require.Equal(t, expectedPackages, packages)
-	require.Equal(t, expectedIndexURLs, indexURLs)
+	require.Equal(t, expected, requirements)
 }
 
 func TestPythonPackagesForArchTensorflowGPU(t *testing.T) {
@@ -275,15 +272,13 @@ func TestPythonPackagesForArchTensorflowGPU(t *testing.T) {
 	require.Equal(t, "10.0", config.Build.CUDA)
 	require.Equal(t, "7", config.Build.CuDNN)
 
-	packages, indexURLs, err := config.PythonRequirementsForArch("", "")
+	requirements, err := config.PythonRequirementsForArch("", "")
 	require.NoError(t, err)
-	expectedPackages := []string{
+	expected := []string{
 		"tensorflow_gpu==1.15.0",
 		"foo==1.0.0",
 	}
-	expectedIndexURLs := []string{}
-	require.Equal(t, expectedPackages, packages)
-	require.Equal(t, expectedIndexURLs, indexURLs)
+	require.Equal(t, expected, requirements)
 }
 
 func TestCUDABaseImageTag(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -19,7 +19,7 @@ func TestPythonPackagesAndRequirementsCantBeUsedTogether(t *testing.T) {
 			PythonRequirements: "requirements.txt",
 		},
 	}
-	err := config.ValidateAndCompleteConfig("")
+	err := config.ValidateAndComplete("")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Only one of python_packages or python_requirements can be set in your cog.yaml, not both")
 }
@@ -40,7 +40,7 @@ foo==1.0.0`), 0o644)
 			PythonRequirements: "requirements.txt",
 		},
 	}
-	err = config.ValidateAndCompleteConfig(tmpDir)
+	err = config.ValidateAndComplete(tmpDir)
 	require.NoError(t, err)
 	require.Equal(t, "11.0.3", config.Build.CUDA)
 	require.Equal(t, "8", config.Build.CuDNN)
@@ -70,7 +70,7 @@ func TestValidateAndCompleteCUDAForAllTF(t *testing.T) {
 			},
 		}
 
-		err := config.ValidateAndCompleteConfig("")
+		err := config.ValidateAndComplete("")
 		require.NoError(t, err)
 		require.Equal(t, compat.CUDA, config.Build.CUDA)
 		require.Equal(t, compat.CuDNN, config.Build.CuDNN)
@@ -90,7 +90,7 @@ func TestValidateAndCompleteCUDAForAllTorch(t *testing.T) {
 			},
 		}
 
-		err := config.ValidateAndCompleteConfig("")
+		err := config.ValidateAndComplete("")
 		require.NoError(t, err)
 		require.NotEqual(t, "", config.Build.CUDA)
 		require.NotEqual(t, "", config.Build.CuDNN)
@@ -115,7 +115,7 @@ func TestValidateAndCompleteCUDAForAllTorch(t *testing.T) {
 				},
 			},
 		}
-		err := config.ValidateAndCompleteConfig("")
+		err := config.ValidateAndComplete("")
 		require.NoError(t, err)
 		require.Equal(t, tt.cuda, config.Build.CUDA)
 		require.Equal(t, tt.cuDNN, config.Build.CuDNN)
@@ -138,7 +138,7 @@ func TestUnsupportedTorch(t *testing.T) {
 			},
 		},
 	}
-	err = config.ValidateAndCompleteConfig("")
+	err = config.ValidateAndComplete("")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Cog doesn't know what CUDA version is compatible with torch==0.4.1.")
 
@@ -152,7 +152,7 @@ func TestUnsupportedTorch(t *testing.T) {
 			},
 		},
 	}
-	err = config.ValidateAndCompleteConfig("")
+	err = config.ValidateAndComplete("")
 	require.NoError(t, err)
 	require.Equal(t, "9.1", config.Build.CUDA)
 	require.Equal(t, "7", config.Build.CuDNN)
@@ -211,7 +211,7 @@ func TestPythonPackagesForArchTorchGPU(t *testing.T) {
 			CUDA: "10.1",
 		},
 	}
-	err := config.ValidateAndCompleteConfig("")
+	err := config.ValidateAndComplete("")
 	require.NoError(t, err)
 	require.Equal(t, "10.1", config.Build.CUDA)
 	require.Equal(t, "8", config.Build.CuDNN)
@@ -243,7 +243,7 @@ func TestPythonPackagesForArchTorchCPU(t *testing.T) {
 			CUDA: "10.1",
 		},
 	}
-	err := config.ValidateAndCompleteConfig("")
+	err := config.ValidateAndComplete("")
 	require.NoError(t, err)
 
 	packages, indexURLs, err := config.PythonPackagesForArch("", "")
@@ -271,7 +271,7 @@ func TestPythonPackagesForArchTensorflowGPU(t *testing.T) {
 			CUDA: "10.0",
 		},
 	}
-	err := config.ValidateAndCompleteConfig("")
+	err := config.ValidateAndComplete("")
 	require.NoError(t, err)
 	require.Equal(t, "10.0", config.Build.CUDA)
 	require.Equal(t, "7", config.Build.CuDNN)
@@ -298,7 +298,7 @@ func TestCUDABaseImageTag(t *testing.T) {
 		},
 	}
 
-	err := config.ValidateAndCompleteConfig("")
+	err := config.ValidateAndComplete("")
 	require.NoError(t, err)
 
 	imageTag, err := config.CUDABaseImageTag()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -54,6 +54,49 @@ foo==1.0.0`
 	require.Equal(t, expected, requirements)
 }
 
+func TestPythonRequirementsWorksWithLinesCogCannotParse(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cog-test")
+	require.NoError(t, err)
+	err = os.WriteFile(path.Join(tmpDir, "requirements.txt"), []byte(`foo==1.0.0
+# a torch which already has a version
+torch==1.7.1+cu110
+# complex requirements
+fastapi>=0.6,<1
+flask>0.4
+# comments!
+# blank lines!
+
+# arguments
+-f http://example.com`), 0o644)
+	require.NoError(t, err)
+
+	config := &Config{
+		Build: &Build{
+			GPU:                true,
+			PythonVersion:      "3.8",
+			PythonRequirements: "requirements.txt",
+		},
+	}
+	err = config.ValidateAndComplete(tmpDir)
+	require.NoError(t, err)
+
+	requirements, err := config.PythonRequirementsForArch("", "")
+	require.NoError(t, err)
+	expected := `foo==1.0.0
+# a torch which already has a version
+torch==1.7.1+cu110
+# complex requirements
+fastapi>=0.6,<1
+flask>0.4
+# comments!
+# blank lines!
+
+# arguments
+-f http://example.com`
+	require.Equal(t, expected, requirements)
+
+}
+
 func TestValidateAndCompleteCUDAForAllTF(t *testing.T) {
 	for _, compat := range TFCompatibilityMatrix {
 		config := &Config{
@@ -172,7 +215,7 @@ func TestUnsupportedTensorflow(t *testing.T) {
 			},
 		},
 	}
-	err = config.validateAndCompleteCUDA()
+	err = config.ValidateAndComplete("")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Cog doesn't know what CUDA version is compatible with tensorflow==0.4.1.")
 
@@ -186,11 +229,10 @@ func TestUnsupportedTensorflow(t *testing.T) {
 			},
 		},
 	}
-	err = config.validateAndCompleteCUDA()
+	err = config.ValidateAndComplete("")
 	require.NoError(t, err)
 	require.Equal(t, "9.1", config.Build.CUDA)
 	require.Equal(t, "7", config.Build.CuDNN)
-
 }
 
 func TestPythonPackagesForArchTorchGPU(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -46,13 +46,11 @@ foo==1.0.0`), 0o644)
 
 	requirements, err := config.PythonRequirementsForArch("", "")
 	require.NoError(t, err)
-	expected := []string{
-		"--find-links https://download.pytorch.org/whl/torch_stable.html",
-		"torch==1.7.1+cu110",
-		"torchvision==0.8.2+cu110",
-		"torchaudio==0.7.2",
-		"foo==1.0.0",
-	}
+	expected := `--find-links https://download.pytorch.org/whl/torch_stable.html
+torch==1.7.1+cu110
+torchvision==0.8.2+cu110
+torchaudio==0.7.2
+foo==1.0.0`
 	require.Equal(t, expected, requirements)
 }
 
@@ -216,13 +214,11 @@ func TestPythonPackagesForArchTorchGPU(t *testing.T) {
 
 	requirements, err := config.PythonRequirementsForArch("", "")
 	require.NoError(t, err)
-	expected := []string{
-		"--find-links https://download.pytorch.org/whl/torch_stable.html",
-		"torch==1.7.1+cu101",
-		"torchvision==0.8.2+cu101",
-		"torchaudio==0.7.2",
-		"foo==1.0.0",
-	}
+	expected := `--find-links https://download.pytorch.org/whl/torch_stable.html
+torch==1.7.1+cu101
+torchvision==0.8.2+cu101
+torchaudio==0.7.2
+foo==1.0.0`
 	require.Equal(t, expected, requirements)
 }
 
@@ -245,13 +241,11 @@ func TestPythonPackagesForArchTorchCPU(t *testing.T) {
 
 	requirements, err := config.PythonRequirementsForArch("", "")
 	require.NoError(t, err)
-	expected := []string{
-		"--find-links https://download.pytorch.org/whl/torch_stable.html",
-		"torch==1.7.1+cpu",
-		"torchvision==0.8.2+cpu",
-		"torchaudio==0.7.2",
-		"foo==1.0.0",
-	}
+	expected := `--find-links https://download.pytorch.org/whl/torch_stable.html
+torch==1.7.1+cpu
+torchvision==0.8.2+cpu
+torchaudio==0.7.2
+foo==1.0.0`
 	require.Equal(t, expected, requirements)
 }
 
@@ -274,10 +268,8 @@ func TestPythonPackagesForArchTensorflowGPU(t *testing.T) {
 
 	requirements, err := config.PythonRequirementsForArch("", "")
 	require.NoError(t, err)
-	expected := []string{
-		"tensorflow_gpu==1.15.0",
-		"foo==1.0.0",
-	}
+	expected := `tensorflow_gpu==1.15.0
+foo==1.0.0`
 	require.Equal(t, expected, requirements)
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -44,7 +44,7 @@ foo==1.0.0`), 0o644)
 	require.Equal(t, "11.0.3", config.Build.CUDA)
 	require.Equal(t, "8", config.Build.CuDNN)
 
-	packages, indexURLs, err := config.PythonPackagesForArch("", "")
+	packages, indexURLs, err := config.PythonRequirementsForArch("", "")
 	require.NoError(t, err)
 	expectedPackages := []string{
 		"torch==1.7.1+cu110",
@@ -215,7 +215,7 @@ func TestPythonPackagesForArchTorchGPU(t *testing.T) {
 	require.Equal(t, "10.1", config.Build.CUDA)
 	require.Equal(t, "8", config.Build.CuDNN)
 
-	packages, indexURLs, err := config.PythonPackagesForArch("", "")
+	packages, indexURLs, err := config.PythonRequirementsForArch("", "")
 	require.NoError(t, err)
 	expectedPackages := []string{
 		"torch==1.7.1+cu101",
@@ -245,7 +245,7 @@ func TestPythonPackagesForArchTorchCPU(t *testing.T) {
 	err := config.ValidateAndComplete("")
 	require.NoError(t, err)
 
-	packages, indexURLs, err := config.PythonPackagesForArch("", "")
+	packages, indexURLs, err := config.PythonRequirementsForArch("", "")
 	require.NoError(t, err)
 	expectedPackages := []string{
 		"torch==1.7.1+cpu",
@@ -275,7 +275,7 @@ func TestPythonPackagesForArchTensorflowGPU(t *testing.T) {
 	require.Equal(t, "10.0", config.Build.CUDA)
 	require.Equal(t, "7", config.Build.CuDNN)
 
-	packages, indexURLs, err := config.PythonPackagesForArch("", "")
+	packages, indexURLs, err := config.PythonRequirementsForArch("", "")
 	require.NoError(t, err)
 	expectedPackages := []string{
 		"tensorflow_gpu==1.15.0",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -27,7 +26,7 @@ func TestPythonPackagesAndRequirementsCantBeUsedTogether(t *testing.T) {
 func TestPythonRequirementsResolvesPythonPackagesAndCudaVersions(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "cog-test")
 	require.NoError(t, err)
-	err = ioutil.WriteFile(path.Join(tmpDir, "requirements.txt"), []byte(`torch==1.7.1
+	err = os.WriteFile(path.Join(tmpDir, "requirements.txt"), []byte(`torch==1.7.1
 torchvision==0.8.2
 torchaudio==0.7.2
 foo==1.0.0`), 0o644)

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -43,7 +43,7 @@ func GetConfig(customDir string) (*Config, string, error) {
 		return nil, "", err
 	}
 
-	err = config.ValidateAndCompleteConfig()
+	err = config.ValidateAndCompleteConfig(rootDir)
 
 	return config, rootDir, err
 }

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -43,7 +43,7 @@ func GetConfig(customDir string) (*Config, string, error) {
 		return nil, "", err
 	}
 
-	err = config.ValidateAndCompleteConfig(rootDir)
+	err = config.ValidateAndComplete(rootDir)
 
 	return config, rootDir, err
 }

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -34,20 +34,12 @@ func TestGetConfigShouldLoadFromCustomDir(t *testing.T) {
 
 	err = ioutil.WriteFile(path.Join(dir, "cog.yaml"), []byte(testConfig), 0o644)
 	require.NoError(t, err)
+	err = ioutil.WriteFile(path.Join(dir, "requirements.txt"), []byte("torch==1.0.0"), 0o644)
+	require.NoError(t, err)
 	conf, _, err := GetConfig(dir)
 	require.NoError(t, err)
-	want := &Config{
-		Predict: "predict.py:SomePredictor",
-		Build: &Build{
-			PythonVersion:      "3.8",
-			PythonRequirements: "requirements.txt",
-			SystemPackages: []string{
-				"libgl1-mesa-glx",
-				"libglib2.0-0",
-			},
-		},
-	}
-	require.Equal(t, want, conf)
+	require.Equal(t, conf.Predict, "predict.py:SomePredictor")
+	require.Equal(t, conf.Build.PythonVersion, "3.8")
 }
 
 func TestFindProjectRootDirShouldFindParentDir(t *testing.T) {

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -197,15 +197,15 @@ func (g *Generator) installCog() (string, error) {
 }
 
 func (g *Generator) pipInstalls() (string, error) {
-	packages, err := g.Config.PythonRequirementsForArch(g.GOOS, g.GOARCH)
+	requirements, err := g.Config.PythonRequirementsForArch(g.GOOS, g.GOARCH)
 	if err != nil {
 		return "", err
 	}
-	if len(packages) == 0 {
+	if strings.Trim(requirements, "") == "" {
 		return "", nil
 	}
 
-	lines, containerPath, err := g.writeTemp("requirements.txt", []byte(strings.Join(packages, "\n")))
+	lines, containerPath, err := g.writeTemp("requirements.txt", []byte(requirements))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -72,11 +72,6 @@ func (g *Generator) GenerateBase() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	pythonRequirements, err := g.pythonRequirements()
-	if err != nil {
-		return "", err
-
-	}
 	pipInstalls, err := g.pipInstalls()
 	if err != nil {
 		return "", err
@@ -97,7 +92,6 @@ func (g *Generator) GenerateBase() (string, error) {
 		installPython,
 		installCog,
 		aptInstalls,
-		pythonRequirements,
 		pipInstalls,
 		run,
 		`WORKDIR /src`,
@@ -203,15 +197,6 @@ func (g *Generator) installCog() (string, error) {
 	}
 	return fmt.Sprintf(`COPY %s /tmp/%s
 RUN --mount=type=cache,target=/root/.cache/pip pip install /tmp/%s`, path.Join(g.relativeTmpDir, cogFilename), cogFilename, cogFilename), nil
-}
-
-func (g *Generator) pythonRequirements() (string, error) {
-	reqs := g.Config.Build.PythonRequirements
-	if reqs == "" {
-		return "", nil
-	}
-	return fmt.Sprintf(`COPY %s /tmp/requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt`, reqs), nil
 }
 
 func (g *Generator) pipInstalls() (string, error) {

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -197,7 +197,7 @@ func (g *Generator) installCog() (string, error) {
 }
 
 func (g *Generator) pipInstalls() (string, error) {
-	packages, indexURLs, err := g.Config.PythonRequirementsForArch(g.GOOS, g.GOARCH)
+	packages, err := g.Config.PythonRequirementsForArch(g.GOOS, g.GOARCH)
 	if err != nil {
 		return "", err
 	}
@@ -210,12 +210,7 @@ func (g *Generator) pipInstalls() (string, error) {
 		return "", err
 	}
 
-	findLinks := ""
-	for _, indexURL := range indexURLs {
-		findLinks += "-f " + indexURL + " "
-	}
-
-	lines = append(lines, "RUN --mount=type=cache,target=/root/.cache/pip pip install "+findLinks+" -r "+containerPath)
+	lines = append(lines, "RUN --mount=type=cache,target=/root/.cache/pip pip install -r "+containerPath)
 	return strings.Join(lines, "\n"), nil
 }
 

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -197,7 +197,7 @@ func (g *Generator) installCog() (string, error) {
 }
 
 func (g *Generator) pipInstalls() (string, error) {
-	packages, indexURLs, err := g.Config.PythonPackagesForArch(g.GOOS, g.GOARCH)
+	packages, indexURLs, err := g.Config.PythonRequirementsForArch(g.GOOS, g.GOARCH)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -205,12 +205,18 @@ func (g *Generator) pipInstalls() (string, error) {
 		return "", nil
 	}
 
+	lines, containerPath, err := g.writeTemp("requirements.txt", []byte(strings.Join(packages, "\n")))
+	if err != nil {
+		return "", err
+	}
+
 	findLinks := ""
 	for _, indexURL := range indexURLs {
 		findLinks += "-f " + indexURL + " "
 	}
 
-	return "RUN --mount=type=cache,target=/root/.cache/pip pip install " + findLinks + " " + strings.Join(packages, " "), nil
+	lines = append(lines, "RUN --mount=type=cache,target=/root/.cache/pip pip install "+findLinks+" -r "+containerPath)
+	return strings.Join(lines, "\n"), nil
 }
 
 func (g *Generator) run() (string, error) {

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -144,7 +144,7 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia
 ` + testInstallCog(gen.relativeTmpDir) + `
 RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip pip install -f https://download.pytorch.org/whl/torch_stable.html  -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r /tmp/requirements.txt
 RUN cowsay moo
 WORKDIR /src
 EXPOSE 5000
@@ -155,7 +155,8 @@ COPY . /src`
 	requirements, err := ioutil.ReadFile(path.Join(gen.tmpDir, "requirements.txt"))
 	require.NoError(t, err)
 
-	require.Equal(t, `torch==1.5.1+cpu
+	require.Equal(t, `--find-links https://download.pytorch.org/whl/torch_stable.html
+torch==1.5.1+cpu
 pandas==1.2.0.12`, string(requirements))
 }
 
@@ -196,7 +197,7 @@ RUN rm -f /etc/apt/sources.list.d/cuda.list && \
 		testInstallCog(gen.relativeTmpDir) + `
 RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip pip install  -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r /tmp/requirements.txt
 RUN cowsay moo
 WORKDIR /src
 EXPOSE 5000
@@ -264,5 +265,5 @@ build:
 	actual, err := gen.Generate()
 	require.NoError(t, err)
 	fmt.Println(actual)
-	require.Contains(t, actual, `pip install  -r /tmp/requirements.txt`)
+	require.Contains(t, actual, `pip install -r /tmp/requirements.txt`)
 }

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -2,7 +2,9 @@ package dockerfile
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -55,7 +57,7 @@ build:
 predict: predict.py:Predictor
 `))
 	require.NoError(t, err)
-	require.NoError(t, conf.ValidateAndCompleteConfig())
+	require.NoError(t, conf.ValidateAndCompleteConfig(""))
 
 	gen, err := NewGenerator(conf, tmpDir)
 	require.NoError(t, err)
@@ -86,7 +88,7 @@ build:
 predict: predict.py:Predictor
 `))
 	require.NoError(t, err)
-	require.NoError(t, conf.ValidateAndCompleteConfig())
+	require.NoError(t, conf.ValidateAndCompleteConfig(""))
 	gen, err := NewGenerator(conf, tmpDir)
 	require.NoError(t, err)
 	actual, err := gen.Generate()
@@ -127,7 +129,7 @@ build:
 predict: predict.py:Predictor
 `))
 	require.NoError(t, err)
-	require.NoError(t, conf.ValidateAndCompleteConfig())
+	require.NoError(t, conf.ValidateAndCompleteConfig(""))
 
 	gen, err := NewGenerator(conf, tmpDir)
 	require.NoError(t, err)
@@ -168,7 +170,7 @@ build:
 predict: predict.py:Predictor
 `))
 	require.NoError(t, err)
-	require.NoError(t, conf.ValidateAndCompleteConfig())
+	require.NoError(t, conf.ValidateAndCompleteConfig(""))
 
 	gen, err := NewGenerator(conf, tmpDir)
 	require.NoError(t, err)
@@ -209,7 +211,7 @@ build:
     - "cowsay moo"
 `))
 	require.NoError(t, err)
-	require.NoError(t, conf.ValidateAndCompleteConfig())
+	require.NoError(t, conf.ValidateAndCompleteConfig(""))
 
 	gen, err := NewGenerator(conf, tmpDir)
 	require.NoError(t, err)
@@ -233,19 +235,21 @@ COPY . /src`
 }
 
 func TestPythonRequirements(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "test")
+	tmpDir, err := os.MkdirTemp("", "cog-test")
+	require.NoError(t, err)
+	err = ioutil.WriteFile(path.Join(tmpDir, "my-requirements.txt"), []byte("torch==1.0.0"), 0o644)
 	require.NoError(t, err)
 	conf, err := config.FromYAML([]byte(`
 build:
   python_requirements: "my-requirements.txt"
 `))
 	require.NoError(t, err)
-	require.NoError(t, conf.ValidateAndCompleteConfig())
+	require.NoError(t, conf.ValidateAndCompleteConfig(tmpDir))
 
 	gen, err := NewGenerator(conf, tmpDir)
 	require.NoError(t, err)
 	actual, err := gen.Generate()
 	require.NoError(t, err)
-	require.Contains(t, actual, `COPY my-requirements.txt /tmp/requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt`)
+	fmt.Println(actual)
+	require.Contains(t, actual, `pip install  torch==1.0.0`)
 }

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -57,7 +57,7 @@ build:
 predict: predict.py:Predictor
 `))
 	require.NoError(t, err)
-	require.NoError(t, conf.ValidateAndCompleteConfig(""))
+	require.NoError(t, conf.ValidateAndComplete(""))
 
 	gen, err := NewGenerator(conf, tmpDir)
 	require.NoError(t, err)
@@ -88,7 +88,7 @@ build:
 predict: predict.py:Predictor
 `))
 	require.NoError(t, err)
-	require.NoError(t, conf.ValidateAndCompleteConfig(""))
+	require.NoError(t, conf.ValidateAndComplete(""))
 	gen, err := NewGenerator(conf, tmpDir)
 	require.NoError(t, err)
 	actual, err := gen.Generate()
@@ -129,7 +129,7 @@ build:
 predict: predict.py:Predictor
 `))
 	require.NoError(t, err)
-	require.NoError(t, conf.ValidateAndCompleteConfig(""))
+	require.NoError(t, conf.ValidateAndComplete(""))
 
 	gen, err := NewGenerator(conf, tmpDir)
 	require.NoError(t, err)
@@ -170,7 +170,7 @@ build:
 predict: predict.py:Predictor
 `))
 	require.NoError(t, err)
-	require.NoError(t, conf.ValidateAndCompleteConfig(""))
+	require.NoError(t, conf.ValidateAndComplete(""))
 
 	gen, err := NewGenerator(conf, tmpDir)
 	require.NoError(t, err)
@@ -211,7 +211,7 @@ build:
     - "cowsay moo"
 `))
 	require.NoError(t, err)
-	require.NoError(t, conf.ValidateAndCompleteConfig(""))
+	require.NoError(t, conf.ValidateAndComplete(""))
 
 	gen, err := NewGenerator(conf, tmpDir)
 	require.NoError(t, err)
@@ -244,7 +244,7 @@ build:
   python_requirements: "my-requirements.txt"
 `))
 	require.NoError(t, err)
-	require.NoError(t, conf.ValidateAndCompleteConfig(tmpDir))
+	require.NoError(t, conf.ValidateAndComplete(tmpDir))
 
 	gen, err := NewGenerator(conf, tmpDir)
 	require.NoError(t, err)


### PR DESCRIPTION
This is a partial implementation of #157 that is mostly backwards compatible.

Previously, we read `python_packages`, did our clever processing on it to resolve PyTorch/Tensorflow versions, then inserted it into the `Dockerfile` as a long `pip install` line. There was also an undocumented `python_requirements` option that naively did `pip install -r requirements.txt` without any dependency resolution.

In #157, we want to migrate to using `python_requirements` instead, and do our clever processing on `requirements.txt`. This pull request is a step towards that.

It does a few things:

- `python_requirements` is read into the system that does our clever dependency resolution. Lines that are not able to be processed by Cog (anything that's not `package==version`) are ignored.
- `python_packages` is fed into the same system for backwards compatibility, as before.
- The requirements are written to a temporary `requirements.txt` file instead of a long `pip install` command, which makes it more robust and means we aren't trying to do shell escaping.

We're still missing a few things like informational messages to the user and documentation. It's backwards compatible-ish, so should be fine to leave that. The rest of the work is tracked in #157.

Commits are significant and deliberate.

## Backwards incompatibility

The minor thing that is not backwards incompatible is that in previous versions of Cog, if you did something like `torch>1.12`, Cog would complain hard that it did not understand it.

In this PR, it will silently be passed straight through and Cog won't do any dependency resolution. #157 intends to add some more useful messages to tell the user what is going on here.

## Todo

- [x] Define Python requirements with `requirements.txt` and `python_requirements`
- [x] Make `python_packages` generate a `requirements.txt` for backwards compatibility
- [x] Parse `python_requirements` to determine versions