### PR TITLE
Push package to PyPi

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,3 +121,17 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Python package
+        run: |
+          # clean package built for go client
+          rm -rf python/dist
+          # set version
+          sed -i -E "s/0.0.1/${GITHUB_REF_NAME:1}/" setup.py
+          # build package
+          python setup.py bdist_wheel
+      - name: Push Python package
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+          packages_dir: python/dist


### PR DESCRIPTION
Push the exact thing we install inside the container to PyPi.

This is not well documented – it's not clear how to use the PyPi package standalone. In short, you can run `python -m cog.server.http`, so long as there's a `cog.yaml` with a `predictor` key in it. Not ideal, but we can fix this up later.

I have tested this little script locally, but not tested the actual push to PyPi obviously. We can fix it live if it doesn't work. I have set the `PYPI_TOKEN` secret.

Closes #146