### PR TITLE
Alternate method for fetching Torch versions

### DIFF
--- a/tools/generate_compatibility_matrices/main.go
+++ b/tools/generate_compatibility_matrices/main.go
@@ -170,6 +170,25 @@ type pypiResponse struct {
 	} `json:"info"`
 }
 
+func fetchTorchVersions() ([]config.TorchCompatibility, error) {
+	compats := []config.TorchCompatibility{}
+	linkRe := regexp.MustCompile(``)
+
+	url := "https://download.pytorch.org/whl/torch_stable.html"
+	resp, err := soup.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to download %s: %w", url, err)
+	}
+	doc := soup.HTMLParse(resp)
+	links := doc.FindAll("a")
+	for _, link := range links {
+		href := link.Attrs()["href"]
+
+	}
+
+	return compats, nil
+}
+
 // Need to get latest versions because PyTorch doesn't specify versions for latest
 func fetchDefaultVersions() (map[string]string, error) {
 	fmt.Println("Fetching default versions...")


### PR DESCRIPTION
https://pytorch.org/get-started/previous-versions/ is no longer kept up to date.

The best solution is probably to manually keep the Torch compatibility matrix up to date. Scraping is so messy and error prone, and releases are infrequent enough.

An alternate approach could be to scrape all the possible package versions: https://download.pytorch.org/whl/torch_stable.html

This pull request is the start of an attempt to do that. I stopped half way through because I realized that this page doesn't gives all the information we need except which torch/vision/audio versions are compatible with each other.

Back to manually updating...