### PR TITLE
Update response schema

### DIFF
--- a/docs/redis.md
+++ b/docs/redis.md
@@ -102,6 +102,8 @@ If the model yields [progressive output](python.md#progressive-output) then a mi
         "started_at": "2022-09-22T14:31:17Z"
     }
 
+Additionally, Cog will include in the response any fields which sent as part of the request, including `input` and `webhook`.
+
 ### Redis responses
 
 Note: this section documents a deprecated feature, which will be removed in a future version of Cog.

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -67,6 +67,8 @@ The message body is a JSON object with the following fields:
 - `output`: The return value of the `predict()` function.
 - `logs`: A list of any logs sent to stdout or stderr during the prediction.
 - `error`: If `status` is `failed`, the error message.
+- `started_at`: An ISO8601/RFC3339 timestamp of when the prediction started.
+- `completed_at`: An ISO8601/RFC3339 timestamp of when the prediction finished.
 
 For example, a message early in the prediction might look like:
 
@@ -76,7 +78,8 @@ For example, a message early in the prediction might look like:
         "logs": [
             "Creating model and diffusion.",
             "Done creating model and diffusion."
-        ]
+        ],
+        "started_at": "2022-09-22T14:31:17Z"
     }
 
 If the model yields [progressive output](python.md#progressive-output) then a mid-prediction message might look like:
@@ -94,7 +97,8 @@ If the model yields [progressive output](python.md#progressive-output) then a mi
             "Iteration: 0, loss: -0.767578125",
             "Iteration: 20, loss: -1.2333984375",
             "Iteration: 40, loss: -1.380859375"
-        ]
+        ],
+        "started_at": "2022-09-22T14:31:17Z"
     }
 
 ### Redis responses
@@ -110,14 +114,6 @@ To get notified of updates to the value, you can `SUBSCRIBE` to [keyspace notifi
     redis:6379> SUBSCRIBE __keyspace@0__:my-response-queue
 
 [keyspace notifications]: https://redis.io/docs/manual/keyspace-notifications/
-
-### Experimental properties
-
-The response may also include experimental properties, prefixed with `x-experimental-`. Experimental properties may change or be removed in any version, not just major versions that would ordinarily be used to indicate a breaking change. Any such change will be documented in release notes.
-
-Current experimental properties are:
-
-- `x-experimental-timestamps`: the time the prediction started and finished.
 
 ## Telemetry
 

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -69,6 +69,7 @@ The message body is a JSON object with the following fields:
 - `error`: If `status` is `failed`, the error message.
 - `started_at`: An ISO8601/RFC3339 timestamp of when the prediction started.
 - `completed_at`: An ISO8601/RFC3339 timestamp of when the prediction finished.
+- `metrics.predict_time`: If succeeded, the time in seconds the prediction took to finish.
 
 For example, a message early in the prediction might look like:
 

--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -198,9 +198,9 @@ class RedisQueueWorker:
                     except Exception as e:
                         response["status"] = Status.FAILED
                         response["error"] = str(e)
-                        response["x-experimental-timestamps"][
-                            "completed_at"
-                        ] = datetime.datetime.now().isoformat()
+                        response["completed_at"] = (
+                            datetime.datetime.now().isoformat() + "Z"
+                        )
                         send_response(response)
                         self.redis.xack(self.input_queue, self.input_queue, message_id)
                         self.redis.xdel(self.input_queue, message_id)
@@ -242,9 +242,7 @@ class RedisQueueWorker:
 
         self.runner.run(**input_obj.dict())
 
-        response["x-experimental-timestamps"] = {
-            "started_at": datetime.datetime.now().isoformat()
-        }
+        response["started_at"] = datetime.datetime.now().isoformat() + "Z"
 
         logs: List[str] = []
         response["logs"] = logs
@@ -260,9 +258,7 @@ class RedisQueueWorker:
         if self.runner.error() is not None:
             response["status"] = Status.FAILED
             response["error"] = str(self.runner.error())  # type: ignore
-            response["x-experimental-timestamps"][
-                "completed_at"
-            ] = datetime.datetime.now().isoformat()
+            response["completed_at"] = datetime.datetime.now().isoformat() + "Z"
             send_response(response)
             span.record_exception(self.runner.error())
             span.set_status(TraceStatus(status_code=StatusCode.ERROR))
@@ -298,9 +294,7 @@ class RedisQueueWorker:
             if self.runner.error() is not None:
                 response["status"] = Status.FAILED
                 response["error"] = str(self.runner.error())  # type: ignore
-                response["x-experimental-timestamps"][
-                    "completed_at"
-                ] = datetime.datetime.now().isoformat()
+                response["completed_at"] = datetime.datetime.now().isoformat() + "Z"
                 send_response(response)
                 span.record_exception(self.runner.error())
                 span.set_status(TraceStatus(status_code=StatusCode.ERROR))
@@ -309,9 +303,7 @@ class RedisQueueWorker:
             span.add_event("received final output")
 
             response["status"] = Status.SUCCEEDED
-            response["x-experimental-timestamps"][
-                "completed_at"
-            ] = datetime.datetime.now().isoformat()
+            response["completed_at"] = datetime.datetime.now().isoformat() + "Z"
             output.extend(self.upload_files(o) for o in self.runner.read_output())
             logs.extend(self.runner.read_logs())
             send_response(response)
@@ -326,9 +318,7 @@ class RedisQueueWorker:
             if self.runner.error() is not None:
                 response["status"] = Status.FAILED
                 response["error"] = str(self.runner.error())  # type: ignore
-                response["x-experimental-timestamps"][
-                    "completed_at"
-                ] = datetime.datetime.now().isoformat()
+                response["completed_at"] = datetime.datetime.now().isoformat() + "Z"
                 send_response(response)
                 span.record_exception(self.runner.error())
                 span.set_status(TraceStatus(status_code=StatusCode.ERROR))
@@ -338,9 +328,7 @@ class RedisQueueWorker:
             assert len(output) == 1
 
             response["status"] = Status.SUCCEEDED
-            response["x-experimental-timestamps"][
-                "completed_at"
-            ] = datetime.datetime.now().isoformat()
+            response["completed_at"] = datetime.datetime.now().isoformat() + "Z"
             response["output"] = self.upload_files(output[0])
             logs.extend(self.runner.read_logs())
             send_response(response)

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -74,6 +74,9 @@ def test_queue_worker_files(
                 "status": "succeeded",
                 "started_at": mock.ANY,
                 "completed_at": mock.ANY,
+                "metrics": {
+                    "predict_time": mock.ANY,
+                },
             },
             method="POST",
         ).respond_with_handler(capture_final_response)
@@ -115,6 +118,7 @@ def test_queue_worker_files(
             r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z",
             final_response["completed_at"],
         )
+        assert type(final_response["metrics"]["predict_time"]) == float
 
         with open(upload_server / "output.txt") as f:
             assert f.read() == "foobaztest"
@@ -209,6 +213,9 @@ def test_queue_worker_yielding_file(
                 "status": "succeeded",
                 "started_at": mock.ANY,
                 "completed_at": mock.ANY,
+                "metrics": {
+                    "predict_time": mock.ANY,
+                },
             },
             method="POST",
         )
@@ -300,6 +307,9 @@ def test_queue_worker_yielding(docker_network, docker_image, redis_client, https
                 "status": "succeeded",
                 "started_at": mock.ANY,
                 "completed_at": mock.ANY,
+                "metrics": {
+                    "predict_time": mock.ANY,
+                },
             },
             method="POST",
         )
@@ -723,6 +733,9 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client, httpse
                 "status": "succeeded",
                 "started_at": mock.ANY,
                 "completed_at": mock.ANY,
+                "metrics": {
+                    "predict_time": mock.ANY,
+                },
             },
             method="POST",
         )
@@ -795,6 +808,9 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
                 "status": "succeeded",
                 "started_at": mock.ANY,
                 "completed_at": mock.ANY,
+                "metrics": {
+                    "predict_time": mock.ANY,
+                },
             },
             method="POST",
         )
@@ -891,6 +907,9 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
                 "status": "succeeded",
                 "started_at": mock.ANY,
                 "completed_at": mock.ANY,
+                "metrics": {
+                    "predict_time": mock.ANY,
+                },
             },
             method="POST",
         )
@@ -971,6 +990,9 @@ def test_queue_worker_yielding_timeout(
                 "status": "succeeded",
                 "started_at": mock.ANY,
                 "completed_at": mock.ANY,
+                "metrics": {
+                    "predict_time": mock.ANY,
+                },
             },
             method="POST",
         )
@@ -1118,6 +1140,9 @@ def test_queue_worker_complex_output(
                 "status": "succeeded",
                 "started_at": mock.ANY,
                 "completed_at": mock.ANY,
+                "metrics": {
+                    "predict_time": mock.ANY,
+                },
             },
             method="POST",
         )
@@ -1224,6 +1249,9 @@ def test_queue_worker_yielding_list_of_complex_output(
                 "status": "succeeded",
                 "started_at": mock.ANY,
                 "completed_at": mock.ANY,
+                "metrics": {
+                    "predict_time": mock.ANY,
+                },
             },
             method="POST",
         )
@@ -1403,6 +1431,9 @@ def test_queue_worker_redis_responses(docker_network, docker_image, redis_client
             "status": "succeeded",
             "started_at": mock.ANY,
             "completed_at": mock.ANY,
+            "metrics": {
+                "predict_time": mock.ANY,
+            },
         }
 
 

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -54,9 +54,7 @@ def test_queue_worker_files(
                 "logs": [],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -74,10 +72,8 @@ def test_queue_worker_files(
                 "logs": [],
                 "output": "http://upload-server:5000/download/output.txt",
                 "status": "succeeded",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                    "completed_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
+                "completed_at": mock.ANY,
             },
             method="POST",
         ).respond_with_handler(capture_final_response)
@@ -112,12 +108,12 @@ def test_queue_worker_files(
         assert waiting.result
 
         assert re.match(
-            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}",
-            final_response["x-experimental-timestamps"]["started_at"],
+            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z",
+            final_response["started_at"],
         )
         assert re.match(
-            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}",
-            final_response["x-experimental-timestamps"]["completed_at"],
+            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z",
+            final_response["completed_at"],
         )
 
         with open(upload_server / "output.txt") as f:
@@ -156,9 +152,7 @@ def test_queue_worker_yielding_file(
                 "logs": [],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -169,9 +163,7 @@ def test_queue_worker_yielding_file(
                 "logs": [],
                 "output": ["http://upload-server:5000/download/out-0.txt"],
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -185,9 +177,7 @@ def test_queue_worker_yielding_file(
                     "http://upload-server:5000/download/out-1.txt",
                 ],
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -202,9 +192,7 @@ def test_queue_worker_yielding_file(
                     "http://upload-server:5000/download/out-2.txt",
                 ],
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -219,10 +207,8 @@ def test_queue_worker_yielding_file(
                     "http://upload-server:5000/download/out-2.txt",
                 ],
                 "status": "succeeded",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                    "completed_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
+                "completed_at": mock.ANY,
             },
             method="POST",
         )
@@ -290,9 +276,7 @@ def test_queue_worker_yielding(docker_network, docker_image, redis_client, https
                 "logs": [],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -303,9 +287,7 @@ def test_queue_worker_yielding(docker_network, docker_image, redis_client, https
                 "logs": [],
                 "output": ["foo", "bar", "baz"],
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -316,10 +298,8 @@ def test_queue_worker_yielding(docker_network, docker_image, redis_client, https
                 "logs": [],
                 "output": ["foo", "bar", "baz"],
                 "status": "succeeded",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                    "completed_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
+                "completed_at": mock.ANY,
             },
             method="POST",
         )
@@ -380,9 +360,7 @@ def test_queue_worker_error(docker_network, docker_image, redis_client, httpserv
                 "logs": [],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -397,9 +375,7 @@ def test_queue_worker_error(docker_network, docker_image, redis_client, httpserv
                 "logs": mock.ANY,  # includes a stack trace
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         ).respond_with_data("OK")
@@ -417,10 +393,8 @@ def test_queue_worker_error(docker_network, docker_image, redis_client, httpserv
                 "logs": mock.ANY,  # might include a stack trace (see above)
                 "output": None,
                 "status": "failed",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                    "completed_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
+                "completed_at": mock.ANY,
             },
             method="POST",
         ).respond_with_handler(capture_final_response)
@@ -483,9 +457,7 @@ def test_queue_worker_error_after_output(
                 "logs": [],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -496,9 +468,7 @@ def test_queue_worker_error_after_output(
                 "logs": [],
                 "output": ["hello bar"],
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -509,9 +479,7 @@ def test_queue_worker_error_after_output(
                 "logs": ["a printed log message"],
                 "output": ["hello bar"],
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -525,9 +493,7 @@ def test_queue_worker_error_after_output(
                 "logs": mock.ANY,  # includes a stack trace
                 "output": ["hello bar"],
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         ).respond_with_data("OK")
@@ -545,10 +511,8 @@ def test_queue_worker_error_after_output(
                 "logs": mock.ANY,  # might include a stack trace
                 "output": ["hello bar"],
                 "status": "failed",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                    "completed_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
+                "completed_at": mock.ANY,
             },
             method="POST",
         ).respond_with_handler(capture_final_response)
@@ -683,9 +647,7 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client, httpse
                 "logs": [],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -698,9 +660,7 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client, httpse
                 ],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -714,9 +674,7 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client, httpse
                 ],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -731,9 +689,7 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client, httpse
                 ],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -749,9 +705,7 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client, httpse
                 ],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -767,10 +721,8 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client, httpse
                 ],
                 "output": "output",
                 "status": "succeeded",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                    "completed_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
+                "completed_at": mock.ANY,
             },
             method="POST",
         )
@@ -830,9 +782,7 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
                 "logs": [],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -843,10 +793,8 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
                 "logs": [],
                 "output": "it worked after 0.1 seconds!",
                 "status": "succeeded",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                    "completed_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
+                "completed_at": mock.ANY,
             },
             method="POST",
         )
@@ -885,9 +833,7 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
                 "logs": [],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -899,10 +845,8 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
                 "logs": [],
                 "output": None,
                 "status": "failed",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                    "completed_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
+                "completed_at": mock.ANY,
             },
             method="POST",
         )
@@ -934,9 +878,7 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
                 "logs": [],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -947,10 +889,8 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
                 "logs": [],
                 "output": "it worked after 0.2 seconds!",
                 "status": "succeeded",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                    "completed_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
+                "completed_at": mock.ANY,
             },
             method="POST",
         )
@@ -1007,9 +947,7 @@ def test_queue_worker_yielding_timeout(
                 "logs": [],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -1020,9 +958,7 @@ def test_queue_worker_yielding_timeout(
                 "logs": [],
                 "output": ["yield 0"],
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -1033,10 +969,8 @@ def test_queue_worker_yielding_timeout(
                 "logs": [],
                 "output": ["yield 0"],
                 "status": "succeeded",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                    "completed_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
+                "completed_at": mock.ANY,
             },
             method="POST",
         )
@@ -1076,9 +1010,7 @@ def test_queue_worker_yielding_timeout(
                 "logs": [],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -1089,9 +1021,7 @@ def test_queue_worker_yielding_timeout(
                 "logs": [],
                 "output": ["yield 0"],
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -1102,9 +1032,7 @@ def test_queue_worker_yielding_timeout(
                 "logs": [],
                 "output": ["yield 0", "yield 1"],
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -1116,10 +1044,8 @@ def test_queue_worker_yielding_timeout(
                 "logs": [],
                 "output": ["yield 0", "yield 1"],
                 "status": "failed",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                    "completed_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
+                "completed_at": mock.ANY,
             },
             method="POST",
         )
@@ -1176,9 +1102,7 @@ def test_queue_worker_complex_output(
                 "logs": [],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -1192,10 +1116,8 @@ def test_queue_worker_complex_output(
                     "goodbye": "goodbye world",
                 },
                 "status": "succeeded",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                    "completed_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
+                "completed_at": mock.ANY,
             },
             method="POST",
         )
@@ -1264,9 +1186,7 @@ def test_queue_worker_yielding_list_of_complex_output(
                 "logs": [],
                 "output": None,
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -1284,9 +1204,7 @@ def test_queue_worker_yielding_list_of_complex_output(
                     ]
                 ],
                 "status": "processing",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
             },
             method="POST",
         )
@@ -1304,10 +1222,8 @@ def test_queue_worker_yielding_list_of_complex_output(
                     ]
                 ],
                 "status": "succeeded",
-                "x-experimental-timestamps": {
-                    "started_at": mock.ANY,
-                    "completed_at": mock.ANY,
-                },
+                "started_at": mock.ANY,
+                "completed_at": mock.ANY,
             },
             method="POST",
         )
@@ -1477,9 +1393,7 @@ def test_queue_worker_redis_responses(docker_network, docker_image, redis_client
             "logs": [],
             "output": None,
             "status": "processing",
-            "x-experimental-timestamps": {
-                "started_at": mock.ANY,
-            },
+            "started_at": mock.ANY,
         }
 
         response = next(responses)
@@ -1487,10 +1401,8 @@ def test_queue_worker_redis_responses(docker_network, docker_image, redis_client
             "logs": [],
             "output": 84,
             "status": "succeeded",
-            "x-experimental-timestamps": {
-                "started_at": mock.ANY,
-                "completed_at": mock.ANY,
-            },
+            "started_at": mock.ANY,
+            "completed_at": mock.ANY,
         }
 
 

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -47,10 +47,21 @@ def test_queue_worker_files(
             "logs",
         ],
     ):
+        predict_id = random_string(10)
+        webhook_url = httpserver.url_for("/webhook").replace(
+            "localhost", "host.docker.internal"
+        )
+
         # we expect a webhook on starting
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "text": "baz",
+                    "path": "http://upload-server:5000/download/input.txt",
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": None,
                 "status": "processing",
@@ -69,6 +80,12 @@ def test_queue_worker_files(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "text": "baz",
+                    "path": "http://upload-server:5000/download/input.txt",
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": "http://upload-server:5000/download/output.txt",
                 "status": "succeeded",
@@ -84,11 +101,6 @@ def test_queue_worker_files(
         redis_client.xgroup_create(
             mkstream=True, groupname="predict-queue", name="predict-queue", id="$"
         )
-
-        webhook_url = httpserver.url_for("/webhook").replace(
-            "localhost", "host.docker.internal"
-        )
-        predict_id = random_string(10)
 
         with httpserver.wait(timeout=15) as waiting:
             redis_client.xadd(
@@ -150,9 +162,19 @@ def test_queue_worker_yielding_file(
             "logs",
         ],
     ):
+        predict_id = random_string(10)
+        webhook_url = httpserver.url_for("/webhook").replace(
+            "localhost", "host.docker.internal"
+        )
+
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "path": "http://upload-server:5000/download/input.txt",
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": None,
                 "status": "processing",
@@ -164,6 +186,11 @@ def test_queue_worker_yielding_file(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "path": "http://upload-server:5000/download/input.txt",
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": ["http://upload-server:5000/download/out-0.txt"],
                 "status": "processing",
@@ -175,6 +202,11 @@ def test_queue_worker_yielding_file(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "path": "http://upload-server:5000/download/input.txt",
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": [
                     "http://upload-server:5000/download/out-0.txt",
@@ -189,6 +221,11 @@ def test_queue_worker_yielding_file(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "path": "http://upload-server:5000/download/input.txt",
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": [
                     "http://upload-server:5000/download/out-0.txt",
@@ -204,6 +241,11 @@ def test_queue_worker_yielding_file(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "path": "http://upload-server:5000/download/input.txt",
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": [
                     "http://upload-server:5000/download/out-0.txt",
@@ -222,11 +264,6 @@ def test_queue_worker_yielding_file(
 
         redis_client.xgroup_create(
             mkstream=True, groupname="predict-queue", name="predict-queue", id="$"
-        )
-
-        predict_id = random_string(10)
-        webhook_url = httpserver.url_for("/webhook").replace(
-            "localhost", "host.docker.internal"
         )
 
         with httpserver.wait(timeout=15) as waiting:
@@ -277,9 +314,19 @@ def test_queue_worker_yielding(docker_network, docker_image, redis_client, https
             "logs",
         ],
     ):
+        predict_id = random_string(10)
+        webhook_url = httpserver.url_for("/webhook").replace(
+            "localhost", "host.docker.internal"
+        )
+
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "text": "bar",
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": None,
                 "status": "processing",
@@ -291,6 +338,11 @@ def test_queue_worker_yielding(docker_network, docker_image, redis_client, https
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "text": "bar",
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": ["foo", "bar", "baz"],
                 "status": "processing",
@@ -302,6 +354,11 @@ def test_queue_worker_yielding(docker_network, docker_image, redis_client, https
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "text": "bar",
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": ["foo", "bar", "baz"],
                 "status": "succeeded",
@@ -316,11 +373,6 @@ def test_queue_worker_yielding(docker_network, docker_image, redis_client, https
 
         redis_client.xgroup_create(
             mkstream=True, groupname="predict-queue", name="predict-queue", id="$"
-        )
-
-        predict_id = random_string(10)
-        webhook_url = httpserver.url_for("/webhook").replace(
-            "localhost", "host.docker.internal"
         )
 
         with httpserver.wait(timeout=15) as waiting:
@@ -364,9 +416,19 @@ def test_queue_worker_error(docker_network, docker_image, redis_client, httpserv
             "logs",
         ],
     ):
+        predict_id = random_string(10)
+        webhook_url = httpserver.url_for("/webhook").replace(
+            "localhost", "host.docker.internal"
+        )
+
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "text": "bar",
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": None,
                 "status": "processing",
@@ -382,6 +444,11 @@ def test_queue_worker_error(docker_network, docker_image, redis_client, httpserv
         httpserver.expect_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "text": "bar",
+                },
+                "webhook": webhook_url,
                 "logs": mock.ANY,  # includes a stack trace
                 "output": None,
                 "status": "processing",
@@ -399,6 +466,11 @@ def test_queue_worker_error(docker_network, docker_image, redis_client, httpserv
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "text": "bar",
+                },
+                "webhook": webhook_url,
                 "error": "over budget",
                 "logs": mock.ANY,  # might include a stack trace (see above)
                 "output": None,
@@ -411,11 +483,6 @@ def test_queue_worker_error(docker_network, docker_image, redis_client, httpserv
 
         redis_client.xgroup_create(
             mkstream=True, groupname="predict-queue", name="predict-queue", id="$"
-        )
-
-        predict_id = random_string(10)
-        webhook_url = httpserver.url_for("/webhook").replace(
-            "localhost", "host.docker.internal"
         )
 
         with httpserver.wait(timeout=15) as waiting:
@@ -461,9 +528,19 @@ def test_queue_worker_error_after_output(
             "logs",
         ],
     ):
+        predict_id = random_string(10)
+        webhook_url = httpserver.url_for("/webhook").replace(
+            "localhost", "host.docker.internal"
+        )
+
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "text": "bar",
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": None,
                 "status": "processing",
@@ -475,6 +552,11 @@ def test_queue_worker_error_after_output(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "text": "bar",
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": ["hello bar"],
                 "status": "processing",
@@ -486,6 +568,11 @@ def test_queue_worker_error_after_output(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "text": "bar",
+                },
+                "webhook": webhook_url,
                 "logs": ["a printed log message"],
                 "output": ["hello bar"],
                 "status": "processing",
@@ -500,6 +587,11 @@ def test_queue_worker_error_after_output(
         httpserver.expect_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "text": "bar",
+                },
+                "webhook": webhook_url,
                 "logs": mock.ANY,  # includes a stack trace
                 "output": ["hello bar"],
                 "status": "processing",
@@ -517,6 +609,11 @@ def test_queue_worker_error_after_output(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "text": "bar",
+                },
+                "webhook": webhook_url,
                 "error": "mid run error",
                 "logs": mock.ANY,  # might include a stack trace
                 "output": ["hello bar"],
@@ -529,11 +626,6 @@ def test_queue_worker_error_after_output(
 
         redis_client.xgroup_create(
             mkstream=True, groupname="predict-queue", name="predict-queue", id="$"
-        )
-
-        predict_id = random_string(10)
-        webhook_url = httpserver.url_for("/webhook").replace(
-            "localhost", "host.docker.internal"
         )
 
         with httpserver.wait(timeout=15) as waiting:
@@ -582,6 +674,11 @@ def test_queue_worker_invalid_input(
             "logs",
         ],
     ):
+        predict_id = random_string(10)
+        webhook_url = httpserver.url_for("/webhook").replace(
+            "localhost", "host.docker.internal"
+        )
+
         final_response = None
 
         def capture_final_response(request):
@@ -591,6 +688,11 @@ def test_queue_worker_invalid_input(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "num": "not a number",
+                },
+                "webhook": webhook_url,
                 "error": mock.ANY,
                 "logs": [],
                 "output": None,
@@ -601,11 +703,6 @@ def test_queue_worker_invalid_input(
 
         redis_client.xgroup_create(
             mkstream=True, groupname="predict-queue", name="predict-queue", id="$"
-        )
-
-        predict_id = random_string(10)
-        webhook_url = httpserver.url_for("/webhook").replace(
-            "localhost", "host.docker.internal"
         )
 
         with httpserver.wait(timeout=15) as waiting:
@@ -651,9 +748,17 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client, httpse
             "logs",
         ],
     ):
+        predict_id = random_string(10)
+        webhook_url = httpserver.url_for("/webhook").replace(
+            "localhost", "host.docker.internal"
+        )
+
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {},
+                "webhook": webhook_url,
                 "logs": [],
                 "output": None,
                 "status": "processing",
@@ -665,6 +770,9 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client, httpse
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {},
+                "webhook": webhook_url,
                 "logs": [
                     "WARNING:root:writing log message",
                 ],
@@ -678,6 +786,9 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client, httpse
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {},
+                "webhook": webhook_url,
                 "logs": [
                     "WARNING:root:writing log message",
                     "writing from C",
@@ -692,6 +803,9 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client, httpse
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {},
+                "webhook": webhook_url,
                 "logs": [
                     "WARNING:root:writing log message",
                     "writing from C",
@@ -707,6 +821,9 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client, httpse
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {},
+                "webhook": webhook_url,
                 "logs": [
                     "WARNING:root:writing log message",
                     "writing from C",
@@ -723,6 +840,9 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client, httpse
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {},
+                "webhook": webhook_url,
                 "logs": [
                     "WARNING:root:writing log message",
                     "writing from C",
@@ -742,11 +862,6 @@ def test_queue_worker_logging(docker_network, docker_image, redis_client, httpse
 
         redis_client.xgroup_create(
             mkstream=True, groupname="predict-queue", name="predict-queue", id="$"
-        )
-
-        predict_id = random_string(10)
-        webhook_url = httpserver.url_for("/webhook").replace(
-            "localhost", "host.docker.internal"
         )
 
         with httpserver.wait(timeout=15) as waiting:
@@ -789,9 +904,19 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
             "2",  # timeout
         ],
     ):
+        predict_id = random_string(10)
+        webhook_url = httpserver.url_for("/webhook").replace(
+            "localhost", "host.docker.internal"
+        )
+
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "sleep_time": 0.1,
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": None,
                 "status": "processing",
@@ -803,6 +928,11 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "sleep_time": 0.1,
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": "it worked after 0.1 seconds!",
                 "status": "succeeded",
@@ -817,11 +947,6 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
 
         redis_client.xgroup_create(
             mkstream=True, groupname="predict-queue", name="predict-queue", id="$"
-        )
-
-        predict_id = random_string(10)
-        webhook_url = httpserver.url_for("/webhook").replace(
-            "localhost", "host.docker.internal"
         )
 
         with httpserver.wait(timeout=15) as waiting:
@@ -843,9 +968,16 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
         # check we received all the webhooks
         assert waiting.result
 
+        predict_id = random_string(10)
+
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "sleep_time": 3.0,
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": None,
                 "status": "processing",
@@ -857,6 +989,11 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "sleep_time": 3.0,
+                },
+                "webhook": webhook_url,
                 "error": "Prediction timed out",
                 "logs": [],
                 "output": None,
@@ -866,8 +1003,6 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
             },
             method="POST",
         )
-
-        predict_id = random_string(10)
 
         with httpserver.wait(timeout=15) as waiting:
             redis_client.xadd(
@@ -888,9 +1023,16 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
         # check we received all the webhooks
         assert waiting.result
 
+        predict_id = random_string(10)
+
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "sleep_time": 0.2,
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": None,
                 "status": "processing",
@@ -902,6 +1044,11 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "sleep_time": 0.2,
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": "it worked after 0.2 seconds!",
                 "status": "succeeded",
@@ -913,8 +1060,6 @@ def test_queue_worker_timeout(docker_network, docker_image, redis_client, httpse
             },
             method="POST",
         )
-
-        predict_id = random_string(10)
 
         with httpserver.wait(timeout=15) as waiting:
             redis_client.xadd(
@@ -960,9 +1105,20 @@ def test_queue_worker_yielding_timeout(
             "2",  # timeout
         ],
     ):
+        predict_id = random_string(10)
+        webhook_url = httpserver.url_for("/webhook").replace(
+            "localhost", "host.docker.internal"
+        )
+
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "sleep_time": 0.1,
+                    "n_iterations": 1,
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": None,
                 "status": "processing",
@@ -974,6 +1130,12 @@ def test_queue_worker_yielding_timeout(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "sleep_time": 0.1,
+                    "n_iterations": 1,
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": ["yield 0"],
                 "status": "processing",
@@ -985,6 +1147,12 @@ def test_queue_worker_yielding_timeout(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "sleep_time": 0.1,
+                    "n_iterations": 1,
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": ["yield 0"],
                 "status": "succeeded",
@@ -999,11 +1167,6 @@ def test_queue_worker_yielding_timeout(
 
         redis_client.xgroup_create(
             mkstream=True, groupname="predict-queue", name="predict-queue", id="$"
-        )
-
-        predict_id = random_string(10)
-        webhook_url = httpserver.url_for("/webhook").replace(
-            "localhost", "host.docker.internal"
         )
 
         with httpserver.wait(timeout=15) as waiting:
@@ -1026,9 +1189,17 @@ def test_queue_worker_yielding_timeout(
         # check we received all the webhooks
         assert waiting.result
 
+        predict_id = random_string(10)
+
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "sleep_time": 0.8,
+                    "n_iterations": 10,
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": None,
                 "status": "processing",
@@ -1040,6 +1211,12 @@ def test_queue_worker_yielding_timeout(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "sleep_time": 0.8,
+                    "n_iterations": 10,
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": ["yield 0"],
                 "status": "processing",
@@ -1051,6 +1228,12 @@ def test_queue_worker_yielding_timeout(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "sleep_time": 0.8,
+                    "n_iterations": 10,
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": ["yield 0", "yield 1"],
                 "status": "processing",
@@ -1062,6 +1245,12 @@ def test_queue_worker_yielding_timeout(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "sleep_time": 0.8,
+                    "n_iterations": 10,
+                },
+                "webhook": webhook_url,
                 "error": "Prediction timed out",
                 "logs": [],
                 "output": ["yield 0", "yield 1"],
@@ -1071,8 +1260,6 @@ def test_queue_worker_yielding_timeout(
             },
             method="POST",
         )
-
-        predict_id = random_string(10)
 
         with httpserver.wait(timeout=15) as waiting:
             redis_client.xadd(
@@ -1118,9 +1305,19 @@ def test_queue_worker_complex_output(
             "logs",
         ],
     ):
+        predict_id = random_string(10)
+        webhook_url = httpserver.url_for("/webhook").replace(
+            "localhost", "host.docker.internal"
+        )
+
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "name": "world",
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": None,
                 "status": "processing",
@@ -1132,6 +1329,11 @@ def test_queue_worker_complex_output(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {
+                    "name": "world",
+                },
+                "webhook": webhook_url,
                 "logs": [],
                 "output": {
                     "hello": "hello world",
@@ -1149,11 +1351,6 @@ def test_queue_worker_complex_output(
 
         redis_client.xgroup_create(
             mkstream=True, groupname="predict-queue", name="predict-queue", id="$"
-        )
-
-        predict_id = random_string(10)
-        webhook_url = httpserver.url_for("/webhook").replace(
-            "localhost", "host.docker.internal"
         )
 
         with httpserver.wait(timeout=15) as waiting:
@@ -1205,9 +1402,17 @@ def test_queue_worker_yielding_list_of_complex_output(
             "logs",
         ],
     ):
+        predict_id = random_string(10)
+        webhook_url = httpserver.url_for("/webhook").replace(
+            "localhost", "host.docker.internal"
+        )
+
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {},
+                "webhook": webhook_url,
                 "logs": [],
                 "output": None,
                 "status": "processing",
@@ -1219,6 +1424,9 @@ def test_queue_worker_yielding_list_of_complex_output(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {},
+                "webhook": webhook_url,
                 "logs": [],
                 "output": [
                     [
@@ -1237,6 +1445,9 @@ def test_queue_worker_yielding_list_of_complex_output(
         httpserver.expect_oneshot_request(
             "/webhook",
             json={
+                "id": predict_id,
+                "input": {},
+                "webhook": webhook_url,
                 "logs": [],
                 "output": [
                     [
@@ -1258,11 +1469,6 @@ def test_queue_worker_yielding_list_of_complex_output(
 
         redis_client.xgroup_create(
             mkstream=True, groupname="predict-queue", name="predict-queue", id="$"
-        )
-
-        predict_id = random_string(10)
-        webhook_url = httpserver.url_for("/webhook").replace(
-            "localhost", "host.docker.internal"
         )
 
         with httpserver.wait(timeout=15) as waiting:
@@ -1418,6 +1624,11 @@ def test_queue_worker_redis_responses(docker_network, docker_image, redis_client
 
         response = next(responses)
         assert response == {
+            "id": predict_id,
+            "input": {
+                "num": 42,
+            },
+            "response_queue": "response-queue",
             "logs": [],
             "output": None,
             "status": "processing",
@@ -1426,6 +1637,11 @@ def test_queue_worker_redis_responses(docker_network, docker_image, redis_client
 
         response = next(responses)
         assert response == {
+            "id": predict_id,
+            "input": {
+                "num": 42,
+            },
+            "response_queue": "response-queue",
             "logs": [],
             "output": 84,
             "status": "succeeded",


### PR DESCRIPTION
Two changes:

- Add `started_at` and `completed_at` and `metrics` to the queue worker response, to match [the API provided by Replicate](https://replicate.com/docs/reference/http).
- Echo back, as part of the webhook response, any and all fields send as part of the request.