### PR TITLE
Send file uploads as a basic PUT

### DIFF
--- a/docs/redis.md
+++ b/docs/redis.md
@@ -15,7 +15,7 @@ The entrypoint to run a Cog model against a queue is `cog.server.redis_queue`. Y
 - `redis_host`: the host your redis server is running on.
 - `redis_port`: the port your redis server is listening on.
 - `input_queue`: the queue the Cog model will listen to for prediction requests. This queue should already exist.
-- `upload_url`: the endpoint Cog will `PUT` output files to. (Note: this will change in the near future. [See this pull request for more details.](https://github.com/replicate/cog/issues/496))
+- `upload_url`: the endpoint base Cog will `PUT` output files to. See below for more details.
 - `consumer_id`: The name the Cog model will use to identify itself in the Redis group (also called "consumer name" by Redis).
 - `model_id`: a unique ID for the Cog model, used to label setup logs.
 - `log_queue`: the queue the Cog model should send setup logs to (prediction logs are sent as part of prediction responses).
@@ -36,6 +36,12 @@ For example:
         120
 
 After starting, [the `setup()` method of the predictor](python.md#predictorsetup) is called. When setup is finished the model will start polling the input queue for prediction request messages.
+
+### File uploads
+
+Cog will make a PUT request to the `upload_url` provided, with the filename appended. For example, if you provide an `upload_url` of `https://example.com/upload/` then Cog might send a PUT request to `https://example.com/upload/output.png`. After the PUT request is finished, it will include the final URL it sent to as the value in the output.
+
+It respects redirects, so you probably want to issue a 307 redirect to a unique URL that Cog can PUT the file to. This also gives an opportunity to sign the URL, if you need to provide permissions, for example to a GCS or S3 bucket. Cog will strip query strings from the final URL, to get rid of any signing information that might be included.
 
 ## Enqueue a prediction
 

--- a/python/cog/files.py
+++ b/python/cog/files.py
@@ -28,3 +28,9 @@ def upload_file(fh: io.IOBase, output_file_prefix: str = None) -> str:
         mime_type = "application/octet-stream"
     s = encoded_body.decode("utf-8")
     return f"data:{mime_type};base64,{s}"
+
+
+def guess_filename(obj: io.IOBase) -> str:
+    """Tries to guess the filename of the given object."""
+    name = getattr(obj, "name", "file")
+    return os.path.basename(name)

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -59,7 +59,7 @@ def test_queue_worker_files(
                 "id": predict_id,
                 "input": {
                     "text": "baz",
-                    "path": "http://upload-server:5000/download/input.txt",
+                    "path": "http://upload-server:5000/files/input.txt",
                 },
                 "webhook": webhook_url,
                 "logs": [],
@@ -83,7 +83,7 @@ def test_queue_worker_files(
                 "id": predict_id,
                 "input": {
                     "text": "baz",
-                    "path": "http://upload-server:5000/download/input.txt",
+                    "path": "http://upload-server:5000/files/input.txt",
                 },
                 "webhook": webhook_url,
                 "logs": [],
@@ -172,7 +172,7 @@ def test_queue_worker_yielding_file(
             json={
                 "id": predict_id,
                 "input": {
-                    "path": "http://upload-server:5000/download/input.txt",
+                    "path": "http://upload-server:5000/files/input.txt",
                 },
                 "webhook": webhook_url,
                 "logs": [],
@@ -188,7 +188,7 @@ def test_queue_worker_yielding_file(
             json={
                 "id": predict_id,
                 "input": {
-                    "path": "http://upload-server:5000/download/input.txt",
+                    "path": "http://upload-server:5000/files/input.txt",
                 },
                 "webhook": webhook_url,
                 "logs": [],
@@ -204,7 +204,7 @@ def test_queue_worker_yielding_file(
             json={
                 "id": predict_id,
                 "input": {
-                    "path": "http://upload-server:5000/download/input.txt",
+                    "path": "http://upload-server:5000/files/input.txt",
                 },
                 "webhook": webhook_url,
                 "logs": [],
@@ -223,7 +223,7 @@ def test_queue_worker_yielding_file(
             json={
                 "id": predict_id,
                 "input": {
-                    "path": "http://upload-server:5000/download/input.txt",
+                    "path": "http://upload-server:5000/files/input.txt",
                 },
                 "webhook": webhook_url,
                 "logs": [],
@@ -243,7 +243,7 @@ def test_queue_worker_yielding_file(
             json={
                 "id": predict_id,
                 "input": {
-                    "path": "http://upload-server:5000/download/input.txt",
+                    "path": "http://upload-server:5000/files/input.txt",
                 },
                 "webhook": webhook_url,
                 "logs": [],

--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -87,7 +87,7 @@ def test_queue_worker_files(
                 },
                 "webhook": webhook_url,
                 "logs": [],
-                "output": "http://upload-server:5000/download/output.txt",
+                "output": "http://upload-server:5000/files/output.txt",
                 "status": "succeeded",
                 "started_at": mock.ANY,
                 "completed_at": mock.ANY,
@@ -111,7 +111,7 @@ def test_queue_worker_files(
                             "id": predict_id,
                             "input": {
                                 "text": "baz",
-                                "path": "http://upload-server:5000/download/input.txt",
+                                "path": "http://upload-server:5000/files/input.txt",
                             },
                             "webhook": webhook_url,
                         }
@@ -192,7 +192,7 @@ def test_queue_worker_yielding_file(
                 },
                 "webhook": webhook_url,
                 "logs": [],
-                "output": ["http://upload-server:5000/download/out-0.txt"],
+                "output": ["http://upload-server:5000/files/out-0.txt"],
                 "status": "processing",
                 "started_at": mock.ANY,
             },
@@ -209,8 +209,8 @@ def test_queue_worker_yielding_file(
                 "webhook": webhook_url,
                 "logs": [],
                 "output": [
-                    "http://upload-server:5000/download/out-0.txt",
-                    "http://upload-server:5000/download/out-1.txt",
+                    "http://upload-server:5000/files/out-0.txt",
+                    "http://upload-server:5000/files/out-1.txt",
                 ],
                 "status": "processing",
                 "started_at": mock.ANY,
@@ -228,9 +228,9 @@ def test_queue_worker_yielding_file(
                 "webhook": webhook_url,
                 "logs": [],
                 "output": [
-                    "http://upload-server:5000/download/out-0.txt",
-                    "http://upload-server:5000/download/out-1.txt",
-                    "http://upload-server:5000/download/out-2.txt",
+                    "http://upload-server:5000/files/out-0.txt",
+                    "http://upload-server:5000/files/out-1.txt",
+                    "http://upload-server:5000/files/out-2.txt",
                 ],
                 "status": "processing",
                 "started_at": mock.ANY,
@@ -248,9 +248,9 @@ def test_queue_worker_yielding_file(
                 "webhook": webhook_url,
                 "logs": [],
                 "output": [
-                    "http://upload-server:5000/download/out-0.txt",
-                    "http://upload-server:5000/download/out-1.txt",
-                    "http://upload-server:5000/download/out-2.txt",
+                    "http://upload-server:5000/files/out-0.txt",
+                    "http://upload-server:5000/files/out-1.txt",
+                    "http://upload-server:5000/files/out-2.txt",
                 ],
                 "status": "succeeded",
                 "started_at": mock.ANY,
@@ -274,7 +274,7 @@ def test_queue_worker_yielding_file(
                         {
                             "id": predict_id,
                             "input": {
-                                "path": "http://upload-server:5000/download/input.txt",
+                                "path": "http://upload-server:5000/files/input.txt",
                             },
                             "webhook": webhook_url,
                         }
@@ -1431,7 +1431,7 @@ def test_queue_worker_yielding_list_of_complex_output(
                 "output": [
                     [
                         {
-                            "file": "http://upload-server:5000/download/file",
+                            "file": "http://upload-server:5000/files/file",
                             "text": "hello",
                         }
                     ]
@@ -1452,7 +1452,7 @@ def test_queue_worker_yielding_list_of_complex_output(
                 "output": [
                     [
                         {
-                            "file": "http://upload-server:5000/download/file",
+                            "file": "http://upload-server:5000/files/file",
                             "text": "hello",
                         }
                     ]

--- a/test-integration/upload_server/app.py
+++ b/test-integration/upload_server/app.py
@@ -1,7 +1,7 @@
 import os
 
 import flask
-from flask import Flask, jsonify, send_from_directory
+from flask import Flask, redirect, request, send_from_directory
 
 app = Flask("upload_server")
 
@@ -11,15 +11,21 @@ def handle_index():
     return "OK"
 
 
-@app.route("/upload", methods=["PUT"])
-def handle_upload():
-    f = flask.request.files["file"]
-    f.save(os.path.join("/uploads", f.filename))
-    return jsonify({"url": "http://upload-server:5000/download/{}".format(f.filename)})
+@app.route("/upload/<name>", methods=["PUT"])
+def redirect_upload(name):
+    print("I'm in here!", name)
+    return redirect(f"/files/{name}", 307)
 
 
-@app.route("/download/<name>")
-def download(name):
+@app.route("/files/<name>", methods=["PUT"])
+def upload_file(name):
+    with open(os.path.join("/uploads", name), "wb") as f:
+        f.write(request.get_data())
+    return "OK"
+
+
+@app.route("/files/<name>", methods=["GET"])
+def download_file(name):
     return send_from_directory("/uploads", name)
 
 


### PR DESCRIPTION
Using a simple PUT request with the file contents as the body, rather than as multipart/form-data, means we can upload directly to GCS with a little redirecting.

Closes #734 

See also #496. We could take this opportunity to adjust the API, which I've not done here yet.