### PR TITLE
WIP: initial support for 'cog serve (image)' command

### DIFF
--- a/pkg/cli/predictor.go
+++ b/pkg/cli/predictor.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/replicate/cog/pkg/config"
+	"github.com/replicate/cog/pkg/docker"
+	"github.com/replicate/cog/pkg/image"
+	"github.com/replicate/cog/pkg/predict"
+	"github.com/replicate/cog/pkg/util/console"
+)
+
+var (
+	predictor *predict.Predictor
+)
+
+func buildOrLoadPredictor(args []string) error {
+	imageName := ""
+	volumes := []docker.Volume{}
+	gpus := ""
+
+	if len(args) == 0 {
+		// Build image
+
+		cfg, projectDir, err := config.GetConfig(projectDirFlag)
+		if err != nil {
+			return err
+		}
+
+		if imageName, err = image.BuildBase(cfg, projectDir, buildProgressOutput); err != nil {
+			return err
+		}
+
+		// Base image doesn't have /src in it, so mount as volume
+		volumes = append(volumes, docker.Volume{
+			Source:      projectDir,
+			Destination: "/src",
+		})
+
+		if cfg.Build.GPU {
+			gpus = "all"
+		}
+
+	} else {
+		// Use existing image
+		imageName = args[0]
+
+		exists, err := docker.ImageExists(imageName)
+		if err != nil {
+			return fmt.Errorf("Failed to determine if %s exists: %w", imageName, err)
+		}
+		if !exists {
+			console.Infof("Pulling image: %s", imageName)
+			if err := docker.Pull(imageName); err != nil {
+				return fmt.Errorf("Failed to pull %s: %w", imageName, err)
+			}
+		}
+		conf, err := image.GetConfig(imageName)
+		if err != nil {
+			return err
+		}
+		if conf.Build.GPU {
+			gpus = "all"
+		}
+	}
+
+	console.Info("")
+	console.Infof("Starting Docker image %s and running setup()...", imageName)
+
+	p := predict.NewPredictor(docker.RunOptions{
+		GPUs:    gpus,
+		Image:   imageName,
+		Volumes: volumes,
+	})
+
+	predictor = &p
+
+	if err := predictor.Start(os.Stderr); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func stopPredictor() {
+	if predictor != nil {
+		console.Info("Stopping container...")
+		if err := predictor.Stop(); err != nil {
+			console.Warnf("Failed to stop container: %s", err)
+		}
+	}
+}
+
+func handleSignalHandler(signal os.Signal) {
+	fmt.Println("Caught signal: ", signal)
+	stopPredictor()
+	os.Exit(0)
+}
+
+func catchSIGINT() {
+	captureSignal := make(chan os.Signal, 1)
+	signal.Notify(captureSignal, syscall.SIGINT)
+	handleSignalHandler(<-captureSignal)
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -43,6 +43,7 @@ https://github.com/replicate/cog`,
 		newPredictCommand(),
 		newPushCommand(),
 		newRunCommand(),
+		newServeCommand(),
 		newLoginCommand(),
 		newInitCommand(),
 	)

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -109,8 +109,7 @@ func CORS(m *http.ServeMux) http.Handler {
 			w.Header().Set("Access-Control-Allow-Headers", "*")
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			return
-		} else {
-			m.ServeHTTP(w, r)
 		}
+		m.ServeHTTP(w, r)
 	})
 }

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -155,7 +155,7 @@ func reallyServeHTTP() {
 			}
 		}
 
-		base := servePredictor.GetUrl("")
+		base := servePredictor.GetURL("")
 		u, err := url.Parse(base + r.URL.Path)
 
 		if err != nil {

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -47,12 +47,8 @@ func cmdServe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	defer func() {
-		console.Debugf("Stopping container...")
-		if err := predictor.Stop(); err != nil {
-			console.Warnf("Failed to stop container: %s", err)
-		}
-	}()
+	go catchSIGINT()
+	defer stopPredictor()
 
 	return reallyServeHTTP()
 }
@@ -91,9 +87,6 @@ func reallyServeHTTP() error {
 	} else {
 		mux.HandleFunc("/", predictHandler)
 	}
-
-	go catchSIGINT()
-	defer stopPredictor()
 
 	listenAddr := fmt.Sprintf("%s:%d", serveHost, servePort)
 	console.Infof("Serving model on %s ...", listenAddr)

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -121,8 +121,6 @@ func cmdServe(cmd *cobra.Command, args []string) error {
 
 // FIXME(ja): this pattern might be useful in predict commands
 func serveSignalHandler(signal os.Signal) {
-	fmt.Printf("\nCaught signal: %+v\n", signal)
-
 	if err := servePredictor.Stop(); err != nil {
 		console.Warnf("Failed to stop container: %s", err)
 	}

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -81,6 +81,10 @@ func initServeSignals() {
 	serveSignalHandler(<-captureSignal)
 }
 
+// FIXME(ja): I think we should invert this logic!
+// the endpoints for the predictor are well defined
+// request to /predict and /openapi.json should go to the predictor
+// otherwize, attempt to serve static files
 func staticMiddleware(next http.Handler) http.Handler {
 	fs := http.FileServer(http.Dir(serveStatic))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -80,6 +80,7 @@ func reallyServeHTTP() error {
 	mux := http.NewServeMux()
 
 	if serveStatic != "" {
+		console.Infof("Serving static files from %s", serveStatic)
 		mux.HandleFunc("/predictions", predictHandler)
 		mux.HandleFunc("/docs", predictHandler)
 		mux.HandleFunc("/openapi.json", predictHandler)
@@ -89,13 +90,14 @@ func reallyServeHTTP() error {
 	}
 
 	listenAddr := fmt.Sprintf("%s:%d", serveHost, servePort)
-	console.Infof("Serving model on %s ...", listenAddr)
 
 	if serveDisableCors {
 		console.Info("CORS is disabled")
+		console.Infof("Serving model on %s ...", listenAddr)
 		return http.ListenAndServe(listenAddr, CORS(mux))
 	}
 
+	console.Infof("Serving model on %s ...", listenAddr)
 	return http.ListenAndServe(listenAddr, mux)
 }
 

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -1,0 +1,182 @@
+package cli
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/replicate/cog/pkg/config"
+	"github.com/replicate/cog/pkg/docker"
+	"github.com/replicate/cog/pkg/image"
+	"github.com/replicate/cog/pkg/predict"
+	"github.com/replicate/cog/pkg/util/console"
+)
+
+var (
+	// inputFlags []string
+	// outPath    string
+	serveHost      = "0.0.0.0"
+	servePort      = 5000
+	servePredictor *predict.Predictor
+)
+
+func newServeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "serve [image]",
+		Short: "Serve a model",
+		Long: `Serve a model using docker.
+
+If 'image' is passed, it will serve the model from on that Docker image.
+It must be an image that has been built by Cog.
+
+Otherwise, it will build the model in the current directory and serve
+the model on that.`,
+		RunE:       cmdServe,
+		Args:       cobra.MaximumNArgs(1),
+		SuggestFor: []string{"infer"},
+	}
+	addBuildProgressOutputFlag(cmd)
+	cmd.Flags().StringVarP(&outPath, "output", "o", "", "Output path")
+	cmd.Flags().IntVarP(&servePort, "port", "p", 5000, "Port to serve on")
+	cmd.Flags().StringVarP(&serveHost, "host", "H", "0.0.0.0", "Host to listen on")
+
+	return cmd
+}
+
+// FIXME(ja): 99% of this is copied from cmdPredict
+func cmdServe(cmd *cobra.Command, args []string) error {
+	imageName := ""
+	volumes := []docker.Volume{}
+	gpus := ""
+
+	if len(args) == 0 {
+		// Build image
+
+		cfg, projectDir, err := config.GetConfig(projectDirFlag)
+		if err != nil {
+			return err
+		}
+
+		if imageName, err = image.BuildBase(cfg, projectDir, buildProgressOutput); err != nil {
+			return err
+		}
+
+		// Base image doesn't have /src in it, so mount as volume
+		volumes = append(volumes, docker.Volume{
+			Source:      projectDir,
+			Destination: "/src",
+		})
+
+		if cfg.Build.GPU {
+			gpus = "all"
+		}
+
+	} else {
+		// Use existing image
+		imageName = args[0]
+
+		exists, err := docker.ImageExists(imageName)
+		if err != nil {
+			return fmt.Errorf("Failed to determine if %s exists: %w", imageName, err)
+		}
+		if !exists {
+			console.Infof("Pulling image: %s", imageName)
+			if err := docker.Pull(imageName); err != nil {
+				return fmt.Errorf("Failed to pull %s: %w", imageName, err)
+			}
+		}
+		conf, err := image.GetConfig(imageName)
+		if err != nil {
+			return err
+		}
+		if conf.Build.GPU {
+			gpus = "all"
+		}
+	}
+
+	console.Info("")
+	console.Infof("Starting Docker image %s and running setup()...", imageName)
+
+	predictor := predict.NewPredictor(docker.RunOptions{
+		GPUs:    gpus,
+		Image:   imageName,
+		Volumes: volumes,
+	})
+	if err := predictor.Start(os.Stderr); err != nil {
+		return err
+	}
+
+	servePredictor = &predictor
+
+	reallyServeHTTP()
+
+	return nil
+}
+
+// FIXME(ja): this pattern might be useful in predict commands
+func serveSignalHandler(signal os.Signal) {
+	fmt.Printf("\nCaught signal: %+v\n", signal)
+
+	if err := servePredictor.Stop(); err != nil {
+		console.Warnf("Failed to stop container: %s", err)
+	}
+	os.Exit(0)
+}
+
+func initServeSignals() {
+	captureSignal := make(chan os.Signal, 1)
+	signal.Notify(captureSignal, syscall.SIGINT)
+	serveSignalHandler(<-captureSignal)
+}
+
+func reallyServeHTTP() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+
+		// always say yes to CORS
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "*")
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		base := servePredictor.GetUrl("")
+		u, err := url.Parse(base + r.URL.Path)
+
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		proxy := &httputil.ReverseProxy{
+			Director: func(req *http.Request) {
+				req.URL = u
+				req.Host = u.Host
+				req.Header.Set("X-Forwarded-Host", req.Header.Get("Host"))
+				req.Header.Set("Host", u.Host)
+			},
+		}
+		proxy.ServeHTTP(w, r)
+	})
+
+	go initServeSignals()
+
+	listenAddr := fmt.Sprintf("%s:%d", serveHost, servePort)
+
+	console.Info("")
+	console.Infof("Serving model on %s ...", listenAddr)
+
+	err := http.ListenAndServe(listenAddr, nil)
+	if err != nil {
+		console.Warnf("Failed to start server: %s", err)
+	}
+}

--- a/pkg/predict/predictor.go
+++ b/pkg/predict/predictor.go
@@ -80,7 +80,7 @@ func (p *Predictor) Start(logsWriter io.Writer) error {
 }
 
 func (p *Predictor) waitForContainerReady() error {
-	url := fmt.Sprintf("http://localhost:%d/", p.port)
+	url := p.GetUrl("/")
 
 	start := time.Now()
 	for {
@@ -114,6 +114,10 @@ func (p *Predictor) Stop() error {
 	return docker.Stop(p.containerID)
 }
 
+func (p *Predictor) GetUrl(path string) string {
+	return fmt.Sprintf("http://localhost:%d%s", p.port, path)
+}
+
 func (p *Predictor) Predict(inputs Inputs) (*Response, error) {
 	inputMap, err := inputs.toMap()
 	if err != nil {
@@ -125,7 +129,7 @@ func (p *Predictor) Predict(inputs Inputs) (*Response, error) {
 		return nil, err
 	}
 
-	url := fmt.Sprintf("http://localhost:%d/predictions", p.port)
+	url := p.GetUrl("/predictions")
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create HTTP request to %s: %w", url, err)
@@ -161,7 +165,7 @@ func (p *Predictor) Predict(inputs Inputs) (*Response, error) {
 }
 
 func (p *Predictor) GetSchema() (*openapi3.T, error) {
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/openapi.json", p.port))
+	resp, err := http.Get(p.GetUrl("/openapi.json"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/predict/predictor.go
+++ b/pkg/predict/predictor.go
@@ -84,7 +84,7 @@ func (p *Predictor) Start(logsWriter io.Writer) error {
 }
 
 func (p *Predictor) waitForContainerReady() error {
-	url := p.GetUrl("/")
+	url := p.GetURL("/")
 
 	start := time.Now()
 	for {
@@ -118,7 +118,7 @@ func (p *Predictor) Stop() error {
 	return docker.Stop(p.containerID)
 }
 
-func (p *Predictor) GetUrl(path string) string {
+func (p *Predictor) GetURL(path string) string {
 	return fmt.Sprintf("http://localhost:%d%s", p.port, path)
 }
 
@@ -133,7 +133,7 @@ func (p *Predictor) Predict(inputs Inputs) (*Response, error) {
 		return nil, err
 	}
 
-	url := p.GetUrl("/predictions")
+	url := p.GetURL("/predictions")
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create HTTP request to %s: %w", url, err)
@@ -169,7 +169,7 @@ func (p *Predictor) Predict(inputs Inputs) (*Response, error) {
 }
 
 func (p *Predictor) GetSchema() (*openapi3.T, error) {
-	resp, err := http.Get(p.GetUrl("/openapi.json"))
+	resp, err := http.Get(p.GetURL("/openapi.json"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/predict/predictor.go
+++ b/pkg/predict/predictor.go
@@ -72,7 +72,11 @@ func (p *Predictor) Start(logsWriter io.Writer) error {
 	}
 	go func() {
 		if err := docker.ContainerLogsFollow(p.containerID, logsWriter); err != nil {
-			console.Warnf("Error getting container logs: %s", err)
+
+			// err is a cmd.Run error, which we should ignore if ctrl-c was pressed
+			if !strings.Contains(err.Error(), "signal: interrupt") {
+				console.Warnf("Error getting container logs: %s", err)
+			}
 		}
 	}()
 


### PR DESCRIPTION
This is a WIP experiment for a more featured local `cog serve` - #739 

This adds new command to the `cog` cli

- spawns docker process to serve model
- cog (golang) has http handler to proxy model running in docker
- ability to disable CORS for remote SPA
- serving static content (SPA mode)
- kill cog via ctrl-c causes docker process to be killed

Status:


- [x] http proxy to docker container
- [x] ctrl-c kills docker container
- [x] ctrl-c shouldn't cause error: `⚠ Error getting container logs: signal: interrupt`
- [ ] ensure docker container is ready before proxying
- [x] make CORS support optional
- [x] fix copy & paste code from `cmdPredict` to `cmdServe`
- [x] add SPA support #687 
- [ ] add local file support #496 
- [ ] add support for http urls for file inputs (replicate.com says: "Files should be passed as data URLs or HTTP URLs.")
- [ ] harmoize cog serve api vs replicate api
- [ ] cleanup pass (middleware messes, cleaning abstractions, ...)
- [ ] tests!

Signed-off-by: Jesse Andrews <anotherjesse@gmail.com>