### PR TITLE
Throttle webhook responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ python/build
 .projections.json
 .venv/
 .idea/
+.DS_Store

--- a/python/cog/response.py
+++ b/python/cog/response.py
@@ -10,7 +10,7 @@ class Status(str, enum.Enum):
     FAILED = "failed"
 
     @staticmethod
-    def is_terminal(status):
+    def is_terminal(status: "Status") -> bool:
         return status in (Status.SUCCEEDED, Status.FAILED)
 
 

--- a/python/cog/response.py
+++ b/python/cog/response.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import enum
 from typing import Optional, Type, Any
 
@@ -10,7 +11,7 @@ class Status(str, enum.Enum):
     FAILED = "failed"
 
     @staticmethod
-    def is_terminal(status: "Status") -> bool:
+    def is_terminal(status: Status) -> bool:
         return status in (Status.SUCCEEDED, Status.FAILED)
 
 

--- a/python/cog/response.py
+++ b/python/cog/response.py
@@ -9,6 +9,10 @@ class Status(str, enum.Enum):
     SUCCEEDED = "succeeded"
     FAILED = "failed"
 
+    @staticmethod
+    def is_terminal(status):
+        return status in (Status.SUCCEEDED, Status.FAILED)
+
 
 def get_response_type(OutputType: Type[BaseModel]) -> Any:
     class Response(BaseModel):

--- a/python/cog/response.py
+++ b/python/cog/response.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import enum
 from typing import Optional, Type, Any
 
@@ -11,7 +10,7 @@ class Status(str, enum.Enum):
     FAILED = "failed"
 
     @staticmethod
-    def is_terminal(status: Status) -> bool:
+    def is_terminal(status: "Status") -> bool:
         return status in (Status.SUCCEEDED, Status.FAILED)
 
 

--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -351,7 +351,8 @@ class RedisQueueWorker:
         return resp.content
 
     def webhook_caller(self, webhook: str) -> Callable:
-        throttler = ResponseThrottler()
+        response_interval = float(os.environ.get("COG_THROTTLE_RESPONSE_INTERVAL", 0))
+        throttler = ResponseThrottler(response_interval=response_interval)
 
         def caller(response: Any) -> None:
             if throttler.should_send_response(response):

--- a/python/cog/server/response_throttler.py
+++ b/python/cog/server/response_throttler.py
@@ -1,0 +1,22 @@
+import time
+import os
+
+from ..response import Status
+
+
+class ResponseThrottler:
+    def __init__(self):
+        self.last_sent_response_time = 0
+        self.response_interval = float(
+            os.environ.get("COG_THROTTLE_RESPONSE_INTERVAL", 0)
+        )
+
+    def should_send_response(self, response):
+        if Status.is_terminal(response["status"]):
+            return True
+
+        seconds_since_last_response = time.time() - self.last_sent_response_time
+        return seconds_since_last_response >= self.response_interval
+
+    def update_last_sent_response_time(self):
+        self.last_sent_response_time = time.time()

--- a/python/cog/server/response_throttler.py
+++ b/python/cog/server/response_throttler.py
@@ -5,18 +5,18 @@ from ..response import Status
 
 
 class ResponseThrottler:
-    def __init__(self):
-        self.last_sent_response_time = 0
+    def __init__(self) -> None:
+        self.last_sent_response_time = 0.0
         self.response_interval = float(
             os.environ.get("COG_THROTTLE_RESPONSE_INTERVAL", 0)
         )
 
-    def should_send_response(self, response):
+    def should_send_response(self, response: dict) -> bool:
         if Status.is_terminal(response["status"]):
             return True
 
         seconds_since_last_response = time.time() - self.last_sent_response_time
         return seconds_since_last_response >= self.response_interval
 
-    def update_last_sent_response_time(self):
+    def update_last_sent_response_time(self) -> None:
         self.last_sent_response_time = time.time()

--- a/python/cog/server/response_throttler.py
+++ b/python/cog/server/response_throttler.py
@@ -5,18 +5,18 @@ from ..response import Status
 
 
 class ResponseThrottler:
-    def __init__(self) -> None:
+    def __init__(self, response_interval: float) -> None:
         self.last_sent_response_time = 0.0
-        self.response_interval = float(
-            os.environ.get("COG_THROTTLE_RESPONSE_INTERVAL", 0)
-        )
+        self.response_interval = response_interval
 
     def should_send_response(self, response: dict) -> bool:
         if Status.is_terminal(response["status"]):
             return True
 
-        seconds_since_last_response = time.time() - self.last_sent_response_time
-        return seconds_since_last_response >= self.response_interval
+        return self.seconds_since_last_response() >= self.response_interval
 
     def update_last_sent_response_time(self) -> None:
         self.last_sent_response_time = time.time()
+
+    def seconds_since_last_response(self) -> float:
+        return time.time() - self.last_sent_response_time

--- a/python/tests/server/test_response_throttler.py
+++ b/python/tests/server/test_response_throttler.py
@@ -1,0 +1,41 @@
+import time
+
+from cog.server.response_throttler import ResponseThrottler
+from cog.response import Status
+
+def test_zero_iterval():
+    throttler = ResponseThrottler()
+    throttler.response_interval = 0
+
+    assert throttler.should_send_response({"status": Status.PROCESSING})
+    throttler.update_last_sent_response_time()
+    assert throttler.should_send_response({"status": Status.SUCCEEDED})
+
+
+def test_terminal_status():
+    throttler = ResponseThrottler()
+    throttler.response_interval = 10
+
+    assert throttler.should_send_response({"status": Status.PROCESSING})
+    throttler.update_last_sent_response_time()
+    assert not throttler.should_send_response({"status": Status.PROCESSING})
+    throttler.update_last_sent_response_time()
+    assert throttler.should_send_response({"status": Status.SUCCEEDED})
+
+
+def test_nonzero_internal():
+    throttler = ResponseThrottler()
+    throttler.response_interval = 0.2
+
+    assert throttler.should_send_response({"status": Status.PROCESSING})
+    throttler.update_last_sent_response_time()
+    assert not throttler.should_send_response({"status": Status.PROCESSING})
+    throttler.update_last_sent_response_time()
+
+    time.sleep(0.3)
+
+    assert throttler.should_send_response({"status": Status.PROCESSING})
+    throttler.update_last_sent_response_time()
+    assert not throttler.should_send_response({"status": Status.PROCESSING})
+    throttler.update_last_sent_response_time()
+    assert throttler.should_send_response({"status": Status.SUCCEEDED})

--- a/python/tests/server/test_response_throttler.py
+++ b/python/tests/server/test_response_throttler.py
@@ -3,6 +3,7 @@ import time
 from cog.server.response_throttler import ResponseThrottler
 from cog.response import Status
 
+
 def test_zero_interval():
     throttler = ResponseThrottler(response_interval=0)
 

--- a/python/tests/server/test_response_throttler.py
+++ b/python/tests/server/test_response_throttler.py
@@ -3,9 +3,8 @@ import time
 from cog.server.response_throttler import ResponseThrottler
 from cog.response import Status
 
-def test_zero_iterval():
-    throttler = ResponseThrottler()
-    throttler.response_interval = 0
+def test_zero_interval():
+    throttler = ResponseThrottler(response_interval=0)
 
     assert throttler.should_send_response({"status": Status.PROCESSING})
     throttler.update_last_sent_response_time()
@@ -13,8 +12,7 @@ def test_zero_iterval():
 
 
 def test_terminal_status():
-    throttler = ResponseThrottler()
-    throttler.response_interval = 10
+    throttler = ResponseThrottler(response_interval=10)
 
     assert throttler.should_send_response({"status": Status.PROCESSING})
     throttler.update_last_sent_response_time()
@@ -24,8 +22,7 @@ def test_terminal_status():
 
 
 def test_nonzero_internal():
-    throttler = ResponseThrottler()
-    throttler.response_interval = 0.2
+    throttler = ResponseThrottler(response_interval=0.2)
 
     assert throttler.should_send_response({"status": Status.PROCESSING})
     throttler.update_last_sent_response_time()
@@ -35,7 +32,3 @@ def test_nonzero_internal():
     time.sleep(0.3)
 
     assert throttler.should_send_response({"status": Status.PROCESSING})
-    throttler.update_last_sent_response_time()
-    assert not throttler.should_send_response({"status": Status.PROCESSING})
-    throttler.update_last_sent_response_time()
-    assert throttler.should_send_response({"status": Status.SUCCEEDED})


### PR DESCRIPTION
Introduces a new environment variable `COG_THROTTLE_RESPONSE_INTERVAL` that lets the user control the rate at which non-terminal webhooks are sent.