### PR TITLE
Handle cancelations in Redis queue worker

### DIFF
--- a/docs/redis.md
+++ b/docs/redis.md
@@ -49,6 +49,7 @@ The message body should be a JSON object with the following fields:
 
 - `input`: a JSON object with the same keys as the [arguments to the `predict()` function](python.md). Any `File` or `Path` inputs are passed as URLs.
 - `webhook`: the URL Cog will send responses to.
+- `cancel_key` (optional): a Redis key to watch to signal that this prediction should be canceled. If the key is created the prediction will be canceled.
 
 There's also one deprecated field:
 

--- a/python/cog/response.py
+++ b/python/cog/response.py
@@ -8,6 +8,7 @@ class Status(str, enum.Enum):
     PROCESSING = "processing"
     SUCCEEDED = "succeeded"
     FAILED = "failed"
+    CANCELED = "canceled"
 
 
 def get_response_type(OutputType: Type[BaseModel]) -> Any:

--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -176,6 +176,8 @@ class RedisQueueWorker:
                         f"Received message {message_id} on {self.input_queue}\n"
                     )
 
+                    should_cancel = self.cancelation_checker(message.get("cancel_key"))
+
                     # use the request message as the basis of our response so
                     # that we echo back any additional fields sent to us
                     response = message
@@ -186,7 +188,9 @@ class RedisQueueWorker:
                     cleanup_functions: List[Callable] = []
                     try:
                         start_time = time.time()
-                        self.handle_message(send_response, response, cleanup_functions)
+                        self.handle_message(
+                            send_response, response, cleanup_functions, should_cancel
+                        )
                         self.redis.xack(self.input_queue, self.input_queue, message_id)
                         self.redis.xdel(
                             self.input_queue, message_id
@@ -225,6 +229,7 @@ class RedisQueueWorker:
         send_response: Callable,
         response: Dict[str, Any],
         cleanup_functions: List[Callable],
+        should_cancel: Callable,
     ) -> None:
         span = trace.get_current_span()
 
@@ -254,6 +259,13 @@ class RedisQueueWorker:
 
         # just send logs until output starts
         while self.runner.is_processing() and not self.runner.has_output_waiting():
+            if should_cancel():
+                self.runner.cancel()
+                response["status"] = Status.CANCELED
+                response["completed_at"] = format_datetime(datetime.datetime.now())
+                send_response(response)
+                return
+
             if self.runner.has_logs_waiting():
                 response["logs"] += self.runner.read_logs()
                 send_response(response)
@@ -274,6 +286,13 @@ class RedisQueueWorker:
 
             while self.runner.is_processing():
                 # TODO: restructure this to avoid the tight CPU-eating loop
+                if should_cancel():
+                    self.runner.cancel()
+                    response["status"] = Status.CANCELED
+                    response["completed_at"] = format_datetime(datetime.datetime.now())
+                    send_response(response)
+                    return
+
                 if self.runner.has_output_waiting() or self.runner.has_logs_waiting():
                     # Object has already passed through `make_encodeable()` in the Runner, so all we need to do here is upload the files
                     new_output = [
@@ -318,6 +337,13 @@ class RedisQueueWorker:
         else:
             # just send logs until output ends
             while self.runner.is_processing():
+                if should_cancel():
+                    self.runner.cancel()
+                    response["status"] = Status.CANCELED
+                    response["completed_at"] = format_datetime(datetime.datetime.now())
+                    send_response(response)
+                    return
+
                 if self.runner.has_logs_waiting():
                     response["logs"] += self.runner.read_logs()
                     send_response(response)
@@ -360,6 +386,12 @@ class RedisQueueWorker:
             self.redis.set(redis_key, json.dumps(response))
 
         return setter
+
+    def cancelation_checker(self, redis_key: str) -> Callable:
+        def checker() -> bool:
+            return redis_key is not None and self.redis.exists(redis_key) > 0
+
+        return checker
 
     def upload_files(self, obj: Any) -> Any:
         def upload_file(fh: io.IOBase) -> str:

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -286,7 +286,7 @@ class PredictionRunner:
                             self.predictor_pipe_writer.send(self.OutputType.SINGLE)
                             self.predictor_pipe_writer.send(make_encodeable(output))
                 except CancelPredictionException:
-                    # it we've been canceled, just stop and wait for cleanup
+                    # we've been canceled, just stop and wait for cleanup
                     pass
                 except Exception as e:
                     # if it timed out there's no stack trace

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -189,7 +189,7 @@ def test_openapi_specification():
                 },
                 "Status": {
                     "title": "Status",
-                    "enum": ["processing", "succeeded", "failed"],
+                    "enum": ["processing", "succeeded", "failed", "canceled"],
                     "description": "An enumeration.",
                     "type": "string",
                 },
@@ -348,7 +348,7 @@ def test_openapi_specification_with_custom_user_defined_output_type():
                 },
                 "Status": {
                     "title": "Status",
-                    "enum": ["processing", "succeeded", "failed"],
+                    "enum": ["processing", "succeeded", "failed", "canceled"],
                     "description": "An enumeration.",
                     "type": "string",
                 },


### PR DESCRIPTION
Allow a Redis key to be provided for each prediction. If that key is created at any point during the prediction, the worker will interrupt the predictor and return a terminal `canceled` response.

Closes #723 