### PR TITLE
stop container on ctrl-c during cog predict

### DIFF
--- a/pkg/predict/predictor.go
+++ b/pkg/predict/predictor.go
@@ -72,7 +72,10 @@ func (p *Predictor) Start(logsWriter io.Writer) error {
 	}
 	go func() {
 		if err := docker.ContainerLogsFollow(p.containerID, logsWriter); err != nil {
-			console.Warnf("Error getting container logs: %s", err)
+			// if user hits ctrl-c we expect an signal error
+			if !strings.Contains(err.Error(), "signal: interrupt") {
+				console.Warnf("Error getting container logs: %s", err)
+			}
 		}
 	}()
 

--- a/pkg/predict/predictor.go
+++ b/pkg/predict/predictor.go
@@ -72,7 +72,7 @@ func (p *Predictor) Start(logsWriter io.Writer) error {
 	}
 	go func() {
 		if err := docker.ContainerLogsFollow(p.containerID, logsWriter); err != nil {
-			// if user hits ctrl-c we expect an signal error
+			// if user hits ctrl-c we expect an error signal
 			if !strings.Contains(err.Error(), "signal: interrupt") {
 				console.Warnf("Error getting container logs: %s", err)
 			}


### PR DESCRIPTION
When running `cog predict` if the user hits "ctrl-c" the docker container is left running

This catches the ctrl-c and terminates docker container