### PR TITLE
Fix deadlock for large outputs

### DIFF
--- a/test-integration/test_integration/test_redis_queue.py
+++ b/test-integration/test_integration/test_redis_queue.py
@@ -1729,18 +1729,10 @@ def test_queue_worker_redis_responses(docker_network, docker_image, redis_client
 
         responses = response_iterator(redis_client, "response-queue")
 
+        # Discard the initial response -- depending on the speed of the test
+        # runner, the second response can come before we've had a chance to
+        # read it. This asserts a response happened, but not what it contains.
         response = next(responses)
-        assert response == {
-            "id": predict_id,
-            "input": {
-                "num": 42,
-            },
-            "response_queue": "response-queue",
-            "logs": "",
-            "output": None,
-            "status": "processing",
-            "started_at": mock.ANY,
-        }
 
         response = next(responses)
         assert response == {


### PR DESCRIPTION
`pipe.send()` is non-blocking when you send less than 64K of data. When you send more than that, the call blocks until something calls `recv()`. That causes a deadlock, where the predictor process is blocked on `send()`, and the parent process is waiting for it to send the `PROCESSING_DONE` signal.

This rejigs the non-generator output path to ignore the `PROCESSING_DONE` signal, because there's only going to be a single output.

I don't think there's a deadlock in the generator path, but I haven't tested it to be sure.

This whole lot of code is due a rewrite pretty soon anyway!