### PR TITLE
Handle dead predictor process

### DIFF
--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -193,6 +193,13 @@ class PredictionRunner:
 
         return self._is_processing
 
+    def is_alive(self) -> bool:
+        """
+        Returns True if the subprocess running the prediction is still
+        alive, i.e. has not died of OOM or some other unhandled error.
+        """
+        return len(multiprocessing.active_children()) > 0
+
     def has_output_waiting(self) -> bool:
         return self.predictor_pipe_reader.poll()
 

--- a/test-integration/test_integration/fixtures/unhandled-error-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/unhandled-error-project/cog.yaml
@@ -1,0 +1,3 @@
+predict: "predict.py:Predictor"
+build:
+  python_version: "3.8"

--- a/test-integration/test_integration/fixtures/unhandled-error-project/predict.py
+++ b/test-integration/test_integration/fixtures/unhandled-error-project/predict.py
@@ -1,0 +1,7 @@
+import sys
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def predict(self, text: str) -> str:
+        sys.exit(1)


### PR DESCRIPTION
Continuously check if the runner has a subprocess that's alive, and return an error if not.

Signed-off-by: andreasjansson <andreas@replicate.ai>