### PR TITLE
Require protobuf<=3.20.3 (fix a potential Denial of Service issue)

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         "fastapi>=0.6,<1",
         "opentelemetry-exporter-otlp>=1.11.1,<2",
         "opentelemetry-sdk>=1.11.1,<2",
-        "protobuf<=3.20",
+        "protobuf<=3.20.3",
         "pydantic>=1,<2",
         "PyYAML",
         "redis>=4,<5",


### PR DESCRIPTION
Currently installed version of protobuf@3.20.0 has a vulnerability
https://security.snyk.io/vuln/SNYK-PYTHON-PROTOBUF-3031740
[A potential Denial of Service issue in protobuf-cpp and protobuf-python ](https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-8gq9-2x98-w8hf)

```
Issues to fix by upgrading dependencies:
  Pin protobuf@3.20.0 to protobuf@3.20.2 to fix
  ✗ Denial of Service (DoS) [Medium Severity][https://snyk.io/vuln/SNYK-PYTHON-PROTOBUF-3031740] in protobuf@3.20.0
    introduced by cog@0.4.4 > protobuf@3.20.0 and 4 other path(s)
```
Allowing protobuf to use the newest patch version fixes the problem.

