### PR TITLE
rename installpython function to include scope - cuda

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -63,7 +63,7 @@ func (g *Generator) GenerateBase() (string, error) {
 	}
 	installPython := ""
 	if g.Config.Build.GPU {
-		installPython, err = g.installPython()
+		installPython, err = g.installPythonCUDA()
 		if err != nil {
 			return "", err
 		}
@@ -158,7 +158,7 @@ func (g *Generator) aptInstalls() (string, error) {
 		" && rm -rf /var/lib/apt/lists/*", nil
 }
 
-func (g *Generator) installPython() (string, error) {
+func (g *Generator) installPythonCUDA() (string, error) {
 	// TODO: check that python version is valid
 
 	py := g.Config.Build.PythonVersion


### PR DESCRIPTION
the function is only used on GPU dockerfile generation. This lets code readers understand the scope of the install

Signed-off-by: Jesse Andrews <anotherjesse@gmail.com>