### PR TITLE
python-openssl system package not used

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -181,7 +181,6 @@ RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get insta
 	tk-dev \
 	libffi-dev \
 	liblzma-dev \
-	python-openssl \
 	git \
 	ca-certificates \
 	&& rm -rf /var/lib/apt/lists/*

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -34,7 +34,6 @@ RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get insta
 	tk-dev \
 	libffi-dev \
 	liblzma-dev \
-	python-openssl \
 	git \
 	ca-certificates \
 	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- container is built with pyenv
- pyenv doesn't need python-openssl installed to function
- appears that cog models do not rely on a side-effect of python-openssl install (libssl-dev is installed explicitly)
- if cog models need python-openssl, it can be installed by updating the model's cog.yaml

```
    python_packages:
      - "pyOpenSSL==22.1.0"
```

This change is because python-openssl was renamed to python3-openssl in more recent versions of ubuntu

Signed-off-by: Jesse Andrews <anotherjesse@gmail.com>