### PR TITLE
Remove python_extra_index_urls and python_find_links

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,17 +17,15 @@ import (
 // TODO(andreas): suggest valid torchvision versions (e.g. if the user wants to use 0.8.0, suggest 0.8.1)
 
 type Build struct {
-	GPU                  bool     `json:"gpu,omitempty" yaml:"gpu"`
-	PythonVersion        string   `json:"python_version,omitempty" yaml:"python_version"`
-	PythonRequirements   string   `json:"python_requirements,omitempty" yaml:"python_requirements"`
-	PythonExtraIndexURLs []string `json:"python_extra_index_urls,omitempty" yaml:"python_extra_index_urls"`
-	PythonFindLinks      []string `json:"python_find_links,omitempty" yaml:"python_find_links"`
-	PythonPackages       []string `json:"python_packages,omitempty" yaml:"python_packages"`
-	Run                  []string `json:"run,omitempty" yaml:"run"`
-	SystemPackages       []string `json:"system_packages,omitempty" yaml:"system_packages"`
-	PreInstall           []string `json:"pre_install,omitempty" yaml:"pre_install"` // Deprecated, but included for backwards compatibility
-	CUDA                 string   `json:"cuda,omitempty" yaml:"cuda"`
-	CuDNN                string   `json:"cudnn,omitempty" yaml:"cudnn"`
+	GPU                bool     `json:"gpu,omitempty" yaml:"gpu"`
+	PythonVersion      string   `json:"python_version,omitempty" yaml:"python_version"`
+	PythonRequirements string   `json:"python_requirements,omitempty" yaml:"python_requirements"`
+	PythonPackages     []string `json:"python_packages,omitempty" yaml:"python_packages"`
+	Run                []string `json:"run,omitempty" yaml:"run"`
+	SystemPackages     []string `json:"system_packages,omitempty" yaml:"system_packages"`
+	PreInstall         []string `json:"pre_install,omitempty" yaml:"pre_install"` // Deprecated, but included for backwards compatibility
+	CUDA               string   `json:"cuda,omitempty" yaml:"cuda"`
+	CuDNN              string   `json:"cudnn,omitempty" yaml:"cudnn"`
 }
 
 type Example struct {

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -227,15 +227,8 @@ func (g *Generator) pipInstalls() (string, error) {
 	for _, indexURL := range indexURLs {
 		findLinks += "-f " + indexURL + " "
 	}
-	for _, indexURL := range g.Config.Build.PythonFindLinks {
-		findLinks += "-f " + indexURL + " "
-	}
-	extraIndexURLs := ""
-	for _, indexURL := range g.Config.Build.PythonExtraIndexURLs {
-		extraIndexURLs += "--extra-index-url=" + indexURL
-	}
 
-	return "RUN --mount=type=cache,target=/root/.cache/pip pip install " + findLinks + " " + extraIndexURLs + " " + strings.Join(packages, " "), nil
+	return "RUN --mount=type=cache,target=/root/.cache/pip pip install " + findLinks + " " + strings.Join(packages, " "), nil
 }
 
 func (g *Generator) run() (string, error) {

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -141,7 +141,7 @@ ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
 ` + testInstallCog(gen.relativeTmpDir) + `
 RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
-RUN --mount=type=cache,target=/root/.cache/pip pip install -f https://download.pytorch.org/whl/torch_stable.html   torch==1.5.1+cpu pandas==1.2.0.12
+RUN --mount=type=cache,target=/root/.cache/pip pip install -f https://download.pytorch.org/whl/torch_stable.html  torch==1.5.1+cpu pandas==1.2.0.12
 RUN cowsay moo
 WORKDIR /src
 EXPOSE 5000
@@ -186,7 +186,7 @@ RUN rm -f /etc/apt/sources.list.d/cuda.list && \
 ` + testInstallPython("3.8") +
 		testInstallCog(gen.relativeTmpDir) + `
 RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
-RUN --mount=type=cache,target=/root/.cache/pip pip install   torch==1.5.1 pandas==1.2.0.12
+RUN --mount=type=cache,target=/root/.cache/pip pip install  torch==1.5.1 pandas==1.2.0.12
 RUN cowsay moo
 WORKDIR /src
 EXPOSE 5000


### PR DESCRIPTION
Undocumented, and GitHub code search implies unused. If you want to do this, you can use `run`, and when we have #714 you can put it in `requirements.txt`.

Yanked out of #714
