### PR TITLE
handle case where runner dies during setup

### DIFF
--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -2,6 +2,7 @@ import sys
 import multiprocessing
 import os
 import signal
+import time
 import traceback
 import types
 from enum import Enum
@@ -107,9 +108,10 @@ class PredictionRunner:
         self._is_processing = True
         self.predictor_process.start()
 
-        # poll with an infinite timeout to avoid burning resources in the loop
-        while self.done_pipe_reader.poll(timeout=None) and self.is_processing():
-            pass
+        while self.is_processing():
+            if not self.is_alive():
+                raise RuntimeError("Predictor process died unexpectedly during setup")
+            time.sleep(0.1)
 
     def _start_predictor_process(self, span_context: SpanContext = None) -> None:
         # Enable OpenTelemetry if the env vars are present. If this block isn't

--- a/test-integration/test_integration/fixtures/failing-setup-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/failing-setup-project/cog.yaml
@@ -1,0 +1,3 @@
+build:
+  python_version: "3.8"
+predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/failing-setup-project/predict.py
+++ b/test-integration/test_integration/fixtures/failing-setup-project/predict.py
@@ -1,0 +1,9 @@
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def setup(self):
+        raise Exception("setup failed")
+
+    def predict(self) -> str:
+        return "nope"

--- a/test-integration/test_integration/util.py
+++ b/test-integration/test_integration/util.py
@@ -32,6 +32,16 @@ def random_string(length):
     return "".join(random.choice(string.ascii_lowercase) for i in range(length))
 
 
+def docker_is_alive(container_name):
+    try:
+        output = subprocess.check_output(
+            ["docker", "inspect", "-f", "'{{.State.Running}}'", container_name]
+        ).trim()
+        return output == "true"
+    except subprocess.CalledProcessError:
+        return False
+
+
 @contextmanager
 def docker_run(
     image,
@@ -73,6 +83,6 @@ def docker_run(
         cmd += command
     try:
         subprocess.Popen(cmd)
-        yield
+        yield name
     finally:
         subprocess.Popen(["docker", "rm", "--force", name]).wait()


### PR DESCRIPTION
in cases where runner OOMs or fails during setup, worker would loop forever waiting for "ready"

Signed-off-by: Jesse Andrews <anotherjesse@gmail.com>