### PR TITLE
Use shared prediction object instead of arbitrary dicts

### DIFF
--- a/python/cog/prediction.py
+++ b/python/cog/prediction.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+import enum
+from typing import Optional, Type, Any
+
+from pydantic import BaseModel, Field
+
+
+class Status(str, enum.Enum):
+    PROCESSING = "processing"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELED = "canceled"
+
+    @staticmethod
+    def is_terminal(status: "Status") -> bool:
+        return status in (Status.SUCCEEDED, Status.FAILED)
+
+
+class Metrics(BaseModel):
+    predict_time: int
+
+
+class BasePrediction(BaseModel):
+    cancel_key: Optional[str] = None  # deprecated, remove when moved to `extensions`
+    completed_at: Optional[datetime] = None
+    created_at: Optional[datetime] = None  # TODO: should be required?
+    error: Optional[str] = None
+    extensions: Optional[dict] = None
+    id: str
+    input: Any
+    logs: Optional[str] = None
+    metrics: Optional[Metrics] = None
+    output: Optional[Any] = None
+    started_at: Optional[datetime] = None
+    status: Optional[Status] = None  # TODO: should be required?
+    traceparent: Optional[str] = None  # deprecated, remove when moved to `extensions`
+    webhook: Optional[str] = None
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+def get_prediction_type(
+    InputType: Type[BaseModel], OutputType: Type[BaseModel]
+) -> BasePrediction:
+    class Prediction(BasePrediction):
+        input: InputType  # type: ignore
+        output: Optional[OutputType] = None  # type: ignore
+
+    return Prediction  # type: ignore

--- a/python/cog/response.py
+++ b/python/cog/response.py
@@ -1,18 +1,8 @@
-import enum
 from typing import Optional, Type, Any
 
 from pydantic import BaseModel, Field
 
-
-class Status(str, enum.Enum):
-    PROCESSING = "processing"
-    SUCCEEDED = "succeeded"
-    FAILED = "failed"
-    CANCELED = "canceled"
-
-    @staticmethod
-    def is_terminal(status: "Status") -> bool:
-        return status in (Status.SUCCEEDED, Status.FAILED)
+from .prediction import Status
 
 
 def get_response_type(OutputType: Type[BaseModel]) -> Any:

--- a/python/cog/server/response_throttler.py
+++ b/python/cog/server/response_throttler.py
@@ -1,7 +1,7 @@
 import time
 import os
 
-from ..response import Status
+from ..prediction import BasePrediction, Status
 
 
 class ResponseThrottler:
@@ -9,8 +9,8 @@ class ResponseThrottler:
         self.last_sent_response_time = 0.0
         self.response_interval = response_interval
 
-    def should_send_response(self, response: dict) -> bool:
-        if Status.is_terminal(response["status"]):
+    def should_send_response(self, prediction: BasePrediction) -> bool:
+        if Status.is_terminal(prediction.status):
             return True
 
         return self.seconds_since_last_response() >= self.response_interval


### PR DESCRIPTION
Playing around with the idea of having a shared `Prediction` object as a potential implementation of #783.

Another line of thinking about having this object defined in code is you could imagine this being a base object for various predictions all the way across the stack (Cog Python clients, Replicate clients, etc).

Got the first redis test almost working, except running into an issue where our Pydantic objects are helpfully downloading the input files and rewriting them to be local files, which is not the thing we want to return as the response. Needs a bit of thought as to how this could work.