### PR TITLE
Flush tee-d output after each line

### DIFF
--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -235,4 +235,5 @@ class _ChildWorker(_spawn.Process):  # type: ignore
     ) -> None:
         if self._tee_output:
             original_stream.write(data)
+            original_stream.flush()
         self._events.send(Log(data, source=stream_name))


### PR DESCRIPTION
This should hopefully fix the problem we're seeing in production of very mixed up Kubernetes logs.