### PR TITLE
load flag is required in buildx

### DIFF
--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -69,7 +69,7 @@ func BuildAddLabelsToImage(image string, labels map[string]string) error {
 }
 
 func m1BuildxBuildArgs() []string {
-	return []string{"buildx", "build", "--platform", "linux/amd64"}
+	return []string{"buildx", "build", "--platform", "linux/amd64", "--load"}
 }
 
 func buildKitBuildArgs() []string {


### PR DESCRIPTION
Signed-off-by: Youka <59315275+youkaclub@users.noreply.github.com>

Usually docker build load automatically the build results to local registry, in buildx --load is required

Close #797 
 