### PR TITLE
Send timings and logs for setup to a URL

### DIFF
--- a/python/cog/server/webhook.py
+++ b/python/cog/server/webhook.py
@@ -35,28 +35,8 @@ def webhook_caller(webhook: str) -> Callable:
     # for every prediction.
     throttler = ResponseThrottler(response_interval=_response_interval)
 
-    default_session = requests.Session()
-    default_session.headers["user-agent"] = (
-        _user_agent + " " + default_session.headers["user-agent"]
-    )
-
-    # This session will retry requests up to 12 times, with exponential
-    # backoff. In total it'll try for up to roughly 320 seconds, providing
-    # resilience through temporary networking and availability issues.
-    retry_session = requests.Session()
-    retry_session.headers["user-agent"] = (
-        _user_agent + " " + retry_session.headers["user-agent"]
-    )
-    adapter = HTTPAdapter(
-        max_retries=Retry(
-            total=12,
-            backoff_factor=0.1,
-            status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods=["POST"],
-        )
-    )
-    retry_session.mount("http://", adapter)
-    retry_session.mount("https://", adapter)
+    default_session = requests_session()
+    retry_session = requests_session_with_retries()
 
     def caller(response: Any) -> None:
         if throttler.should_send_response(response):
@@ -69,3 +49,30 @@ def webhook_caller(webhook: str) -> Callable:
             throttler.update_last_sent_response_time()
 
     return caller
+
+
+def requests_session() -> requests.Session:
+    session = requests.Session()
+    session.headers["user-agent"] = _user_agent + " " + session.headers["user-agent"]
+
+    return session
+
+
+def requests_session_with_retries() -> requests.Session:
+    # This session will retry requests up to 12 times, with exponential
+    # backoff. In total it'll try for up to roughly 320 seconds, providing
+    # resilience through temporary networking and availability issues.
+    session = requests.Session()
+    session.headers["user-agent"] = _user_agent + " " + session.headers["user-agent"]
+    adapter = HTTPAdapter(
+        max_retries=Retry(
+            total=12,
+            backoff_factor=0.1,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=["POST"],
+        )
+    )
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+
+    return session

--- a/test-integration/test_integration/fixtures/failed-setup-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/failed-setup-project/cog.yaml
@@ -1,0 +1,3 @@
+build:
+  python_version: "3.8"
+predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/failed-setup-project/predict.py
+++ b/test-integration/test_integration/fixtures/failed-setup-project/predict.py
@@ -1,0 +1,11 @@
+from time import sleep
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def setup(self):
+        raise Exception("Failed during setup")
+
+    def predict(self) -> str:
+        return "done"


### PR DESCRIPTION
Expose setup logs in a similar way to prediction outputs.