### PR TITLE
Write a file when setup is complete

### DIFF
--- a/docs/redis.md
+++ b/docs/redis.md
@@ -125,6 +125,32 @@ To get notified of updates to the value, you can `SUBSCRIBE` to [keyspace notifi
 
 [keyspace notifications]: https://redis.io/docs/manual/keyspace-notifications/
 
+## Kubernetes probes
+
+If the queue worker detects that it is running inside Kubernetes, it will create
+an empty file at `/var/run/cog/ready` when the predictor's `setup()` method has
+completed successfully.
+
+This can be used together with a [readiness probe][k8s-readiness] and a [rollout
+strategy][k8s-rollout] to ensure safe rollouts of Kubernetes deployments running
+the queue worker.
+
+[k8s-readiness]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
+[k8s-rollout]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+
+An example readiness probe configuration might look like:
+
+```yaml
+readinessProbe:
+  exec:
+    command:
+    - test
+    - -f
+    - /var/run/cog/ready
+  initialDelaySeconds: 1
+  periodSeconds: 1
+```
+
 ## Telemetry
 
 Cog's queue worker is instrumented using [OpenTelemetry](https://opentelemetry.io). For setup it sends:

--- a/python/cog/server/probes.py
+++ b/python/cog/server/probes.py
@@ -1,0 +1,37 @@
+import logging
+import os
+from pathlib import Path
+from typing import Optional, Union
+
+log = logging.getLogger(__name__)
+
+PathLike = Union[Path, str, None]
+
+
+class ProbeHelper:
+
+    _root = Path("/var/run/cog")
+    _enabled = False
+
+    def __init__(self, root: PathLike = None):
+        if "KUBERNETES_SERVICE_HOST" not in os.environ:
+            log.info("Not running in Kubernetes: disabling probe helpers.")
+            return
+
+        if root is not None:
+            self._root = Path(root)
+
+        try:
+            self._root.mkdir(exist_ok=True)
+        except OSError:
+            log.error(
+                f"Failed to create cog runtime state directory ({self._root}). "
+                "Does it already exist and is a file? Does the user running cog "
+                "have permissions?"
+            )
+        else:
+            self._enabled = True
+
+    def ready(self) -> None:
+        if self._enabled:
+            (self._root / "ready").touch()

--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -34,6 +34,7 @@ from ..predictor import (
 )
 from ..response import Status
 from .eventtypes import Done, Heartbeat, Log, PredictionOutput, PredictionOutputType
+from .probes import ProbeHelper
 from .webhook import webhook_caller
 from .worker import Worker
 
@@ -86,6 +87,7 @@ class RedisQueueWorker:
         self.predict_time_queue = input_queue + self.RUN_TIME_QUEUE_SUFFIX
         self.stats_queue_length = 100
         self.tracer = trace.get_tracer("cog")
+        self.probes = ProbeHelper()
 
         sys.stderr.write(
             f"Connected to Redis: {self.redis_host}:{self.redis_port} (db {self.redis_db})\n"
@@ -138,6 +140,9 @@ class RedisQueueWorker:
             for event in self.worker.setup():
                 # TODO: send worker logs somewhere useful!
                 pass
+
+            # Signal pod readiness (when in k8s)
+            self.probes.ready()
 
             setup_time = time.time() - start_time
             self.redis.xadd(

--- a/python/tests/server/test_probes.py
+++ b/python/tests/server/test_probes.py
@@ -1,0 +1,55 @@
+import logging
+import os
+import tempfile
+from unittest import mock
+
+import pytest
+from cog.server.probes import ProbeHelper
+
+
+@pytest.fixture
+def tmpdir():
+    with tempfile.TemporaryDirectory() as td:
+        yield td
+
+
+@mock.patch.dict(os.environ, {"KUBERNETES_SERVICE_HOST": "0.0.0.0"})
+def test_ready(tmpdir):
+    p = ProbeHelper(root=tmpdir)
+
+    p.ready()
+
+    assert os.path.isfile(os.path.join(tmpdir, "ready"))
+
+
+def test_does_nothing_when_not_in_k8s(tmpdir, caplog):
+    with caplog.at_level(logging.INFO):
+        p = ProbeHelper(root=tmpdir)
+        p.ready()
+
+    assert os.listdir(tmpdir) == []
+    assert "disabling probe helpers" in caplog.text
+
+
+@mock.patch.dict(os.environ, {"KUBERNETES_SERVICE_HOST": "0.0.0.0"})
+def test_creates_probe_dir_if_needed(tmpdir):
+    root = os.path.join(tmpdir, "probes")
+    p = ProbeHelper(root=root)
+
+    p.ready()
+
+    assert os.path.isdir(os.path.join(tmpdir, "probes"))
+    assert os.path.isfile(os.path.join(tmpdir, "probes", "ready"))
+
+
+@mock.patch.dict(os.environ, {"KUBERNETES_SERVICE_HOST": "0.0.0.0"})
+def test_no_exception_when_probe_dir_exists(tmpdir, caplog):
+    root = os.path.join(tmpdir, "probes")
+
+    # Create a file
+    open(root, "a").close()
+
+    p = ProbeHelper(root=root)
+    p.ready()
+
+    assert "Failed to create cog runtime state directory" in caplog.text


### PR DESCRIPTION
This can be checked by an exec readiness probe and used to control deployment rollout for model pods.