### PR TITLE
Accept list of events to send webhooks for

### DIFF
--- a/docs/redis.md
+++ b/docs/redis.md
@@ -49,6 +49,7 @@ The message body should be a JSON object with the following fields:
 
 - `input`: a JSON object with the same keys as the [arguments to the `predict()` function](python.md). Any `File` or `Path` inputs are passed as URLs.
 - `webhook`: the URL Cog will send responses to.
+- `webhook_events_filter` (optional): a list of events to send webhooks for. May contain `start`, `output`, `logs` and `completed`. Defaults to all events. Will always send `completed` events, even if omitted from the list.
 - `cancel_key` (optional): a Redis key to watch to signal that this prediction should be canceled. If the key is created the prediction will be canceled.
 
 There's also one deprecated field:

--- a/python/cog/response.py
+++ b/python/cog/response.py
@@ -1,7 +1,39 @@
 import enum
-from typing import Optional, Type, Any
+from typing import Any, List, Optional, Type
 
 from pydantic import BaseModel, Field
+
+
+class Event(str, enum.Enum):
+    START = "start"
+    OUTPUT = "output"
+    LOGS = "logs"
+    COMPLETED = "completed"
+
+    @staticmethod
+    def validate(events: List[str]) -> List[str]:
+        for event in events:
+            assert event in {
+                Event.START,
+                Event.OUTPUT,
+                Event.LOGS,
+                Event.COMPLETED,
+            }, f"Unexpected event {event}. Must be from {Event.START}, {Event.OUTPUT}, {Event.LOGS}, {Event.COMPLETED}"
+
+        # Always include COMPLETED events
+        if Event.COMPLETED not in events:
+            events.append(Event.COMPLETED)
+
+        return events
+
+    @staticmethod
+    def default_events() -> List[str]:
+        return [
+            Event.START,
+            Event.OUTPUT,
+            Event.LOGS,
+            Event.COMPLETED,
+        ]
 
 
 class Status(str, enum.Enum):


### PR DESCRIPTION
The main reason for this is to allow us to not send a webhook every time there's a new log line (which can happen a lot!) when all the consumer cares about is new outputs.

Closes #786.

---

I'm interested in feedback on the API this provides as much as the implementation. `webhook_events` feels like a natural accompaniment to `webhook`, and is something we would want to provide through other interfaces like the HTTP API.

It can also naturally encompass the `webhook_completed` property currently exposed through the Replicate API, by passing `{"webhook": "...", "webhook_events": ["done"]}`.