### PR TITLE
Expand the BasePredictor API to configure the FastAPI app #713

### DIFF
--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -4,6 +4,7 @@ import enum
 import importlib.util
 import inspect
 import os.path
+from fastapi import FastAPI
 from pathlib import Path
 from pydantic import create_model, BaseModel, Field
 from pydantic.fields import FieldInfo
@@ -24,6 +25,13 @@ class BasePredictor(ABC):
     def setup(self) -> None:
         """
         An optional method to prepare the model so multiple predictions run efficiently.
+        """
+
+    def configure_api(self, app: FastAPI) -> None:
+        """
+        An optional method to configure the FastAPI app.
+
+        This is a useful place to configure any CORS settings.
         """
 
     @abstractmethod

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -31,6 +31,8 @@ def create_app(predictor: BasePredictor, threads: int = 1) -> FastAPI:
         title="Cog",  # TODO: mention model name?
         # version=None # TODO
     )
+    # Run any configurations required by the predictor.
+    predictor.configure_api(app)
 
     @app.on_event("startup")
     def startup() -> None:


### PR DESCRIPTION
This adds a new _optional_ method to the `BasePredictor` class: `configure_app`.  Any predictor can implement `configure_app` to change how the Fast API server handles requests.  The documented example shows how to solve issue #713 by allowing for cross origin requests.

With this users can customize how cross origin requests are handled without limitation and without having to rely on complex environment variables.