### PR TITLE
Refactor `Makefile`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,8 +40,8 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ secrets.CACHE_VERSION }}-
-      - name: "Build"
-        run: make build
+      - name: Build
+        run: make cog
       - name: Test
         run: make test-go
 
@@ -118,8 +118,8 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - name: Build dependencies
-        run: make build-dependencies
+      - name: Build
+        run: make cog
       - uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-release
+cog
 .ipynb_checkpoints/
 Untitled*.ipynb
 __pycache__

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ MAIN := cmd/cog/cog.go
 BUILD_TIME := $(shell date +%Y-%m-%dT%H:%M:%S%z)
 LDFLAGS := -ldflags "-X github.com/replicate/cog/pkg/global.Version=$(COG_VERSION) -X github.com/replicate/cog/pkg/global.BuildTime=$(BUILD_TIME) -w"
 
+default: all
 
-default: build
+.PHONY: all
+all: cog
 
 pkg/dockerfile/embed/cog.whl: python/* python/cog/* python/cog/server/* python/cog/command/*
 	@echo "Building Python library"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 SHELL := /bin/bash
 
+PREFIX = /usr/local
+BINDIR = $(PREFIX)/bin
+
+INSTALL := install -m 0755
+INSTALL_PROGRAM := $(INSTALL)
+
 COG_VERSION ?= $(shell git describe --tags --match 'v*' --abbrev=0)+dev
 RELEASE_DIR := release
 GOOS := $(shell go env GOOS)
@@ -27,6 +33,8 @@ cog: pkg/dockerfile/embed/cog.whl
 
 .PHONY: install
 install: cog
+	$(INSTALL_PROGRAM) cog $(BINDIR)/cog
+
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,6 @@ PYTHON := python
 PYTEST := pytest
 MYPY := mypy
 
-COG_VERSION ?= $(shell git describe --tags --match 'v*' --abbrev=0)+dev
-BUILD_TIME := $(shell date +%Y-%m-%dT%H:%M:%S%z)
-LDFLAGS := -ldflags "-X github.com/replicate/cog/pkg/global.Version=$(COG_VERSION) -X github.com/replicate/cog/pkg/global.BuildTime=$(BUILD_TIME) -w"
-
 default: all
 
 .PHONY: all
@@ -32,7 +28,10 @@ pkg/dockerfile/embed/cog.whl: python/* python/cog/* python/cog/server/* python/c
 	cp python/dist/*.whl $@
 
 cog: pkg/dockerfile/embed/cog.whl
-	CGO_ENABLED=0 $(GO) build $(LDFLAGS) -o $@ cmd/cog/cog.go
+	$(eval COG_VERSION ?= $(shell git describe --tags --always --dirty))
+	CGO_ENABLED=0 $(GO) build -o $@ \
+		-ldflags "-X github.com/replicate/cog/pkg/global.Version=$(COG_VERSION) -X github.com/replicate/cog/pkg/global.BuildTime=$(shell date +%Y-%m-%dT%H:%M:%S%z) -w" \
+		cmd/cog/cog.go
 
 .PHONY: install
 install: cog

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ cog: pkg/dockerfile/embed/cog.whl
 install: cog
 	$(INSTALL_PROGRAM) cog $(BINDIR)/cog
 
+.PHONY: uninstall
+uninstall:
+	rm -f $(DESTDIR)$(BINDIR)/cog
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,9 @@ test-go: pkg/dockerfile/embed/cog.whl | check-fmt vet lint
 	$(GO) get gotest.tools/gotestsum
 	$(GO) run gotest.tools/gotestsum -- -timeout 1200s -parallel 5 ./... $(ARGS)
 
-# TODO(bfirsh): use local copy of cog so we don't have to install globally
 .PHONY: test-integration
 test-integration: cog
-	cd test-integration/ && $(MAKE)
+	cd test-integration/ && $(MAKE) PATH="$(PWD):$(PATH)" test
 
 .PHONY: test-python
 test-python:

--- a/Makefile
+++ b/Makefile
@@ -20,16 +20,15 @@ pkg/dockerfile/embed/cog.whl: python/* python/cog/* python/cog/server/* python/c
 	mkdir -p pkg/dockerfile/embed
 	cp python/dist/*.whl pkg/dockerfile/embed/cog.whl
 
-build-dependencies: pkg/dockerfile/embed/cog.whl
+cog: pkg/dockerfile/embed/cog.whl
+	CGO_ENABLED=0 go build $(LDFLAGS) -o $@ cmd/cog/cog.go
 
-.PHONY: build
-build: clean build-dependencies
-	@mkdir -p $(RELEASE_DIR)
-	CGO_ENABLED=0 go build $(LDFLAGS) -o $(BINARY) $(MAIN)
+.PHONY: install
+install: cog
 
 .PHONY: clean
 clean:
-	rm -rf $(RELEASE_DIR)
+	rm -f cog
 	rm -f pkg/dockerfile/embed/cog.whl
 
 .PHONY: generate
@@ -43,7 +42,7 @@ test-go: build-dependencies check-fmt vet lint
 
 # TODO(bfirsh): use local copy of cog so we don't have to install globally
 .PHONY: test-integration
-test-integration: install
+test-integration: cog
 	cd test-integration/ && $(MAKE)
 
 .PHONY: test-python

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
 
+DESTDIR ?=
 PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 
@@ -35,7 +36,7 @@ cog: pkg/dockerfile/embed/cog.whl
 
 .PHONY: install
 install: cog
-	$(INSTALL_PROGRAM) cog $(BINDIR)/cog
+	$(INSTALL_PROGRAM) cog $(DESTDIR)$(BINDIR)/cog
 
 .PHONY: uninstall
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,15 @@ BINDIR = $(PREFIX)/bin
 INSTALL := install -m 0755
 INSTALL_PROGRAM := $(INSTALL)
 
+GO := go
+GOOS := $(shell $(GO) env GOOS)
+GOARCH := $(shell $(GO) env GOARCH)
+
+PYTHON := python
+PYTEST := pytest
+MYPY := mypy
+
 COG_VERSION ?= $(shell git describe --tags --match 'v*' --abbrev=0)+dev
-RELEASE_DIR := release
-GOOS := $(shell go env GOOS)
-GOARCH := $(shell go env GOARCH)
-BINARY := $(RELEASE_DIR)/$(GOOS)/$(GOARCH)/cog
-INSTALL_PATH := /usr/local/bin/cog
-MAIN := cmd/cog/cog.go
 BUILD_TIME := $(shell date +%Y-%m-%dT%H:%M:%S%z)
 LDFLAGS := -ldflags "-X github.com/replicate/cog/pkg/global.Version=$(COG_VERSION) -X github.com/replicate/cog/pkg/global.BuildTime=$(BUILD_TIME) -w"
 
@@ -24,12 +26,12 @@ all: cog
 pkg/dockerfile/embed/cog.whl: python/* python/cog/* python/cog/server/* python/cog/command/*
 	@echo "Building Python library"
 	rm -rf python/dist
-	cd python && python setup.py bdist_wheel
+	cd python && $(PYTHON) setup.py bdist_wheel
 	mkdir -p pkg/dockerfile/embed
-	cp python/dist/*.whl pkg/dockerfile/embed/cog.whl
+	cp python/dist/*.whl $@
 
 cog: pkg/dockerfile/embed/cog.whl
-	CGO_ENABLED=0 go build $(LDFLAGS) -o $@ cmd/cog/cog.go
+	CGO_ENABLED=0 $(GO) build $(LDFLAGS) -o $@ cmd/cog/cog.go
 
 .PHONY: install
 install: cog
@@ -41,17 +43,14 @@ uninstall:
 
 .PHONY: clean
 clean:
+	$(GO) clean
 	rm -f cog
 	rm -f pkg/dockerfile/embed/cog.whl
 
-.PHONY: generate
-generate:
-	go generate ./...
-
 .PHONY: test-go
-test-go: build-dependencies check-fmt vet lint
-	go get gotest.tools/gotestsum
-	go run gotest.tools/gotestsum -- -timeout 1200s -parallel 5 ./... $(ARGS)
+test-go: pkg/dockerfile/embed/cog.whl | check-fmt vet lint
+	$(GO) get gotest.tools/gotestsum
+	$(GO) run gotest.tools/gotestsum -- -timeout 1200s -parallel 5 ./... $(ARGS)
 
 # TODO(bfirsh): use local copy of cog so we don't have to install globally
 .PHONY: test-integration
@@ -60,35 +59,36 @@ test-integration: cog
 
 .PHONY: test-python
 test-python:
-	cd python/ && pytest -vv
-
+	cd python/ && $(PYTEST) -vv
 
 .PHONY: test
 test: test-go test-python test-integration
 
-.PHONY: install
-install: build-dependencies
-	go install $(LDFLAGS) $(MAIN)
 
 .PHONY: fmt
 fmt:
-	go run golang.org/x/tools/cmd/goimports -w -d .
+	$(GO) run golang.org/x/tools/cmd/goimports -w -d .
+
+.PHONY: generate
+generate:
+	$(GO) generate ./...
+
 
 .PHONY: vet
 vet:
-	go vet ./...
+	$(GO) vet ./...
 
 
 .PHONY: check-fmt
 check-fmt:
-	go run golang.org/x/tools/cmd/goimports -d .
-	@test -z $$(go run golang.org/x/tools/cmd/goimports -l .)
+	$(GO) run golang.org/x/tools/cmd/goimports -d .
+	@test -z $$($(GO) run golang.org/x/tools/cmd/goimports -l .)
 
 .PHONY: lint
 lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint run ./...
-	mypy python/cog 
+	$(GO) run github.com/golangci/golangci-lint/cmd/golangci-lint run ./...
+	$(MYPY) python/cog
 
 .PHONY: mod-tidy
 mod-tidy:
-	go mod tidy
+	$(GO) mod tidy


### PR DESCRIPTION
This PR implements some changes I needed to get a Homebrew formula working (see https://github.com/replicate/cog/issues/822), specifically:

- Defining constants for executables like `PYTHON`. When Homebrew installs Python 3, my understanding is that it links to `python3`, keeping the default `python` (2.7) executable accessible in the default `PATH`. Because Python 3 is a prerequisite for building from source, we need a way to override this when running `make`.
- Adding an `install` target. In this PR, it's configured to be overridden by conventional `PREFIX` / `BINDIR` constants. It also supports [staged installs](https://www.gnu.org/prep/standards/html_node/DESTDIR.html) using a `DESTDIR` constant.

This PR includes some other changes to keep the rest of the `Makefile` more consistent:

- Adding an `uninstall` target, to keep symmetry with `install`.
- Defining and using constants for `GO` and other executables.
- Adding a new default `all` target that builds `cog` as a prerequisite.
- Adding `go clean` to the `clean` target.

Finally, I noticed a TODO comment from @bfirsh for the `test-integration` target:

> `TODO(bfirsh): use local copy of cog so we don't have to install globally`

With the new `cog` target, we can run integration tests against local executables without installing them by prepending `PWD` to `PATH`. (afbd925bdb2458291493dc6b939d37b9a7d018e5) 