### PR TITLE
Update install instructions in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Hit us up if you're interested in using it or want to collaborate with us. [We'r
 
 ## Install
 
+<a id="upgrade"></a>
+
 You can download and install the latest release of Cog
 by running the following commands in a terminal:
 

--- a/README.md
+++ b/README.md
@@ -115,22 +115,18 @@ Hit us up if you're interested in using it or want to collaborate with us. [We'r
 
 ## Install
 
-First, [install Docker if you haven't already](https://docs.docker.com/get-docker/). Then, run this in a terminal:
+First, [install Docker if you haven't already](https://docs.docker.com/get-docker/). 
+
+Next, 
+download and install a precompiled executable
+by running the following terminal commands:
 
 ```console
 sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m)"
 sudo chmod +x /usr/local/bin/cog
 ```
 
-## Upgrade
-
-If you're already got Cog installed and want to update to a newer version:
-
-```console
-sudo rm $(which cog)
-sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m)"
-sudo chmod +x /usr/local/bin/cog
-```
+You can re-run these commands to update your installation to the latest release.
 
 ## Next steps
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ class Predictor(BasePredictor):
 
 Now, you can run predictions on this model:
 
-```
+```console
 $ cog predict -i @input.jpg
 --> Building Docker image...
 --> Running Prediction...
@@ -68,7 +68,7 @@ $ cog predict -i @input.jpg
 
 Or, build a Docker image for deployment:
 
-```
+```console
 $ cog build -t my-colorization-model
 --> Building Docker image...
 --> Built my-colorization-model:latest
@@ -84,14 +84,14 @@ $ curl http://localhost:5000/predictions -X POST \
 
 In development, you can also run arbitrary commands inside the Docker environment:
 
-```
+```console
 $ cog run python train.py
 ...
 ```
 
 Or, [spin up a Jupyter notebook](docs/notebooks.md):
 
-```
+```console
 $ cog run -p 8888 jupyter notebook --allow-root --ip=0.0.0.0
 ```
 -->
@@ -117,7 +117,7 @@ Hit us up if you're interested in using it or want to collaborate with us. [We'r
 
 First, [install Docker if you haven't already](https://docs.docker.com/get-docker/). Then, run this in a terminal:
 
-```
+```console
 sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m)"
 sudo chmod +x /usr/local/bin/cog
 ```
@@ -126,7 +126,7 @@ sudo chmod +x /usr/local/bin/cog
 
 If you're already got Cog installed and want to update to a newer version:
 
-```
+```console
 sudo rm $(which cog)
 sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m)"
 sudo chmod +x /usr/local/bin/cog

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ sudo chmod +x /usr/local/bin/cog
 Alternatively, you can build Cog from source and install it with these commands:
 
 ```console
-$ make
-$ sudo make install
+make
+sudo make install
 ```
 
 ## Next steps

--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ sudo chmod +x /usr/local/bin/cog
 
 You can re-run these commands to update your installation to the latest release.
 
+Alternatively, you can build Cog from source by running the following commands:
+
+```console
+$ make
+$ sudo make install
+```
+
 ## Next steps
 
 - [Get started with an example model](docs/getting-started.md)

--- a/README.md
+++ b/README.md
@@ -115,16 +115,15 @@ Hit us up if you're interested in using it or want to collaborate with us. [We'r
 
 ## Install
 
-Download and install a pre-built executable by running the following commands:
+You can download and install the latest release of Cog
+by running the following commands in a terminal:
 
 ```console
 sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m)"
 sudo chmod +x /usr/local/bin/cog
 ```
 
-You can re-run these commands to update your installation to the latest release.
-
-Alternatively, you can build Cog from source by running the following commands:
+Alternatively, you can build Cog from source and install it with these commands:
 
 ```console
 $ make

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Hit us up if you're interested in using it or want to collaborate with us. [We'r
 First, [install Docker if you haven't already](https://docs.docker.com/get-docker/). Then, run this in a terminal:
 
 ```
-sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
+sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m)"
 sudo chmod +x /usr/local/bin/cog
 ```
 
@@ -128,7 +128,7 @@ If you're already got Cog installed and want to update to a newer version:
 
 ```
 sudo rm $(which cog)
-sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
+sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m)"
 sudo chmod +x /usr/local/bin/cog
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,11 +115,7 @@ Hit us up if you're interested in using it or want to collaborate with us. [We'r
 
 ## Install
 
-First, [install Docker if you haven't already](https://docs.docker.com/get-docker/). 
-
-Next, 
-download and install a precompiled executable
-by running the following terminal commands:
+Download and install a pre-built executable by running the following commands:
 
 ```console
 sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m)"


### PR DESCRIPTION
Fixes #818 

The current instructions use [backquoted command substitution](https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_06_03) (<code>``</code>) to select the appropriate release artifact for the current machine. This PR updates this command to use dollar sign syntax (`$()`) instead, which is more widely supported.

Following up on the changes in #823, this PR also updates the "Install" section of the README to provide instructions for building from source. This PR also consolidates the "Upgrade" section, since you can re-run the same install command to get the latest version. Finally, I went through and annotated terminal commands with the <code>```console</code>, which adds some syntax highlighting on GitHub.

Feel free to cherry-pick only the `$()` change (6855f2310bae76c6286137269deb5cb631e0436e) if you disagree with the more subjective copy editing changes. 