### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/pkg/cli/init_test.go
+++ b/pkg/cli/init_test.go
@@ -9,12 +9,11 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	dir, err := os.MkdirTemp("/tmp", "cog-init-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	require.NoError(t, os.Chdir(dir))
 
-	err = initCommand([]string{})
+	err := initCommand([]string{})
 	require.NoError(t, err)
 
 	require.FileExists(t, path.Join(dir, "cog.yaml"))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -24,9 +24,8 @@ func TestPythonPackagesAndRequirementsCantBeUsedTogether(t *testing.T) {
 }
 
 func TestPythonRequirementsResolvesPythonPackagesAndCudaVersions(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "cog-test")
-	require.NoError(t, err)
-	err = os.WriteFile(path.Join(tmpDir, "requirements.txt"), []byte(`torch==1.7.1
+	tmpDir := t.TempDir()
+	err := os.WriteFile(path.Join(tmpDir, "requirements.txt"), []byte(`torch==1.7.1
 torchvision==0.8.2
 torchaudio==0.7.2
 foo==1.0.0`), 0o644)
@@ -55,9 +54,8 @@ foo==1.0.0`
 }
 
 func TestPythonRequirementsResolvesPythonPackagesAndCudaVersionsWithExtraIndexURL(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "cog-test")
-	require.NoError(t, err)
-	err = os.WriteFile(path.Join(tmpDir, "requirements.txt"), []byte(`torch==1.12.1
+	tmpDir := t.TempDir()
+	err := os.WriteFile(path.Join(tmpDir, "requirements.txt"), []byte(`torch==1.12.1
 torchvision==0.13.1
 torchaudio==0.12.1
 foo==1.0.0`), 0o644)
@@ -86,9 +84,8 @@ foo==1.0.0`
 }
 
 func TestPythonRequirementsWorksWithLinesCogCannotParse(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "cog-test")
-	require.NoError(t, err)
-	err = os.WriteFile(path.Join(tmpDir, "requirements.txt"), []byte(`foo==1.0.0
+	tmpDir := t.TempDir()
+	err := os.WriteFile(path.Join(tmpDir, "requirements.txt"), []byte(`foo==1.0.0
 # a torch which already has a version
 torch==1.7.1+cu110
 # complex requirements

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -27,11 +27,9 @@ func TestGetProjectDirWithFlagSet(t *testing.T) {
 }
 
 func TestGetConfigShouldLoadFromCustomDir(t *testing.T) {
-	dir, err := os.MkdirTemp("", "cog-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
-	err = os.WriteFile(path.Join(dir, "cog.yaml"), []byte(testConfig), 0o644)
+	err := os.WriteFile(path.Join(dir, "cog.yaml"), []byte(testConfig), 0o644)
 	require.NoError(t, err)
 	err = os.WriteFile(path.Join(dir, "requirements.txt"), []byte("torch==1.0.0"), 0o644)
 	require.NoError(t, err)
@@ -42,11 +40,9 @@ func TestGetConfigShouldLoadFromCustomDir(t *testing.T) {
 }
 
 func TestFindProjectRootDirShouldFindParentDir(t *testing.T) {
-	projectDir, err := os.MkdirTemp("", "cog-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(projectDir)
+	projectDir := t.TempDir()
 
-	err = os.WriteFile(path.Join(projectDir, "cog.yaml"), []byte(testConfig), 0o644)
+	err := os.WriteFile(path.Join(projectDir, "cog.yaml"), []byte(testConfig), 0o644)
 	require.NoError(t, err)
 
 	subdir := path.Join(projectDir, "some/sub/dir")
@@ -59,12 +55,10 @@ func TestFindProjectRootDirShouldFindParentDir(t *testing.T) {
 }
 
 func TestFindProjectRootDirShouldReturnErrIfNoConfig(t *testing.T) {
-	projectDir, err := os.MkdirTemp("", "cog-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(projectDir)
+	projectDir := t.TempDir()
 
 	subdir := path.Join(projectDir, "some/sub/dir")
-	err = os.MkdirAll(subdir, 0o700)
+	err := os.MkdirAll(subdir, 0o700)
 	require.NoError(t, err)
 
 	_, err = findProjectRootDir(subdir)

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -47,8 +47,7 @@ RUN curl -s -S -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master
 }
 
 func TestGenerateEmptyCPU(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	conf, err := config.FromYAML([]byte(`
 build:
@@ -78,8 +77,7 @@ COPY . /src`
 }
 
 func TestGenerateEmptyGPU(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	conf, err := config.FromYAML([]byte(`
 build:
@@ -111,8 +109,7 @@ COPY . /src`
 }
 
 func TestGenerateFullCPU(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	conf, err := config.FromYAML([]byte(`
 build:
@@ -160,8 +157,7 @@ pandas==1.2.0.12`, string(requirements))
 }
 
 func TestGenerateFullGPU(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	conf, err := config.FromYAML([]byte(`
 build:
@@ -213,8 +209,7 @@ pandas==1.2.0.12`, string(requirements))
 
 // pre_install is deprecated but supported for backwards compatibility
 func TestPreInstall(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	conf, err := config.FromYAML([]byte(`
 build:
@@ -248,9 +243,8 @@ COPY . /src`
 }
 
 func TestPythonRequirements(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "cog-test")
-	require.NoError(t, err)
-	err = os.WriteFile(path.Join(tmpDir, "my-requirements.txt"), []byte("torch==1.0.0"), 0o644)
+	tmpDir := t.TempDir()
+	err := os.WriteFile(path.Join(tmpDir, "my-requirements.txt"), []byte("torch==1.0.0"), 0o644)
 	require.NoError(t, err)
 	conf, err := config.FromYAML([]byte(`
 build:

--- a/pkg/util/files/files_test.go
+++ b/pkg/util/files/files_test.go
@@ -9,10 +9,9 @@ import (
 )
 
 func TestIsExecutable(t *testing.T) {
-	dir, err := os.MkdirTemp("/tmp", "test-files")
-	require.NoError(t, err)
+	dir := t.TempDir()
 	path := filepath.Join(dir, "test-file")
-	err = os.WriteFile(path, []byte{}, 0o644)
+	err := os.WriteFile(path, []byte{}, 0o644)
 	require.NoError(t, err)
 
 	require.False(t, IsExecutable(path))


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	assert.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```