### PR TITLE
Add an explicit handler to die on SIGTERM

### DIFF
--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -483,7 +483,17 @@ def _queue_worker_from_argv(
     )
 
 
+def _die(signum: Any, frame: Any) -> None:
+    print("Caught early SIGTERM. Exiting immediately!", file=sys.stderr)
+    sys.exit(1)
+
+
 if __name__ == "__main__":
+    # We are probably running as PID 1 so need to explicitly register a handler
+    # to die on SIGTERM. This will be overwritten once we start the
+    # RedisQueueWorker.
+    signal.signal(signal.SIGTERM, _die)
+
     # Enable OpenTelemetry if the env vars are present. If this block isn't
     # run, all the opentelemetry calls are no-ops.
     if "OTEL_SERVICE_NAME" in os.environ:


### PR DESCRIPTION
If SIGTERM arrives before we have started RedisQueueWorker (where we explicitly register a handler for that signal) and we are running as PID 1, the kernel will decline to kill the process.

This means that there is a period during startup where a SIGTERM will be ignored.

To avoid/minimise the possibility of this, this commit sets an explicit SIGTERM handler to quit the process which is used until overridden by the more graceful handler inside RedisQueueWorker.