### PR TITLE
Install tini as image entrypoint

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -89,6 +89,7 @@ func (g *Generator) GenerateBase() (string, error) {
 		"# syntax = docker/dockerfile:1.2",
 		"FROM " + baseImage,
 		g.preamble(),
+		g.installTini(),
 		installPython,
 		installCog,
 		aptInstalls,
@@ -139,6 +140,26 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia
     apt-key del 7fa2af80`)
 	}
 
+	return strings.Join(lines, "\n")
+}
+
+func (g *Generator) installTini() string {
+	// Install tini as the image entrypoint to provide signal handling and process
+	// reaping appropriate for PID 1.
+	//
+	// N.B. If you remove/change this, consider removing/changing the `has_init`
+	// image label applied in image/build.go.
+	lines := []string{
+		`RUN --mount=type=cache,target=/var/cache/apt set -eux; \
+apt-get update -qq; \
+apt-get install -qqy --no-install-recommends curl; \
+rm -rf /var/lib/apt/lists/*; \
+TINI_VERSION=v0.19.0; \
+TINI_ARCH="$(dpkg --print-architecture)"; \
+curl -sSL -o /sbin/tini "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TINI_ARCH}"; \
+chmod +x /sbin/tini`,
+		`ENTRYPOINT ["/sbin/tini", "--"]`,
+	}
 	return strings.Join(lines, "\n")
 }
 

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -11,6 +11,19 @@ import (
 	"github.com/replicate/cog/pkg/config"
 )
 
+func testTini() string {
+	return `RUN --mount=type=cache,target=/var/cache/apt set -eux; \
+apt-get update -qq; \
+apt-get install -qqy --no-install-recommends curl; \
+rm -rf /var/lib/apt/lists/*; \
+TINI_VERSION=v0.19.0; \
+TINI_ARCH="$(dpkg --print-architecture)"; \
+curl -sSL -o /sbin/tini "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TINI_ARCH}"; \
+chmod +x /sbin/tini
+ENTRYPOINT ["/sbin/tini", "--"]
+`
+}
+
 func testInstallCog(relativeTmpDir string) string {
 	return fmt.Sprintf(`COPY %s/cog-0.0.1.dev-py3-none-any.whl /tmp/cog-0.0.1.dev-py3-none-any.whl
 RUN --mount=type=cache,target=/root/.cache/pip pip install /tmp/cog-0.0.1.dev-py3-none-any.whl`, relativeTmpDir)
@@ -67,7 +80,7 @@ FROM python:3.8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
-` + testInstallCog(gen.relativeTmpDir) + `
+` + testTini() + testInstallCog(gen.relativeTmpDir) + `
 WORKDIR /src
 EXPOSE 5000
 CMD ["python", "-m", "cog.server.http"]
@@ -99,7 +112,7 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia
 RUN rm -f /etc/apt/sources.list.d/cuda.list && \
     rm -f /etc/apt/sources.list.d/nvidia-ml.list && \
     apt-key del 7fa2af80
-` + testInstallPython("3.8") + testInstallCog(gen.relativeTmpDir) + `
+` + testTini() + testInstallPython("3.8") + testInstallCog(gen.relativeTmpDir) + `
 WORKDIR /src
 EXPOSE 5000
 CMD ["python", "-m", "cog.server.http"]
@@ -137,7 +150,7 @@ FROM python:3.8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
-` + testInstallCog(gen.relativeTmpDir) + `
+` + testTini() + testInstallCog(gen.relativeTmpDir) + `
 RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip pip install -r /tmp/requirements.txt
@@ -188,7 +201,8 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia
 RUN rm -f /etc/apt/sources.list.d/cuda.list && \
     rm -f /etc/apt/sources.list.d/nvidia-ml.list && \
     apt-key del 7fa2af80
-` + testInstallPython("3.8") +
+` + testTini() +
+		testInstallPython("3.8") +
 		testInstallCog(gen.relativeTmpDir) + `
 RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
@@ -231,7 +245,7 @@ FROM python:3.8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
-` + testInstallCog(gen.relativeTmpDir) + `
+` + testTini() + testInstallCog(gen.relativeTmpDir) + `
 RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy cowsay && rm -rf /var/lib/apt/lists/*
 RUN cowsay moo
 WORKDIR /src

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -52,6 +52,9 @@ func Build(cfg *config.Config, dir, imageName string, progressOutput string) err
 	labels := map[string]string{
 		global.LabelNamespace + "version": global.Version,
 		global.LabelNamespace + "config":  string(bytes.TrimSpace(configJSON)),
+		// Mark the image as having an appropriate init entrypoint. We can use this
+		// to decide how/if to shim the image.
+		global.LabelNamespace + "has_init": "true",
 		// Backwards compatibility. Remove for 1.0.
 		"org.cogmodel.deprecated":  "The org.cogmodel labels are deprecated. Use run.cog.",
 		"org.cogmodel.cog_version": global.Version,


### PR DESCRIPTION
Configure krallin/tini as the Docker image entrypoint. Ensures that signals are handled appropriately and any child processes are correctly reaped inside Cog containers.

Fixes #840.

Signed-off-by: Nick Stenning <nick@whiteink.com>