### PR TITLE
cog/async-api: log prediction id

### DIFF
--- a/python/cog/director/queue_worker.py
+++ b/python/cog/director/queue_worker.py
@@ -139,6 +139,13 @@ class QueueWorker:
             return
 
         message = json.loads(message_json)
+        log.info(
+            "received message",
+            message_id=message_id,
+            queue=self.redis_consumer.redis_input_queue,
+            prediction_id=message['id'],
+            model_version=message['version'],
+        )
         should_cancel = self.redis_consumer.checker(message.get("cancel_key"))
         prediction_id = message["id"]
 

--- a/python/cog/director/redis.py
+++ b/python/cog/director/redis.py
@@ -54,9 +54,6 @@ class RedisConsumer:
 
             message_id = key.decode()
             message = raw_message[1].decode()
-            log.info(
-                "received message", message_id=message_id, queue=self.redis_input_queue
-            )
             return message_id, message
 
         # if no old messages exist, get message from main queue


### PR DESCRIPTION
Very simple change.

It would be slightly more work to also re-write Cog to include this when it logs to stdout; but it's certainly something I could do in a follow-up.

@nickstenning @evilstreak 