### PR TITLE
Tighten up error handling in PredictionRunner

### DIFF
--- a/python/cog/director/queue_worker.py
+++ b/python/cog/director/queue_worker.py
@@ -194,6 +194,8 @@ class QueueWorker:
         started_at = datetime.datetime.now()
 
         while True:
+            # FIXME: gracefully handle the model container crashing
+
             if self.prediction_event.wait(POLL_INTERVAL):
                 break
 

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -349,6 +349,7 @@ def test_asynchronous_prediction_endpoint(client):
             "id": "12345abcde",
             "input": {"text": "hello world"},
             "webhook": "https://example.com/webhook",
+            "webhook_events_filter": ["completed"],
         },
         headers={"Prefer": "respond-async"},
     )


### PR DESCRIPTION
The general principles here:

- if we're at all able to, trigger a final "failed" webhook with the error and all the logs and output so far
- if the error is irrecoverable, crash the server -- the director has to be able to handle a crashed sibling container anyway, so don't try any heroics to stay alive

---

This is untested – consider this a sketch for feedback rather than a polished-and-ready-to-go piece of code!