### PR TITLE
observability: add utilization span + prediction span

### DIFF
--- a/python/cog/director/__main__.py
+++ b/python/cog/director/__main__.py
@@ -8,14 +8,26 @@ from typing import Any
 
 import structlog
 import uvicorn
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from ..logging import setup_logging
 from .director import Director
 from .healthchecker import Healthchecker, http_fetcher
 from .http import Server, create_app
+from .monitor import Monitor
 from .redis import RedisConsumer, RedisConsumerRotator
 
 log = structlog.get_logger("cog.director")
+
+# Enable OpenTelemetry if the env vars are present. If this block isn't
+# run, all the opentelemetry calls are no-ops.
+if "OTEL_SERVICE_NAME" in os.environ:
+    trace.set_tracer_provider(TracerProvider())
+    span_processor = BatchSpanProcessor(OTLPSpanExporter())
+    trace.get_tracer_provider().add_span_processor(span_processor)  # type: ignore
 
 
 def _die(signum: Any, frame: Any) -> None:
@@ -58,6 +70,9 @@ healthchecker = Healthchecker(
 )
 healthchecker.start()
 
+monitor = Monitor()
+monitor.start()
+
 if (len(args.redis_url) != len(args.redis_input_queue)) or (
     len(args.redis_url) != len(args.redis_consumer_id)
 ):
@@ -88,14 +103,19 @@ redis_consumer_rotator = RedisConsumerRotator(consumers=redis_consumers)
 director = Director(
     events=events,
     healthchecker=healthchecker,
+    monitor=monitor,
     redis_consumer_rotator=redis_consumer_rotator,
     predict_timeout=args.predict_timeout,
     max_failure_count=args.max_failure_count,
     report_setup_run_url=args.report_setup_run_url,
 )
+
+
 director.register_shutdown_hook(healthchecker.stop)
 director.register_shutdown_hook(server.stop)
+director.register_shutdown_hook(monitor.stop)
 director.start()
 
+monitor.join()
 healthchecker.join()
 server.join()

--- a/python/cog/director/monitor.py
+++ b/python/cog/director/monitor.py
@@ -1,0 +1,93 @@
+import threading
+import time
+from queue import Empty, Full, Queue
+from typing import Optional
+
+import structlog
+from opentelemetry import trace
+
+from .. import schema
+
+log = structlog.get_logger(__name__)
+
+
+class Monitor:
+    def __init__(self, utilization_interval=15):
+        self._thread = None
+        self._should_exit = threading.Event()
+        self._tracer = trace.get_tracer("cog-director")
+        self._prediction_events = Queue()
+        self.utilization_interval = utilization_interval
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._run)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._should_exit.set()
+
+    def join(self) -> None:
+        if self._thread is not None:
+            self._thread.join()
+
+    def set_current_prediction(self, prediction: Optional[schema.PredictionResponse]):
+        try:
+            self._prediction_events.put_nowait(prediction)
+        except Full:
+            log.info("prediction event queue is full, dropping event")
+
+    def _run(self) -> None:
+        last_span_at = time.perf_counter() - self.utilization_interval
+        active_sec = 0.0
+        current_prediction: Optional[schema.PredictionResponse] = None
+        current_prediction_started_at: Optional[float] = None
+
+        while not self._should_exit.is_set():
+            try:
+                current_prediction = self._prediction_events.get_nowait()
+                # Set to None or schema.PredictionResponse
+                # Will raise Empty when there is nothing in the queue in the timeout
+
+                if current_prediction_started_at:  # count utilization in window
+                    active_sec += time.perf_counter() - current_prediction_started_at
+
+                if current_prediction:  # new prediction
+                    current_prediction_started_at = time.perf_counter()
+                else:  # switched to idling
+                    current_prediction_started_at = None
+            except Empty:
+                pass
+
+            if time.perf_counter() >= last_span_at + self.utilization_interval:
+                with self._tracer.start_as_current_span(
+                    name="cog.director.utilization"
+                ) as span:
+                    if current_prediction_started_at:  # event didn't finish in window
+                        active_sec += (
+                            time.perf_counter() - current_prediction_started_at
+                        )
+
+                    utilization_for_window = min(
+                        active_sec / self.utilization_interval, 1.0
+                    )
+                    span.set_attributes(
+                        {
+                            "utilization": utilization_for_window,
+                            "metric_duration": time.perf_counter() - last_span_at,
+                        }
+                    )
+                    if current_prediction and current_prediction.version:
+                        span.set_attribute("model.version", current_prediction.version)
+
+                last_span_at = last_span_at + self.utilization_interval
+
+                active_sec = 0.0
+                if current_prediction:
+                    current_prediction_started_at = last_span_at
+
+            # Can't just sleep; we need to check for events, emit spans at the
+            # right time, and whether to exit. We can't block on only one of
+            # those things.
+            time.sleep(0.01)
+
+        log.info("shutting down monitor")

--- a/python/cog/schema.py
+++ b/python/cog/schema.py
@@ -58,6 +58,7 @@ class PredictionResponse(PredictionBaseModel):
     output: t.Any
 
     id: t.Optional[str]
+    version: t.Optional[str]
 
     created_at: t.Optional[datetime]
     started_at: t.Optional[datetime]

--- a/python/tests/director/test_monitor.py
+++ b/python/tests/director/test_monitor.py
@@ -1,0 +1,78 @@
+import time
+from asyncio import wait_for
+from os import wait
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+
+from cog.director.monitor import Monitor
+from cog.schema import PredictionResponse
+
+
+class MockSpanProvider:
+    def __init__(self):
+        self.spans = []
+
+    def on_start(self, span, parent_context):
+        self.spans.append(span)
+        pass
+
+    def on_end(self, span):
+        pass
+
+    def shutdown(*args):
+        pass
+
+
+def setup_span_provider():
+    span_provider = MockSpanProvider()
+
+    # use a tracing provider in test that just puts it into memory
+    trace.set_tracer_provider(TracerProvider())
+    trace.get_tracer_provider().add_span_processor(span_provider)
+
+    return span_provider
+
+
+def wait_for_num_spans(span_provider, num):
+    start = time.perf_counter()
+    while len(span_provider.spans) != num:
+        time.sleep(0.01)
+        if time.perf_counter() - start > 5:
+            raise Exception("timed out waiting for spans")
+
+    return span_provider.spans
+
+
+def test_emit_utilization_span():
+    span_provider = setup_span_provider()
+
+    monitor = Monitor(utilization_interval=1)
+    monitor.start()
+
+    prediction = PredictionResponse(
+        id="narwhal",
+        input={"foo": "bar"},
+        version="walrus1",
+    )
+    monitor.set_current_prediction(prediction)
+    time.sleep(1.5)
+    monitor.set_current_prediction(None)
+
+    spans = wait_for_num_spans(span_provider, 4)
+
+    assert spans[0].name == "cog.director.utilization"
+    # Either 0.0 or 1.0, depending on whether thread gets to emit span before or
+    # after `set_current_prediction` runs in the main thread
+    assert "utilization" in spans[0].attributes
+
+    assert abs(1.0 - spans[1].attributes["utilization"]) <= 0.3
+    assert "walrus1" == spans[1].attributes["model.version"]
+
+    assert abs(0.5 - spans[2].attributes["utilization"]) <= 0.3
+
+    assert spans[3].attributes["utilization"] == 0.0
+
+    monitor.stop()
+    monitor.join()


### PR DESCRIPTION
@nickstenning @evilstreak 

This adds a `cog.prediction` and `cog.director.idle` spans from Cog

**Should we set the parent span on `cog.prediction`?** We could probably pass down the parent span id in the `Prediction` message and then set the parent span. I didn't want to go through this effort of changing yet another repo if you guys didn't think it was worth it! Let me know.

**Why do you need both `cog.director.utilization` and `cog.prediction`?** I want to be able to get a utilization number between 0 and 1, and we can't use `CONCURRENCY(cog.prediction) / availableReplicas` or something to compute it. We can get away without it, but I would love to have this 0..1 utilization number.

**How many events will this generate per month?** This will generate [around 100M events ](https://share.cleanshot.com/CqHzC538) per month, or [6% of our quota](https://share.cleanshot.com/Y7KpzkLZ). We could reduce by sampling less often.