### PR TITLE
Fix a bunch of error handling edge cases in director

### DIFF
--- a/python/cog/director/__main__.py
+++ b/python/cog/director/__main__.py
@@ -1,4 +1,5 @@
 import logging
+import queue
 import os
 import signal
 import sys
@@ -9,7 +10,6 @@ import structlog
 import uvicorn
 
 from ..logging import setup_logging
-from .http import create_app, Server
 from .redis import RedisConsumer
 from .queue_worker import QueueWorker
 
@@ -52,6 +52,7 @@ redis_consumer = RedisConsumer(
     predict_timeout=args.predict_timeout,
 )
 worker = QueueWorker(
+    events=queue.Queue(maxsize=128),
     redis_consumer=redis_consumer,
     predict_timeout=args.predict_timeout,
     max_failure_count=args.max_failure_count,

--- a/python/cog/director/__main__.py
+++ b/python/cog/director/__main__.py
@@ -11,7 +11,7 @@ import uvicorn
 
 from ..logging import setup_logging
 from .redis import RedisConsumer
-from .queue_worker import QueueWorker
+from .director import Director
 
 log = structlog.get_logger("cog.director")
 
@@ -51,11 +51,11 @@ redis_consumer = RedisConsumer(
     redis_consumer_id=args.redis_consumer_id,
     predict_timeout=args.predict_timeout,
 )
-worker = QueueWorker(
+director = Director(
     events=queue.Queue(maxsize=128),
     redis_consumer=redis_consumer,
     predict_timeout=args.predict_timeout,
     max_failure_count=args.max_failure_count,
     report_setup_run_url=args.report_setup_run_url,
 )
-worker.start()
+director.start()

--- a/python/cog/director/director.py
+++ b/python/cog/director/director.py
@@ -43,7 +43,7 @@ class Abort(Exception):
     pass
 
 
-class QueueWorker:
+class Director:
     def __init__(
         self,
         events: queue.Queue,

--- a/python/cog/director/eventtypes.py
+++ b/python/cog/director/eventtypes.py
@@ -1,0 +1,8 @@
+from attrs import define
+
+from .. import schema
+
+
+@define
+class Webhook:
+    payload: schema.PredictionResponse

--- a/python/cog/director/eventtypes.py
+++ b/python/cog/director/eventtypes.py
@@ -1,8 +1,24 @@
+from typing import Any, Callable, Dict, Optional
+from enum import Enum, auto, unique
+
 from attrs import define
 
 from .. import schema
 
 
+@unique
+class Health(Enum):
+    UNKNOWN = auto()
+    HEALTHY = auto()
+    SETUP_FAILED = auto()
+
+
 @define
 class Webhook:
     payload: schema.PredictionResponse
+
+
+@define
+class HealthcheckStatus:
+    health: Health
+    metadata: Optional[Dict[str, Any]] = None

--- a/python/cog/director/healthchecker.py
+++ b/python/cog/director/healthchecker.py
@@ -1,0 +1,132 @@
+import queue
+import time
+import threading
+from typing import Any, Callable, Dict, Optional
+
+import requests
+import structlog
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+from .eventtypes import Health, HealthcheckStatus
+
+log = structlog.get_logger(__name__)
+
+# How often to healthcheck when state is unknown
+UNKNOWN_POLL_INTERVAL = 0.1
+
+# How often to healthcheck when state is known
+POLL_INTERVAL = 5
+
+
+class Healthchecker:
+    def __init__(
+        self, *, events: queue.Queue, fetcher: Callable[[], HealthcheckStatus]
+    ):
+        self._events = events
+        self._fetch = fetcher
+
+        self._thread = None
+        self._should_exit = threading.Event()
+
+        self._last_check = time.perf_counter()
+        self._state = HealthcheckStatus(health=Health.UNKNOWN)
+
+    def start(self) -> None:
+        """
+        Start the background healthchecker thread.
+        """
+        self._thread = threading.Thread(target=self._run)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """
+        Trigger the termination of the healthcheck thread.
+        """
+        self._should_exit.set()
+
+    def join(self) -> None:
+        if self._thread is not None:
+            self._thread.join()
+
+    def _run(self) -> None:
+        while not self._should_exit.is_set():
+            if self._check_due():
+                self._set_state(self._fetch())
+                self._last_check = time.perf_counter()
+            else:
+                time.sleep(min(POLL_INTERVAL, UNKNOWN_POLL_INTERVAL))
+
+    def _set_state(self, state: HealthcheckStatus) -> None:
+        if self._state == state:
+            return
+        self._state = state
+        log.debug("healthchecker status changed", state=state)
+        try:
+            self._events.put(self._state, timeout=0.1)
+        except queue.Full:
+            log.warn("failed to enqueue healthcheck status change: queue full")
+
+    def _check_due(self) -> bool:
+        last_check_delta = time.perf_counter() - self._last_check
+        if self._state.health == Health.UNKNOWN:
+            return last_check_delta > UNKNOWN_POLL_INTERVAL
+        else:
+            return last_check_delta > POLL_INTERVAL
+
+
+def http_fetcher(url: str):
+    c = _make_http_client()
+
+    def _fetch():
+        try:
+            resp = c.get(url, timeout=1)
+        except requests.exceptions.RequestException:
+            return HealthcheckStatus(health=Health.UNKNOWN)
+        else:
+            return _state_from_response(resp)
+
+    return _fetch
+
+
+def _make_http_client() -> requests.Session:
+    session = requests.Session()
+    adapter = HTTPAdapter(
+        max_retries=Retry(
+            total=3,
+            backoff_factor=0.1,
+            status_forcelist=[429, 500, 502, 503, 504],
+        ),
+    )
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
+def _state_from_response(resp: requests.Response) -> HealthcheckStatus:
+    if resp.status_code != 200:
+        return HealthcheckStatus(health=Health.UNKNOWN)
+
+    try:
+        body = resp.json()
+    except requests.exceptions.JSONDecodeError:
+        log.warn("received invalid JSON from healthcheck endpoint", response=resp.text)
+        return HealthcheckStatus(health=Health.UNKNOWN)
+
+    if "status" not in body or "setup" not in body:
+        log.warn(
+            "received response with invalid schema from healthcheck endpoint",
+            response=resp.text,
+        )
+        return HealthcheckStatus(health=Health.UNKNOWN)
+
+    if body["status"] != "healthy":
+        return HealthcheckStatus(health=Health.UNKNOWN)
+
+    if body["setup"] is None:
+        return HealthcheckStatus(health=Health.UNKNOWN)
+
+    if body["setup"].get("status") == "succeeded":
+        return HealthcheckStatus(health=Health.HEALTHY, metadata=body["setup"])
+
+    return HealthcheckStatus(health=Health.SETUP_FAILED, metadata=body["setup"])

--- a/python/cog/director/http.py
+++ b/python/cog/director/http.py
@@ -29,7 +29,7 @@ class Server(uvicorn.Server):
 def create_app(events: queue.Queue) -> FastAPI:
     app = FastAPI(title="Director")
 
-    # The event queue is used to communicate with QueueWorker when webhook
+    # The event queue is used to communicate with Director when webhook
     # events are received.
     app.state.events = events
 

--- a/python/cog/director/http.py
+++ b/python/cog/director/http.py
@@ -1,6 +1,4 @@
-import multiprocessing
-import os
-import signal
+import queue
 import threading
 from typing import Any
 
@@ -10,8 +8,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from .. import schema
-from ..json import make_encodeable
-from ..server.webhook import webhook_caller
+from .eventtypes import Webhook
 
 log = structlog.get_logger(__name__)
 
@@ -29,116 +26,24 @@ class Server(uvicorn.Server):
         self._thread.join()
 
 
-def create_app(
-    prediction_event: threading.Event,
-    prediction_timeout_event: threading.Event,
-    prediction_request_pipe: multiprocessing.connection.Connection,
-    max_failure_count: int,
-) -> FastAPI:
+def create_app(events: queue.Queue) -> FastAPI:
     app = FastAPI(title="Director")
 
-    # Used to signal between webserver and queue worker when a prediction is
-    # running or not.
-    app.state.prediction_event = prediction_event
-
-    # Used to signal to the webserver that a prediction timed out and was
-    # canceled automatically.
-    app.state.prediction_timeout_event = prediction_timeout_event
-
-    # Used to send the original prediction request from the queue worker to the
-    # webserver for constructing outgoing webhooks.
-    app.state.prediction_request_pipe = prediction_request_pipe
-    app.state.prediction_request = None
-
-    # Number of consecutive failures seen
-    app.state.failure_count = 0
-
-    def check_failure_count() -> None:
-        if max_failure_count is None:
-            return
-        if app.state.failure_count <= max_failure_count:
-            return
-
-        log.error(
-            "saw too many failures in a row, exiting...",
-            failure_count=app.state.failure_count,
-        )
-
-        # TODO: find a better way to shut down uvicorn
-        os.kill(os.getpid(), signal.SIGTERM)
+    # The event queue is used to communicate with QueueWorker when webhook
+    # events are received.
+    app.state.events = events
 
     @app.post("/webhook")
     def webhook(payload: schema.PredictionResponse) -> Any:
-        # TODO the logic here seems weird, might need to invert the variable
-        # name to something like `prediction_running`?
-        if app.state.prediction_event.is_set():
+        event = Webhook(payload=payload)
+        try:
+            app.state.events.put(event, timeout=0.1)
+        except queue.Full:
             return JSONResponse(
-                {"detail": "cannot receive webhooks when no prediction is running"},
-                status_code=409,
+                {"detail": "cannot receive webhooks: queue is full"},
+                status_code=503,
             )
-
-        if payload.status is None:
-            return JSONResponse(
-                {"detail": "webhook payload must have a status"}, status_code=400
-            )
-
-        if app.state.prediction_request is None:
-            log.info("Getting updated prediction_request from pipe")
-            # TODO how defensive do we need to be reading from this pipe?
-            app.state.prediction_request = app.state.prediction_request_pipe.recv()
-            app.state.send_webhook = webhook_caller(
-                app.state.prediction_request["webhook"]
-            )
-
-        # only permit a limited set of keys from the payload, to prevent
-        # untrusted code from setting things like IDs and internal data
-        outgoing_response = make_encodeable(
-            {
-                **app.state.prediction_request,
-                **allowed_fields(payload.dict()),
-            }
-        )
-
-        # if the prediction was canceled, that might be because it timed out:
-        # change the status to match that set by redis_queue if so...
-        if (
-            outgoing_response["status"] == schema.Status.CANCELED
-            and app.state.prediction_timeout_event.is_set()
-        ):
-            outgoing_response["status"] = schema.Status.FAILED
-            outgoing_response["error"] = "Prediction timed out"
-
-        app.state.send_webhook(outgoing_response)
-
-        if schema.Status.is_terminal(payload.status):
-            app.state.prediction_request = None
-            app.state.prediction_event.set()
-
-        if payload.status == schema.Status.FAILED:
-            app.state.failure_count += 1
-            check_failure_count()
-        else:
-            app.state.failure_count = 0
 
         return JSONResponse({"status": "ok"}, status_code=200)
 
     return app
-
-
-ALLOWED_FIELDS_FROM_UNTRUSTED_CONTAINER = (
-    # TODO: we shouldn't trust the timings (or derived metrics) either
-    "completed_at",
-    "started_at",
-    "metrics",
-    # Prediction output and output metadata
-    "error",
-    "logs",
-    "output",
-    "status",
-)
-
-
-def allowed_fields(payload: dict):
-    return {
-        k: v for k, v in payload.items() if k in ALLOWED_FIELDS_FROM_UNTRUSTED_CONTAINER
-    }

--- a/python/cog/director/prediction_tracker.py
+++ b/python/cog/director/prediction_tracker.py
@@ -53,6 +53,11 @@ class PredictionTracker:
         self._update(payload)
 
     @property
+    def runtime(self):
+        now = datetime.now(tz=timezone.utc)
+        return (now - self._response.started_at).total_seconds()
+
+    @property
     def status(self):
         return self._response.status
 

--- a/python/cog/director/prediction_tracker.py
+++ b/python/cog/director/prediction_tracker.py
@@ -41,6 +41,10 @@ class PredictionTracker:
     def update_from_webhook_payload(self, payload: schema.PredictionResponse):
         self._update(allowed_fields(payload.dict()))
 
+    @property
+    def status(self):
+        return self._response.status
+
     def _update(self, mapping: Dict[str, Any]):
         self._response = self._response.copy(update=mapping)
         self._adjust_cancelation_status()

--- a/python/cog/director/prediction_tracker.py
+++ b/python/cog/director/prediction_tracker.py
@@ -37,6 +37,12 @@ class PredictionTracker:
         self._timed_out = True
 
     def update_from_webhook_payload(self, payload: schema.PredictionResponse):
+        # Safety check -- only allow payloads with IDs matching self._response.
+        if payload.id != self._response.id:
+            raise PredictionMismatchError(
+                f"received webhook payload for {payload.id} while tracking {self._response.id}"
+            )
+
         self._update(allowed_fields(payload.dict()))
 
     def fail(self, message):

--- a/python/cog/director/prediction_tracker.py
+++ b/python/cog/director/prediction_tracker.py
@@ -1,0 +1,69 @@
+import threading
+from typing import Any, Callable, Dict, Optional
+
+from .. import schema
+from ..json import make_encodeable
+
+
+ALLOWED_FIELDS_FROM_UNTRUSTED_CONTAINER = (
+    # TODO: we shouldn't trust the timings (or derived metrics) either
+    "completed_at",
+    "started_at",
+    "metrics",
+    # Prediction output and output metadata
+    "error",
+    "logs",
+    "output",
+    "status",
+)
+
+
+class PredictionMismatchError(Exception):
+    pass
+
+
+class PredictionTracker:
+    def __init__(
+        self,
+        response: schema.PredictionResponse,
+        webhook_caller: Optional[Callable] = None,
+    ):
+        self._webhook_caller = webhook_caller
+        self._response = response
+        self._timed_out = False
+
+    def is_complete(self):
+        return schema.Status.is_terminal(self._response.status)
+
+    def timed_out(self):
+        self._timed_out = True
+
+    def update_from_webhook_payload(self, payload: schema.PredictionResponse):
+        self._update(allowed_fields(payload.dict()))
+
+    def _update(self, mapping: Dict[str, Any]):
+        self._response = self._response.copy(update=mapping)
+        self._adjust_cancelation_status()
+        self._send_webhook()
+
+    def _adjust_cancelation_status(self):
+        if not self._timed_out:
+            return
+        if self._response.status != schema.Status.CANCELED:
+            return
+        self._response.status = schema.Status.FAILED
+        self._response.error = "Prediction timed out"
+
+    def _send_webhook(self):
+        if not self._webhook_caller:
+            return
+
+        state = self._response.dict()
+        payload = make_encodeable(state)
+        self._webhook_caller(payload)
+
+
+def allowed_fields(payload: dict):
+    return {
+        k: v for k, v in payload.items() if k in ALLOWED_FIELDS_FROM_UNTRUSTED_CONTAINER
+    }

--- a/python/tests/director/test_healthchecker.py
+++ b/python/tests/director/test_healthchecker.py
@@ -1,0 +1,148 @@
+import queue
+import time
+
+import pytest
+import requests
+import responses
+from responses.registries import OrderedRegistry
+
+
+from cog.director.eventtypes import Health, HealthcheckStatus
+from cog.director.healthchecker import Healthchecker, http_fetcher
+
+
+def fake_fetcher(statuses):
+    def _fetch():
+        try:
+            return statuses.pop()
+        except IndexError:
+            return HealthcheckStatus(health=Health.UNKNOWN)
+
+    return _fetch
+
+
+def test_healthchecker():
+    events = queue.Queue(maxsize=64)
+    fetcher = fake_fetcher(
+        [
+            HealthcheckStatus(health=Health.UNKNOWN),
+            HealthcheckStatus(health=Health.UNKNOWN),
+            HealthcheckStatus(health=Health.UNKNOWN),
+            HealthcheckStatus(health=Health.UNKNOWN),
+            HealthcheckStatus(health=Health.HEALTHY, metadata={"animal": "giraffe"}),
+        ]
+    )
+
+    h = Healthchecker(events=events, fetcher=fetcher)
+    h.start()
+
+    result = events.get(timeout=1)
+
+    assert result == HealthcheckStatus(
+        health=Health.HEALTHY, metadata={"animal": "giraffe"}
+    )
+
+    h.stop()
+    h.join()
+
+
+@responses.activate
+def test_http_fetcher_ok():
+    responses.add(
+        responses.GET,
+        "https://example.com/health-check",
+        json={
+            "status": "healthy",
+            "setup": {"status": "succeeded", "logs": "hello there"},
+        },
+        status=200,
+    )
+    fetcher = http_fetcher("https://example.com/health-check")
+
+    status = fetcher()
+
+    assert status.health == Health.HEALTHY
+    assert status.metadata == {"status": "succeeded", "logs": "hello there"}
+
+
+@responses.activate
+def test_http_fetcher_non_200_response():
+    responses.add(
+        responses.GET,
+        "https://example.com/health-check",
+        status=404,
+    )
+    fetcher = http_fetcher("https://example.com/health-check")
+
+    status = fetcher()
+
+    assert status.health == Health.UNKNOWN
+    assert status.metadata is None
+
+
+@responses.activate
+def test_http_fetcher_invalid_json():
+    responses.add(
+        responses.GET,
+        "https://example.com/health-check",
+        headers={"content-type": "application/json"},
+        body='{"malformed":"json"',
+        status=200,
+    )
+    fetcher = http_fetcher("https://example.com/health-check")
+
+    status = fetcher()
+
+    assert status.health == Health.UNKNOWN
+    assert status.metadata is None
+
+
+@responses.activate
+def test_http_fetcher_missing_fields():
+    responses.add(
+        responses.GET,
+        "https://example.com/health-check",
+        json='{"status":"healthy"}',  # missing "setup" field
+        status=200,
+    )
+    fetcher = http_fetcher("https://example.com/health-check")
+
+    status = fetcher()
+
+    assert status.health == Health.UNKNOWN
+    assert status.metadata is None
+
+
+@responses.activate
+def test_http_fetcher_connection_errors():
+    connerror_resp = responses.Response(
+        responses.GET,
+        "https://example.com/health-check",
+        status=200,
+    )
+    connerror_exc = requests.ConnectionError("failed to connect")
+    connerror_exc.response = connerror_resp
+    connerror_resp.body = connerror_exc
+    responses.add(connerror_resp)
+    fetcher = http_fetcher("https://example.com/health-check")
+
+    status = fetcher()
+
+    assert status.health == Health.UNKNOWN
+    assert status.metadata is None
+
+
+@responses.activate
+def test_http_fetcher_setup_failed():
+    responses.add(
+        responses.GET,
+        "https://example.com/health-check",
+        json={"status": "healthy", "setup": {"status": "failed"}},
+        status=200,
+    )
+    fetcher = http_fetcher("https://example.com/health-check")
+
+    status = fetcher()
+
+    assert status.health == Health.SETUP_FAILED
+    assert status.metadata == {"status": "failed"}

--- a/python/tests/director/test_http.py
+++ b/python/tests/director/test_http.py
@@ -1,0 +1,65 @@
+import queue
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cog.director.eventtypes import Webhook
+from cog.director.http import create_app
+from cog.schema import PredictionResponse
+
+
+@pytest.fixture
+def events():
+    return queue.Queue(maxsize=64)
+
+
+@pytest.fixture
+def client(events):
+    app = create_app(events=events)
+    with TestClient(app) as c:
+        yield c
+
+
+def read_all_events(q):
+    result = []
+    while True:
+        try:
+            result.append(q.get_nowait())
+        except queue.Empty:
+            return result
+
+
+def test_webhook_enqueues_payloads(client, events):
+    resp = client.post(
+        "/webhook",
+        json={"input": {"prompt": "hello world"}, "logs": "running prediction"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+    enqueued = read_all_events(events)
+
+    assert enqueued == [
+        Webhook(
+            payload=PredictionResponse(
+                input={"prompt": "hello world"}, logs="running prediction"
+            )
+        )
+    ]
+
+
+def test_webhook_returns_503s_with_full_queue(client, events):
+    for _ in range(64):
+        client.post(
+            "/webhook",
+            json={"input": {"prompt": "hello world"}, "logs": "running prediction"},
+        )
+
+    resp = client.post(
+        "/webhook",
+        json={"input": {"prompt": "hello world"}, "logs": "running prediction"},
+    )
+    assert resp.status_code == 503
+
+    enqueued = read_all_events(events)
+    assert len(enqueued) == 64

--- a/python/tests/director/test_prediction_tracker.py
+++ b/python/tests/director/test_prediction_tracker.py
@@ -1,0 +1,46 @@
+from unittest import mock
+
+from cog.director.prediction_tracker import PredictionTracker
+from cog.schema import PredictionResponse
+
+
+def test_prediction_tracker_basic():
+    response = PredictionResponse(id="abc123", input={"prompt": "hello, world"})
+    webhook_caller = mock.Mock()
+    pt = PredictionTracker(response, webhook_caller=webhook_caller)
+
+    payload = response.copy(update={"logs": "running prediction"})
+    pt.update_from_webhook_payload(payload)
+
+    webhook_caller.assert_called_once()
+    (webhook_payload,) = webhook_caller.call_args.args
+    assert webhook_payload["logs"] == "running prediction"
+
+
+def test_prediction_tracker_adjusts_status_for_cancelations():
+    response = PredictionResponse(id="abc123", input={"prompt": "hello, world"})
+    webhook_caller = mock.Mock()
+    pt = PredictionTracker(response, webhook_caller=webhook_caller)
+
+    pt.timed_out()
+    payload = response.copy(update={"status": "canceled"})
+    pt.update_from_webhook_payload(payload)
+
+    webhook_caller.assert_called_once()
+    (webhook_payload,) = webhook_caller.call_args.args
+    assert webhook_payload["status"] == "failed"
+    assert webhook_payload["error"] == "Prediction timed out"
+
+
+def test_prediction_tracker_is_complete():
+    response = PredictionResponse(id="abc123", input={"prompt": "hello, world"})
+    pt = PredictionTracker(response)
+
+    assert not pt.is_complete()
+
+    response = PredictionResponse(
+        id="abc123", input={"prompt": "hello, world"}, status="succeeded"
+    )
+    pt = PredictionTracker(response)
+
+    assert pt.is_complete()


### PR DESCRIPTION
First of all, I apologise for opening a pull request on the weekend. I forgot that I'm out on Monday, and I had a moment of inspiration (or at least it felt like it to me!) today and figured I would try and get ahead of things.

If I haven't completely messed this up, this PR should:

1. Address most of the remaining error handling we need to do on the director side. It handles:
    - sending failure webhooks for input validation errors
    - sending failure webhooks when the model container ignores cancelations
    - ensuring that handled failure modes result in the redis message being ACKed

2. Make it much clearer how to integrate detection of failure of the model container while a prediction is running. This isn't done yet, but the model container healthchecking moves into its own logical thread, and there's a `TODO` in `director.py` which notes where we'd do this.

3. Make it much harder to accidentally mix up state between predictions (e.g. as you saw at the weekend, @evilstreak).

4. Untrust timestamps set by the model container.

5. Make it a lot easier to test the various components involved in director.

The critical change that makes all of this a lot easier is moving all control of the lifecycle of the process into Director itself. All communication from the auxiliary threads is mediated through a shared queue.

For example, the webserver code is now extremely uncomplicated. It receives webhook requests and publishes them onto a queue.

The healthchecker thread periodically makes an HTTP request to the model container to establish its health, and publishes changes of health status onto the queue.

The shutdown of these auxiliary threads is coordinated by allowing the registration of "shutdown hooks" with the director. In this way, the director doesn't need to know anything about the auxiliary threads, it just reads from a shared queue which they can publish to.

This will likely be easier to review commit by commit.
