### PR TITLE
Abort prediction on a failed healthcheck event

### DIFF
--- a/python/cog/director/director.py
+++ b/python/cog/director/director.py
@@ -218,8 +218,10 @@ class Director:
                 if isinstance(event, Webhook):
                     tracker.update_from_webhook_payload(event.payload)
                 elif isinstance(event, HealthcheckStatus):
-                    # TODO: handle these appropriately
                     log.info("received healthcheck status update", data=event)
+                    if event.health != Health.HEALTHY:
+                        tracker.fail("Model stopped responding during prediction.")
+                        self._abort("model container no longer healthy")
                 else:
                     log.warn("received unknown event", data=event)
 

--- a/python/cog/director/healthchecker.py
+++ b/python/cog/director/healthchecker.py
@@ -93,8 +93,8 @@ def _make_http_client() -> requests.Session:
     session = requests.Session()
     adapter = HTTPAdapter(
         max_retries=Retry(
-            total=3,
-            backoff_factor=0.1,
+            total=6,
+            backoff_factor=0.2,
             status_forcelist=[429, 500, 502, 503, 504],
         ),
     )


### PR DESCRIPTION
Increase the number of retries so that the healthcheck endpoint has to fail for roughly ~6s before emitting a `HealthcheckStatus` event with a status of `Health.UNKNOWN`. That roughly mirrors the ~5s interval we poll at when the model container is healthy.

If we get a non-healthy status event during a prediction, abort the prediction and shut everything down.