### PR TITLE
Remove Redis XAUTOCLAIM and ack messages whenever possible

### DIFF
--- a/python/cog/director/director.py
+++ b/python/cog/director/director.py
@@ -169,9 +169,9 @@ class Director:
             except Exception:
                 self._record_failure()
                 log.error("caught exception while running prediction", exc_info=True)
-            else:
-                # If we completed _handle_message without an exception, we
-                # acknowledge the message so nobody else picks it up.
+            finally:
+                # See the comment in RedisConsumer.get to understand why we ack
+                # even when an exception is thrown while handling a message.
                 self.redis_consumer.ack(message_id)
                 log.info("acked message")
 


### PR DESCRIPTION
At the moment we're failing to ack messages in exceptional cases (e.g. when we call _abort while handling a prediction). This is leading to a build-up of pending messages in the Redis stream which in turn results in autoscaler requesting additional replicas which are unneeded and will not participate in handling the pending messages.

For now, remove all ability to handle pending stream messages, and instead ack every message handled, whether it completed successfully or not.