### PR TITLE
Retry file upload requests

### DIFF
--- a/python/cog/files.py
+++ b/python/cog/files.py
@@ -37,11 +37,13 @@ def guess_filename(obj: io.IOBase) -> str:
     return os.path.basename(name)
 
 
-def put_file_to_signed_endpoint(fh: io.IOBase, endpoint: str) -> str:
+def put_file_to_signed_endpoint(
+    fh: io.IOBase, endpoint: str, client: requests.Session
+) -> str:
     filename = guess_filename(fh)
     content_type, _ = mimetypes.guess_type(filename)
 
-    resp = requests.put(
+    resp = client.put(
         ensure_trailing_slash(endpoint) + filename,
         fh,  # type: ignore
         headers={"Content-type": content_type},


### PR DESCRIPTION
We're seeing a handful of 408 errors when uploading files. We're assuming the upload requests reuses a connection that the destination considers stale. There's probably some smarter things to do with connection pooling, but the approach here of retrying them a few times seems like it'll catch a wider variety of intermittent network errors.