### PR TITLE
Revert how `COG_VERSION` is set in cog Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ pkg/dockerfile/embed/cog.whl: python/* python/cog/* python/cog/server/* python/c
 	cp python/dist/*.whl $@
 
 cog: pkg/dockerfile/embed/cog.whl
-	$(eval COG_VERSION ?= $(shell git describe --tags --always --dirty))
+	$(eval COG_VERSION ?= $(shell git describe --tags --match 'v*' --abbrev=0)+dev)
 	CGO_ENABLED=0 $(GO) build -o $@ \
 		-ldflags "-X github.com/replicate/cog/pkg/global.Version=$(COG_VERSION) -X github.com/replicate/cog/pkg/global.BuildTime=$(shell date +%Y-%m-%dT%H:%M:%S%z) -w" \
 		cmd/cog/cog.go


### PR DESCRIPTION
Fixes a regression introduced in [#823](https://github.com/replicate/cog/pull/823).

**Before**

```console
$ make clean cog
$ ./cog --version
cog version v0.6.1-19-g08f4c8f (built 2023-01-25T05:21:05-0800)
```

**After**

```console
$ make clean cog
$ ./cog --version
cog version v0.6.1+dev (built 2023-01-25T05:18:20-0800)
```