### PR TITLE
Improve server shutdown behaviour

### DIFF
--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -113,9 +113,9 @@ class PredictionRunner:
         return False
 
     def shutdown(self) -> None:
+        self._worker.terminate()
         self._threadpool.terminate()
         self._threadpool.join()
-        self._worker.terminate()
 
     def cancel(self) -> None:
         self._should_cancel.set()

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -80,12 +80,12 @@ class Worker:
         if self._state == WorkerState.DEFUNCT:
             return
 
+        self._terminating = True
         self._state = WorkerState.DEFUNCT
 
         if self._child.is_alive():
             self._child.terminate()
             self._child.join()
-        self._child.close()
 
     def cancel(self) -> None:
         if self._allow_cancel and self._child.is_alive():

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -153,6 +153,11 @@ class _ChildWorker(_spawn.Process):  # type: ignore
         super().__init__()
 
     def run(self) -> None:
+        # If we're running at a shell, SIGINT will be sent to every process in
+        # the process group. We ignore it in the child process and require that
+        # shutdown is coordinated by the parent process.
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+
         # We use SIGUSR1 to signal an interrupt for cancelation.
         signal.signal(signal.SIGUSR1, self._signal_handler)
 

--- a/python/tests/server/conftest.py
+++ b/python/tests/server/conftest.py
@@ -1,4 +1,5 @@
 import os
+import threading
 
 from fastapi.testclient import TestClient
 import pytest
@@ -34,7 +35,7 @@ def make_client(fixture_name: str):
     Creates a fastapi test client for an app that uses the requested Predictor.
     """
     predictor_ref = _fixture_path(fixture_name)
-    app = create_app(predictor_ref)
+    app = create_app(predictor_ref=predictor_ref, shutdown_event=threading.Event())
     return TestClient(app)
 
 


### PR DESCRIPTION
This commit attempts to improve how server shutdown occurs, in a few different ways:

1. Exceptions thrown while running a prediction are caught, logged, and used to trigger a clean shutdown of the server. Unfortunately we cannot currently recover from an exception thrown while a prediction is running, because we have no way to resume and drain the prediction event stream.

2. Server shutdown tries to proceed gracefully, but will escalate to sending SIGKILL to the process if needs be.

3. SIGINT at the terminal is now always respected if possible.

One minor note of caution here: we are running Worker.terminate() to kill the worker, which is not a graceful shutdown. In-flight predictions will be killed immediately, and no final status webhooks will be sent. It is beholden on the director to ensure that webhooks are sent for predictions running when a shutdown request is sent.

Note also that an exception during even synchronous prediction processing will shut down the webserver. This is likely not expected behaviour, and we will likely want to revisit it in future.