### PR TITLE
Explicitly healthcheck the model container before each prediction

### DIFF
--- a/python/cog/director/__main__.py
+++ b/python/cog/director/__main__.py
@@ -67,6 +67,7 @@ redis_consumer = RedisConsumer(
 
 director = Director(
     events=events,
+    healthchecker=healthchecker,
     redis_consumer=redis_consumer,
     predict_timeout=args.predict_timeout,
     max_failure_count=args.max_failure_count,


### PR DESCRIPTION
We wait up to 10 seconds for an explicit confirmation of the model container's health before fetching the next prediction from Redis. This should hopefully prevent us from dequeueing predictions that are bound to fail (e.g. when the model container has crashed but we have not yet detected that with the regular background checks).