### PR TITLE
Loosen response type annotations

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -151,7 +151,7 @@ def create_app(
         return JSONResponse(content=encoded_response)
 
     @app.post("/predictions/{prediction_id}/cancel")
-    def cancel(prediction_id: str = Path(..., title="Prediction ID")) -> JSONResponse:
+    def cancel(prediction_id: str = Path(..., title="Prediction ID")) -> Any:
         """
         Cancel a running prediction
         """
@@ -162,7 +162,7 @@ def create_app(
             return JSONResponse({}, status_code=404)
 
     @app.post("/shutdown")
-    def start_shutdown() -> JSONResponse:
+    def start_shutdown() -> Any:
         log.info("shutdown requested via http")
         shutdown_event.set()
         return JSONResponse({}, status_code=200)


### PR DESCRIPTION
FastAPI 0.89.0 has a bug which causes the model to fail to start if handlers annotate a response class of Response (or its subclasses).

See: https://github.com/tiangolo/fastapi/pull/5855