### PR TITLE
Ensure go bin directory exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ cog: pkg/dockerfile/embed/cog.whl
 
 .PHONY: install
 install: cog
+	$(INSTALL_PROGRAM) -d $(DESTDIR)$(BINDIR)
 	$(INSTALL_PROGRAM) cog $(DESTDIR)$(BINDIR)/cog
 
 .PHONY: uninstall


### PR DESCRIPTION
On a fresh machine, GOPATH might exist but GOPATH/bin might not have been created yet.  This updates the Makefile so that we create it if it's not there already.

Signed-off-by: Philip Potter <philip.g.potter@gmail.com>