### PR TITLE
Add an idempotent PUT endpoint for prediction creation

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -50,7 +50,7 @@ Or, with curl:
     curl -X POST -H "Content-Type: application/json" -d '{"input": {"image": "https://example.com/image.jpg", "text": "Hello world!"}}' http://localhost:5000/predictions
 
 
-### `POST /predictions` (asynchronous)
+## `POST /predictions` (asynchronous)
 
 Make a single prediction without waiting for the prediction to complete.
 
@@ -86,7 +86,7 @@ using the provided `--upload-url` as a prefix, in much the same way that
 works the same way for both synchronous and asynchronous prediction creation.
 This will be addressed in a future version of Cog.
 
-#### Webhooks
+### Webhooks
 
 Clients can (and should, if a prediction is created asynchronously) provide a
 `webhook` parameter at the top level of the prediction request, e.g.
@@ -132,7 +132,45 @@ Prefer: respond-async
 }
 ```
 
-### `POST /predictions/<prediction_id>/cancel`
+## `PUT /predictions/<prediction_id>` (synchronous)
+
+Make a single prediction.
+
+This is the idempotent version of the `POST /predictions` endpoint. If you call
+it multiple times with the same ID (for example, because of a network
+interruption) and the prediction is still running, the request will not create
+further predictions but will wait for the original prediction to complete.
+
+**Note:** It is currently the caller's responsibility to ensure that the
+supplied prediction ID is unique. We recommend you use base32-encoded UUID4s
+(stripped of any padding characters) to ensure forward compatibility: these will
+be 26 ASCII characters long.
+
+## `PUT /predictions/<prediction_id>` (asynchronous)
+
+Make a single prediction without waiting for the prediction to complete.
+
+Callers can specify an HTTP header of `Prefer: respond-async` when calling the
+`PUT /predictions/<prediction_id>` endpoint. If provided, the request will
+return immediately after starting the prediction with an HTTP `202 Accepted`
+status and a prediction object in status `processing`.
+
+This is the idempotent version of the asynchronous `POST /predictions` endpoint.
+If you call it multiple times with the same ID (for example, because of a
+network interruption) and the prediction is still running, the request will not
+create further predictions. The caller will receive a 202 Accepted response
+with the initial state of the prediction.
+
+**Note 1:** It is currently the caller's responsibility to ensure that the
+supplied prediction ID is unique. We recommend you use base32-encoded UUID4s
+(stripped of any padding characters) to ensure forward compatibility: these will
+be 26 ASCII characters long.
+
+**Note 2:** As noted earlier, Cog can only run one prediction at a time, and it is
+the caller's responsibility to make sure that earlier predictions are complete
+before new ones (with new IDs) are created.
+
+## `POST /predictions/<prediction_id>/cancel`
 
 While an asynchronous prediction is running, clients can cancel it by making a
 request to `POST /predictions/<prediction_id>/cancel`. The prediction `id` must

--- a/python/cog/director/director.py
+++ b/python/cog/director/director.py
@@ -214,8 +214,8 @@ class Director:
 
         # Call the model container to start the prediction
         try:
-            resp = self.cog_client.post(
-                self.cog_http_base + "/predictions",
+            resp = self.cog_client.put(
+                self.cog_http_base + "/predictions/" + prediction_id,
                 json=message,
                 headers={"Prefer": "respond-async"},
                 timeout=PREDICTION_CREATE_TIMEOUT,

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -323,6 +323,40 @@ def test_yielding_files_from_generator_predictors(client):
     assert image_color(output[2]) == (255, 255, 0)  # yellow
 
 
+@uses_predictor("input_none")
+def test_prediction_idempotent_endpoint(client, match):
+    resp = client.put("/predictions/abcd1234", json={})
+    assert resp.status_code == 200
+    assert resp.json() == match(
+        {"id": "abcd1234", "status": "succeeded", "output": "foobar"}
+    )
+
+
+@uses_predictor("input_none")
+def test_prediction_idempotent_endpoint_matched_ids(client, match):
+    resp = client.put(
+        "/predictions/abcd1234",
+        json={
+            "id": "abcd1234",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json() == match(
+        {"id": "abcd1234", "status": "succeeded", "output": "foobar"}
+    )
+
+
+@uses_predictor("input_none")
+def test_prediction_idempotent_endpoint_mismatched_ids(client, match):
+    resp = client.put(
+        "/predictions/abcd1234",
+        json={
+            "id": "foobar",
+        },
+    )
+    assert resp.status_code == 422
+
+
 # a basic end-to-end test for async predictions. if you're adding more
 # exhaustive tests of webhooks, consider adding them to test_runner.py
 @responses.activate


### PR DESCRIPTION
The motivation here is that we've been seeing a few problems in production where director's call to the POST endpoint times out but succeeds on the model container. Director then retries the "failed" request and gets a failure from the Cog HTTP API because the model container is now busy.

This PR adds an idempotent `PUT /predictions/<prediction_id>` endpoint, and switches director over to using that. Hopefully, this means that an initial request timeout will be much less likely to result in a prediction failure, because subsequent retries will succeed.

The core of the change makes `PredictionRunner.predict(...)` itself idempotent if (and only if) the prediction request includes an ID. If the prediction request includes an ID, then subsequent calls to `predict()` with the same ID will return the preliminary response and async result object as normal.

The behaviour of the HTTP endpoints is as follows:

- Both sync and async POST endpoints will return a `409 Conflict` immediately if the runner is busy, regardless of whether or not an ID is specified in the prediction request.

- A second synchronous PUT for the same prediction ID (received while the prediction is running) will wait for prediction completion just like the initial request.

- A second asynchronous PUT for the same prediction ID (received while the prediction is running) will return the initial state of the prediction just like the initial request.

- A second PUT (either asynchronous or synchronous) with a prediction ID other than the running prediction will receive a `409 Conflict`.