### PR TITLE
Build director image after release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,6 +118,8 @@ jobs:
       - test-python
       - test-integration
     if: startsWith(github.ref, 'refs/tags/v')
+    outputs:
+      cog_version: ${{ steps.build-python-package.outputs.version }}
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v3
@@ -136,6 +138,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Python package
+        id: build-python-package
         run: |
           # clean package built for go client
           rm -rf python/dist
@@ -143,9 +146,34 @@ jobs:
           pip install build
           # build package
           python -m build python/ --wheel
+          # set output
+          echo "version=$(ls python/dist/ | cut -d- -f2)" >> $GITHUB_OUTPUT
       - name: Push Python package
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
           packages_dir: python/dist
+
+  build-director:
+    name: Build director
+    needs: release
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    env:
+      COG_VERSION: ${{ needs.release.outputs.cog_version }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          workload_identity_provider: 'projects/1025538909507/locations/global/workloadIdentityPools/github/providers/github-actions'
+          service_account: 'builder@replicate.iam.gserviceaccount.com'
+
+      - uses: 'google-github-actions/setup-gcloud@v1'
+
+      - name: 'Build image'
+        working-directory: python/cog/director/
+        run: script/build >> $GITHUB_OUTPUT

--- a/python/cog/director/Dockerfile
+++ b/python/cog/director/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.10
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+
+RUN set -eux; \
+apt-get update -qq; \
+apt-get install -qqy --no-install-recommends curl; \
+rm -rf /var/lib/apt/lists/*; \
+TINI_VERSION=v0.19.0; \
+TINI_ARCH="$(dpkg --print-architecture)"; \
+curl -sSL -o /sbin/tini "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TINI_ARCH}"; \
+chmod +x /sbin/tini
+ENTRYPOINT ["/sbin/tini", "--"]
+
+ARG cog_version
+RUN pip install cog==${cog_version}
+
+WORKDIR /src
+EXPOSE 4900
+CMD ["python", "-m", "cog.director"]

--- a/python/cog/director/cloudbuild.yaml
+++ b/python/cog/director/cloudbuild.yaml
@@ -1,0 +1,12 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - "build"
+  - "--build-arg"
+  - "cog_version=$_COG_VERSION"
+  - "-t"
+  - "us-central1-docker.pkg.dev/replicate/replicate-alpha/cog-director:$_COG_VERSION"
+  - "."
+images:
+  - "us-central1-docker.pkg.dev/replicate/replicate-alpha/cog-director:$_COG_VERSION"
+logsBucket: "gs://replicate-cloudbuild"

--- a/python/cog/director/script/build
+++ b/python/cog/director/script/build
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eux -o pipefail
+
+gcloud builds submit \
+    --project=replicate \
+    --config cloudbuild.yaml \
+    --substitutions=_COG_VERSION=$COG_VERSION \
+| tee /tmp/cluster-build.txt >&2


### PR DESCRIPTION
We get the version of the published package by looking at the filename of the wheel during the python package build step. We could try loading that wheel and checking `cog.__version__`, but that requires installing a bunch of dependencies which is more of a faff than just looking at the file. This may end up being error prone, in which case we can revisit it!