### PR TITLE
Defer downloading of URLs provided to Path inputs

### DIFF
--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -14,7 +14,7 @@ from typing_extensions import get_origin, get_args, Annotated
 import yaml
 
 from .errors import ConfigDoesNotExist, PredictorNotSet
-from .types import Input, Path as CogPath, File as CogFile
+from .types import Input, Path as CogPath, File as CogFile, URLPath
 
 
 ALLOWED_INPUT_TYPES = [str, int, float, bool, CogFile, CogPath]
@@ -106,9 +106,12 @@ class BaseInput(BaseModel):
         Cleanup any temporary files created by the input.
         """
         for _, value in self:
+            # Handle URLPath objects specially for cleanup.
+            if isinstance(value, URLPath):
+                value.unlink()
             # Note this is pathlib.Path, which cog.Path is a subclass of. A pathlib.Path object shouldn't make its way here,
             # but both have an unlink() method, so may as well be safe.
-            if isinstance(value, Path):
+            elif isinstance(value, Path):
                 # This could be missing_ok=True when we drop support for Python 3.7
                 if value.exists():
                     value.unlink()


### PR DESCRIPTION
This commit moves the downloading of URLs provided as Path input parameters off the main thread and into the worker thread handling the prediction.

This has been causing issues in production because large files are downloaded before the initial PUT /predictions/<id> request responds, which results in director timing out the request and the prediction failing.

This is not code to be proud of, and we will almost certainly need to rethink it in the near future. For now, though, it appears to do the right thing: async create prediction requests now respond immediately.