### PR TITLE
Incorporate READY/BUSY status into model healthcheck

### DIFF
--- a/python/cog/director/eventtypes.py
+++ b/python/cog/director/eventtypes.py
@@ -4,13 +4,7 @@ from typing import Any, Dict, Optional
 from attrs import define
 
 from .. import schema
-
-
-@unique
-class Health(Enum):
-    UNKNOWN = auto()
-    HEALTHY = auto()
-    SETUP_FAILED = auto()
+from ..server.http import Health
 
 
 @define


### PR DESCRIPTION
This commit tightens up the contract between director and the model container's `/health-check` endpoint.

Specifically, the `status` field of the healthcheck endpoint now reports one of four health statuses: STARTING, READY, BUSY, SETUP_FAILED.

The expected state transitions between these four states are as follows:

                             ┌────────┐
                             ▼        │
            STARTING ────► READY     BUSY
                │            │        ▲
                │            └────────┘
                ▼
          SETUP_FAILED

Once setup is complete, we expect the model pod to cycle between READY and BUSY. If any other status is seen, or if BUSY is seen when we expect the container to be READY, we abort the pod.