### PR TITLE
Stop leaking Redis secrets on connection

### DIFF
--- a/python/cog/director/redis.py
+++ b/python/cog/director/redis.py
@@ -30,7 +30,10 @@ class RedisConsumer:
             self.autoclaim_messages_after = 10 * 60
 
         self.redis = redis.from_url(self.redis_url)
-        log.info("connected to redis", url=self.redis_url)
+        log.info(
+            "connected to redis",
+            host=self.redis.get_connection_kwargs().get("host"),
+        )
 
     def get(self) -> Tuple[str, str]:
         # Redis streams are reliable queues: messages must be acked once

--- a/python/cog/server/redis_queue.py
+++ b/python/cog/server/redis_queue.py
@@ -78,7 +78,9 @@ class RedisQueueWorker:
         self.tracer = trace.get_tracer("cog")
         self.probes = ProbeHelper()
 
-        sys.stderr.write(f"Connected to Redis: {self.redis_url}\n")
+        sys.stderr.write(
+            f"Connected to Redis: {self.redis.get_connection_kwargs().get('host')}\n"
+        )
 
     def signal_exit(self, signum: Any, frame: Any) -> None:
         self.should_exit = True


### PR DESCRIPTION
We provide the host as context instead.