### PR TITLE
director: change default trace exporter to http

### DIFF
--- a/python/cog/director/__main__.py
+++ b/python/cog/director/__main__.py
@@ -9,7 +9,7 @@ from typing import Any
 import structlog
 import uvicorn
 from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 


### PR DESCRIPTION
Given that e.g. Refinery disables GRPC by default, I anticipate Protobuf over HTTP is the more common protocol—so we're going to default to that. I can't find an easy way for the Python SDK to properly respect `OTEL_EXPORTER_OTLP_PROTOCOL` that wouldn't be super hacky, so we'll default to this for now until the use-case arises for someone to need GRPC.

@nickstenning 