### PR TITLE
director: set span attributes from env

### DIFF
--- a/python/cog/director/director.py
+++ b/python/cog/director/director.py
@@ -17,7 +17,7 @@ from ..server.probes import ProbeHelper
 from ..server.webhook import requests_session, webhook_caller
 from .eventtypes import HealthcheckStatus, Webhook
 from .healthchecker import Healthchecker
-from .monitor import Monitor
+from .monitor import Monitor, span_attributes_from_env
 from .prediction_tracker import PredictionTracker
 from .redis import EmptyRedisStream, RedisConsumerRotator
 
@@ -181,7 +181,8 @@ class Director:
             try:
                 log.info("received message")
                 with self._tracer.start_as_current_span(
-                    name="cog.prediction"
+                    name="cog.prediction",
+                    attributes=span_attributes_from_env(),
                 ) as span:
                     self._handle_message(message_id, message_json, span)
             except Exception:

--- a/python/tests/director/test_monitor.py
+++ b/python/tests/director/test_monitor.py
@@ -68,8 +68,6 @@ def test_emit_utilization_span():
     assert "utilization" in spans[0].attributes
 
     assert abs(1.0 - spans[1].attributes["utilization"]) <= 0.3
-    assert "walrus1" == spans[1].attributes["model.version"]
-
     assert abs(0.5 - spans[2].attributes["utilization"]) <= 0.3
 
     assert spans[3].attributes["utilization"] == 0.0


### PR DESCRIPTION
This sets span attributes from the environment if they're set. I'm not using `None` because OpenTelemetry emits warnings for span attributes set to `None`.

I could now make `set_current_prediction` in `Monitor` be replaced with `working` and `idle` methods, but it could be useful in the future for other monitoring of e.g. emitting utilization by user (highly sampled). Doesn't really do any damage IMO.

@nickstenning @evilstreak 