### PR TITLE
director: add prediction.error

### DIFF
--- a/python/cog/director/director.py
+++ b/python/cog/director/director.py
@@ -335,6 +335,8 @@ class Director:
     # OpenTelemetry is very picky about not accepting None types
     def _set_span_attributes_from_tracker(self, span, tracker):
         span.set_attribute("prediction.uuid", tracker._response.id)
+        if tracker._response.error:
+            span.set_attribute("prediction.error", tracker._response.error)
         if tracker._response.version:
             span.set_attribute("model.version", tracker._response.version)
         if tracker._response.started_at:


### PR DESCRIPTION
The `Prediction` object has a nice error field from the model that we weren't populating span attributes with. Now we are! Examples of this error from various models might be:

```
NSFW content detected. Try running it again, or try a different prompt.

CUDA out of memory. Tried to allocate 5.92 GiB (GPU 0; 14.76 GiB total capacity; 6.65 GiB already allocated; 4.28 GiB free; 9.52 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.  See documentation for Memory Management and PYTORCH_CUDA_ALLOC_CONF
```

@evilstreak @nickstenning 