### PR TITLE
director: only emit utilization after model is ready

### DIFF
--- a/python/tests/director/test_monitor.py
+++ b/python/tests/director/test_monitor.py
@@ -50,6 +50,8 @@ def test_emit_utilization_span():
 
     monitor = Monitor(utilization_interval=1)
     monitor.start()
+    time.sleep(0.02)
+    assert len(span_provider.spans) == 0
 
     prediction = PredictionResponse(
         id="narwhal",


### PR DESCRIPTION
This changes it so that utilization is only emitted after the model is ready.

But shouldn't a model be penalized in its utilization for booting slowly? Yes, but not in this metric. That would typically be something you'd want to monitor as part of the utilization of the node itself that this is running on: a node is utilized if a model is _ready_ and booted on the node. Then your final utilization is `node_utilization * pod_utilization`.

**Edit:** I realized it's a bit more complicated, we need to make one of these two definitions come true, either (1):

```
Node Idle: When a Director pod is not up
Cog Idle: When a Model pod is not running a prediction, emitted from when Director is up 
```

OR (2)

```
Node Idle: When a Model pod is up
Cog Idle: When a Model pod is not running a prediction, emitted from when Model is up
```

Neither is true right now. This would enable us to do (2), or we change our own `Node Idle` to honour (1). Either way, our current situation is not correct.

@evilstreak @nickstenning 