### PR TITLE
Configure cog base URI via args to director

### DIFF
--- a/python/cog/director/__main__.py
+++ b/python/cog/director/__main__.py
@@ -53,6 +53,7 @@ parser.add_argument(
     help="Maximum number of consecutive failures before the worker should exit",
 )
 parser.add_argument("--report-setup-run-url")
+parser.add_argument("--model-base-uri", type=str, default="http://localhost:5000")
 
 log_level = logging.getLevelName(os.environ.get("LOG_LEVEL", "INFO").upper())
 setup_logging(log_level=log_level)
@@ -66,7 +67,7 @@ server = Server(config)
 server.start()
 
 healthchecker = Healthchecker(
-    events=events, fetcher=http_fetcher("http://localhost:5000/health-check")
+    events=events, fetcher=http_fetcher(args.model_base_uri + "/health-check")
 )
 healthchecker.start()
 
@@ -108,6 +109,7 @@ director = Director(
     predict_timeout=args.predict_timeout,
     max_failure_count=args.max_failure_count,
     report_setup_run_url=args.report_setup_run_url,
+    cog_http_base=args.model_base_uri,
 )
 
 

--- a/python/cog/director/director.py
+++ b/python/cog/director/director.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import queue
 import signal
@@ -57,6 +56,7 @@ class Director:
         predict_timeout: int,
         max_failure_count: int,
         report_setup_run_url: str,
+        cog_http_base: str,
     ):
         self.events = events
         self.healthchecker = healthchecker
@@ -72,7 +72,7 @@ class Director:
         self._tracer = trace.get_tracer("cog-director")
 
         self.cog_client = _make_local_http_client()
-        self.cog_http_base = "http://localhost:5000"
+        self.cog_http_base = cog_http_base
 
     def start(self) -> None:
         try:


### PR DESCRIPTION
While we run these on the same network, it can be useful to not have to. For example, when using Docker Compose to spin up a local development environment, the model and director might use different services. Being able to configure the endpoints will make setting that up a lot simpler.