### PR TITLE
Repeatedly claim Redis messages during processing

### DIFF
--- a/python/cog/director/redis.py
+++ b/python/cog/director/redis.py
@@ -22,13 +22,6 @@ class RedisConsumer:
         self.redis_input_queue = redis_input_queue
         self.redis_consumer_id = redis_consumer_id
 
-        if predict_timeout is not None:
-            # 30s grace period allows final responses to be sent and job to be acked
-            self.autoclaim_messages_after = predict_timeout + 30
-        else:
-            # retry after 10 minutes by default
-            self.autoclaim_messages_after = 10 * 60
-
         self.redis = redis.from_url(self.redis_url)
         log.info(
             "connected to redis",


### PR DESCRIPTION
If director catastrophically fails (oom killed, preempted, etc) then the only signal we have that something has gone wrong is that the prediction never finishes and the message in the queue is never acked. To make use of that signal we have to wait longer than the prediction could possibly take.

This changes the behaviour of director so that it uses `XCLAIM` to continuously update the idle time of the message it's processing. If the idle time of any message is longer than the `claim_interval` used (with a resonable margin for error) then we can assume the director responsible for it has somehow died, and we can either retry it or fail it from whatever system monitors the queue.

This is done in a thread so that issues with, eg, webhook delivery don't stop the idle time from being updated at the interval.