### PR TITLE
Only mark container as ready after successful setup

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -30,7 +30,6 @@ from ..predictor import (
     load_config,
     load_predictor_from_ref,
 )
-from .probes import ProbeHelper
 from .runner import PredictionRunner, RunnerBusyError, UnknownPredictionError
 
 log = structlog.get_logger("cog.server.http")
@@ -82,9 +81,6 @@ def create_app(
         RunVar("_default_thread_limiter").set(CapacityLimiter(threads))  # type: ignore
 
         app.state.setup_result = runner.setup()
-
-        probes = ProbeHelper()
-        probes.ready()
 
     @app.on_event("shutdown")
     def shutdown() -> None:

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -16,6 +16,7 @@ from .. import types
 from ..files import put_file_to_signed_endpoint
 from ..json import upload_files
 from .eventtypes import Done, Heartbeat, Log, PredictionOutput, PredictionOutputType
+from .probes import ProbeHelper
 from .webhook import webhook_caller_filtered
 from .worker import Worker
 
@@ -303,6 +304,11 @@ def setup(*, worker: Worker):
         status = schema.Status.FAILED
 
     completed_at = datetime.now(tz=timezone.utc)
+
+    # Only if setup succeeded, mark the container as "ready".
+    if status == schema.Status.SUCCEEDED:
+        probes = ProbeHelper()
+        probes.ready()
 
     return {
         "logs": "".join(logs),


### PR DESCRIPTION
8a72ba8 accidentally changed the behaviour of container readiness checks: model containers started marking themselves as "ready" before the model setup had successfully completed.

This is a problem, because it means a deployment rollout will potentially proceed before a new container is actually ready to service incoming predictions.

This change moves our use of ProbeHelper into Runner so that it's only called once a model has successfully completed setup.