### PR TITLE
Add ConcatenateIterator type

### DIFF
--- a/docs/redis.md
+++ b/docs/redis.md
@@ -91,7 +91,7 @@ For example, a message early in the prediction might look like:
         "started_at": "2022-09-22T14:31:17Z"
     }
 
-If the model yields [progressive output](python.md#progressive-output) then a mid-prediction message might look like:
+If the model yields [streaming output](python.md#streaming-output) then a mid-prediction message might look like:
 
     {
         "status": "processing",
@@ -145,9 +145,9 @@ An example readiness probe configuration might look like:
 readinessProbe:
   exec:
     command:
-    - test
-    - -f
-    - /var/run/cog/ready
+      - test
+      - -f
+      - /var/run/cog/ready
   initialDelaySeconds: 1
   periodSeconds: 1
 ```
@@ -166,7 +166,7 @@ For each prediction it sends:
 - a span when the request is received
 - a span wrapping your `predict()` method
 - an event when the first output is received from your `predict()` method
-- for progressive output, an event when the final output is received from your `predict()` method
+- for streaming output, an event when the final output is received from your `predict()` method
 
 If the runner encounters an error during the prediction it will record it and set the span's status to error.
 

--- a/python/cog/__init__.py
+++ b/python/cog/__init__.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 
 from .predictor import BasePredictor
-from .types import File, Input, Path
+from .types import File, Input, Path, ConcatenateIterator
 
 try:
     from ._version import __version__
@@ -13,6 +13,7 @@ __all__ = [
     "__version__",
     "BaseModel",
     "BasePredictor",
+    "ConcatenateIterator",
     "File",
     "Input",
     "Path",

--- a/python/tests/server/fixtures/yield_concatenate_iterator.py
+++ b/python/tests/server/fixtures/yield_concatenate_iterator.py
@@ -1,0 +1,10 @@
+from cog import BasePredictor, ConcatenateIterator
+
+
+class Predictor(BasePredictor):
+    def predict(
+        self,
+    ) -> ConcatenateIterator[str]:
+        predictions = ["foo", "bar", "baz"]
+        for prediction in predictions:
+            yield prediction

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -248,6 +248,22 @@ def test_openapi_specification_with_yield(client):
     }
 
 
+@uses_predictor("yield_concatenate_iterator")
+def test_openapi_specification_with_yield(client):
+    resp = client.get("/openapi.json")
+    assert resp.status_code == 200
+
+    assert resp.json()["components"]["schemas"]["Output"] == {
+        "title": "Output",
+        "type": "array",
+        "items": {
+            "type": "string",
+        },
+        "x-cog-array-type": "iterator",
+        "x-cog-array-display": "concatenate",
+    }
+
+
 @uses_predictor("openapi_output_list")
 def test_openapi_specification_with_list(client):
     resp = client.get("/openapi.json")
@@ -284,6 +300,15 @@ def test_openapi_specification_with_int_choices(client):
 
 @uses_predictor("yield_strings")
 def test_yielding_strings_from_generator_predictors(client, match):
+    resp = client.post("/predictions")
+    assert resp.status_code == 200
+    assert resp.json() == match(
+        {"status": "succeeded", "output": ["foo", "bar", "baz"]}
+    )
+
+
+@uses_predictor("yield_concatenate_iterator")
+def test_yielding_strings_from_concatenate_iterator(client, match):
     resp = client.post("/predictions")
     assert resp.status_code == 200
     assert resp.json() == match(


### PR DESCRIPTION
Implements https://github.com/replicate/cog/issues/969 

It's the same thing, just with a different name. `Stream` is a new noun, whereas `ConcatenateIterator` is a verbose description of what it does: it is an iterator that gets concatenated.

This is an experiment at passing hints about how outputs should be displayed to Replicate. You can imagine other hints about display that we might want to pass.