### PR TITLE
Training 🚂

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ pkg/dockerfile/embed/cog.whl: python/* python/cog/* python/cog/server/* python/c
 	mkdir -p pkg/dockerfile/embed
 	cp python/dist/*.whl $@
 
+.PHONY: cog
 cog: pkg/dockerfile/embed/cog.whl
 	$(eval COG_VERSION ?= $(shell git describe --tags --match 'v*' --abbrev=0)+dev)
 	CGO_ENABLED=0 $(GO) build -o $@ \

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -40,11 +40,12 @@ https://github.com/replicate/cog`,
 	rootCmd.AddCommand(
 		newBuildCommand(),
 		newDebugCommand(),
+		newInitCommand(),
+		newLoginCommand(),
 		newPredictCommand(),
 		newPushCommand(),
 		newRunCommand(),
-		newLoginCommand(),
-		newInitCommand(),
+		newTrainCommand(),
 	)
 
 	return &rootCmd, nil

--- a/pkg/cli/train.go
+++ b/pkg/cli/train.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/replicate/cog/pkg/config"
+	"github.com/replicate/cog/pkg/docker"
+	"github.com/replicate/cog/pkg/image"
+	"github.com/replicate/cog/pkg/predict"
+	"github.com/replicate/cog/pkg/util/console"
+	"github.com/spf13/cobra"
+)
+
+var (
+	trainInputFlags []string
+)
+
+func newTrainCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "train",
+		Short: "Run a training",
+		Long: `Run a training.
+
+It will build the model in the current directory and train it.`,
+		RunE:   cmdTrain,
+		Args:   cobra.MaximumNArgs(1),
+		Hidden: true,
+	}
+	addBuildProgressOutputFlag(cmd)
+	cmd.Flags().StringArrayVarP(&trainInputFlags, "input", "i", []string{}, "Inputs, in the form name=value. if value is prefixed with @, then it is read from a file on disk. E.g. -i path=@image.jpg")
+
+	return cmd
+}
+
+func cmdTrain(cmd *cobra.Command, args []string) error {
+	imageName := ""
+	volumes := []docker.Volume{}
+	gpus := ""
+	weightsPath := "weights"
+
+	// Build image
+
+	cfg, projectDir, err := config.GetConfig(projectDirFlag)
+	if err != nil {
+		return err
+	}
+
+	if imageName, err = image.BuildBase(cfg, projectDir, buildProgressOutput); err != nil {
+		return err
+	}
+
+	// Base image doesn't have /src in it, so mount as volume
+	volumes = append(volumes, docker.Volume{
+		Source:      projectDir,
+		Destination: "/src",
+	})
+
+	if cfg.Build.GPU {
+		gpus = "all"
+	}
+
+	console.Info("")
+	console.Infof("Starting Docker image %s...", imageName)
+
+	predictor := predict.NewPredictor(docker.RunOptions{
+		GPUs:    gpus,
+		Image:   imageName,
+		Volumes: volumes,
+		Args:    []string{"python", "-m", "cog.server.http", "--x-mode", "train"},
+	})
+
+	go func() {
+		captureSignal := make(chan os.Signal, 1)
+		signal.Notify(captureSignal, syscall.SIGINT)
+
+		<-captureSignal
+
+		console.Info("Stopping container...")
+		if err := predictor.Stop(); err != nil {
+			console.Warnf("Failed to stop container: %s", err)
+		}
+	}()
+
+	if err := predictor.Start(os.Stderr); err != nil {
+		return err
+	}
+
+	// FIXME: will not run on signal
+	defer func() {
+		console.Debugf("Stopping container...")
+		if err := predictor.Stop(); err != nil {
+			console.Warnf("Failed to stop container: %s", err)
+		}
+	}()
+
+	return predictIndividualInputs(predictor, trainInputFlags, weightsPath)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	Build   *Build `json:"build" yaml:"build"`
 	Image   string `json:"image,omitempty" yaml:"image"`
 	Predict string `json:"predict,omitempty" yaml:"predict"`
+	Train   string `json:"train,omitempty" yaml:"train"`
 }
 
 func DefaultConfig() *Config {

--- a/pkg/config/data/config_schema_v1.0.json
+++ b/pkg/config/data/config_schema_v1.0.json
@@ -101,6 +101,11 @@
       "$id": "#/properties/predict",
       "type": "string",
       "description": "The pointer to the `Predictor` object in your code, which defines how predictions are run on your model."
+    },
+    "train": {
+      "$id": "#/properties/train",
+      "type": "string",
+      "description": "The pointer to the `Predictor` object in your code, which defines how predictions are run on your model."
     }
   },
   "additionalProperties": false

--- a/python/cog/command/openapi_schema.py
+++ b/python/cog/command/openapi_schema.py
@@ -16,13 +16,12 @@ if __name__ == "__main__":
     try:
         with suppress_output():
             config = load_config()
-            predictor_ref = get_predictor_ref(config)
     except (ConfigDoesNotExist, PredictorNotSet):
         # If there is no cog.yaml or 'predict' has not been set, then there is no type signature.
         # Not an error, there just isn't anything.
         pass
     else:
         with suppress_output():
-            app = create_app(predictor_ref, shutdown_event=None)
+            app = create_app(config, shutdown_event=None)
         schema = app.openapi()
     print(json.dumps(schema, indent=2))

--- a/python/cog/command/openapi_schema.py
+++ b/python/cog/command/openapi_schema.py
@@ -16,12 +16,10 @@ if __name__ == "__main__":
     try:
         with suppress_output():
             config = load_config()
+            app = create_app(config, shutdown_event=None)
+            schema = app.openapi()
     except (ConfigDoesNotExist, PredictorNotSet):
         # If there is no cog.yaml or 'predict' has not been set, then there is no type signature.
         # Not an error, there just isn't anything.
         pass
-    else:
-        with suppress_output():
-            app = create_app(config, shutdown_event=None)
-        schema = app.openapi()
     print(json.dumps(schema, indent=2))

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -49,20 +49,19 @@ def run_setup(predictor: BasePredictor) -> None:
         predictor.setup()
         return
 
-    weights: Union[io.IOBase, CogPath, None]
+    weights: Union[io.IOBase, Path, None]
 
     weights_url = os.environ.get("COG_WEIGHTS")
     weights_path = "weights"
 
+    # TODO: Cog{File,Path}.validate(...) methods accept either "real"
+    # paths/files or URLs to those things. In future we can probably tidy this
+    # up a little bit.
     if weights_url:
         if weights_type == CogFile:
-            weights = URLFile(weights_url)
+            weights = CogFile.validate(weights_url)
         elif weights_type == CogPath:
-            weights = URLPath(
-                source=weights_url,
-                filename=get_filename(weights_url),
-                fileobj=CogFile.validate(weights_url),
-            )
+            weights = CogPath.validate(weights_url)
         else:
             raise ValueError(
                 f"Predictor.setup() has an argument 'weights' of type {weights_type}, but only File and Path are supported"

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -72,13 +72,16 @@ def load_predictor(config: Dict[str, Any]) -> BasePredictor:
     return load_predictor_from_ref(ref)
 
 
-def get_predictor_ref(config: Dict[str, Any]) -> str:
-    if "predict" not in config:
+def get_predictor_ref(config: Dict[str, Any], mode: str = "predict") -> str:
+    if mode not in ["predict", "train"]:
+        raise ValueError(f"Invalid mode: {mode}")
+
+    if mode not in config:
         raise PredictorNotSet(
-            "Can't run predictions: 'predict' option not found in cog.yaml"
+            f"Can't run predictions: '{mode}' option not found in cog.yaml"
         )
 
-    return config["predict"]
+    return config[mode]
 
 
 def load_predictor_from_ref(ref: str) -> BasePredictor:

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -28,7 +28,7 @@ from ..predictor import (
     get_output_type,
     get_predictor_ref,
     load_config,
-    load_predictor,
+    load_predictor_from_ref,
 )
 from .runner import PredictionRunner, RunnerBusyError, UnknownPredictionError
 
@@ -67,7 +67,7 @@ def create_app(
         upload_url=upload_url,
     )
     # TODO: avoid loading predictor code in this process
-    predictor = load_predictor(config)
+    predictor = load_predictor_from_ref(predictor_ref)
 
     InputType = get_input_type(predictor)
     OutputType = get_output_type(predictor)

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -49,6 +49,7 @@ def create_app(
     shutdown_event: threading.Event,
     threads: int = 1,
     upload_url: Optional[str] = None,
+    mode: str = "predict",
 ) -> FastAPI:
     app = FastAPI(
         title="Cog",  # TODO: mention model name?
@@ -59,7 +60,7 @@ def create_app(
     app.state.setup_result = None
     app.state.setup_result_payload = None
 
-    predictor_ref = get_predictor_ref(config)
+    predictor_ref = get_predictor_ref(config, mode)
 
     runner = PredictionRunner(
         predictor_ref=predictor_ref,
@@ -323,6 +324,14 @@ if __name__ == "__main__":
         default=False,
         help="Ignore SIGTERM and wait for a request to /shutdown (or a SIGINT) before exiting",
     )
+    parser.add_argument(
+        "--x-mode",
+        dest="mode",
+        type=str,
+        default="predict",
+        choices=["predict", "train"],
+        help="Experimental: Run in 'predict' or 'train' mode",
+    )
     args = parser.parse_args()
 
     # log level is configurable so we can make it quiet or verbose for `cog predict`
@@ -347,6 +356,7 @@ if __name__ == "__main__":
         shutdown_event=shutdown_event,
         threads=threads,
         upload_url=args.upload_url,
+        mode=args.mode,
     )
 
     port = int(os.getenv("PORT", 5000))

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -123,7 +123,7 @@ class Worker:
 
         if done:
             if done.error and raise_on_error:
-                raise FatalWorkerException(raise_on_error)
+                raise FatalWorkerException(raise_on_error + ": " + done.error_detail)
             else:
                 self._state = WorkerState.READY
                 self._allow_cancel = False

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -9,11 +9,7 @@ from multiprocessing.connection import Connection
 from typing import Any, Dict, Iterable, Optional, TextIO, Union
 
 from ..json import make_encodeable
-from ..predictor import (
-    BasePredictor,
-    get_predict,
-    load_predictor_from_ref,
-)
+from ..predictor import BasePredictor, load_predictor_from_ref, get_predict, run_setup
 from .eventtypes import (
     Done,
     Heartbeat,
@@ -186,7 +182,7 @@ class _ChildWorker(_spawn.Process):  # type: ignore
             self._predictor = load_predictor_from_ref(self._predictor_ref)
             # Could be a function or a class
             if hasattr(self._predictor, "setup"):
-                self._predictor.setup()
+                run_setup(self._predictor)
         except Exception as e:
             traceback.print_exc()
             done.error = True

--- a/python/tests/server/conftest.py
+++ b/python/tests/server/conftest.py
@@ -17,8 +17,12 @@ class AppConfig:
 
 
 def _fixture_path(name):
+    # HACK: `name` can either be in the form "<name>.py:Predictor" or just "<name>".
+    if ":" not in name:
+        name = f"{name}.py:Predictor"
+
     test_dir = os.path.dirname(os.path.realpath(__file__))
-    return os.path.join(test_dir, f"fixtures/{name}.py") + ":Predictor"
+    return os.path.join(test_dir, f"fixtures/{name}")
 
 
 def uses_predictor(name):

--- a/python/tests/server/conftest.py
+++ b/python/tests/server/conftest.py
@@ -37,9 +37,9 @@ def make_client(fixture_name: str, upload_url: Optional[str] = None):
     """
     Creates a fastapi test client for an app that uses the requested Predictor.
     """
-    predictor_ref = _fixture_path(fixture_name)
+    config = {"predict": _fixture_path(fixture_name)}
     app = create_app(
-        predictor_ref=predictor_ref,
+        config=config,
         shutdown_event=threading.Event(),
         upload_url=upload_url,
     )

--- a/python/tests/server/fixtures/function.py
+++ b/python/tests/server/fixtures/function.py
@@ -1,0 +1,2 @@
+def predict(text: str) -> str:
+    return "hello " + text

--- a/python/tests/server/fixtures/missing_setup.py
+++ b/python/tests/server/fixtures/missing_setup.py
@@ -1,5 +1,0 @@
-class Predictor:
-    # This predictor has no setup method
-
-    def predict(self):
-        print("did predict")

--- a/python/tests/server/fixtures/setup_weights.py
+++ b/python/tests/server/fixtures/setup_weights.py
@@ -1,0 +1,9 @@
+from cog import File
+
+
+class Predictor:
+    def setup(self, weights: File):
+        self.text = weights.read()
+
+    def predict(self) -> None:
+        return self.text

--- a/python/tests/server/fixtures/setup_weights.py
+++ b/python/tests/server/fixtures/setup_weights.py
@@ -5,5 +5,5 @@ class Predictor:
     def setup(self, weights: File):
         self.text = weights.read()
 
-    def predict(self) -> None:
+    def predict(self) -> str:
         return self.text

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -10,7 +10,7 @@ from PIL import Image
 import pytest
 import unittest.mock as mock
 
-from .conftest import make_client, uses_predictor
+from .conftest import make_client, uses_predictor, uses_predictor_with_client_options
 
 
 @uses_predictor("setup")
@@ -489,12 +489,11 @@ def test_prediction_cancel(client):
     assert resp.status_code == 200
 
 
-@uses_predictor("setup_weights")
+@uses_predictor_with_client_options(
+    "setup_weights",
+    env={"COG_WEIGHTS": "data:text/plain; charset=utf-8;base64,aGVsbG8="},
+)
 def test_weights_are_read_from_environment_variables(client, match):
-    os.environ["COG_WEIGHTS"] = "data:text/plain; charset=utf-8;base64,aGVsbG8="
-
     resp = client.post("/predictions")
     assert resp.status_code == 200
     assert resp.json() == match({"status": "succeeded", "output": "hello"})
-
-    del os.environ["COG_WEIGHTS"]

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -19,6 +19,13 @@ def test_setup_is_called(client, match):
     assert resp.json() == match({"status": "succeeded", "output": "bar"})
 
 
+@uses_predictor("function.py:predict")
+def test_predict_works_with_functions(client, match):
+    resp = client.post("/predictions", json={"input": {"text": "baz"}})
+    assert resp.status_code == 200
+    assert resp.json() == match({"status": "succeeded", "output": "hello baz"})
+
+
 @uses_predictor("openapi_complex_input")
 def test_openapi_specification(client):
     resp = client.get("/openapi.json")

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import base64
 import io
+import os
 import responses
 from responses import matchers
 import time
@@ -486,3 +487,14 @@ def test_prediction_cancel(client):
 
     resp = client.post("/predictions/123/cancel")
     assert resp.status_code == 200
+
+
+@uses_predictor("setup_weights")
+def test_weights_are_read_from_environment_variables(client, match):
+    os.environ["COG_WEIGHTS"] = "data:text/plain; charset=utf-8;base64,aGVsbG8="
+
+    resp = client.post("/predictions")
+    assert resp.status_code == 200
+    assert resp.json() == match({"status": "succeeded", "output": "hello"})
+
+    del os.environ["COG_WEIGHTS"]

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -40,7 +40,6 @@ SETUP_FATAL_FIXTURES = [
     ("exit_in_setup", {}),
     ("exit_on_import", {}),
     ("missing_predictor", {}),
-    ("missing_setup", {}),
     ("nonexistent_file", {}),  # this fixture doesn't even exist
 ]
 

--- a/python/tests/test_predictor.py
+++ b/python/tests/test_predictor.py
@@ -1,0 +1,25 @@
+from typing import Optional
+from cog import File, Path
+from cog.predictor import get_weights_type
+
+
+def test_get_weights_type() -> None:
+    def f() -> None:
+        pass
+
+    assert get_weights_type(f) is None
+
+    def f(weights: File) -> None:
+        pass
+
+    assert get_weights_type(f) == File
+
+    def f(weights: Path) -> None:
+        pass
+
+    assert get_weights_type(f) == Path
+
+    def f(weights: Optional[File]) -> None:
+        pass
+
+    assert get_weights_type(f) == File

--- a/test-integration/test_integration/fixtures/train-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/train-project/cog.yaml
@@ -1,0 +1,4 @@
+build:
+  python_version: "3.8"
+predict: "predict.py:Predictor"
+train: "train.py:train"

--- a/test-integration/test_integration/fixtures/train-project/predict.py
+++ b/test-integration/test_integration/fixtures/train-project/predict.py
@@ -1,0 +1,9 @@
+from cog import BasePredictor, File
+
+
+class Predictor(BasePredictor):
+    def setup(self, weights: File):
+        self.text = weights.read()
+
+    def predict(self) -> str:
+        return f"hello {self.text}"

--- a/test-integration/test_integration/fixtures/train-project/train.py
+++ b/test-integration/test_integration/fixtures/train-project/train.py
@@ -1,0 +1,5 @@
+from cog import File
+import io
+
+def train(text: str) -> File:
+    return io.StringIO(text)

--- a/test-integration/test_integration/fixtures/train-project/train.py
+++ b/test-integration/test_integration/fixtures/train-project/train.py
@@ -1,5 +1,11 @@
-from cog import File
+from cog import BaseModel, File
 import io
 
-def train(text: str) -> File:
-    return io.StringIO(text)
+
+class TrainingOutput(BaseModel):
+    weights: File
+
+
+def train(text: str) -> TrainingOutput:
+    weights = io.StringIO(text)
+    return TrainingOutput(weights=weights)


### PR DESCRIPTION
This adds a `train` option to `cog.yaml` and a `cog train` command to run it.

There are a few bits of refactoring to make this possible, contained in some significant commits. Notably, predictors can now just be functions if you have no `setup()`.

## How it works

`cog.yaml`:

```yaml
build:
  python_version: "3.10"
train: "train.py:train"
```

`train.py`:

```python
from cog import BasePredictor, File
import io

def train(param: str) -> File:
    return io.StringIO("hello " + param)
```

Then you can run it like this:

```
$ cog train -i param=train
...

$ cat weights
hello train
```

## API

The HTTP server can be booted up in two different modes, specified with the `--x-mode` argument: `predict` and `train`.

In `predict` mode, it behaves like it did before.

In `train` mode, if you call `POST /predictions` it actually runs the thing specified by `train` in `cog.yaml`.

## Notes

- The way the API works is obviously... suboptimal. Ideally we'd have something like a separate `/trainings` endpoint and both predictions and trainings can be run when the container is booted up.
  - Unfortunately this is fiddly, so I opted to not do it this way. For example, `Predictor.setup()` gets called on boot, but we don't want to do that if we're training. Also, the worker would require a lot of rewiring to support both things.
  - So – I opted for a bodge where the HTTP server can be booted up in either prediction or training mode, and in training mode `POST /predictions` does a training (bleurgh).
  - This should probably be tidied up at some point but this will get us going.
- Weights need to be loaded in `setup()` somehow. This is not done yet, and I have a half-working version locally.
- We probably want to support directories as `Path`, because this is often the format that weights are in. Perhaps we can add support in Cog to turn a `Path` that points to a directory into a tarball, which is a common pattern (e.g. zip files in DreamBooth).
- We probably want to pass the weights as an input to the trainer to use as the base weights.
- `cog train` passes around files with data URLs, which ain't going to scale. We probably want to use `file://` and store it on the shared Docker volume.
- There aren't any schemas! The model will have to boot up to get validation errors, we can't generate GUIs, etc.