### PR TITLE
Return better error code when setup is running 

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -30,6 +30,7 @@ from ..predictor import (
     load_config,
     load_predictor_from_ref,
 )
+from .exceptions import InvalidStateException
 from .runner import PredictionRunner, RunnerBusyError, UnknownPredictionError
 
 log = structlog.get_logger("cog.server.http")
@@ -194,6 +195,10 @@ def create_app(
         except ValidationError as e:
             _log_invalid_output(e)
             raise HTTPException(status_code=500)
+        except InvalidStateException as e:
+            _log_invalid_output(e)
+            raise HTTPException(
+                status_code=503, detail="Server not ready. Try again later")
 
         response_object = response.dict()
         response_object["output"] = upload_files(

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -19,6 +19,13 @@ def test_setup_is_called(client, match):
     assert resp.json() == match({"status": "succeeded", "output": "bar"})
 
 
+def test_predict_before_setup_complete():
+    client = make_client("sleep")
+    resp = client.post("/predictions")
+    assert resp.status_code == 503
+    assert resp.json() == {"detail": "Server not ready. Try again later"}
+
+
 @uses_predictor("openapi_complex_input")
 def test_openapi_specification(client):
     resp = client.get("/openapi.json")


### PR DESCRIPTION
If the server is still running setup and we issue a new predict call, there is an exception thrown because the workers aren't ready yet.
```
 cog.server.exceptions.InvalidStateException: Invalid operation: state is WorkerState.NEW (must be WorkerState.READY)
```

This commit catches that exception and returns a 503 - retryable server error to ask the client to retry prediction when the server is ready.

---

Note: The runner doesn't seem to throw a RunnerBusyError if it's doing setup. Instead it throws an InvalidStateException.