### PR TITLE
Enable building of GPU image on macOS

### DIFF
--- a/pkg/docker/run.go
+++ b/pkg/docker/run.go
@@ -111,7 +111,8 @@ func RunWithIO(options RunOptions, stdin io.Reader, stdout, stderr io.Writer) er
 
 	err := cmd.Run()
 	if err != nil {
-		if strings.Contains(stderrCopy.String(), "could not select device driver") {
+		if strings.Contains(stderrCopy.String(), "could not select device driver") ||
+			strings.Contains(stderrCopy.String(), "nvidia-container-cli: initialization") {
 			return ErrMissingDeviceDriver
 		}
 		return err


### PR DESCRIPTION
On macOS, 
Docker returns the error message 
'nvidia-container-cli: initialization error: load library failed: libnvidia-ml.so.1: cannot open shared object file: no such file or directory: unknown.' 
