### PR TITLE
fix(python): put file to endpoint `file.seek(0)`

### DIFF
--- a/python/cog/files.py
+++ b/python/cog/files.py
@@ -40,6 +40,8 @@ def guess_filename(obj: io.IOBase) -> str:
 def put_file_to_signed_endpoint(
     fh: io.IOBase, endpoint: str, client: requests.Session
 ) -> str:
+    fh.seek(0)
+
     filename = guess_filename(fh)
     content_type, _ = mimetypes.guess_type(filename)
 


### PR DESCRIPTION
I deploy models with cog use: `docker run -d -p 5000:5000 my-model python -m cog.server.http --upload-url http://host:port/file`.

I found that when I used an asynchronous method to generate images and then uploaded to 'upload-url', the result was empt.

when I modified it using `fh.seek(0)`, I succeeded.