### PR TITLE
Add /trainings API and integrate with CLI

### DIFF
--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -106,7 +106,7 @@ func cmdPredict(cmd *cobra.Command, args []string) error {
 		GPUs:    gpus,
 		Image:   imageName,
 		Volumes: volumes,
-	})
+	}, "predictions")
 
 	go func() {
 		captureSignal := make(chan os.Signal, 1)

--- a/pkg/cli/train.go
+++ b/pkg/cli/train.go
@@ -69,7 +69,7 @@ func cmdTrain(cmd *cobra.Command, args []string) error {
 		Image:   imageName,
 		Volumes: volumes,
 		Args:    []string{"python", "-m", "cog.server.http", "--x-mode", "train"},
-	})
+	}, "trainings")
 
 	go func() {
 		captureSignal := make(chan os.Signal, 1)

--- a/pkg/config/data/config_schema_v1.0.json
+++ b/pkg/config/data/config_schema_v1.0.json
@@ -105,7 +105,7 @@
     "train": {
       "$id": "#/properties/train",
       "type": "string",
-      "description": "The pointer to the `Predictor` object in your code, which defines how predictions are run on your model."
+      "description": "The pointer to the train function in your code, which defines how to train your model."
     }
   },
   "additionalProperties": false

--- a/python/cog/__init__.py
+++ b/python/cog/__init__.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-from .predictor import BasePredictor
+from .predictor import BasePredictor, BaseTrainer
 from .types import File, Input, Path, ConcatenateIterator
 
 try:
@@ -13,6 +13,7 @@ __all__ = [
     "__version__",
     "BaseModel",
     "BasePredictor",
+    "BaseTrainer",
     "ConcatenateIterator",
     "File",
     "Input",

--- a/python/cog/command/openapi_schema.py
+++ b/python/cog/command/openapi_schema.py
@@ -8,7 +8,7 @@ import json
 from ..errors import ConfigDoesNotExist, PredictorNotSet
 from ..suppress_output import suppress_output
 
-from ..predictor import get_predictor_ref, load_config
+from ..predictor import get_runnable_ref, load_config
 from ..server.http import create_app
 
 if __name__ == "__main__":

--- a/python/cog/errors.py
+++ b/python/cog/errors.py
@@ -8,3 +8,7 @@ class ConfigDoesNotExist(CogError):
 
 class PredictorNotSet(CogError):
     """Exception raised when 'predict' is not set in cog.yaml when it needs to be."""
+
+
+class TrainerNotSet(CogError):
+    """Exception raised when 'train' is not set in cog.yaml."""

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -199,10 +199,15 @@ class BaseInput(BaseModel):
                     value.unlink()
 
 
-def get_run_method(runnable: Runnable):
+def get_run_method(runnable: Union[Runnable, Callable]):
+    # For backwards compatibility, Cog currently accepts any class that implements
+    # a `predict` method.
     if hasattr(runnable, "predict"):
         return runnable.predict
-    if hasattr(runnable, "train"):
+    # Otherwise, the user should extend `BasePredictor` or `BaseTrainer`
+    if isinstance(runnable, BasePredictor) and hasattr(runnable, "predict"):
+        return runnable.predict
+    if isinstance(runnable, BaseTrainer) and hasattr(runnable, "train"):
         return runnable.train
     return runnable
 

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -44,11 +44,6 @@ class BasePredictor(BaseRunnable):
 
 
 class BaseTrainer(BaseRunnable):
-    def setup(self, weights: Optional[Union[CogFile, CogPath]] = None) -> None:
-        """
-        An optional method to initialize the trainer.
-        """
-
     @abstractmethod
     def train(self, **kwargs: Any) -> Any:
         """

--- a/python/cog/schema.py
+++ b/python/cog/schema.py
@@ -91,7 +91,6 @@ class TrainingResponse(JobResponse):
 class PredictionRequest(JobRequest):
     # TODO: deprecate this
     output_file_prefix: t.Optional[str]
-    pass
 
 
 class PredictionResponse(JobResponse):

--- a/python/cog/schema.py
+++ b/python/cog/schema.py
@@ -28,16 +28,13 @@ class WebhookEvent(str, Enum):
         return {cls.START, cls.OUTPUT, cls.LOGS, cls.COMPLETED}
 
 
-class PredictionBaseModel(pydantic.BaseModel, extra=pydantic.Extra.allow):
+class JobBaseModel(pydantic.BaseModel, extra=pydantic.Extra.allow):
     input: t.Dict[str, t.Any]
 
 
-class PredictionRequest(PredictionBaseModel):
+class JobRequest(JobBaseModel):
     id: t.Optional[str]
     created_at: t.Optional[datetime]
-
-    # TODO: deprecate this
-    output_file_prefix: t.Optional[str]
 
     webhook: t.Optional[pydantic.AnyHttpUrl]
     webhook_events_filter: t.Optional[
@@ -54,7 +51,7 @@ class PredictionRequest(PredictionBaseModel):
         )
 
 
-class PredictionResponse(PredictionBaseModel):
+class JobResponse(JobBaseModel):
     output: t.Any
 
     id: t.Optional[str]
@@ -81,3 +78,21 @@ class PredictionResponse(PredictionBaseModel):
             input=(t.Optional[input_type], None),
             output=(output_type, None),
         )
+
+
+class TrainingRequest(JobRequest):
+    pass
+
+
+class TrainingResponse(JobResponse):
+    pass
+
+
+class PredictionRequest(JobRequest):
+    # TODO: deprecate this
+    output_file_prefix: t.Optional[str]
+    pass
+
+
+class PredictionResponse(JobResponse):
+    pass

--- a/python/cog/server/eventtypes.py
+++ b/python/cog/server/eventtypes.py
@@ -6,7 +6,7 @@ from attrs import define, field, validators
 # From worker parent process
 #
 @define
-class PredictionInput:
+class JobInput:
     payload: Dict[str, Any]
 
 
@@ -24,12 +24,12 @@ class Log:
 
 
 @define
-class PredictionOutput:
+class JobOutput:
     payload: Any
 
 
 @define
-class PredictionOutputType:
+class JobOutputType:
     multi: bool = False
 
 

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -149,21 +149,11 @@ def create_app(
         return _train(request=request, respond_async=respond_async)
 
     def _train(*, request: TrainingRequest, respond_async: bool) -> Response:
-        # [compat] If no body is supplied, assume that this model can be run
-        # with empty input. This will throw a ValidationError if that's not
-        # possible.
-        if request is None:
-            request = TrainingRequest(input={})
-        # [compat] If body is supplied but input is None, set it to an empty
-        # dictionary so that later code can be simpler.
-        if request.input is None:
-            request.input = {}
-
         try:
             # For now, we only ask the Runner to handle file uploads for
-            # async predictions. This is unfortunate but required to ensure
-            # backwards-compatible behaviour for synchronous predictions.
-            initial_response, async_result = runner.run(request, upload=respond_async)
+            # async trainings. This is unfortunate but required to ensure
+            # backwards-compatible behaviour for synchronous training.
+            initial_response, async_result = runner.run(request, upload=True)
         except RunnerBusyError:
             return JSONResponse(
                 {"detail": "Already running training."}, status_code=409
@@ -179,10 +169,6 @@ def create_app(
             raise HTTPException(status_code=500)
 
         response_object = response.dict()
-        response_object["output"] = upload_files(
-            response_object["output"],
-            upload_file=lambda fh: upload_file(fh, request.output_file_prefix),  # type: ignore
-        )
 
         # FIXME: clean up output files
         encoded_response = jsonable_encoder(response_object)

--- a/python/tests/server/conftest.py
+++ b/python/tests/server/conftest.py
@@ -33,21 +33,33 @@ def uses_predictor(name):
     )
 
 
+def uses_trainer(name):
+    return pytest.mark.parametrize(
+        "training_client",
+        [AppConfig(predictor_fixture=name, options={})],
+        indirect=True,
+    )
+
+
 def uses_predictor_with_client_options(name, **options):
     return pytest.mark.parametrize(
         "client", [AppConfig(predictor_fixture=name, options=options)], indirect=True
     )
 
 
-def make_client(fixture_name: str, upload_url: Optional[str] = None):
+def make_client(fixture_name: str, mode: str, upload_url: Optional[str] = None):
     """
-    Creates a fastapi test client for an app that uses the requested Predictor.
+    Creates a fastapi test client for an app that uses the requested Predictor or Trainer.
     """
-    config = {"predict": _fixture_path(fixture_name)}
+    config = {
+        "predict": _fixture_path(fixture_name),
+        "train": _fixture_path(fixture_name),
+    }
     app = create_app(
         config=config,
         shutdown_event=threading.Event(),
         upload_url=upload_url,
+        mode=mode,
     )
     return TestClient(app)
 
@@ -72,7 +84,24 @@ def client(request):
             del options["env"]
 
         # Use context manager to trigger setup/shutdown events.
-        c = make_client(fixture_name=fixture_name, **options)
+        c = make_client(fixture_name=fixture_name, mode="predict", **options)
+        stack.enter_context(c)
+        wait_for_setup(c)
+        yield c
+
+
+@pytest.fixture
+def training_client(request):
+    fixture_name = request.param.predictor_fixture
+    options = request.param.options
+
+    with ExitStack() as stack:
+        if "env" in options:
+            stack.enter_context(mock.patch.dict(os.environ, options["env"]))
+            del options["env"]
+
+        # Use context manager to trigger setup/shutdown events.
+        c = make_client(fixture_name=fixture_name, mode="train", **options)
         stack.enter_context(c)
         wait_for_setup(c)
         yield c

--- a/python/tests/server/fixtures/train_function.py
+++ b/python/tests/server/fixtures/train_function.py
@@ -1,0 +1,2 @@
+def train(num: int) -> int:
+    return num

--- a/python/tests/server/fixtures/trainer_class.py
+++ b/python/tests/server/fixtures/trainer_class.py
@@ -1,0 +1,9 @@
+from cog import BaseTrainer
+
+
+class Trainer(BaseTrainer):
+    def setup(self) -> None:
+        self.num = 42
+
+    def train(self) -> int:
+        return self.num

--- a/python/tests/server/fixtures/trainer_sleep.py
+++ b/python/tests/server/fixtures/trainer_sleep.py
@@ -1,0 +1,13 @@
+import time
+
+
+class Trainer:
+    def setup(self) -> None:
+        print("Setting up.")
+
+    def train(self, sleep: float = 0) -> str:
+        time.sleep(sleep)
+        return f"done in {sleep} seconds"
+
+    def cancel(self) -> None:
+        print("Canceling.")

--- a/python/tests/server/fixtures/trainer_sleep.py
+++ b/python/tests/server/fixtures/trainer_sleep.py
@@ -1,7 +1,9 @@
 import time
 
+from cog import BaseTrainer
 
-class Trainer:
+
+class Trainer(BaseTrainer):
     def setup(self) -> None:
         print("Setting up.")
 

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -20,11 +20,12 @@ from cog.server.eventtypes import (
     Done,
     Heartbeat,
     Log,
-    PredictionOutput,
-    PredictionOutputType,
+    JobOutput,
+    JobOutputType,
 )
 from cog.server.exceptions import FatalWorkerException, InvalidStateException
 from cog.server.worker import Worker
+from tests.server.conftest import _fixture_path
 
 # Set a longer deadline on CI as the instances are a bit slower.
 settings.register_profile("ci", max_examples=100, deadline=1000)
@@ -95,7 +96,7 @@ class Result:
     stdout: str = ""
     stderr: str = ""
     heartbeat_count: int = 0
-    output_type: Optional[PredictionOutputType] = None
+    output_type: Optional[JobOutputType] = None
     output: Any = None
     done: Optional[Done] = None
     exception: Optional[Exception] = None
@@ -120,7 +121,7 @@ def _process(events, swallow_exceptions=False):
             elif isinstance(event, Done):
                 assert not result.done
                 result.done = event
-            elif isinstance(event, PredictionOutput):
+            elif isinstance(event, JobOutput):
                 assert result.output_type, "Should get output type before any output"
                 if result.output_type.multi:
                     result.output.append(event.payload)
@@ -129,7 +130,7 @@ def _process(events, swallow_exceptions=False):
                         result.output is None
                     ), "Should not get multiple outputs for output type single"
                     result.output = event.payload
-            elif isinstance(event, PredictionOutputType):
+            elif isinstance(event, JobOutputType):
                 assert (
                     result.output_type is None
                 ), "Should not get multiple output type events"
@@ -147,17 +148,12 @@ def _process(events, swallow_exceptions=False):
     return result
 
 
-def _fixture_path(name):
-    test_dir = os.path.dirname(os.path.realpath(__file__))
-    return os.path.join(test_dir, f"fixtures/{name}.py") + ":Predictor"
-
-
 @pytest.mark.parametrize("name,payloads", SETUP_FATAL_FIXTURES)
 def test_fatalworkerexception_from_setup_failures(name, payloads):
     """
     Any failure during setup is fatal and should raise FatalWorkerException.
     """
-    w = Worker(predictor_ref=_fixture_path(name), tee_output=False)
+    w = Worker(job_ref=_fixture_path(name), tee_output=False)
 
     with pytest.raises(FatalWorkerException):
         _process(w.setup())
@@ -172,7 +168,7 @@ def test_fatalworkerexception_from_irrecoverable_failures(data, name, payloads):
     Certain kinds of failure during predict (crashes, unexpected exits) are
     irrecoverable and should raise FatalWorkerException.
     """
-    w = Worker(predictor_ref=_fixture_path(name), tee_output=False)
+    w = Worker(job_ref=_fixture_path(name), tee_output=False)
 
     result = _process(w.setup())
     assert not result.done.error
@@ -180,7 +176,7 @@ def test_fatalworkerexception_from_irrecoverable_failures(data, name, payloads):
     with pytest.raises(FatalWorkerException):
         for _ in range(5):
             payload = data.draw(st.fixed_dictionaries(payloads))
-            _process(w.predict(payload))
+            _process(w.run(payload))
 
     w.terminate()
 
@@ -192,7 +188,7 @@ def test_no_exceptions_from_recoverable_failures(data, name, payloads):
     Well-behaved predictors, or those that only throw exceptions, should not
     raise.
     """
-    w = Worker(predictor_ref=_fixture_path(name), tee_output=False)
+    w = Worker(job_ref=_fixture_path(name), tee_output=False)
 
     try:
         result = _process(w.setup())
@@ -200,7 +196,7 @@ def test_no_exceptions_from_recoverable_failures(data, name, payloads):
 
         for _ in range(5):
             payload = data.draw(st.fixed_dictionaries(payloads))
-            _process(w.predict(payload))
+            _process(w.run(payload))
     finally:
         w.terminate()
 
@@ -213,7 +209,7 @@ def test_output(data, name, payloads, output_generator):
 
     Note that most of the validation work here is actually done in _process.
     """
-    w = Worker(predictor_ref=_fixture_path(name), tee_output=False)
+    w = Worker(job_ref=_fixture_path(name), tee_output=False)
 
     try:
         result = _process(w.setup())
@@ -222,7 +218,7 @@ def test_output(data, name, payloads, output_generator):
         payload = data.draw(st.fixed_dictionaries(payloads))
         expected_output = output_generator(payload)
 
-        result = _process(w.predict(payload))
+        result = _process(w.run(payload))
 
         assert result.output == expected_output
     finally:
@@ -235,7 +231,7 @@ def test_setup_logging(name, expected_stdout, expected_stderr):
     We should get the logs we expect from predictors that generate logs during
     setup.
     """
-    w = Worker(predictor_ref=_fixture_path(name), tee_output=False)
+    w = Worker(job_ref=_fixture_path(name), tee_output=False)
 
     try:
         result = _process(w.setup())
@@ -255,13 +251,13 @@ def test_predict_logging(name, payloads, expected_stdout, expected_stderr):
     We should get the logs we expect from predictors that generate logs during
     predict.
     """
-    w = Worker(predictor_ref=_fixture_path(name), tee_output=False)
+    w = Worker(job_ref=_fixture_path(name), tee_output=False)
 
     try:
         result = _process(w.setup())
         assert not result.done.error
 
-        result = _process(w.predict({}))
+        result = _process(w.run({}))
 
         assert result.stdout == expected_stdout
         assert result.stderr == expected_stderr
@@ -275,7 +271,7 @@ def test_cancel_is_safe():
     happening or the cancelation of unexpected predictions.
     """
 
-    w = Worker(predictor_ref=_fixture_path("sleep"), tee_output=True)
+    w = Worker(job_ref=_fixture_path("sleep"), tee_output=True)
 
     try:
         for _ in range(50):
@@ -286,12 +282,12 @@ def test_cancel_is_safe():
         for _ in range(50):
             w.cancel()
 
-        result1 = _process(w.predict({"sleep": 0.5}), swallow_exceptions=True)
+        result1 = _process(w.run({"sleep": 0.5}), swallow_exceptions=True)
 
         for _ in range(50):
             w.cancel()
 
-        result2 = _process(w.predict({"sleep": 0.1}), swallow_exceptions=True)
+        result2 = _process(w.run({"sleep": 0.1}), swallow_exceptions=True)
 
         assert not result1.exception
         assert not result1.done.canceled
@@ -302,20 +298,44 @@ def test_cancel_is_safe():
         w.terminate()
 
 
+def test_cancel_hook():
+    """
+    Tests that the worker calls the cancel method on a Trainer that implements it.
+    """
+
+    try:
+        w = Worker(job_ref=_fixture_path("trainer_sleep.py:Trainer"), tee_output=True)
+        result = _process(w.setup(), swallow_exceptions=True)
+        assert result.stdout == "Setting up.\n"
+
+        canceled = False
+        logs = []
+        for event in w.run({"sleep": 0.5}, poll=0.1):
+            if not canceled:
+                w.cancel()
+                canceled = True
+            if isinstance(event, Log):
+                logs.append(event.message)
+
+        assert logs[0] == "Canceling.\n"
+    finally:
+        w.terminate()
+
+
 def test_cancel_idempotency():
     """
     Multiple calls to cancel within the same prediction, while not necessary or
     recommended, should still only result in a single cancelled prediction, and
     should not affect subsequent predictions.
     """
-    w = Worker(predictor_ref=_fixture_path("sleep"), tee_output=True)
+    w = Worker(job_ref=_fixture_path("sleep"), tee_output=True)
 
     try:
         _process(w.setup())
 
         p1_done = None
 
-        for event in w.predict({"sleep": 0.5}, poll=0.01):
+        for event in w.run({"sleep": 0.5}, poll=0.01):
             # We call cancel a WHOLE BUNCH to make sure that we don't propagate
             # any of those cancelations to subsequent predictions, regardless
             # of the internal implementation of exceptions raised inside signal
@@ -328,7 +348,7 @@ def test_cancel_idempotency():
 
         assert p1_done.canceled
 
-        result2 = _process(w.predict({"sleep": 0.1}))
+        result2 = _process(w.run({"sleep": 0.1}))
 
         assert not result2.done.canceled
         assert result2.output == "done in 0.1 seconds"
@@ -343,7 +363,7 @@ def test_cancel_multiple_predictions():
     reset every time a prediction starts.
     """
 
-    w = Worker(predictor_ref=_fixture_path("sleep"), tee_output=True)
+    w = Worker(job_ref=_fixture_path("sleep"), tee_output=True)
 
     try:
         _process(w.setup())
@@ -353,7 +373,7 @@ def test_cancel_multiple_predictions():
         for _ in range(5):
             canceled = False
 
-            for event in w.predict({"sleep": 0.5}, poll=0.01):
+            for event in w.run({"sleep": 0.5}, poll=0.01):
                 if not canceled:
                     w.cancel()
                     canceled = True
@@ -373,12 +393,12 @@ def test_heartbeats():
     heartbeat events which allow the caller to do other stuff while waiting on
     completion.
     """
-    w = Worker(predictor_ref=_fixture_path("sleep"), tee_output=False)
+    w = Worker(job_ref=_fixture_path("sleep"), tee_output=False)
 
     try:
         _process(w.setup())
 
-        result = _process(w.predict({"sleep": 0.5}, poll=0.1))
+        result = _process(w.run({"sleep": 0.5}, poll=0.1))
 
         assert result.heartbeat_count > 0
     finally:
@@ -390,7 +410,7 @@ def test_heartbeats_cancel():
     Heartbeats should happen even when we cancel the prediction.
     """
 
-    w = Worker(predictor_ref=_fixture_path("sleep"), tee_output=False)
+    w = Worker(job_ref=_fixture_path("sleep"), tee_output=False)
 
     try:
         _process(w.setup())
@@ -399,7 +419,7 @@ def test_heartbeats_cancel():
         heartbeat_count = 0
         start = time.time()
 
-        for event in w.predict({"sleep": 10}, poll=0.1):
+        for event in w.run({"sleep": 10}, poll=0.1):
             if isinstance(event, Heartbeat):
                 heartbeat_count += 1
             if time.time() - start > 0.5:
@@ -420,12 +440,12 @@ def test_graceful_shutdown():
     then exit.
     """
 
-    w = Worker(predictor_ref=_fixture_path("sleep"), tee_output=False)
+    w = Worker(job_ref=_fixture_path("sleep"), tee_output=False)
 
     try:
         _process(w.setup())
 
-        events = w.predict({"sleep": 1}, poll=0.1)
+        events = w.run({"sleep": 1}, poll=0.1)
 
         # get one event to make sure we've started the prediction
         assert isinstance(next(events), Heartbeat)
@@ -500,7 +520,7 @@ class WorkerState(RuleBasedStateMachine):
     def predict(self, name, steps):
         try:
             payload = {"name": name, "steps": steps}
-            self.predict_generator = self.worker.predict(payload)
+            self.predict_generator = self.worker.run(payload)
             self.predict_payload = payload
             self.predict_events = []
         except InvalidStateException:

--- a/test-integration/test_integration/fixtures/predict.py
+++ b/test-integration/test_integration/fixtures/predict.py
@@ -1,0 +1,6 @@
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def predict(self, s: str) -> str:
+        return "hello " + s

--- a/test-integration/test_integration/fixtures/train-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/train-project/cog.yaml
@@ -1,0 +1,3 @@
+build:
+  python_version: "3.8"
+train: "train.py:train"

--- a/test-integration/test_integration/fixtures/train-project/train.py
+++ b/test-integration/test_integration/fixtures/train-project/train.py
@@ -1,0 +1,3 @@
+def train(s: str) -> str:
+    return "hello " + s
+

--- a/test-integration/test_integration/fixtures/trainer-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/trainer-project/cog.yaml
@@ -1,0 +1,3 @@
+build:
+  python_version: "3.8"
+train: "train.py:Trainer"

--- a/test-integration/test_integration/fixtures/trainer-project/train.py
+++ b/test-integration/test_integration/fixtures/trainer-project/train.py
@@ -1,0 +1,12 @@
+from cog import BaseTrainer
+
+
+class Trainer(BaseTrainer):
+    def setup(self) -> None:
+        self.hello = "hello "
+
+    def train(self, s: str) -> str:
+        return self.hello + s
+
+    def cancel(self) -> None:
+        pass

--- a/test-integration/test_integration/test_train.py
+++ b/test-integration/test_integration/test_train.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+import subprocess
+
+
+def test_trainer():
+    project_dir = Path(__file__).parent / "fixtures/trainer-project"
+    subprocess.run(
+        ["cog", "train", "-i", "world"],
+        cwd=project_dir,
+        check=True,
+    )
+    weights_file = os.path.join(project_dir, "weights")
+    with open(weights_file, "r") as f:
+        assert f.read() == "hello world"
+
+
+def test_train():
+    project_dir = Path(__file__).parent / "fixtures/train-project"
+    subprocess.run(
+        ["cog", "train", "-i", "world"],
+        cwd=project_dir,
+        check=True,
+    )
+    weights_file = os.path.join(project_dir, "weights")
+    with open(weights_file, "r") as f:
+        assert f.read() == "hello world"


### PR DESCRIPTION
## Background

#976 added a `cog train` command to the CLI pointed at the `/predictions` API, allowing the user to specify a value for `train` in `cog.yaml` specifying a path to a callable.

## Overview

This PR adds a `/trainings` API to Cog containers and points the CLI to it. It additionally defines a base class `Trainer` that has an optional `cancel` method.

```python
from cog import BaseTrainer

class Trainer(BaseTrainer):
    @abstractmethod
    def train(self, **kwargs: Any) -> Any:
        """
        Train a model.
        """

    def cancel(self) -> None:
        """
        An optional method to handle training cancellation to save model weights.
        """
```

The `cancel` method is run upon a cancellation request being received. This is an especially important use case for training, when one may want to save model weights or other state when, for example, a job is  running for considerably longer than expected, or when the user inspects the training logs and suspects the model is being over-trained.

## Remarks

* This PR doesn't solve the problem Ben notes in #976 about being able to run both predictions and trainings in a single container, since this would require loading and unloading the model a Predictor would load during set-up, making interleaving predictions and trainings complicated.
* There's still work to do in the CLI to disentangle the `train` command from the `predict` package.