### PR TITLE
[WIP] Introduce `groupfile` cmd opt grouping small file in separate docker layers

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -9,8 +9,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var buildTag string
-var buildProgressOutput string
+var (
+	buildTag            string
+	buildProgressOutput string
+	groupFile           bool
+)
 
 func newBuildCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -20,6 +23,7 @@ func newBuildCommand() *cobra.Command {
 		RunE:  buildCommand,
 	}
 	addBuildProgressOutputFlag(cmd)
+	addGroupFileFlag(cmd)
 	cmd.Flags().StringVarP(&buildTag, "tag", "t", "", "A name for the built image in the form 'repository:tag'")
 	return cmd
 }
@@ -38,7 +42,7 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 		imageName = config.DockerImageName(projectDir)
 	}
 
-	if err := image.Build(cfg, projectDir, imageName, buildProgressOutput); err != nil {
+	if err := image.Build(cfg, projectDir, imageName, buildProgressOutput, groupFile); err != nil {
 		return err
 	}
 
@@ -53,4 +57,8 @@ func addBuildProgressOutputFlag(cmd *cobra.Command) {
 		defaultOutput = "plain"
 	}
 	cmd.Flags().StringVar(&buildProgressOutput, "progress", defaultOutput, "Set type of build progress output, 'auto' (default), 'tty' or 'plain'")
+}
+
+func addGroupFileFlag(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(&groupFile, "filegroup", "f", false, "If set, cog will group small files into independent docker layer")
 }

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -60,5 +60,5 @@ func addBuildProgressOutputFlag(cmd *cobra.Command) {
 }
 
 func addGroupFileFlag(cmd *cobra.Command) {
-	cmd.Flags().BoolVarP(&groupFile, "filegroup", "f", false, "If set, cog will group small files into independent docker layer")
+	cmd.Flags().BoolVarP(&groupFile, "groupfile", "g", false, "If set, cog will group small files into independent docker layer")
 }

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -25,6 +25,7 @@ func newDebugCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(debug)
+	addGroupFileFlag(cmd)
 
 	return cmd
 }
@@ -35,7 +36,7 @@ func cmdDockerfile(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	generator, err := dockerfile.NewGenerator(config, projectDir)
+	generator, err := dockerfile.NewGenerator(config, projectDir, groupFile)
 	if err != nil {
 		return fmt.Errorf("Error creating Dockerfile generator: %w", err)
 	}

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -45,6 +45,7 @@ the prediction on that.`,
 	addBuildProgressOutputFlag(cmd)
 	cmd.Flags().StringArrayVarP(&inputFlags, "input", "i", []string{}, "Inputs, in the form name=value. if value is prefixed with @, then it is read from a file on disk. E.g. -i path=@image.jpg")
 	cmd.Flags().StringVarP(&outPath, "output", "o", "", "Output path")
+	addGroupFileFlag(cmd)
 
 	return cmd
 }
@@ -62,7 +63,7 @@ func cmdPredict(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		if imageName, err = image.BuildBase(cfg, projectDir, buildProgressOutput); err != nil {
+		if imageName, err = image.BuildBase(cfg, projectDir, buildProgressOutput, groupFile); err != nil {
 			return err
 		}
 

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -23,7 +23,7 @@ func newPushCommand() *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 	}
 	addBuildProgressOutputFlag(cmd)
-
+	addGroupFileFlag(cmd)
 	return cmd
 }
 
@@ -42,7 +42,7 @@ func push(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("To push images, you must either set the 'image' option in cog.yaml or pass an image name as an argument. For example, 'cog push registry.hooli.corp/hotdog-detector'")
 	}
 
-	if err := image.Build(cfg, projectDir, imageName, buildProgressOutput); err != nil {
+	if err := image.Build(cfg, projectDir, imageName, buildProgressOutput, groupFile); err != nil {
 		return err
 	}
 

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -31,6 +31,7 @@ func newRunCommand() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&runPorts, "publish", "p", []string{}, "Publish a container's port to the host, e.g. -p 8000")
 
 	flags.SetInterspersed(false)
+	addGroupFileFlag(cmd)
 
 	return cmd
 }
@@ -41,7 +42,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	imageName, err := image.BuildBase(cfg, projectDir, buildProgressOutput)
+	imageName, err := image.BuildBase(cfg, projectDir, buildProgressOutput, groupFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/train.go
+++ b/pkg/cli/train.go
@@ -30,6 +30,7 @@ It will build the model in the current directory and train it.`,
 	}
 	addBuildProgressOutputFlag(cmd)
 	cmd.Flags().StringArrayVarP(&trainInputFlags, "input", "i", []string{}, "Inputs, in the form name=value. if value is prefixed with @, then it is read from a file on disk. E.g. -i path=@image.jpg")
+	addGroupFileFlag(cmd)
 
 	return cmd
 }
@@ -47,7 +48,7 @@ func cmdTrain(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if imageName, err = image.BuildBase(cfg, projectDir, buildProgressOutput); err != nil {
+	if imageName, err = image.BuildBase(cfg, projectDir, buildProgressOutput, groupFile); err != nil {
 		return err
 	}
 

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -15,10 +15,10 @@ import (
 // Build a Cog model from a config
 //
 // This is separated out from docker.Build(), so that can be as close as possible to the behavior of 'docker build'.
-func Build(cfg *config.Config, dir, imageName string, progressOutput string) error {
+func Build(cfg *config.Config, dir, imageName string, progressOutput string, groupFile bool) error {
 	console.Infof("Building Docker image from environment in cog.yaml as %s...", imageName)
 
-	generator, err := dockerfile.NewGenerator(cfg, dir)
+	generator, err := dockerfile.NewGenerator(cfg, dir, groupFile)
 	if err != nil {
 		return fmt.Errorf("Error creating Dockerfile generator: %w", err)
 	}
@@ -77,13 +77,13 @@ func Build(cfg *config.Config, dir, imageName string, progressOutput string) err
 	return nil
 }
 
-func BuildBase(cfg *config.Config, dir string, progressOutput string) (string, error) {
+func BuildBase(cfg *config.Config, dir string, progressOutput string, groupFile bool) (string, error) {
 	// TODO: better image management so we don't eat up disk space
 	// https://github.com/replicate/cog/issues/80
 	imageName := config.BaseDockerImageName(dir)
 
 	console.Info("Building Docker image from environment in cog.yaml...")
-	generator, err := dockerfile.NewGenerator(cfg, dir)
+	generator, err := dockerfile.NewGenerator(cfg, dir, groupFile)
 	if err != nil {
 		return "", fmt.Errorf("Error creating Dockerfile generator: %w", err)
 	}


### PR DESCRIPTION
Resolve #1004 

This pull request adds a new command line option called "groupfile" that can be enabled to group small files in the user's workspace into separate Docker layers. This approach helps to reduce overhead and potential deployment slowdowns that may be caused by frequent small file updates. The motivation for this feature is based on the observation that large files, such as model weights, are typically updated less frequently compared to small files like source code.

Once this PR is merged, the Cog tool will perform the following actions:

1. Divide files in the top-level of the user's workspace into small and large files, using a threshold value of 100 megabytes (hardcoded for now).
2. For small files, group them into separate file groups based on the maximum number of layers allowed in a Docker image (42 for old aufs, 127 for newer kernel versions).
3. Place all large files in an independent layer.

