### PR TITLE
Record git commit on images

### DIFF
--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
+	"path"
 
 	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/docker"
@@ -71,6 +74,14 @@ func Build(cfg *config.Config, dir, imageName string, progressOutput string) err
 		labels["org.cogmodel.openapi_schema"] = string(schemaJSON)
 	}
 
+	commit, err := GitHead(dir)
+	if err != nil {
+		console.Warnf("Failed to get Git commit hash: %s", err)
+	}
+	if commit != nil {
+		labels[global.LabelNamespace+"git_commit"] = *commit
+	}
+
 	if err := docker.BuildAddLabelsToImage(imageName, labels); err != nil {
 		return fmt.Errorf("Failed to add labels to image: %w", err)
 	}
@@ -100,4 +111,18 @@ func BuildBase(cfg *config.Config, dir string, progressOutput string) (string, e
 		return "", fmt.Errorf("Failed to build Docker image: %w", err)
 	}
 	return imageName, nil
+}
+
+func GitHead(dir string) (*string, error) {
+	if _, err := os.Stat(path.Join(dir, ".git")); os.IsNotExist(err) {
+		return nil, nil
+	}
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	commit := string(bytes.TrimSpace(out))
+	return &commit, nil
 }

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -109,6 +109,11 @@ build:
         cwd=tmpdir,
         check=True,
     )
+    subprocess.run(
+        ["git", "tag", "0.0.1"],
+        cwd=tmpdir,
+        check=True,
+    )
 
     subprocess.run(
         ["cog", "build", "-t", docker_image],
@@ -150,6 +155,7 @@ build:
     }
     assert "org.cogmodel.openapi_schema" not in labels
 
+    assert len(labels["org.opencontainers.image.version"]) > 0
     assert len(labels["org.opencontainers.image.revision"]) > 0
 
 

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -150,7 +150,7 @@ build:
     }
     assert "org.cogmodel.openapi_schema" not in labels
 
-    assert len(labels["run.cog.git_commit"]) > 0
+    assert len(labels["org.opencontainers.image.revision"]) > 0
 
 
 def test_build_with_cog_init_templates(tmpdir, docker_image):

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -100,6 +100,17 @@ build:
         f.write(cog_yaml)
 
     subprocess.run(
+        ["git", "init"],
+        cwd=tmpdir,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "initial"],
+        cwd=tmpdir,
+        check=True,
+    )
+
+    subprocess.run(
         ["cog", "build", "-t", docker_image],
         cwd=tmpdir,
         check=True,
@@ -138,6 +149,8 @@ build:
         }
     }
     assert "org.cogmodel.openapi_schema" not in labels
+
+    assert len(labels["run.cog.git_commit"]) > 0
 
 
 def test_build_with_cog_init_templates(tmpdir, docker_image):


### PR DESCRIPTION
If a `.git` directory exists when doing `cog build` or `cog push`, this pull request sets the label `run.cog.git_commit` from `HEAD`. This lets us link an image back to the code it was built from.

An alternate name could be `run.cog.git_head` to make it clear precisely what it is.

In the future, you could imagine some indication of whether the commit is dirty or not. I wonder whether there is a standard format for indicating this stuff beyond just appending `-dirty`?