### PR TITLE
Pin `pypa/gh-action-pypi-publish` to `release/v1` in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - '**'
+      - "**"
   pull_request:
     branches:
       - main
@@ -149,7 +149,7 @@ jobs:
           # set output
           echo "version=$(ls python/dist/ | cut -d- -f2)" >> $GITHUB_OUTPUT
       - name: Push Python package
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
From https://github.com/pypa/gh-action-pypi-publish:

> The `master` branch version has been sunset. Please, change the GitHub Action version you use from `master` to `release/v1` or use an exact tag, or a full Git commit SHA.

