### PR TITLE
Rename `test` job to `test-go` in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
       - main
 
 jobs:
-  test:
+  test-go:
     name: "Test Go"
     strategy:
       fail-fast: false
@@ -81,7 +81,7 @@ jobs:
 
   release:
     needs:
-      - test
+      - test-go
       - test-python
       - test-integration
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
For consistency with Make target names.