### PR TITLE
Run `test-integration` job on macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,14 @@ jobs:
         platform: [ubuntu-latest-16-cores, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
+      - name: Setup Docker on macOS
+        if: matrix.platform == 'macos-latest'
+        run: |
+          brew install docker docker-buildx
+          mkdir -p ~/.docker/cli-plugins
+          ln -sfn $(which docker-buildx) ~/.docker/cli-plugins/docker-buildx
+          docker buildx install
+          colima start --runtime docker
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,7 @@ jobs:
           ln -sfn $(which docker-buildx) ~/.docker/cli-plugins/docker-buildx
           docker buildx install
           colima start --runtime docker
+          echo DOCKER_HOST="unix:///${HOME}/.colima/default/docker.sock" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
-        platform: [ubuntu-latest-8-cores, macos-12]
+        platform: [ubuntu-latest-8-cores, macos-latest]
     runs-on: ${{ matrix.platform }}
     defaults:
       run:
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
-        platform: [ubuntu-latest-16-cores, macos-12]
+        platform: [ubuntu-latest-16-cores, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,10 +61,14 @@ jobs:
         env:
           HYPOTHESIS_PROFILE: ci
 
-  # cannot run this on mac due to licensing issues: https://github.com/actions/virtual-environments/issues/2150
   test-integration:
     name: "Test integration"
-    runs-on: ubuntu-latest-16-cores
+    strategy:
+      fail-fast: false
+      matrix:
+        # https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
+        platform: [ubuntu-latest-16-cores, macos-12]
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4


### PR DESCRIPTION
macOS support has been added to GitHub Actions runners with Colima: https://github.com/actions/runner-images/issues/6216.