### PR TITLE
Update Python version requirements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -189,9 +189,7 @@ class BaseInput(BaseModel):
             # Note this is pathlib.Path, which cog.Path is a subclass of. A pathlib.Path object shouldn't make its way here,
             # but both have an unlink() method, so may as well be safe.
             elif isinstance(value, Path):
-                # This could be missing_ok=True when we drop support for Python 3.7
-                if value.exists():
-                    value.unlink()
+                value.unlink(missing_ok=True)
 
 
 def get_predict(predictor):

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -8,10 +8,20 @@ import os.path
 from pathlib import Path
 from pydantic import create_model, BaseModel, Field
 from pydantic.fields import FieldInfo
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Type,
+    Union,
+    get_origin,
+    get_args,
+)
 
-# Added in Python 3.8. Can be from typing if we drop support for <3.8.
-from typing_extensions import get_origin, get_args, Annotated
+# Added in Python 3.9. Can be from typing if we drop support for <3.9
+from typing_extensions import Annotated
 import yaml
 
 from .errors import ConfigDoesNotExist, PredictorNotSet

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 license.file = "LICENSE"
 urls."Source" = "https://github.com/replicate/cog"
 
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 dependencies = [
     # intentionally loose. perhaps these should be vendored to not collide with user code?
     "attrs>=20.1,<23",


### PR DESCRIPTION
This package currently specifies `python_requires=>=3.6` and tests Python 3.7 – 3.10. 

Python 3.7 reaches EOL in June 2023 [(source)](https://devguide.python.org/versions/). Many popular libraries including [Pytorch](https://github.com/pytorch/pytorch#prerequisites) and [numpy](https://github.com/numpy/numpy/blob/954aa5856c9812b71162415b6573b397368a1da7/setup.py#L526) now require Python>=3.8.

<img width="759" alt="Screenshot 2023-04-07 at 14 58 25" src="https://user-images.githubusercontent.com/7659/230684085-67beaaf8-93c6-4d5c-8ad4-218732e5ed64.png">

This PR raises the Python version requirements to >= 3.8. It also adds Python 3.11 to the test matrix in our CI workflow.