### PR TITLE
Catch missing GPU when running cog build

### DIFF
--- a/pkg/docker/run.go
+++ b/pkg/docker/run.go
@@ -111,7 +111,8 @@ func RunWithIO(options RunOptions, stdin io.Reader, stdout, stderr io.Writer) er
 
 	err := cmd.Run()
 	if err != nil {
-		if strings.Contains(stderrCopy.String(), "could not select device driver") {
+		stderrString := stderrCopy.String()
+		if strings.Contains(stderrString, "could not select device driver") || strings.Contains(stderrString, "nvidia-container-cli: initialization error") {
 			return ErrMissingDeviceDriver
 		}
 		return err


### PR DESCRIPTION
We have [logic](https://github.com/replicate/cog/blob/642f550f8cdb1fa1ff52074c5aa3f7508a351778/pkg/docker/run.go#L114) to detect when a GPU isn't available locally. Recently a user reported the following error when building a GPU model locally on a Mac:

```
docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running hook #0: error running hook: exit status 1, stdout: , stderr: Auto-detected mode as 'legacy'
nvidia-container-cli: initialization error: load library failed: libnvidia-ml.so.1: cannot open shared object file: no such file or directory: unknown.
```

This PR catches that case too.