### PR TITLE
Update ambiguous webhook events filter docs

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -113,7 +113,7 @@ the prediction, namely:
 
 Requests for event types `output` and `logs` will be sent at most once every
 500ms. This interval is currently not configurable. Requests for event types
-`start` and `completed` will always be sent.
+`start` and `completed` will be sent immediately.
 
 By default, Cog will send requests for all event types. Clients can change which
 events trigger webhook requests by specifying `webhook_events_filter` in the


### PR DESCRIPTION
This could imply the filtered events always get sent, but in reality they're only sent *if* requested, and the "always sent" refers to the lack of throttling.