### PR TITLE
doc: add best practices to building images

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -217,8 +217,7 @@ cog push
 The Docker image is now accessible to anyone or any system that has access to this Docker registry.
 
 > **Note**
-> When you build an image, Cog copies large files to a separate layer before copying source code. This reduces the time needed to rebuild after making changes to code. For best results, put any weights, checkpoints, or other model files in a separate subdirectory.
-> If you put both weights and code in the same directory, Cog will NOT copy the weights to a distinct layer, and you will have to wait for the weights to be copied every time you make a change to the code.
+> Model repos often contain large data files, like weights and checkpoints. If you put these files in their own subdirectory, Cog can copy these files into a separate Docker layer, which reduces the time needed to rebuild after making changes to code.
 >
 > ```shell
 > # ✅ Yes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -216,71 +216,31 @@ cog push
 
 The Docker image is now accessible to anyone or any system that has access to this Docker registry.
 
-## Best Practices for Building Images
-
-When building an image, cog will copy large model files first before copying the codebase to Docker image. This means that if you change your code, the layer containing the model files will be reused. This makes the build process much faster. See https://github.com/replicate/cog/pull/1041 for more details.
-
-To make this work better, there are best practices to follow:
-
-1. Do not put any code in the same dir or sub-dir of the directory that contains your models.
-
-   ```shell
-   # Bad
-   .
-   ├── checkpoints/
-   │   ├── model_base_caption.pth
-   │   ├── model_vqa.pth
-   │   ├── model_base_retrieval_coco.pth
-   │   └── train_caption.py <-- Code file should not exist in the same dir as model files
-   ├── predict.py
-   └── cog.yaml
-
-   # Bad
-   .
-   ├── checkpoints/
-   │   ├── model_base_caption.pth
-   │   ├── model_vqa.pth
-   │   ├── model_base_retrieval_coco.pth
-   │   └── training/
-   │       └── train_caption.py <-- Code file should not exist in the sub dir of model dir
-   ├── predict.py
-   └── cog.yaml
-
-   # Good
-   .
-   ├── checkpoints/
-   │   ├── model_base_caption.pth
-   │   ├── model_vqa.pth
-   │   └── model_base_retrieval_coco.pth
-   ├── training/
-   │   └── train_caption.py
-   ├── predict.py
-   └── cog.yaml
-   ```
-
-2. You should keep your model files in a directory, not in the root directory of the project repo.
-
-   ```shell
-   # Bad
-   .
-   ├── model_base_caption.pth
-   ├── model_vqa.pth
-   ├── model_base_retrieval_coco.pth
-   ├── predict.py
-   └── cog.yaml
-
-   # Good
-   .
-   ├── checkpoints/
-   │   ├── model_base_caption.pth
-   │   ├── model_vqa.pth
-   │   └── model_base_retrieval_coco.pth
-   ├── predict.py
-   └── cog.yaml
-   ```
-
-> Note that the root directory of the project repo is an exception. It can still contain models and code files. cog will just copy them to the Docker image one file at a time. But this will create more layers.
-> This is for some projects for fast prototyping. But it is not recommended.
+> **Note**
+> When you build an image, Cog copies large files to a separate layer before copying source code. This reduces the time needed to rebuild after making changes to code. For best results, put any weights, checkpoints, or other model files in a separate subdirectory.
+>
+> ```shell
+> # ✅ Yes
+> .
+> ├── checkpoints/
+> │   └── weights.ckpt
+> ├── predict.py
+> └── cog.yaml
+>
+> # ❌ No
+> .
+> ├── weights.ckpt # <- Don't put weights in root directory
+> ├── predict.py
+> └── cog.yaml
+>
+> # ❌ No
+> .
+> ├── checkpoints/
+> │   ├── weights.ckpt
+> │   └── load_weights.py # <- Don't put code in weights directory
+> ├── predict.py
+> └── cog.yaml
+> ```
 
 ## Next steps
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -218,6 +218,7 @@ The Docker image is now accessible to anyone or any system that has access to th
 
 > **Note**
 > When you build an image, Cog copies large files to a separate layer before copying source code. This reduces the time needed to rebuild after making changes to code. For best results, put any weights, checkpoints, or other model files in a separate subdirectory.
+> If you put both weights and code in the same directory, Cog will NOT copy the weights to a distinct layer, and you will have to wait for the weights to be copied every time you make a change to the code.
 >
 > ```shell
 > # ✅ Yes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,6 +26,7 @@ mkdir cog-quickstart
 cd cog-quickstart
 
 ```
+
 ## Run commands
 
 The simplest thing you can do with Cog is run a command inside a Docker environment.
@@ -38,11 +39,14 @@ build:
 ```
 
 Then, you can run any command inside this environment. For example, enter
+
 ```bash
 cog run python
 
 ```
+
 and you'll get an interactive Python shell:
+
 ```none
 ✓ Building Docker image from cog.yaml... Successfully built 8f54020c8981
 Running 'python' in Docker with the current directory mounted as a volume...
@@ -53,6 +57,7 @@ Python 3.8.10 (default, May 12 2021, 23:32:14)
 Type "help", "copyright", "credits" or "license" for more information.
 >>>
 ```
+
 (Hit Ctrl-D to exit the Python shell.)
 
 Inside this Docker environment you can do anything – run a Jupyter notebook, your training script, your evaluation script, and so on.
@@ -72,6 +77,7 @@ curl -O $WEIGHTS_URL
 Then, we need to write some code to describe how predictions are run on the model.
 
 Save this to `predict.py`:
+
 ```python
 from typing import Any
 from cog import BasePredictor, Input, Path
@@ -118,13 +124,16 @@ IMAGE_URL=https://gist.githubusercontent.com/bfirsh/3c2115692682ae260932a67d93fd
 curl $IMAGE_URL > input.jpg
 
 ```
+
 Now, let's run the model using Cog:
 
 ```bash
 cog predict -i image=@input.jpg
 
 ```
+
 If you see the following output
+
 ```
 [
   [
@@ -144,6 +153,7 @@ If you see the following output
   ]
 ]
 ```
+
 then it worked!
 
 Note: The first time you run `cog predict`, the build process will be triggered to generate a Docker container that can run your model. The next time you run `cog predict` the pre-built container will be used.
@@ -180,6 +190,7 @@ docker run -d --rm -p 5000:5000 resnet
 ```
 
 We can send inputs directly with `curl`:
+
 ```bash
 curl http://localhost:5000/predictions -X POST \
     -H 'Content-Type: application/json' \
@@ -213,60 +224,60 @@ To make this work better, there are best practices to follow:
 
 1. Do not put any code in the same dir or sub-dir of the directory that contains your models.
 
-    ```shell
-    # Bad
-    .
-    ├── checkpoints/
-    │   ├── model_base_caption.pth
-    │   ├── model_vqa.pth
-    │   ├── model_base_retrieval_coco.pth
-    │   └── train_caption.py <-- Code file should not exist in the same dir as model files
-    ├── predict.py
-    └── cog.yaml
+   ```shell
+   # Bad
+   .
+   ├── checkpoints/
+   │   ├── model_base_caption.pth
+   │   ├── model_vqa.pth
+   │   ├── model_base_retrieval_coco.pth
+   │   └── train_caption.py <-- Code file should not exist in the same dir as model files
+   ├── predict.py
+   └── cog.yaml
 
-    # Bad
-    .
-    ├── checkpoints/
-    │   ├── model_base_caption.pth
-    │   ├── model_vqa.pth
-    │   ├── model_base_retrieval_coco.pth
-    │   └── training/
-    │       └── train_caption.py <-- Code file should not exist in the sub dir of model dir
-    ├── predict.py
-    └── cog.yaml
+   # Bad
+   .
+   ├── checkpoints/
+   │   ├── model_base_caption.pth
+   │   ├── model_vqa.pth
+   │   ├── model_base_retrieval_coco.pth
+   │   └── training/
+   │       └── train_caption.py <-- Code file should not exist in the sub dir of model dir
+   ├── predict.py
+   └── cog.yaml
 
-    # Good
-    .
-    ├── checkpoints/
-    │   ├── model_base_caption.pth
-    │   ├── model_vqa.pth
-    │   └── model_base_retrieval_coco.pth
-    ├── training/
-    │   └── train_caption.py
-    ├── predict.py
-    └── cog.yaml
-    ```
+   # Good
+   .
+   ├── checkpoints/
+   │   ├── model_base_caption.pth
+   │   ├── model_vqa.pth
+   │   └── model_base_retrieval_coco.pth
+   ├── training/
+   │   └── train_caption.py
+   ├── predict.py
+   └── cog.yaml
+   ```
 
 2. You should keep your model files in a directory, not in the root directory of the project repo.
 
-    ```shell
-    # Bad
-    .
-    ├── model_base_caption.pth
-    ├── model_vqa.pth
-    ├── model_base_retrieval_coco.pth
-    ├── predict.py
-    └── cog.yaml
+   ```shell
+   # Bad
+   .
+   ├── model_base_caption.pth
+   ├── model_vqa.pth
+   ├── model_base_retrieval_coco.pth
+   ├── predict.py
+   └── cog.yaml
 
-    # Good
-    .
-    ├── checkpoints/
-    │   ├── model_base_caption.pth
-    │   ├── model_vqa.pth
-    │   └── model_base_retrieval_coco.pth
-    ├── predict.py
-    └── cog.yaml
-    ```
+   # Good
+   .
+   ├── checkpoints/
+   │   ├── model_base_caption.pth
+   │   ├── model_vqa.pth
+   │   └── model_base_retrieval_coco.pth
+   ├── predict.py
+   └── cog.yaml
+   ```
 
 > Note that the root directory of the project repo is an exception. It can still contain models and code files. cog will just copy them to the Docker image one file at a time. But this will create more layers.
 > This is for some projects for fast prototyping. But it is not recommended.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -162,7 +162,7 @@ cog build -t resnet
 Once you've built the image, you can optionally view the generated dockerfile to get a sense of what Cog is doing under the hood:
 
 ```bash
-cog debug dockerfile
+cog debug
 ```
 
 You can run this image with `cog predict` by passing the filename as an argument:
@@ -204,6 +204,72 @@ cog push
 ```
 
 The Docker image is now accessible to anyone or any system that has access to this Docker registry.
+
+## Best Practices for Building Images
+
+When building an image, cog will copy large model files first before copying the codebase to Docker image. This means that if you change your code, the layer containing the model files will be reused. This makes the build process much faster. See https://github.com/replicate/cog/pull/1041 for more details.
+
+To make this work better, there are best practices to follow:
+
+1. Do not put any code in the same dir or sub-dir of the directory that contains your models.
+
+    ```shell
+    # Bad
+    .
+    ├── checkpoints/
+    │   ├── model_base_caption.pth
+    │   ├── model_vqa.pth
+    │   ├── model_base_retrieval_coco.pth
+    │   └── train_caption.py <-- Code file should not exist in the same dir as model files
+    ├── predict.py
+    └── cog.yaml
+
+    # Bad
+    .
+    ├── checkpoints/
+    │   ├── model_base_caption.pth
+    │   ├── model_vqa.pth
+    │   ├── model_base_retrieval_coco.pth
+    │   └── training/
+    │       └── train_caption.py <-- Code file should not exist in the sub dir of model dir
+    ├── predict.py
+    └── cog.yaml
+
+    # Good
+    .
+    ├── checkpoints/
+    │   ├── model_base_caption.pth
+    │   ├── model_vqa.pth
+    │   └── model_base_retrieval_coco.pth
+    ├── training/
+    │   └── train_caption.py
+    ├── predict.py
+    └── cog.yaml
+    ```
+
+2. You should keep your model files in a directory, not in the root directory of the project repo.
+
+    ```shell
+    # Bad
+    .
+    ├── model_base_caption.pth
+    ├── model_vqa.pth
+    ├── model_base_retrieval_coco.pth
+    ├── predict.py
+    └── cog.yaml
+
+    # Good
+    .
+    ├── checkpoints/
+    │   ├── model_base_caption.pth
+    │   ├── model_vqa.pth
+    │   └── model_base_retrieval_coco.pth
+    ├── predict.py
+    └── cog.yaml
+    ```
+
+> Note that the root directory of the project repo is an exception. It can still contain models and code files. cog will just copy them to the Docker image one file at a time. But this will create more layers.
+> This is for some projects for fast prototyping. But it is not recommended.
 
 ## Next steps
 


### PR DESCRIPTION
This relies on https://github.com/replicate/cog/pull/1041. We need to merge that first.
I separate the doc change out because every git push takes a long cycle on CI testing. I would like to decouple them since this change doesn't need any CI.