### PR TITLE
Fix various mypy type checking errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dynamic = ["version"]
 write_to = "python/cog/_version.py"
 
 [tool.mypy]
+plugins = "pydantic.mypy"
 disallow_untyped_defs = true
 # TODO: remove this and bring the codebase inline with the current mypy default
 no_implicit_optional = false

--- a/python/cog/logging.py
+++ b/python/cog/logging.py
@@ -60,9 +60,9 @@ def setup_logging(*, log_level: int = logging.NOTSET) -> None:
     )
 
     if development_logs:
-        log_renderer = structlog.dev.ConsoleRenderer(event_key="message")
+        log_renderer = structlog.dev.ConsoleRenderer(event_key="message")  # type: ignore
     else:
-        log_renderer = structlog.processors.JSONRenderer()
+        log_renderer = structlog.processors.JSONRenderer()  # type: ignore
 
     formatter = structlog.stdlib.ProcessorFormatter(
         foreign_pre_chain=processors,

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -95,7 +95,7 @@ def run_setup(predictor: BasePredictor) -> None:
     predictor.setup(weights=weights)
 
 
-def get_weights_type(setup_function) -> Optional[Any]:
+def get_weights_type(setup_function: Callable) -> Optional[Any]:
     signature = inspect.signature(setup_function)
     if "weights" not in signature.parameters:
         return None

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -277,7 +277,7 @@ def get_input_type(predictor: BasePredictor) -> Type[BaseInput]:
         __module__=__name__,
         __validators__=None,
         **create_model_kwargs,
-    )
+    )  # type: ignore
 
 
 def get_output_type(predictor: BasePredictor) -> Type[BaseModel]:

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -45,7 +45,7 @@ class Health(Enum):
 
 def create_app(
     config: Dict[str, Any],
-    shutdown_event: threading.Event,
+    shutdown_event: Optional[threading.Event],
     threads: int = 1,
     upload_url: Optional[str] = None,
     mode: str = "predict",
@@ -224,7 +224,8 @@ def create_app(
     @app.post("/shutdown")
     def start_shutdown() -> Any:
         log.info("shutdown requested via http")
-        shutdown_event.set()
+        if shutdown_event is not None:
+            shutdown_event.set()
         return JSONResponse({}, status_code=200)
 
     def _check_setup_result() -> Any:

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -39,7 +39,7 @@ class PredictionRunner:
         self,
         *,
         predictor_ref: str,
-        shutdown_event: threading.Event,
+        shutdown_event: Optional[threading.Event],
         upload_url: Optional[str] = None,
     ) -> None:
         self._thread = None
@@ -66,7 +66,8 @@ class PredictionRunner:
                 raise error
             except Exception:
                 log.error("caught exception while running setup", exc_info=True)
-                self._shutdown_event.set()
+                if self._shutdown_event is not None:
+                    self._shutdown_event.set()
 
         self._result = self._threadpool.apply_async(
             func=setup,
@@ -112,7 +113,8 @@ class PredictionRunner:
                 raise error
             except Exception:
                 log.error("caught exception while running prediction", exc_info=True)
-                self._shutdown_event.set()
+                if self._shutdown_event is not None:
+                    self._shutdown_event.set()
 
         self._response = event_handler.response
         self._result = self._threadpool.apply_async(

--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -117,9 +117,9 @@ class URLPath(pathlib.PosixPath):
             self._path = Path(dest.name)
         return self._path
 
-    def unlink(self) -> None:
+    def unlink(self, missing_ok: bool = False) -> None:
         if self._path and self._path.exists():
-            self._path.unlink()
+            self._path.unlink(missing_ok=missing_ok)
 
     def __str__(self) -> str:
         # FastAPI's jsonable_encoder will encode subclasses of pathlib.Path by

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -393,11 +393,14 @@ def test_heartbeats_cancel():
         heartbeat_count = 0
         start = time.time()
 
+        canceled = False
         for event in w.predict({"sleep": 10}, poll=0.1):
             if isinstance(event, Heartbeat):
                 heartbeat_count += 1
             if time.time() - start > 0.5:
-                w.cancel()
+                if not canceled:
+                    w.cancel()
+                    canceled = True
 
         elapsed = time.time() - start
 


### PR DESCRIPTION
Based on #1060 

This PR resolves the mypy type checking errors in `python/cog`. 

The only remaining issues have to do with the `weights` argument passed to setup and the dynamically defined `PredictionRequest` / `PredictionResponse` types:

```console
$ python -m mypy python/cog
python/cog/predictor.py:95: error: Argument "weights" to "setup" of "BasePredictor" has incompatible type "Union[IOBase, pathlib.Path, None]"; expected "Union[File, cog.types.Path, None]"  [arg-type]
python/cog/server/http.py:141: error: Variable "PredictionRequest" is not valid as a type  [valid-type]
python/cog/server/http.py:141: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
python/cog/server/http.py:147: error: PredictionRequest? has no attribute "id"  [attr-defined]
python/cog/server/http.py:161: error: PredictionRequest? has no attribute "id"  [attr-defined]
python/cog/server/http.py:169: error: Variable "PredictionRequest" is not valid as a type  [valid-type]
python/cog/server/http.py:169: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
python/cog/server/http.py:178: error: PredictionRequest? has no attribute "input"  [attr-defined]
python/cog/server/http.py:179: error: PredictionRequest? has no attribute "input"  [attr-defined]
```