### PR TITLE
Enable Dependabot version updates for pip dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR updates `dependabot.yml` to enable automatic version updates for Python dependencies.

For more information, see ["About Dependabot version updates"](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) in GitHub's documentation.