### PR TITLE
Automatically re-run command when GPU isn't available

### DIFF
--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -124,7 +125,7 @@ func cmdPredict(cmd *cobra.Command, args []string) error {
 	if err := predictor.Start(&stderr); err != nil {
 		console.Debug(stderr.String())
 
-		if gpus != "" && strings.Contains(err.Error(), docker.ErrMissingDeviceDriver.Error()) {
+		if gpus != "" && errors.Is(err, docker.ErrMissingDeviceDriver) {
 			console.Debug("Missing device driver, re-trying without GPU")
 
 			_ = predictor.Stop()

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -126,7 +126,7 @@ func cmdPredict(cmd *cobra.Command, args []string) error {
 		console.Debug(stderr.String())
 
 		if gpus != "" && errors.Is(err, docker.ErrMissingDeviceDriver) {
-			console.Debug("Missing device driver, re-trying without GPU")
+			console.Info("Missing device driver, re-trying without GPU")
 
 			_ = predictor.Stop()
 			predictor = predict.NewPredictor(docker.RunOptions{

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -121,10 +121,7 @@ func cmdPredict(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	var stderr bytes.Buffer
-	if err := predictor.Start(&stderr); err != nil {
-		console.Debug(stderr.String())
-
+	if err := predictor.Start(os.Stderr); err != nil {
 		if gpus != "" && errors.Is(err, docker.ErrMissingDeviceDriver) {
 			console.Info("Missing device driver, re-trying without GPU")
 

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"bytes"
 	"strconv"
 	"strings"
 
@@ -72,17 +71,12 @@ func run(cmd *cobra.Command, args []string) error {
 	console.Info("")
 	console.Infof("Running '%s' in Docker with the current directory mounted as a volume...", strings.Join(args, " "))
 
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-
-	err = docker.RunWithIO(runOptions, nil, &stdout, &stderr)
+	err = docker.Run(runOptions)
 	if runOptions.GPUs != "" && err == docker.ErrMissingDeviceDriver {
-		console.Debug(stdout.String())
-		console.Debug(stderr.String())
-		console.Debug("Missing device driver, re-trying without GPU")
+		console.Info("Missing device driver, re-trying without GPU")
 
 		runOptions.GPUs = ""
-		err = docker.RunWithIO(runOptions, nil, &stdout, &stderr)
+		err = docker.Run(runOptions)
 	}
 
 	return err

--- a/pkg/predict/predictor.go
+++ b/pkg/predict/predictor.go
@@ -63,7 +63,7 @@ func (p *Predictor) Start(logsWriter io.Writer) error {
 
 	p.runOptions.Ports = append(p.runOptions.Ports, docker.Port{HostPort: 0, ContainerPort: containerPort})
 
-	p.containerID, err = docker.RunDaemon(p.runOptions)
+	p.containerID, err = docker.RunDaemon(p.runOptions, logsWriter)
 	if err != nil {
 		return fmt.Errorf("Failed to start container: %w", err)
 	}


### PR DESCRIPTION
Fixes #590

I was able to reproduce the described behavior with the following example project:

```yaml
# cog.yaml
build:
  python_version: "3.8"
  gpu: true
  python_packages:
    - torch
    - numpy
predict: "predict.py:Predictor"
```

```python
# predict.py
from cog import BasePredictor
import torch

class Predictor(BasePredictor):
    def predict(self, size: int) -> int:
        n = torch.randn([size])

        if torch.cuda.is_available():
            n = n.cuda()

        return n.sum().item()
```

With the latest version of Cog, `cog predict` fails on my local machine with the following error:

```console
$ cog predict -i size=100
Starting Docker image cog-gpu-project-base and running setup()...
docker: Error response from daemon: could not select device driver "" with capabilities: [[gpu]].
ⅹ Failed to start container: exit status 125
```

This PR updates the `cog run` and `cog predict` subcommands to automatically re-run themselves in the event of this error, bringing them in line with `cog build` which already has this behavior.