### PR TITLE
Provide details in Internal Server Error responses for predict endpoint

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -195,7 +195,7 @@ def create_app(
             response = PredictionResponse(**async_result.get().dict())
         except ValidationError as e:
             _log_invalid_output(e)
-            raise HTTPException(status_code=500) from e
+            raise HTTPException(status_code=500, detail=str(e)) from e
 
         response_object = response.dict()
         response_object["output"] = upload_files(


### PR DESCRIPTION
Reimplementation of https://github.com/replicate/cog/pull/709

Things have moved around a bit in `http.py` since the original PR was opened. Notably, the predict function is now delegated to a helper that's shared by a `POST` and idempotent `PUT` endpoint. That `raise HTTPException` call now has exception chaining that includes details in the traceback.

This PR reapplies https://github.com/replicate/cog/pull/709/commits/893b28bf7b5c4a57f3a86727fd725421c351d22e to include the original error message in the raised exception as well as chaining to that error.