### PR TITLE
Allow null/empty lists for `python_packages`, `system_packages`, `pre_install`, and `run` in `cog.yaml`

### DIFF
--- a/pkg/config/data/config_schema_v1.0.json
+++ b/pkg/config/data/config_schema_v1.0.json
@@ -26,7 +26,7 @@
         },
         "python_packages": {
           "$id": "#/properties/build/properties/python_packages",
-          "type": "array",
+          "type": ["array", "null"],
           "description": "A list of Python packages to install, in the format `package==version`.",
           "additionalItems": true,
           "items": {
@@ -41,7 +41,7 @@
         },
         "pre_install": {
           "$id": "#/properties/build/properties/pre_install",
-          "type": "array",
+          "type": ["array", "null"],
           "description": "A list of setup commands to run in the environment before your Python packages are installed.",
           "additionalItems": true,
           "items": {
@@ -61,7 +61,7 @@
         },
         "system_packages": {
           "$id": "#/properties/build/properties/system_packages",
-          "type": "array",
+          "type": ["array", "null"],
           "description": "A list of Ubuntu APT packages to install.",
           "additionalItems": true,
           "items": {
@@ -76,7 +76,7 @@
         },
         "run": {
           "$id": "#/properties/build/properties/run",
-          "type": "array",
+          "type": ["array", "null"],
           "description": "A list of setup commands to run in the environment after your system packages and Python packages have been installed. If you're familiar with Docker, it's like a `RUN` instruction in your `Dockerfile`.",
           "additionalItems": true,
           "items": {

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -79,3 +79,15 @@ func TestValidatePythonVersionIsRequired(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Additional property python_versions is not allowed")
 }
+
+func TestValidateNullListsAllowed(t *testing.T) {
+	config := `build:
+  gpu: true
+  python_version: "3.8"
+  system_packages:
+  python_packages:
+  run:`
+
+	err := Validate(config, "1.0")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Resolves https://github.com/replicate/cog/issues/368