### PR TITLE
Copy weights using `--link` option

### DIFF
--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -49,7 +49,6 @@ func Build(dir, dockerfile, imageName string, secrets []string, noCache bool, pr
 }
 
 func BuildAddLabelsToImage(image string, labels map[string]string) error {
-	dockerfile := "FROM " + image
 	var args []string
 
 	args = append(args,
@@ -72,6 +71,8 @@ func BuildAddLabelsToImage(image string, labels map[string]string) error {
 	// We're not using context, but Docker requires we pass a context
 	args = append(args, ".")
 	cmd := exec.Command("docker", args...)
+
+	dockerfile := "FROM " + image
 	cmd.Stdin = strings.NewReader(dockerfile)
 
 	console.Debug("$ " + strings.Join(cmd.Args, " "))

--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -14,10 +14,12 @@ import (
 func Build(dir, dockerfile, imageName string, secrets []string, noCache bool, progressOutput string) error {
 	var args []string
 
+	args = append(args,
+		"buildx", "build",
+	)
+
 	if util.IsM1Mac(runtime.GOOS, runtime.GOARCH) {
-		args = m1BuildxBuildArgs()
-	} else {
-		args = buildKitBuildArgs()
+		args = append(args, "--platform", "linux/amd64", "--load")
 	}
 
 	for _, secret := range secrets {
@@ -50,10 +52,13 @@ func Build(dir, dockerfile, imageName string, secrets []string, noCache bool, pr
 func BuildAddLabelsToImage(image string, labels map[string]string) error {
 	dockerfile := "FROM " + image
 	var args []string
+
+	args = append(args,
+		"buildx", "build",
+	)
+
 	if util.IsM1Mac(runtime.GOOS, runtime.GOARCH) {
-		args = m1BuildxBuildArgs()
-	} else {
-		args = buildKitBuildArgs()
+		args = append(args, "--platform", "linux/amd64", "--load")
 	}
 
 	args = append(args,
@@ -77,12 +82,4 @@ func BuildAddLabelsToImage(image string, labels map[string]string) error {
 		return err
 	}
 	return nil
-}
-
-func m1BuildxBuildArgs() []string {
-	return []string{"buildx", "build", "--platform", "linux/amd64", "--load"}
-}
-
-func buildKitBuildArgs() []string {
-	return []string{"build"}
 }

--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -32,7 +32,7 @@ func Build(dir, dockerfile, imageName string, secrets []string, noCache bool, pr
 
 	args = append(args,
 		"--file", "-",
-		"--build-arg", "BUILDKIT_INLINE_CACHE=1",
+		"--cache-to", "type=inline",
 		"--tag", imageName,
 		"--progress", progressOutput,
 		".",

--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -39,7 +39,6 @@ func Build(dir, dockerfile, imageName string, secrets []string, noCache bool, pr
 	)
 
 	cmd := exec.Command("docker", args...)
-	cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
 	cmd.Dir = dir
 	cmd.Stdout = os.Stderr // redirect stdout to stderr - build output is all messaging
 	cmd.Stderr = os.Stderr

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -113,7 +113,7 @@ func (g *Generator) GenerateBase() (string, error) {
 	}
 
 	return strings.Join(filterEmpty([]string{
-		"# syntax = docker/dockerfile:1.2",
+		"#syntax=docker/dockerfile:1.4",
 		"FROM " + baseImage,
 		g.preamble(),
 		g.installTini(),
@@ -181,7 +181,7 @@ func (g *Generator) Generate(imageName string) (weightsBase string, dockerfile s
 	}
 
 	base := []string{
-		"# syntax = docker/dockerfile:1.2",
+		"#syntax=docker/dockerfile:1.4",
 		fmt.Sprintf("FROM %s AS %s", imageName+"-weights", "weights"),
 		"FROM " + baseImage,
 		g.preamble(),
@@ -215,7 +215,7 @@ func (g *Generator) generateForWeights() (string, []string, []string, error) {
 		return "", nil, nil, err
 	}
 	// generate dockerfile to store these model weights files
-	dockerfileContents := `# syntax = docker/dockerfile:1.2
+	dockerfileContents := `#syntax=docker/dockerfile:1.4
 FROM scratch
 `
 	for _, p := range append(modelDirs, modelFiles...) {

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -192,7 +192,7 @@ func (g *Generator) Generate(imageName string) (weightsBase string, dockerfile s
 	}
 
 	for _, p := range append(modelDirs, modelFiles...) {
-		base = append(base, "", fmt.Sprintf("COPY --from=%s %[2]s %[2]s", "weights", path.Join("/src", p)))
+		base = append(base, "", fmt.Sprintf("COPY --from=%s --link %[2]s %[2]s", "weights", path.Join("/src", p)))
 	}
 
 	// the dependencies and code layers

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -354,9 +354,9 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia
 		testInstallPython("3.8") +
 		testInstallCog(gen.relativeTmpDir) + `
 RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
-COPY --from=weights /src/checkpoints /src/checkpoints
-COPY --from=weights /src/models /src/models
-COPY --from=weights /src/root-large /src/root-large
+COPY --from=weights --link /src/checkpoints /src/checkpoints
+COPY --from=weights --link /src/models /src/models
+COPY --from=weights --link /src/root-large /src/root-large
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip pip install -r /tmp/requirements.txt
 RUN cowsay moo

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -77,7 +77,7 @@ predict: predict.py:Predictor
 	_, actual, _, err := gen.Generate("r8.im/replicate/cog-test")
 	require.NoError(t, err)
 
-	expected := `# syntax = docker/dockerfile:1.2
+	expected := `#syntax=docker/dockerfile:1.4
 FROM r8.im/replicate/cog-test-weights AS weights
 FROM python:3.8
 ENV DEBIAN_FRONTEND=noninteractive
@@ -107,7 +107,7 @@ predict: predict.py:Predictor
 	_, actual, _, err := gen.Generate("r8.im/replicate/cog-test")
 	require.NoError(t, err)
 
-	expected := `# syntax = docker/dockerfile:1.2
+	expected := `#syntax=docker/dockerfile:1.4
 FROM r8.im/replicate/cog-test-weights AS weights
 FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
 ENV DEBIAN_FRONTEND=noninteractive
@@ -146,7 +146,7 @@ predict: predict.py:Predictor
 	_, actual, _, err := gen.Generate("r8.im/replicate/cog-test")
 	require.NoError(t, err)
 
-	expected := `# syntax = docker/dockerfile:1.2
+	expected := `#syntax=docker/dockerfile:1.4
 FROM r8.im/replicate/cog-test-weights AS weights
 FROM python:3.8
 ENV DEBIAN_FRONTEND=noninteractive
@@ -195,7 +195,7 @@ predict: predict.py:Predictor
 	_, actual, _, err := gen.Generate("r8.im/replicate/cog-test")
 	require.NoError(t, err)
 
-	expected := `# syntax = docker/dockerfile:1.2
+	expected := `#syntax=docker/dockerfile:1.4
 FROM r8.im/replicate/cog-test-weights AS weights
 FROM nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04
 ENV DEBIAN_FRONTEND=noninteractive
@@ -240,7 +240,7 @@ build:
 	_, actual, _, err := gen.Generate("r8.im/replicate/cog-test")
 	require.NoError(t, err)
 
-	expected := `# syntax = docker/dockerfile:1.2
+	expected := `#syntax=docker/dockerfile:1.4
 FROM r8.im/replicate/cog-test-weights AS weights
 FROM python:3.8
 ENV DEBIAN_FRONTEND=noninteractive
@@ -334,7 +334,7 @@ predict: predict.py:Predictor
 	modelDockerfile, runnerDockerfile, dockerignore, err := gen.Generate("r8.im/replicate/cog-test")
 	require.NoError(t, err)
 
-	expected := `# syntax = docker/dockerfile:1.2
+	expected := `#syntax=docker/dockerfile:1.4
 FROM scratch
 
 COPY checkpoints /src/checkpoints
@@ -344,7 +344,7 @@ COPY root-large /src/root-large`
 	require.Equal(t, expected, modelDockerfile)
 
 	// model copy should be run before dependency install and code copy
-	expected = `# syntax = docker/dockerfile:1.2
+	expected = `#syntax=docker/dockerfile:1.4
 FROM r8.im/replicate/cog-test-weights AS weights
 FROM nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04
 ENV DEBIAN_FRONTEND=noninteractive
@@ -418,7 +418,7 @@ predict: predict.py:Predictor
 	actual, err := gen.GenerateDockerfileWithoutSeparateWeights()
 	require.NoError(t, err)
 
-	expected := `# syntax = docker/dockerfile:1.2
+	expected := `#syntax=docker/dockerfile:1.4
 FROM python:3.8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
Follow up to #1041 

This PR updates the `COPY --from=weights` command to use the [`--link` flag](https://github.com/moby/buildkit/blob/dockerfile/1.4.0/frontend/dockerfile/docs/syntax.md#linked-copies-copy---link-add---link) that was [added in Dockerfile 1.4](https://www.docker.com/blog/image-rebase-and-improved-remote-cache-support-in-new-buildkit/). This should improve performance when rebasing existing Cog images onto new base images.

This PR also updates our invocation of `docker buildx build` to replace `BUILDKIT_INLINE_CACHE=1` with `--cache-to type=inline` and remove the redundant `DOCKER_BUILDKIT=1` environment variable.

/cc @hongchaodeng