### PR TITLE
Update `cog init` template to use Python 3.11

### DIFF
--- a/pkg/cli/init-templates/cog.yaml
+++ b/pkg/cli/init-templates/cog.yaml
@@ -7,22 +7,22 @@ build:
 
   # a list of ubuntu apt packages to install
   # system_packages:
-    # - "libgl1-mesa-glx"
-    # - "libglib2.0-0"
+  #   - "libgl1-mesa-glx"
+  #   - "libglib2.0-0"
 
   # python version in the form '3.11' or '3.11.4'
   python_version: "3.11"
 
   # a list of packages in the format <package-name>==<version>
   # python_packages:
-    # - "numpy==1.19.4"
-    # - "torch==1.8.0"
-    # - "torchvision==0.9.0"
-  
+  #   - "numpy==1.19.4"
+  #   - "torch==1.8.0"
+  #   - "torchvision==0.9.0"
+
   # commands run after the environment is setup
   # run:
-    # - "echo env is ready!"
-    # - "echo another command if needed"
+  #   - "echo env is ready!"
+  #   - "echo another command if needed"
 
 # predict.py defines how predictions are run on your model
 predict: "predict.py:Predictor"

--- a/pkg/cli/init-templates/cog.yaml
+++ b/pkg/cli/init-templates/cog.yaml
@@ -10,8 +10,8 @@ build:
     # - "libgl1-mesa-glx"
     # - "libglib2.0-0"
 
-  # python version in the form '3.8' or '3.8.12'
-  python_version: "3.8"
+  # python version in the form '3.11' or '3.11.4'
+  python_version: "3.11"
 
   # a list of packages in the format <package-name>==<version>
   # python_packages:


### PR DESCRIPTION
This PR updates the `cog.yaml` file template created when running `cog init` to use [Python 3.11](https://www.python.org/downloads/release/python-3110/). It's currently set to use Python 3.8.