### PR TITLE
Automatically set `DOCKER_DEFAULT_PLATFORM=linux/amd64` when running `cog predict` on M1/M2 Macs

### DIFF
--- a/pkg/config/compatibility.go
+++ b/pkg/config/compatibility.go
@@ -363,7 +363,7 @@ func torchvisionGPUPackage(ver, cuda string) (name, cpuVersion, findLinks, extra
 // TODO(andreas): clean up this hack by actually parsing the torch_stable.html list in the generator
 func torchStripCPUSuffixForM1(version string, goos string, goarch string) string {
 	// TODO(andreas): clean up this hack
-	if util.IsM1Mac(goos, goarch) {
+	if util.IsAppleSiliconMac(goos, goarch) {
 		return strings.ReplaceAll(version, "+cpu", "")
 	}
 	return version

--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -19,6 +19,7 @@ func Build(dir, dockerfile, imageName string, secrets []string, noCache bool, pr
 	)
 
 	if util.IsAppleSiliconMac(runtime.GOOS, runtime.GOARCH) {
+		// Fixes "WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested"
 		args = append(args, "--platform", "linux/amd64", "--load")
 	}
 
@@ -56,6 +57,7 @@ func BuildAddLabelsToImage(image string, labels map[string]string) error {
 	)
 
 	if util.IsAppleSiliconMac(runtime.GOOS, runtime.GOARCH) {
+		// Fixes "WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested"
 		args = append(args, "--platform", "linux/amd64", "--load")
 	}
 

--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -18,7 +18,7 @@ func Build(dir, dockerfile, imageName string, secrets []string, noCache bool, pr
 		"buildx", "build",
 	)
 
-	if util.IsM1Mac(runtime.GOOS, runtime.GOARCH) {
+	if util.IsAppleSiliconMac(runtime.GOOS, runtime.GOARCH) {
 		args = append(args, "--platform", "linux/amd64", "--load")
 	}
 
@@ -55,7 +55,7 @@ func BuildAddLabelsToImage(image string, labels map[string]string) error {
 		"buildx", "build",
 	)
 
-	if util.IsM1Mac(runtime.GOOS, runtime.GOARCH) {
+	if util.IsAppleSiliconMac(runtime.GOOS, runtime.GOARCH) {
 		args = append(args, "--platform", "linux/amd64", "--load")
 	}
 

--- a/pkg/docker/run.go
+++ b/pkg/docker/run.go
@@ -9,10 +9,12 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 
 	"github.com/mattn/go-isatty"
+	"github.com/replicate/cog/pkg/util"
 	"github.com/replicate/cog/pkg/util/console"
 )
 
@@ -86,6 +88,16 @@ func generateDockerArgs(options internalRunOptions) []string {
 	return dockerArgs
 }
 
+func generateEnv(options internalRunOptions) []string {
+	env := os.Environ()
+	if util.IsM1Mac(runtime.GOOS, runtime.GOARCH) {
+		// Fixes "WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested"
+		env = append(env, "DOCKER_DEFAULT_PLATFORM=linux/amd64")
+	}
+
+	return env
+}
+
 func Run(options RunOptions) error {
 	return RunWithIO(options, os.Stdin, os.Stdout, os.Stderr)
 }
@@ -103,7 +115,7 @@ func RunWithIO(options RunOptions, stdin io.Reader, stdout, stderr io.Writer) er
 
 	dockerArgs := generateDockerArgs(internalOptions)
 	cmd := exec.Command("docker", dockerArgs...)
-	cmd.Env = os.Environ()
+	cmd.Env = generateEnv(internalOptions)
 	cmd.Stdout = stdout
 	cmd.Stdin = stdin
 	cmd.Stderr = stderrMultiWriter
@@ -129,7 +141,7 @@ func RunDaemon(options RunOptions, stderr io.Writer) (string, error) {
 
 	dockerArgs := generateDockerArgs(internalOptions)
 	cmd := exec.Command("docker", dockerArgs...)
-	cmd.Env = os.Environ()
+	cmd.Env = generateEnv(internalOptions)
 	cmd.Stderr = stderrMultiWriter
 
 	console.Debug("$ " + strings.Join(cmd.Args, " "))

--- a/pkg/docker/run.go
+++ b/pkg/docker/run.go
@@ -90,7 +90,7 @@ func generateDockerArgs(options internalRunOptions) []string {
 
 func generateEnv(options internalRunOptions) []string {
 	env := os.Environ()
-	if util.IsM1Mac(runtime.GOOS, runtime.GOARCH) {
+	if util.IsAppleSiliconMac(runtime.GOOS, runtime.GOARCH) {
 		// Fixes "WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested"
 		env = append(env, "DOCKER_DEFAULT_PLATFORM=linux/amd64")
 	}

--- a/pkg/util/platform.go
+++ b/pkg/util/platform.go
@@ -1,5 +1,6 @@
 package util
 
-func IsM1Mac(goos string, goarch string) bool {
+// IsAppleSiliconMac returns whether the current machine is an Apple silicon computer, such as the MacBook Air with M1.
+func IsAppleSiliconMac(goos string, goarch string) bool {
 	return goos == "darwin" && goarch == "arm64"
 }


### PR DESCRIPTION
Resolves https://github.com/replicate/cog/issues/1086
Resolves https://github.com/replicate/cog/issues/1085

This PR automatically sets the `DOCKER_DEFAULT_PLATFORM=linux/amd64` environment variable for the `docker run` invocation when running `cog predict`. Without setting this, Cog logs the following warning:

> WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested