### PR TITLE
Copy weights after installing Python dependencies and running setup commands

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -189,15 +189,14 @@ func (g *Generator) Generate(imageName string) (weightsBase string, dockerfile s
 		installPython,
 		installCog,
 		aptInstalls,
+		pipInstalls,
 	}
 
 	for _, p := range append(modelDirs, modelFiles...) {
 		base = append(base, "", fmt.Sprintf("COPY --from=%s --link %[2]s %[2]s", "weights", path.Join("/src", p)))
 	}
 
-	// the dependencies and code layers
 	base = append(base,
-		pipInstalls,
 		run,
 		`WORKDIR /src`,
 		`EXPOSE 5000`,

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -107,7 +107,7 @@ func (g *Generator) GenerateBase() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	run, err := g.run()
+	run, err := g.runCommands()
 	if err != nil {
 		return "", err
 	}
@@ -175,7 +175,7 @@ func (g *Generator) Generate(imageName string) (weightsBase string, dockerfile s
 	if err != nil {
 		return "", "", "", err
 	}
-	run, err := g.run()
+	runCommands, err := g.runCommands()
 	if err != nil {
 		return "", "", "", err
 	}
@@ -190,6 +190,7 @@ func (g *Generator) Generate(imageName string) (weightsBase string, dockerfile s
 		installCog,
 		aptInstalls,
 		pipInstalls,
+		runCommands,
 	}
 
 	for _, p := range append(modelDirs, modelFiles...) {
@@ -197,7 +198,6 @@ func (g *Generator) Generate(imageName string) (weightsBase string, dockerfile s
 	}
 
 	base = append(base,
-		run,
 		`WORKDIR /src`,
 		`EXPOSE 5000`,
 		`CMD ["python", "-m", "cog.server.http"]`,
@@ -347,7 +347,7 @@ func (g *Generator) pipInstalls() (string, error) {
 	return strings.Join(lines, "\n"), nil
 }
 
-func (g *Generator) run() (string, error) {
+func (g *Generator) runCommands() (string, error) {
 	runCommands := g.Config.Build.Run
 
 	// For backwards compatibility

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -354,12 +354,12 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia
 		testInstallPython("3.8") +
 		testInstallCog(gen.relativeTmpDir) + `
 RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
-COPY --from=weights --link /src/checkpoints /src/checkpoints
-COPY --from=weights --link /src/models /src/models
-COPY --from=weights --link /src/root-large /src/root-large
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip pip install -r /tmp/requirements.txt
 RUN cowsay moo
+COPY --from=weights --link /src/checkpoints /src/checkpoints
+COPY --from=weights --link /src/models /src/models
+COPY --from=weights --link /src/root-large /src/root-large
 WORKDIR /src
 EXPOSE 5000
 CMD ["python", "-m", "cog.server.http"]


### PR DESCRIPTION
Weights are more likely to change than Python requirements and setup commands, so they should be copied after those layers.