### PR TITLE
Configure Git user in GPU build integration test

### DIFF
--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -98,6 +98,18 @@ build:
         f.write(cog_yaml)
 
     subprocess.run(
+        ["git", "config", "--global", "user.email", "noreply@replicate.com"],
+        cwd=tmpdir,
+        check=True,
+    )
+
+    subprocess.run(
+        ["git", "config", "--global", "user.name", "Replicate Test Bot"],
+        cwd=tmpdir,
+        check=True,
+    )
+
+    subprocess.run(
         ["git", "init"],
         cwd=tmpdir,
         check=True,


### PR DESCRIPTION
Follow up to #1008

I've noticed that the `test_build_gpu_model_on_cpu` integration test is flakey, sometimes failing with the following error:

```
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'runner@runner.(none)')
--------------------------- Captured stderr teardown ---------------------------
Error: No such image: cog-test-iwmtrwwpjd
=========================== short test summary info ============================
FAILED test_integration/test_build.py::test_build_gpu_model_on_cpu - subprocess.CalledProcessError: Command '['git', 'commit', '--allow-empty', '-m', 'initial']' returned non-zero exit status 128.
```

This PR configures the Git user so that `git commit` doesn't fail for lack of auto-detecting an email address.

