### PR TITLE
Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    allow:
+      - dependency-type: "direct"


### PR DESCRIPTION
This PR updates `dependabot.yml` so that Dependabot only opens PRs to update direct dependencies.