### PR TITLE
Update Python and dependency versions in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ build:
   system_packages:
     - "libgl1-mesa-glx"
     - "libglib2.0-0"
-  python_version: "3.8"
+  python_version: "3.11"
   python_packages:
     - "torch==1.8.1"
 predict: "predict.py:Predictor"

--- a/docs/getting-started-own-model.md
+++ b/docs/getting-started-own-model.md
@@ -36,12 +36,12 @@ For example:
 
 ```yaml
 build:
-  python_version: "3.8"
+  python_version: "3.11"
   python_packages:
-    - "torch==1.7.0"
+    - "torch==2.0.1"
 ```
 
-This will generate a Docker image with Python 3.8 and PyTorch 1.7 installed, for both CPU and GPU, with the correct version of CUDA, and various other sensible best-practices.
+This will generate a Docker image with Python 3.11 and PyTorch 2 installed, for both CPU and GPU, with the correct version of CUDA, and various other sensible best-practices.
 
 To run a command inside this environment, prefix it with `cog run`:
 
@@ -51,7 +51,7 @@ $ cog run python
 Running 'python' in Docker with the current directory mounted as a volume...
 ────────────────────────────────────────────────────────────────────────────────────────
 
-Python 3.8.10 (default, May 12 2021, 23:32:14)
+Python 3.11.1 (main, Jan 27 2023, 10:52:46)
 [GCC 9.3.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>>
@@ -110,9 +110,9 @@ Next, add the line `predict: "predict.py:Predictor"` to your `cog.yaml`, so it l
 
 ```yaml
 build:
-  python_version: "3.8"
+  python_version: "3.11"
   python_packages:
-    - "torch==1.7.0"
+    - "torch==2.0.1"
 predict: "predict.py:Predictor"
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ The first thing you need to do is create a file called `cog.yaml`:
 
 ```yaml
 build:
-  python_version: "3.8"
+  python_version: "3.11"
 ```
 
 Then, you can run any command inside this environment. For example, enter
@@ -52,7 +52,7 @@ and you'll get an interactive Python shell:
 Running 'python' in Docker with the current directory mounted as a volume...
 ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
-Python 3.8.10 (default, May 12 2021, 23:32:14)
+Python 3.11.1 (main, Jan 27 2023, 10:52:46)
 [GCC 9.3.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>>
@@ -110,10 +110,10 @@ We also need to point Cog at this, and tell it what Python dependencies to insta
 
 ```yaml
 build:
-  python_version: "3.8"
+  python_version: "3.11"
   python_packages:
-    - pillow==9.1.0
-    - tensorflow==2.8.0
+    - pillow==9.5.0
+    - tensorflow==2.12.0
 predict: "predict.py:Predictor"
 ```
 

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -6,9 +6,9 @@ It has three keys: [`build`](#build), [`image`](#image), and [`predict`](#predic
 
 ```yaml
 build:
-  python_version: "3.8"
+  python_version: "3.11"
   python_packages:
-    - pytorch==1.4.0
+    - pytorch==2.0.1
   system_packages:
     - "ffmpeg"
     - "libavcodec-dev"
@@ -71,14 +71,14 @@ Your `cog.yaml` file can set either `python_packages` or `python_requirements`, 
 
 ### `python_version`
 
-The minor (`3.8`) or patch (`3.8.1`) version of Python to use. For example:
+The minor (`3.11`) or patch (`3.11.1`) version of Python to use. For example:
 
 ```yaml
 build:
-  python_version: "3.8.1"
+  python_version: "3.11.1"
 ```
 
-Cog supports all active branches of Python: 3.7, 3.8, 3.9, 3.10.
+Cog supports all active branches of Python: 3.8, 3.9, 3.10, 3.11.
 
 Note that these are the versions supported **in the Docker container**, not your host machine. You can run any version(s) of Python you wish on your host machine.
 


### PR DESCRIPTION
This PR updates our documentation to use Python 3.11 and the latest versions of PyTorch, TensorFlow, and Pillow.