### PR TITLE
Configure Dependabot to run weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     allow:
       - dependency-type: "direct"


### PR DESCRIPTION
Currently, it's set up to run daily, which I find to be too noisy. This PR updates the `dependabot.yaml` configuration to run weekly instead.