### PR TITLE
Make separate weights feature opt-in

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -217,7 +217,7 @@ cog push
 The Docker image is now accessible to anyone or any system that has access to this Docker registry.
 
 > **Note**
-> Model repos often contain large data files, like weights and checkpoints. If you put these files in their own subdirectory, Cog can copy these files into a separate Docker layer, which reduces the time needed to rebuild after making changes to code.
+> Model repos often contain large data files, like weights and checkpoints. If you put these files in their own subdirectory and run `cog build` with the `--separate-weights` flag, Cog will copy these files into a separate Docker layer, which reduces the time needed to rebuild after making changes to code.
 >
 > ```shell
 > # ✅ Yes

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -10,7 +10,7 @@ import (
 )
 
 var buildTag string
-var buildNoWeightsImage bool
+var buildSeparateWeights bool
 var buildSecrets []string
 var buildNoCache bool
 var buildProgressOutput string
@@ -25,7 +25,7 @@ func newBuildCommand() *cobra.Command {
 	addBuildProgressOutputFlag(cmd)
 	addSecretsFlag(cmd)
 	addNoCacheFlag(cmd)
-	addNoWeightsImageFlag(cmd)
+	addSeparateWeightsFlag(cmd)
 	cmd.Flags().StringVarP(&buildTag, "tag", "t", "", "A name for the built image in the form 'repository:tag'")
 	return cmd
 }
@@ -44,7 +44,7 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 		imageName = config.DockerImageName(projectDir)
 	}
 
-	if err := image.Build(cfg, projectDir, imageName, buildSecrets, buildNoCache, buildNoWeightsImage, buildProgressOutput); err != nil {
+	if err := image.Build(cfg, projectDir, imageName, buildSecrets, buildNoCache, buildSeparateWeights, buildProgressOutput); err != nil {
 		return err
 	}
 
@@ -69,6 +69,6 @@ func addNoCacheFlag(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&buildNoCache, "no-cache", false, "Do not use cache when building the image")
 }
 
-func addNoWeightsImageFlag(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&buildNoWeightsImage, "no-weights-image", false, "Do not separate weights from code in image layers")
+func addSeparateWeightsFlag(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&buildSeparateWeights, "separate-weights", false, "Separate model weights from code in image layers")
 }

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -27,7 +27,7 @@ func newDebugCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(debug)
-	addNoWeightsImageFlag(debug)
+	addSeparateWeightsFlag(debug)
 	cmd.Flags().StringVarP(&imageName, "image-name", "", "", "The image name to use for the generated Dockerfile")
 
 	return cmd
@@ -49,7 +49,7 @@ func cmdDockerfile(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	if buildNoWeightsImage {
+	if !buildSeparateWeights {
 		dockerfile, err := generator.GenerateDockerfileWithoutSeparateWeights()
 		if err != nil {
 			return err

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -49,27 +49,27 @@ func cmdDockerfile(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	if !buildSeparateWeights {
+	if buildSeparateWeights {
+		if imageName == "" {
+			imageName = config.DockerImageName(projectDir)
+		}
+
+		weightsDockerfile, RunnerDockerfile, dockerignore, err := generator.Generate(imageName)
+		if err != nil {
+			return err
+		}
+
+		console.Output(fmt.Sprintf("=== Weights Dockerfile contents:\n%s\n===\n", weightsDockerfile))
+		console.Output(fmt.Sprintf("=== Runner Dockerfile contents:\n%s\n===\n", RunnerDockerfile))
+		console.Output(fmt.Sprintf("=== DockerIgnore contents:\n%s===\n", dockerignore))
+	} else {
 		dockerfile, err := generator.GenerateDockerfileWithoutSeparateWeights()
 		if err != nil {
 			return err
 		}
+
 		console.Output(dockerfile)
-		return nil
 	}
-
-	if imageName == "" {
-		imageName = config.DockerImageName(projectDir)
-	}
-
-	weightsDockerfile, RunnerDockerfile, dockerignore, err := generator.Generate(imageName)
-	if err != nil {
-		return err
-	}
-
-	console.Output(fmt.Sprintf("=== Weights Dockerfile contents:\n%s\n===\n", weightsDockerfile))
-	console.Output(fmt.Sprintf("=== Runner Dockerfile contents:\n%s\n===\n", RunnerDockerfile))
-	console.Output(fmt.Sprintf("=== DockerIgnore contents:\n%s===\n", dockerignore))
 
 	return nil
 }

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -25,7 +25,7 @@ func newPushCommand() *cobra.Command {
 	addBuildProgressOutputFlag(cmd)
 	addSecretsFlag(cmd)
 	addNoCacheFlag(cmd)
-	addNoWeightsImageFlag(cmd)
+	addSeparateWeightsFlag(cmd)
 
 	return cmd
 }
@@ -45,7 +45,7 @@ func push(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("To push images, you must either set the 'image' option in cog.yaml or pass an image name as an argument. For example, 'cog push registry.hooli.corp/hotdog-detector'")
 	}
 
-	if err := image.Build(cfg, projectDir, imageName, buildSecrets, buildNoCache, buildNoWeightsImage, buildProgressOutput); err != nil {
+	if err := image.Build(cfg, projectDir, imageName, buildSecrets, buildNoCache, buildSeparateWeights, buildProgressOutput); err != nil {
 		return err
 	}
 

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -20,7 +20,7 @@ const dockerignoreBackupPath = ".dockerignore.cog.bak"
 // Build a Cog model from a config
 //
 // This is separated out from docker.Build(), so that can be as close as possible to the behavior of 'docker build'.
-func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache, noWeightsImage bool, progressOutput string) error {
+func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache, separateWeights bool, progressOutput string) error {
 	console.Infof("Building Docker image from environment in cog.yaml as %s...", imageName)
 
 	generator, err := dockerfile.NewGenerator(cfg, dir)
@@ -33,8 +33,7 @@ func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache,
 		}
 	}()
 
-	// By default, generate a Dockerfile that separates model weights from code.
-	if !noWeightsImage {
+	if separateWeights {
 		weightsDockerfile, runnerDockerfile, dockerignore, err := generator.Generate(imageName)
 		if err != nil {
 			return fmt.Errorf("Failed to generate Dockerfile: %w", err)


### PR DESCRIPTION
#1041 adds a feature that allows large weight files to be copied in a separate layer from code, which reduces the amount of time needed to rebuild an image. This feature works well, but some users have reported problems that we should resolve before making it the default behavior.

#1095 Added a `--no-weights-image` flag to opt out of this behavior. This PR replaces that flag with a new `--separate-weights` flag that opts in to this behavior.

When separated weights becomes the default behavior, we can make this Boolean flag default to `true` and allow opting out with `--separate-weights=false`.  