### PR TITLE
don't install curl when building from python:3

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -262,7 +262,9 @@ func (g *Generator) installTini() string {
 	// N.B. If you remove/change this, consider removing/changing the `has_init`
 	// image label applied in image/build.go.
 
+    // python:3 includes curl, so it does not need to be installed
 	install := `RUN set -eux; \`
+	// nvidia/cuda does not include curl, so it must be installed
 	if g.Config.Build.GPU {
 		install = `RUN --mount=type=cache,target=/var/cache/apt set -eux; \
 apt-get update -qq; \

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -261,12 +261,17 @@ func (g *Generator) installTini() string {
 	//
 	// N.B. If you remove/change this, consider removing/changing the `has_init`
 	// image label applied in image/build.go.
-	lines := []string{
-		`RUN --mount=type=cache,target=/var/cache/apt set -eux; \
+
+	install := `RUN set -eux; \`
+	if g.Config.Build.GPU {
+		install = `RUN --mount=type=cache,target=/var/cache/apt set -eux; \
 apt-get update -qq; \
 apt-get install -qqy --no-install-recommends curl; \
-rm -rf /var/lib/apt/lists/*; \
-TINI_VERSION=v0.19.0; \
+rm -rf /var/lib/apt/lists/*; \`
+	}
+	lines := []string{
+		install,
+		`TINI_VERSION=v0.19.0; \
 TINI_ARCH="$(dpkg --print-architecture)"; \
 curl -sSL -o /sbin/tini "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TINI_ARCH}"; \
 chmod +x /sbin/tini`,

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -262,7 +262,7 @@ func (g *Generator) installTini() string {
 	// N.B. If you remove/change this, consider removing/changing the `has_init`
 	// image label applied in image/build.go.
 
-    // python:3 includes curl, so it does not need to be installed
+	// python:3 includes curl, so it does not need to be installed
 	install := `RUN set -eux; \`
 	// nvidia/cuda does not include curl, so it must be installed
 	if g.Config.Build.GPU {

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -26,6 +26,16 @@ ENTRYPOINT ["/sbin/tini", "--"]
 `
 }
 
+func testTiniNoCurl() string {
+	return `RUN set -eux; \
+TINI_VERSION=v0.19.0; \
+TINI_ARCH="$(dpkg --print-architecture)"; \
+curl -sSL -o /sbin/tini "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TINI_ARCH}"; \
+chmod +x /sbin/tini
+ENTRYPOINT ["/sbin/tini", "--"]
+`
+}
+
 func testInstallCog(relativeTmpDir string) string {
 	return fmt.Sprintf(`COPY %s/cog-0.0.1.dev-py3-none-any.whl /tmp/cog-0.0.1.dev-py3-none-any.whl
 RUN --mount=type=cache,target=/root/.cache/pip pip install /tmp/cog-0.0.1.dev-py3-none-any.whl`, relativeTmpDir)
@@ -83,7 +93,7 @@ FROM python:3.8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
-` + testTini() + testInstallCog(gen.relativeTmpDir) + `
+` + testTiniNoCurl() + testInstallCog(gen.relativeTmpDir) + `
 WORKDIR /src
 EXPOSE 5000
 CMD ["python", "-m", "cog.server.http"]
@@ -152,7 +162,7 @@ FROM python:3.8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
-` + testTini() + testInstallCog(gen.relativeTmpDir) + `
+` + testTiniNoCurl() + testInstallCog(gen.relativeTmpDir) + `
 RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip pip install -r /tmp/requirements.txt
@@ -246,7 +256,7 @@ FROM python:3.8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
-` + testTini() + testInstallCog(gen.relativeTmpDir) + `
+` + testTiniNoCurl() + testInstallCog(gen.relativeTmpDir) + `
 RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy cowsay && rm -rf /var/lib/apt/lists/*
 RUN cowsay moo
 WORKDIR /src
@@ -423,7 +433,7 @@ FROM python:3.8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
-` + testTini() + testInstallCog(gen.relativeTmpDir) + `
+` + testTiniNoCurl() + testInstallCog(gen.relativeTmpDir) + `
 WORKDIR /src
 EXPOSE 5000
 CMD ["python", "-m", "cog.server.http"]


### PR DESCRIPTION
`python:3` already includes curl. This lets users skip an unnecessary apt update, and makes the tini layer faster to pull. 

for this cog.yaml:
```yaml
build:
  gpu: false
  python_version: "3.10"
```

before: 4.82MB
after: 23.1KB