### PR TITLE
Install tini with apt

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -264,13 +264,8 @@ func (g *Generator) installTini() string {
 	lines := []string{
 		`RUN --mount=type=cache,target=/var/cache/apt set -eux; \
 apt-get update -qq; \
-apt-get install -qqy --no-install-recommends curl; \
-rm -rf /var/lib/apt/lists/*; \
-TINI_VERSION=v0.19.0; \
-TINI_ARCH="$(dpkg --print-architecture)"; \
-curl -sSL -o /sbin/tini "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TINI_ARCH}"; \
-chmod +x /sbin/tini`,
-		`ENTRYPOINT ["/sbin/tini", "--"]`,
+apt-get install -qqy --no-install-recommends tini;`,
+		`ENTRYPOINT ["/usr/bin/tini", "--"]`,
 	}
 	return strings.Join(lines, "\n")
 }

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -16,13 +16,8 @@ import (
 func testTini() string {
 	return `RUN --mount=type=cache,target=/var/cache/apt set -eux; \
 apt-get update -qq; \
-apt-get install -qqy --no-install-recommends curl; \
-rm -rf /var/lib/apt/lists/*; \
-TINI_VERSION=v0.19.0; \
-TINI_ARCH="$(dpkg --print-architecture)"; \
-curl -sSL -o /sbin/tini "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TINI_ARCH}"; \
-chmod +x /sbin/tini
-ENTRYPOINT ["/sbin/tini", "--"]
+apt-get install -qqy --no-install-recommends tini;
+ENTRYPOINT ["/usr/bin/tini", "--"]
 `
 }
 


### PR DESCRIPTION
Alternative to #1156 

The [tini README](https://github.com/krallin/tini#debian) provides installation instructions for installing with `apt`. I believe this should work for both the Python and CUDA base images.