### PR TITLE
fix: debug cmd should have --separate-weights

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -17,17 +17,11 @@ func newDebugCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "debug",
 		Hidden: true,
+		Short:  "Generate a Dockerfile from " + global.ConfigFilename,
 		RunE:   cmdDockerfile,
 	}
 
-	debug := &cobra.Command{
-		Use:    "debug",
-		Short:  "Generate a Dockerfile from " + global.ConfigFilename,
-		Hidden: true,
-	}
-
-	cmd.AddCommand(debug)
-	addSeparateWeightsFlag(debug)
+	addSeparateWeightsFlag(cmd)
 	cmd.Flags().StringVarP(&imageName, "image-name", "", "", "The image name to use for the generated Dockerfile")
 
 	return cmd


### PR DESCRIPTION
fix https://github.com/replicate/cog/issues/1168

Actually the flag has been implemented. The code doesn't look right to extra command.
cc @mattt 