### PR TITLE
Accumulate errors in `ValidateAndComplete`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Common contribution types include: `doc`, `code`, `bug`, and `ideas`. See the fu
 
 ## Development environment
 
-You'll need to [install Go 1.19](https://golang.org/doc/install). If you're using a newer Mac with an M1 chip, be sure to download the `darwin-arm64` installer package. Alternatively you can run `brew install go` which will automatically detect and use the appropriate installer for your system architecture.
+You'll need to [install Go 1.20](https://golang.org/doc/install). If you're using a newer Mac with an M1 chip, be sure to download the `darwin-arm64` installer package. Alternatively you can run `brew install go` which will automatically detect and use the appropriate installer for your system architecture.
 
 Install the Python dependencies:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/replicate/cog
 
-go 1.19
+go 1.20
 
 require (
 	github.com/anaskhan96/soup v1.2.5


### PR DESCRIPTION
This PR resolves a TODO comment to make `ValidateAndComplete` return all errors generated when validating a config file instead of just the first. It relies on a [new language feature for wrapping multiple errors](https://go.dev/doc/go1.20#errors), so this PR depends on #1177