### PR TITLE
Allow `MAJOR.MINOR` to match `MAJOR.MINOR.PATCH` with non-zero patch

### DIFF
--- a/pkg/config/compatibility.go
+++ b/pkg/config/compatibility.go
@@ -111,7 +111,7 @@ func init() {
 	filteredTorchCompatibilityMatrix := []TorchCompatibility{}
 	for _, compat := range torchCompatibilityMatrix {
 		for _, cudaBaseImage := range CUDABaseImages {
-			if compat.CUDA == nil || strings.HasPrefix(cudaBaseImage.CUDA, *compat.CUDA) {
+			if compat.CUDA != nil && version.Matches(*compat.CUDA, cudaBaseImage.CUDA) {
 				filteredTorchCompatibilityMatrix = append(filteredTorchCompatibilityMatrix, compat)
 				break
 			}
@@ -192,7 +192,7 @@ func resolveMinorToPatch(minor string) (string, error) {
 func latestCuDNNForCUDA(cuda string) (string, error) {
 	cuDNNs := []string{}
 	for _, image := range CUDABaseImages {
-		if version.Equal(image.CUDA, cuda) {
+		if version.Matches(cuda, image.CUDA) {
 			cuDNNs = append(cuDNNs, image.CuDNN)
 		}
 	}
@@ -241,7 +241,7 @@ func versionGreater(a string, b string) (bool, error) {
 
 func CUDABaseImageFor(cuda string, cuDNN string) (string, error) {
 	for _, image := range CUDABaseImages {
-		if version.Equal(image.CUDA, cuda) && image.CuDNN == cuDNN {
+		if version.Matches(cuda, image.CUDA) && image.CuDNN == cuDNN {
 			return image.ImageTag(), nil
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -317,9 +317,8 @@ func TestPythonPackagesForArchTorchCPU(t *testing.T) {
 
 	requirements, err := config.PythonRequirementsForArch("", "")
 	require.NoError(t, err)
-	expected := `--find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.7.1+cpu
-torchvision==0.8.2+cpu
+	expected := `torch==1.7.1
+torchvision==0.8.2
 torchaudio==0.7.2
 foo==1.0.0`
 	require.Equal(t, expected, requirements)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -146,29 +146,24 @@ func TestValidateAndCompleteCUDAForAllTF(t *testing.T) {
 	}
 }
 
-// func TestValidateAndCompleteCUDAForAllTorch(t *testing.T) {
-// 	// test that all torch versions fill out cuda
-// 	for _, compat := range TorchCompatibilityMatrix {
-// 		config := &Config{
-// 			Build: &Build{
-// 				GPU:           true,
-// 				PythonVersion: "3.8",
-// 				PythonPackages: []string{
-// 					"torch==" + compat.TorchVersion(),
-// 				},
-// 			},
-// 		}
+func TestValidateAndCompleteCUDAForAllTorch(t *testing.T) {
+	for _, compat := range TorchCompatibilityMatrix {
+		config := &Config{
+			Build: &Build{
+				GPU:           compat.CUDA != nil,
+				PythonVersion: "3.8",
+				PythonPackages: []string{
+					"torch==" + compat.TorchVersion(),
+				},
+			},
+		}
 
-// 		for _, cudaBaseImage := range CUDABaseImages {
-// 			if compat.CUDA == nil || strings.HasPrefix(cudaBaseImage.CUDA, *compat.CUDA) {
-// 				err := config.ValidateAndComplete("")
-// 				require.NoError(t, err)
-// 				require.NotEqual(t, "", config.Build.CUDA)
-// 				require.NotEqual(t, "", config.Build.CuDNN)
-// 			}
-// 		}
-// 	}
-// }
+		err := config.ValidateAndComplete("")
+		require.NoError(t, err)
+		require.NotEqual(t, "", config.Build.CUDA)
+		require.NotEqual(t, "", config.Build.CuDNN)
+	}
+}
 
 func TestValidateAndCompleteCUDAForSelectedTorch(t *testing.T) {
 	for _, tt := range []struct {

--- a/pkg/config/data/config_schema_v1.0.json
+++ b/pkg/config/data/config_schema_v1.0.json
@@ -14,6 +14,11 @@
           "type": "string",
           "description": "Cog automatically picks the correct version of CUDA to install, but this lets you override it for whatever reason."
         },
+        "cudnn": {
+          "$id": "#/properties/build/properties/cudnn",
+          "type": "string",
+          "description": "Cog automatically picks the correct version of cuDNN to install, but this lets you override it for whatever reason."
+        },
         "gpu": {
           "$id": "#/properties/build/properties/gpu",
           "type": "boolean",

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -166,8 +166,7 @@ COPY . /src`
 	requirements, err := os.ReadFile(path.Join(gen.tmpDir, "requirements.txt"))
 	require.NoError(t, err)
 
-	require.Equal(t, `--find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.5.1+cpu
+	require.Equal(t, `torch==1.5.1
 pandas==1.2.0.12`, string(requirements))
 }
 

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -85,3 +85,20 @@ func EqualMinor(v1 string, v2 string) bool {
 func Greater(v1 string, v2 string) bool {
 	return MustVersion(v1).Greater(MustVersion(v2))
 }
+
+func (v *Version) Matches(other *Version) bool {
+	switch {
+	case v.Major != other.Major:
+		return false
+	case v.Minor != other.Minor:
+		return false
+	case v.Patch != 0 && v.Patch != other.Patch:
+		return false
+	default:
+		return true
+	}
+}
+
+func Matches(v1 string, v2 string) bool {
+	return MustVersion(v1).Matches(MustVersion(v2))
+}


### PR DESCRIPTION
Follow-up to #1170 

Given a `cog.yaml` file that specifies `cuda: 11.6` and a dependency on `torch==1.13.0`, running `cog build` with Cog [v0.8.0-beta9](https://github.com/replicate/cog/releases/tag/v0.8.0-beta9) fails with the following error:

> ⅹ CUDA 11.6 is not supported by Cog

It should instead have matched these entries:

```jsonc
// CUDA
{
  "Tag": "11.6.2-cudnn8-devel-ubuntu20.04",
  "CUDA": "11.6.2",
  "CuDNN": "8",
  "IsDevel": true,
  "Ubuntu": "20.04"
}

// Torch
{
  "Torch": "1.13.0+cu116",
  "Torchvision": "0.14.0+cu116",
  "Torchaudio": "0.13.0",
  "FindLinks": "",
  "ExtraIndexURL": "https://download.pytorch.org/whl/cu116",
  "CUDA": "11.6",
  "Pythons": [
    "3.6",
    "3.7",
    "3.8",
    "3.9",
    "3.10",
    "3.11"
  ]
}
```

However, Cog was looking for a strict match on CUDA 11.6.0.

This PR changes the check to allow non-zero patch versions to be matched when finding compatible CUDA x Torch mappings.

This PR also adds the `build.cudnn` property to the `cog.yaml` schema. Something about the new combination of CUDA images and Torch libraries caused Cog to resolve with an explicit `cudnn` setting, which raised a new validation error in the resulting config. Since `CuDNN` is a valid property of `config.Build`, it should be included in the schema.