### PR TITLE
Update `goreleaser` configuration to remove deprecated `replacements` field

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,12 +17,12 @@ builds:
       - "-s -w -X github.com/replicate/cog/pkg/global.Version={{.Version}} -X github.com/replicate/cog/pkg/global.Commit={{.Commit}} -X github.com/replicate/cog/pkg/global.BuildTime={{.Date}}"
 archives:
   - format: binary
-    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      386: i386
-      amd64: x86_64
+    name_template: >-
+      {{ .ProjectName }}_{{ .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}
+      {{end}}
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
`archives.replacements` was [deprecated](https://goreleaser.com/deprecations/#archivesreplacements), and now removed from `goreleaser`. This has caused our recent CI release workflow runs to [fail](https://github.com/replicate/cog/actions/runs/5455502299/jobs/9927244941).

This PR updates our `.goreleaser.yaml` configuration file to remove the deprecated `replacements` field and make equivalent changes to the name template to keep the same file naming conventions for artifacts.