### PR TITLE
Exclude Makefile from GitHub repository statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 python/.git_archival.txt export-subst
+Makefile -linguist-detectable


### PR DESCRIPTION
Cog is about 50/50 split between Python and Go, both in fact and in principal. This PR adds an attribute to hide Makefile from the GitHub repo statistics to draw this out more clearly.

<img width="321" alt="Screenshot 2023-07-07 at 11 45 21" src="https://github.com/replicate/cog/assets/7659/db871d8c-5bc4-4915-9c80-8226526e195b">
