### PR TITLE
don't import numpy at the top of json.py

### DIFF
--- a/python/cog/json.py
+++ b/python/cog/json.py
@@ -8,13 +8,6 @@ from pydantic import BaseModel
 
 from .types import Path
 
-try:
-    import numpy as np  # type: ignore
-
-    has_numpy = True
-except ImportError:
-    has_numpy = False
-
 
 def make_encodeable(obj: Any) -> Any:
     """
@@ -24,6 +17,13 @@ def make_encodeable(obj: Any) -> Any:
 
     Somewhat based on FastAPI's jsonable_encoder().
     """
+    try:
+        import numpy as np  # type: ignore
+
+        has_numpy = True
+    except ImportError:
+        has_numpy = False
+
     if isinstance(obj, BaseModel):
         return make_encodeable(obj.dict(exclude_unset=True))
     if isinstance(obj, dict):

--- a/python/cog/json.py
+++ b/python/cog/json.py
@@ -17,13 +17,6 @@ def make_encodeable(obj: Any) -> Any:
 
     Somewhat based on FastAPI's jsonable_encoder().
     """
-    try:
-        import numpy as np  # type: ignore
-
-        has_numpy = True
-    except ImportError:
-        has_numpy = False
-
     if isinstance(obj, BaseModel):
         return make_encodeable(obj.dict(exclude_unset=True))
     if isinstance(obj, dict):
@@ -34,6 +27,12 @@ def make_encodeable(obj: Any) -> Any:
         return obj.value
     if isinstance(obj, datetime):
         return obj.isoformat()
+    try:
+        import numpy as np  # type: ignore
+
+        has_numpy = True
+    except ImportError:
+        has_numpy = False
     if has_numpy:
         if isinstance(obj, np.integer):
             return int(obj)


### PR DESCRIPTION
It takes a little while to import numpy and it's not necessary for the server process to do up front. 

Signed-off-by: technillogue <technillogue@gmail.com>
