### PR TITLE
fix: tiny installation should include TINI_ARCH

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -114,7 +114,6 @@ func (g *Generator) GenerateBase() (string, error) {
 
 	return strings.Join(filterEmpty([]string{
 		"#syntax=docker/dockerfile:1.4",
-		g.tiniStage(),
 		"FROM " + baseImage,
 		g.preamble(),
 		g.installTini(),
@@ -184,7 +183,6 @@ func (g *Generator) Generate(imageName string) (weightsBase string, dockerfile s
 	base := []string{
 		"#syntax=docker/dockerfile:1.4",
 		fmt.Sprintf("FROM %s AS %s", imageName+"-weights", "weights"),
-		g.tiniStage(),
 		"FROM " + baseImage,
 		g.preamble(),
 		g.installTini(),
@@ -257,16 +255,6 @@ ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin`
 }
 
-func (g *Generator) tiniStage() string {
-	lines := []string{
-		`FROM curlimages/curl AS downloader`,
-		`ARG TINI_VERSION=0.19.0`,
-		`WORKDIR /tmp`,
-		`RUN curl -fsSL -O "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini" && chmod +x tini`,
-	}
-	return strings.Join(lines, "\n")
-}
-
 func (g *Generator) installTini() string {
 	// Install tini as the image entrypoint to provide signal handling and process
 	// reaping appropriate for PID 1.
@@ -274,7 +262,14 @@ func (g *Generator) installTini() string {
 	// N.B. If you remove/change this, consider removing/changing the `has_init`
 	// image label applied in image/build.go.
 	lines := []string{
-		`COPY --link --from=downloader /tmp/tini /sbin/tini`,
+		`RUN --mount=type=cache,target=/var/cache/apt set -eux; \
+		apt-get update -qq; \
+		apt-get install -qqy --no-install-recommends curl; \
+		rm -rf /var/lib/apt/lists/*; \
+		TINI_VERSION=v0.19.0; \
+		TINI_ARCH="$(dpkg --print-architecture)"; \
+		curl -sSL -o /sbin/tini "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TINI_ARCH}"; \
+		chmod +x /sbin/tini`,
 		`ENTRYPOINT ["/sbin/tini", "--"]`,
 	}
 	return strings.Join(lines, "\n")

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -13,16 +13,15 @@ import (
 	"github.com/replicate/cog/pkg/config"
 )
 
-func testTiniStage() string {
-	return `FROM curlimages/curl AS downloader
-ARG TINI_VERSION=0.19.0
-WORKDIR /tmp
-RUN curl -fsSL -O "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini" && chmod +x tini
-`
-}
-
 func testInstallTini() string {
-	return `COPY --link --from=downloader /tmp/tini /sbin/tini
+	return `RUN --mount=type=cache,target=/var/cache/apt set -eux; \
+		apt-get update -qq; \
+		apt-get install -qqy --no-install-recommends curl; \
+		rm -rf /var/lib/apt/lists/*; \
+		TINI_VERSION=v0.19.0; \
+		TINI_ARCH="$(dpkg --print-architecture)"; \
+		curl -sSL -o /sbin/tini "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TINI_ARCH}"; \
+		chmod +x /sbin/tini
 ENTRYPOINT ["/sbin/tini", "--"]
 `
 }
@@ -80,8 +79,7 @@ predict: predict.py:Predictor
 
 	expected := `#syntax=docker/dockerfile:1.4
 FROM r8.im/replicate/cog-test-weights AS weights
-` + testTiniStage() +
-		`FROM python:3.8
+FROM python:3.8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
@@ -111,8 +109,7 @@ predict: predict.py:Predictor
 
 	expected := `#syntax=docker/dockerfile:1.4
 FROM r8.im/replicate/cog-test-weights AS weights
-` + testTiniStage() +
-		`FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
@@ -151,8 +148,7 @@ predict: predict.py:Predictor
 
 	expected := `#syntax=docker/dockerfile:1.4
 FROM r8.im/replicate/cog-test-weights AS weights
-` + testTiniStage() +
-		`FROM python:3.8
+FROM python:3.8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
@@ -200,8 +196,7 @@ predict: predict.py:Predictor
 
 	expected := `#syntax=docker/dockerfile:1.4
 FROM r8.im/replicate/cog-test-weights AS weights
-` + testTiniStage() +
-		`FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
@@ -247,8 +242,7 @@ build:
 
 	expected := `#syntax=docker/dockerfile:1.4
 FROM r8.im/replicate/cog-test-weights AS weights
-` + testTiniStage() +
-		`FROM python:3.8
+FROM python:3.8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
@@ -352,8 +346,7 @@ COPY root-large /src/root-large`
 	// model copy should be run before dependency install and code copy
 	expected = `#syntax=docker/dockerfile:1.4
 FROM r8.im/replicate/cog-test-weights AS weights
-` + testTiniStage() +
-		`FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
@@ -427,8 +420,7 @@ predict: predict.py:Predictor
 	require.NoError(t, err)
 
 	expected := `#syntax=docker/dockerfile:1.4
-` + testTiniStage() +
-		`FROM python:3.8
+FROM python:3.8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin


### PR DESCRIPTION
This will fix https://github.com/replicate/cog/issues/1189

TLDR: missing the TINI_ARCH causes the apt-get commands fail.

See the details in [this discussion ](https://github.com/replicate/cog/issues/1189#issuecomment-1635244643).