### PR TITLE
Set architecture for tini to amd64

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -262,7 +262,7 @@ func (g *Generator) tiniStage() string {
 		`FROM curlimages/curl AS downloader`,
 		`ARG TINI_VERSION=0.19.0`,
 		`WORKDIR /tmp`,
-		`RUN curl -fsSL -O "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini" && chmod +x tini`,
+		`RUN curl -fsSL -O "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-amd64" && chmod +x tini`,
 	}
 	return strings.Join(lines, "\n")
 }

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -17,7 +17,7 @@ func testTiniStage() string {
 	return `FROM curlimages/curl AS downloader
 ARG TINI_VERSION=0.19.0
 WORKDIR /tmp
-RUN curl -fsSL -O "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini" && chmod +x tini
+RUN curl -fsSL -O "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-amd64" && chmod +x tini
 `
 }
 


### PR DESCRIPTION
Alpine doesn't have dpkg, so --print-architecture doesn't work, we would need to parse uname -m or apk --print-arch and map x86_64 to amd64. Also, in production only amd64 is used, never arm64. The architecture of the machine building the image is not relevant.

Should fix #1189, though truthfully I'm not sure why this could relate to problems with libc-bin or ldconfig.real. 

Signed-off-by: technillogue <technillogue@gmail.com>
