### PR TITLE
Remove exception for 'compatability' in misspell configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -63,8 +63,6 @@ linters-settings:
     # Default is to use a neutral variety of English.
     # Setting locale to US will correct the British spelling of 'colour' to 'color'.
     locale: US
-    ignore-words:
-      - compatability # TODO(andreas): fix this
   revive:
     rules:
       - name: unused-parameter


### PR DESCRIPTION
Follow up to ffd9edb2d8e1c699b406c8a480dac4fbc104c23d