### PR TITLE
Configure goimports local prefix

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,7 +24,6 @@ linters:
   enable:
     - errcheck
     - exportloopref
-    # - gci
     - gocritic
     - gosec
     - govet
@@ -47,11 +46,6 @@ linters-settings:
     # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
     # default is false: such cases aren't reported by default.
     check-blank: false
-  # gci:
-  #   sections:
-  #     - standard # Captures all standard packages if they do not match another section.
-  #     - default # Contains all imports that could not be matched to another section type.
-  #     - prefix(github.com/replicate) # Groups all imports with the specified Prefix.
   gosec:
     excludes:
       - G306 # Expect WriteFile permissions to be 0600 or less

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
   "go.lintTool": "golangci-lint",
   "go.formatTool": "goimports",
   "go.testOnSave": true,
+  "gopls": { "formatting.local": "github.com/replicate/cog" },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -3,10 +3,11 @@ package cli
 import (
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/image"
 	"github.com/replicate/cog/pkg/util/console"
-	"github.com/spf13/cobra"
 )
 
 var buildTag string

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -4,11 +4,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/docker"
 	"github.com/replicate/cog/pkg/image"
 	"github.com/replicate/cog/pkg/util/console"
-	"github.com/spf13/cobra"
 )
 
 var (

--- a/pkg/cli/train.go
+++ b/pkg/cli/train.go
@@ -5,12 +5,13 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/spf13/cobra"
+
 	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/docker"
 	"github.com/replicate/cog/pkg/image"
 	"github.com/replicate/cog/pkg/predict"
 	"github.com/replicate/cog/pkg/util/console"
-	"github.com/spf13/cobra"
 )
 
 var (

--- a/pkg/docker/image_inspect.go
+++ b/pkg/docker/image_inspect.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types"
+
 	"github.com/replicate/cog/pkg/util/console"
 )
 

--- a/pkg/docker/login.go
+++ b/pkg/docker/login.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/types"
+
 	"github.com/replicate/cog/pkg/util/console"
 )
 

--- a/pkg/docker/run.go
+++ b/pkg/docker/run.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/mattn/go-isatty"
+
 	"github.com/replicate/cog/pkg/util"
 	"github.com/replicate/cog/pkg/util/console"
 )

--- a/pkg/image/openapi_schema.go
+++ b/pkg/image/openapi_schema.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/getkin/kin-openapi/openapi3"
+
 	"github.com/replicate/cog/pkg/docker"
 	"github.com/replicate/cog/pkg/global"
 	"github.com/replicate/cog/pkg/util/console"

--- a/pkg/predict/input.go
+++ b/pkg/predict/input.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
+	"github.com/vincent-petithory/dataurl"
+
 	"github.com/replicate/cog/pkg/util/console"
 	"github.com/replicate/cog/pkg/util/mime"
-	"github.com/vincent-petithory/dataurl"
 )
 
 type Input struct {

--- a/pkg/predict/predictor.go
+++ b/pkg/predict/predictor.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
+
 	"github.com/replicate/cog/pkg/docker"
 	"github.com/replicate/cog/pkg/global"
 	"github.com/replicate/cog/pkg/util/console"

--- a/tools/compatgen/internal/cuda.go
+++ b/tools/compatgen/internal/cuda.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/anaskhan96/soup"
+
 	"github.com/replicate/cog/pkg/config"
 )
 

--- a/tools/compatgen/internal/torch.go
+++ b/tools/compatgen/internal/torch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/anaskhan96/soup"
 
 	"github.com/hashicorp/go-version"
+
 	"github.com/replicate/cog/pkg/config"
 )
 

--- a/tools/compatgen/main.go
+++ b/tools/compatgen/main.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/replicate/cog/pkg/util/console"
 	"github.com/replicate/cog/tools/compatgen/internal"
-	"github.com/spf13/cobra"
 )
 
 func main() {


### PR DESCRIPTION
This PR updates the VSCode settings to automatically run `goimports` with local configured to sort `github.com/replicate/cog` imports separately from 3rd party imports.