### PR TITLE
Small fix: don't install python when using python base image

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -97,7 +97,7 @@ func (g *Generator) GenerateBase() (string, error) {
 		return "", err
 	}
 	installPython := ""
-	if g.Config.Build.GPU {
+	if g.Config.Build.GPU && g.useCudaBaseImage {
 		installPython, err = g.installPythonCUDA()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
In #1214 we accidentally left it so pyenv is installed when gpu: true even if  --use-cuda-base-image=false. This PR fixes that.