### PR TITLE
Validate model schema on build

### DIFF
--- a/pkg/image/openapi_schema.go
+++ b/pkg/image/openapi_schema.go
@@ -14,7 +14,7 @@ import (
 
 // GenerateOpenAPISchema by running the image and executing Cog
 // This will be run as part of the build process then added as a label to the image. It can be retrieved more efficiently with the label by using GetOpenAPISchema
-func GenerateOpenAPISchema(imageName string, enableGPU bool) (*interface{}, error) {
+func GenerateOpenAPISchema(imageName string, enableGPU bool) (map[string]any, error) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
@@ -44,7 +44,7 @@ func GenerateOpenAPISchema(imageName string, enableGPU bool) (*interface{}, erro
 		console.Info(stderr.String())
 		return nil, err
 	}
-	var schema *interface{}
+	var schema map[string]any
 	if err := json.Unmarshal(stdout.Bytes(), &schema); err != nil {
 		// Exit code was 0, but JSON was not returned.
 		// This is verbose, but print so anything that gets printed in Python bubbles up here.

--- a/test-integration/test_integration/fixtures/invalid-int-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/invalid-int-project/cog.yaml
@@ -1,0 +1,3 @@
+build:
+  python_version: "3.8"
+predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/invalid-int-project/predict.py
+++ b/test-integration/test_integration/fixtures/invalid-int-project/predict.py
@@ -1,0 +1,8 @@
+from cog import BasePredictor, Input
+
+
+class Predictor(BasePredictor):
+    def predict(
+        self, num: int = Input(description="Number of things", default=1, ge=2, le=10)
+    ) -> int:
+        return num * 2

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -91,6 +91,17 @@ def test_build_with_model(docker_image):
     }
 
 
+def test_build_invalid_schema(docker_image):
+    project_dir = Path(__file__).parent / "fixtures/invalid-int-project"
+    build_process = subprocess.run(
+        ["cog", "build", "-t", docker_image],
+        cwd=project_dir,
+        capture_output=True,
+    )
+    assert build_process.returncode > 0
+    assert "invalid default: number must be at least 2" in build_process.stderr.decode()
+
+
 def test_build_gpu_model_on_cpu(tmpdir, docker_image):
     if os.environ.get("CI") != "true":
         pytest.skip("only runs on CI environment")


### PR DESCRIPTION
It's important that the OpenAPI schema generated by cog validates. This adds a validation step into the `cog build` process.

This should at least help us reduce the number of invalid schemas pushed to r8.im.