### PR TITLE
Add GitHub Actions to Dependabot Version Updates configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
       interval: "weekly"
     allow:
       - dependency-type: "direct"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR updates `dependabot.yml` to add `gitHub-actions` to the list of package ecosystems for this project.

For more information, see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot