### PR TITLE
Fix weight manifest change check

### DIFF
--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -50,8 +50,8 @@ func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache,
 		if err != nil {
 			return fmt.Errorf("Failed to generate weights manifest: %w", err)
 		}
-		cachedManifest, err := weights.LoadManifest(weightsManifestPath)
-		changed := err != nil && weightsManifest.Equal(cachedManifest)
+		cachedManifest, _ := weights.LoadManifest(weightsManifestPath)
+		changed := cachedManifest == nil || !weightsManifest.Equal(cachedManifest)
 		if changed {
 			if err := buildWeightsImage(dir, weightsDockerfile, imageName+"-weights", secrets, noCache, progressOutput); err != nil {
 				return fmt.Errorf("Failed to build model weights Docker image: %w", err)


### PR DESCRIPTION
The weights are changed if there is no cache (no previous value) or the value differs.

Introduced in #1223

On a tangential note -- if cog crashes around the `Equal` function, the `.dockerignore` is in an inconsistent state, which leads to weights being ignored (because it thinks the `.dockerignore` cog created is the real one, next time you run it) ... ideally there should be a finally block in the right place to restore the original `.dockerignore` if any, even if the code crashes.