### PR TITLE
Build Docker images with SBOM and provenance attestation

### DIFF
--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -56,6 +56,8 @@ func Build(dir, dockerfile, imageName string, secrets []string, noCache bool, pr
 
 	args = append(args,
 		"--file", "-",
+		"--sbom=true",
+		"--provenance=true",
 		"--tag", imageName,
 		"--progress", progressOutput,
 		".",


### PR DESCRIPTION
From [Docker's docs](https://docs.docker.com/build/attestations/):

> Build attestations describe how an image was built, and what it contains. The attestations are created at build-time by BuildKit, and become attached to the final image as metadata.

> Attestations are stored as manifest objects in the image index, similar in style to OCI artifacts.

This PR adds injects the `--sbom=true` and `--provenance=true` flags into the `docker build` command.