### PR TITLE
.github: add issue template file with bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Something isn't working
+title: ''
+labels: "type/bug"
+assignees: ''
+
+---
+
+### Description
+
+<!-- Describe the bug that you encountered -->
+
+### Reproduction Steps
+
+<!--
+Include steps to reproduce the bug including:
+- Screenshots
+- Code snippets
+- Loom video/gifs
+- Error messages
+-->


### PR DESCRIPTION
Add a first issue template of type bug report - this create issues with a label of `type/bug` and gives users the below experience when opening issues.

![Screen Shot 2023-08-07 at 4 16 06 PM](https://github.com/replicate/cog/assets/4915950/270843e2-8bfb-42de-aa56-35d705562d04)
