### PR TITLE
support env vars for predict & run

### DIFF
--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -24,6 +24,7 @@ import (
 )
 
 var (
+	envFlags   []string
 	inputFlags []string
 	outPath    string
 )
@@ -49,6 +50,7 @@ the prediction on that.`,
 
 	cmd.Flags().StringArrayVarP(&inputFlags, "input", "i", []string{}, "Inputs, in the form name=value. if value is prefixed with @, then it is read from a file on disk. E.g. -i path=@image.jpg")
 	cmd.Flags().StringVarP(&outPath, "output", "o", "", "Output path")
+	cmd.Flags().StringArrayVarP(&envFlags, "env", "e", []string{}, "Environment variables, in the form name=value")
 
 	return cmd
 }
@@ -110,6 +112,7 @@ func cmdPredict(cmd *cobra.Command, args []string) error {
 		GPUs:    gpus,
 		Image:   imageName,
 		Volumes: volumes,
+		Env:     envFlags,
 	})
 
 	go func() {

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -31,6 +31,7 @@ func newRunCommand() *cobra.Command {
 
 	// This is called `publish` for consistency with `docker run`
 	cmd.Flags().StringArrayVarP(&runPorts, "publish", "p", []string{}, "Publish a container's port to the host, e.g. -p 8000")
+	cmd.Flags().StringArrayVarP(&envFlags, "env", "e", []string{}, "Environment variables, in the form name=value")
 
 	flags.SetInterspersed(false)
 
@@ -55,6 +56,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	runOptions := docker.RunOptions{
 		Args:    args,
+		Env:     envFlags,
 		GPUs:    gpus,
 		Image:   imageName,
 		Volumes: []docker.Volume{{Source: projectDir, Destination: "/src"}},


### PR DESCRIPTION
This PR adds support for setting an environment variable when running a model (not during building)

This is meant to augment the development process of "cog train" - where fine-tuned models are different from the original model only by the presence of a `COG_WEIGHTS` variable.

Currently there is no easy way of using `cog predict` or `cog run` to test models during development with the results of fine-tuning.

After this PR lands, if you are doing development of a cog model such as llama or sdxl, you can test that the fine-tuned code-path works before pushing to replicate by doing:

    cog predict -e COG_WEIGHTS=https://replicate.delivery/pbxt/xyz/weights.tar -i prompt="a photo of TOK"

or if you want to test that it works for multiple predictions (and doesn't leak memory), you can:

    cog run -e COG_WEIGHTS=https://replicate.delivery/pbxt/xyz/weights.tar -p 5000 python -m cog.http.server

I didn't add this to documentation yet as my understanding is `cog train` isn't yet finalized/documented