### PR TITLE
Attempt to parse predict input as JSON

### DIFF
--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -199,3 +199,14 @@ def test_predict_many_inputs(tmpdir_factory):
         capture_output=True,
     )
     assert result.stdout.decode() == "hello default 20 world jpg foo 6\n"
+
+def test_predict_unescapes_newlines():
+    project_dir = Path(__file__).parent / "fixtures/string-project"
+    result = subprocess.run(
+        ["cog", "predict", "-i", 's="wo\\nrld"'],
+        cwd=project_dir,
+        check=True,
+        capture_output=True,
+    )
+    # stdout should be clean without any log messages so it can be piped to other commands
+    assert result.stdout == b"hello wo\nrld\n"


### PR DESCRIPTION
We want to unescape things like `\n` that are escaped to `\\n` when serialized, but still fall back to the raw value if that fails for any reason (like the input not deserializing being to a string).