### PR TITLE
update pip install command in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ You'll need to [install Go 1.20](https://golang.org/doc/install). If you're usin
 
 Install the Python dependencies:
 
-    pip install -r requirements-dev.txt
+    python -m pip install '.[dev]'
 
 Once you have Go installed, run:
 


### PR DESCRIPTION
`requirements-dev.txt` was removed in https://github.com/replicate/cog/pull/1201

This PR updates the contributing docs with a [new command](https://chat.openai.com/share/ce6d4db5-0da8-44c1-a344-5e11835a4667).

cc @nickstenning 

---

<img width="743" alt="Screenshot 2023-08-29 at 10 12 03 AM" src="https://github.com/replicate/cog/assets/2289/f745139f-971a-4c7f-a7b6-9e56510de252">