### PR TITLE
Add ENV NVIDIA_DRIVER_CAPABILITIES=all to permit Video SDK transcoding, 3D rendering, and X11 OpenGL Display

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -106,3 +106,13 @@ This section lists the relevant environment variables for Cog's built-in queue w
 This determines whether to enable or disable the usage of OpenTelemetry. OpenTelemetry (OTEL) is an open-source technology used to capture and measure metrics, traces, and logs. It is used for Cog's queue worker.
 
 This can either be set / unset in order to determine whether or not to enable OpenTelemtry. If it is set, then Cog will handle the necessary setup for OpenTelemtry. Otherwise, OpenTelemetry calls will be treated as no-ops. If OpenTelemetry is enabled, the OTLP exporter may also need to be [configured via environment variables](https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html).
+
+
+## Docker Image
+
+### `NVIDIA_DRIVER_CAPABILITIES`
+This [controls which Nvidia driver libraries/binaries will be mounted inside the container](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities). The generated Docker image will set this to  `all` which will mount all Nvidia driver libraries/binaries inside the container beyond the default `utility` and `compute` capabilities.
+
+`graphics`, `video`, and `display` add additional interesting capabilities beyond the default that may be useful for some models running in the container. `graphics` is required for accelerated OpenGL support. `video` is required for accelerated video encoding/decoding. `display` is required for accelerated X11 support.
+
+This is set to `all`, is non-configurable, and is documented here as an environment variable of interest. Setting or changing this during runtime inside the image will have no effect.

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -254,7 +254,8 @@ func (g *Generator) baseImage() (string, error) {
 func (g *Generator) preamble() string {
 	return `ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin`
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
+ENV NVIDIA_DRIVER_CAPABILITIES=all`
 }
 
 func (g *Generator) installTini() string {

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -89,6 +89,7 @@ FROM python:3.8-slim
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
+ENV NVIDIA_DRIVER_CAPABILITIES=all
 ` + testTini() + `COPY --from=deps --link /dep /usr/local/lib/python3.8/site-packages
 WORKDIR /src
 EXPOSE 5000
@@ -120,6 +121,7 @@ FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
+ENV NVIDIA_DRIVER_CAPABILITIES=all
 ` + testTini() + testInstallPython("3.8") + `RUN --mount=type=bind,from=deps,source=/dep,target=/dep cp -rf /dep/* $(pyenv prefix)/lib/python*/site-packages || true
 WORKDIR /src
 EXPOSE 5000
@@ -162,6 +164,7 @@ FROM python:3.8-slim
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
+ENV NVIDIA_DRIVER_CAPABILITIES=all
 ` + testTini() + `RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
 COPY --from=deps --link /dep /usr/local/lib/python3.8/site-packages
 RUN cowsay moo
@@ -211,6 +214,7 @@ FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
+ENV NVIDIA_DRIVER_CAPABILITIES=all
 ` + testTini() +
 		testInstallPython("3.8") + `RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
 RUN --mount=type=bind,from=deps,source=/dep,target=/dep cp -rf /dep/* $(pyenv prefix)/lib/python*/site-packages || true
@@ -255,6 +259,7 @@ FROM python:3.8-slim
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
+ENV NVIDIA_DRIVER_CAPABILITIES=all
 ` + testTini() + `RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy cowsay && rm -rf /var/lib/apt/lists/*
 COPY --from=deps --link /dep /usr/local/lib/python3.8/site-packages
 RUN cowsay moo
@@ -362,6 +367,7 @@ FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
+ENV NVIDIA_DRIVER_CAPABILITIES=all
 ` + testTini() +
 		testInstallPython("3.8") + `RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
 RUN --mount=type=bind,from=deps,source=/dep,target=/dep cp -rf /dep/* $(pyenv prefix)/lib/python*/site-packages || true
@@ -434,6 +440,7 @@ FROM python:3.8-slim
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
+ENV NVIDIA_DRIVER_CAPABILITIES=all
 ` + testTini() + `COPY --from=deps --link /dep /usr/local/lib/python3.8/site-packages
 WORKDIR /src
 EXPOSE 5000


### PR DESCRIPTION
https://github.com/NVIDIA/nvidia-container-runtime/issues/112

I'm interested in capabilities beyond the default Nvidia base images of just compute and utility. I'm particularly interested in using the video encoding and decoding functionality and OpenGL in an X11 application.