### PR TITLE
COG_EXPERIMENTAL_BUILD_STAGE_DEPS for dependencies required in the pip install stage

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -357,7 +357,7 @@ func (g *Generator) pipInstallStage() (string, error) {
 	// Sometimes, in order to run `pip install` successfully, some system packages need to be installed
 	// or some other change needs to happen
 	// this is a bodge to support that
-	// it will be reverted when we add custom dockerfiles 
+	// it will be reverted when we add custom dockerfiles
 	buildStageDeps := os.Getenv("COG_EXPERIMENTAL_BUILD_STAGE_DEPS")
 	if buildStageDeps != "" {
 		fromLine = fromLine + "\nRUN " + buildStageDeps

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -358,7 +358,7 @@ func (g *Generator) pipInstallStage() (string, error) {
 	// or some other change needs to happen
 	// this is a bodge to support that
 	// it will be reverted when we add custom dockerfiles 
-	buildStageDeps := os.Getenv("REPLICATE_EXPERIMENTAL_BUILD_STAGE_DEPS")
+	buildStageDeps := os.Getenv("COG_EXPERIMENTAL_BUILD_STAGE_DEPS")
 	if buildStageDeps != "" {
 		fromLine = fromLine + "\nRUN " + buildStageDeps
 	}


### PR DESCRIPTION
this is like #1233. however, there's no way to configure anything to be installed in the pip install build stage. llama requires sentencepiece, which requires cmake to build from source. we don't want to put cmake in system_packages (and it wouldn't help anyway). so there's this envvar as a stopgap until we decide to have a build_system_packages setting or something
