### PR TITLE
add --force flag to ln

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -380,7 +380,7 @@ func (g *Generator) pipInstalls() string {
 		return strings.Join(
 			[]string{
 				"COPY --from=deps --link /dep /dep",
-				"RUN ln -s /dep/* $(pyenv prefix)/lib/python*/site-packages",
+				"RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages",
 			},
 			"\n")
 	}

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -121,7 +121,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
 ` + testTini() + testInstallPython("3.8") + `COPY --from=deps --link /dep /dep
-RUN ln -s /dep/* $(pyenv prefix)/lib/python*/site-packages
+RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages
 WORKDIR /src
 EXPOSE 5000
 CMD ["python", "-m", "cog.server.http"]
@@ -215,7 +215,7 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia
 ` + testTini() +
 		testInstallPython("3.8") + `RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
 COPY --from=deps --link /dep /dep
-RUN ln -s /dep/* $(pyenv prefix)/lib/python*/site-packages
+RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages
 RUN cowsay moo
 WORKDIR /src
 EXPOSE 5000
@@ -367,7 +367,7 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia
 ` + testTini() +
 		testInstallPython("3.8") + `RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
 COPY --from=deps --link /dep /dep
-RUN ln -s /dep/* $(pyenv prefix)/lib/python*/site-packages
+RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages
 RUN cowsay moo
 COPY --from=weights --link /src/checkpoints /src/checkpoints
 COPY --from=weights --link /src/models /src/models


### PR DESCRIPTION
The pip install stage by default brings pip's dependencies: distutils, setuptools, wheel. Pyenv also brings these packages, so trying to symlink the ones from pip causes an error

```
 => CACHED [stage-1 5/7] COPY --from=deps --link /dep /dep                                                                                                                                                                   0.0s
 => ERROR [stage-1 6/7] RUN ln -s /dep/* $(pyenv prefix)/lib/python*/site-packages                                                                                                                                           0.5s
------
 > [stage-1 6/7] RUN ln -s /dep/* $(pyenv prefix)/lib/python*/site-packages:
#0 0.388 ln: failed to create symbolic link '/root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/_distutils_hack': File exists
#0 0.388 ln: failed to create symbolic link '/root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/distutils-precedence.pth': File exists
#0 0.389 ln: failed to create symbolic link '/root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/pkg_resources': File exists
#0 0.389 ln: failed to create symbolic link '/root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/setuptools': File exists
#0 0.390 ln: failed to create symbolic link '/root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/wheel': File exists
#0 0.390 ln: failed to create symbolic link '/root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/wheel-0.41.2.dist-info': File exists
------
error: failed to solve: executor failed running [/bin/sh -c ln -s /dep/* $(pyenv prefix)/lib/python*/site-packages]: exit code: 1
ⅹ Failed to build Docker image: exit status 1
```