### PR TITLE
Override `sys.argv` while importing predictor module

### DIFF
--- a/python/tests/fixtures/argv_override.py
+++ b/python/tests/fixtures/argv_override.py
@@ -1,0 +1,8 @@
+import sys
+
+argv_on_import = sys.argv[:]
+
+
+class Predictor:
+    def predict(self):
+        return argv_on_import

--- a/python/tests/test_predictor.py
+++ b/python/tests/test_predictor.py
@@ -1,7 +1,10 @@
+import os
+import sys
 from typing import Optional
+from unittest.mock import patch
 
 from cog import File, Path
-from cog.predictor import get_weights_type
+from cog.predictor import get_weights_type, load_predictor_from_ref
 
 
 def test_get_weights_type() -> None:
@@ -24,3 +27,18 @@ def test_get_weights_type() -> None:
         pass
 
     assert get_weights_type(f) == File
+
+
+def test_load_predictor_from_ref_overrides_argv():
+    with patch("sys.argv", ["foo.py", "exec", "--giraffes=2", "--eat-cookies"]):
+        predictor = load_predictor_from_ref(_fixture_path("argv_override"))
+
+        # check the predictor module saw no args
+        assert predictor.predict() == ["foo.py"]
+        # check we reset the args correctly
+        assert sys.argv == ["foo.py", "exec", "--giraffes=2", "--eat-cookies"]
+
+
+def _fixture_path(name):
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+    return os.path.join(test_dir, f"fixtures/{name}.py") + ":Predictor"


### PR DESCRIPTION
In production, any sys.argv should not be exposed to user code. Partly because this might leak information about the production environment, but primarily because user code often has its own argument parsing code which gets confused when it sees our arguments to cog/server/http.py.

This uses mock.patch to ensure that sys.argv contains just sys.argv[0] when user code is executing.

Even though we (Cog) have already done all argument parsing long before this executes, we also put the original value back once we're done running user code.