### PR TITLE
fix an error with multistage symlinks

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -380,7 +380,7 @@ func (g *Generator) pipInstalls() string {
 		return strings.Join(
 			[]string{
 				"COPY --from=deps --link /dep /dep",
-				"RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages",
+				"RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages || true",
 			},
 			"\n")
 	}

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -121,7 +121,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
 ` + testTini() + testInstallPython("3.8") + `COPY --from=deps --link /dep /dep
-RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages
+RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages || true
 WORKDIR /src
 EXPOSE 5000
 CMD ["python", "-m", "cog.server.http"]
@@ -215,7 +215,7 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia
 ` + testTini() +
 		testInstallPython("3.8") + `RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
 COPY --from=deps --link /dep /dep
-RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages
+RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages || true
 RUN cowsay moo
 WORKDIR /src
 EXPOSE 5000
@@ -367,7 +367,7 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia
 ` + testTini() +
 		testInstallPython("3.8") + `RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
 COPY --from=deps --link /dep /dep
-RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages
+RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages || true
 RUN cowsay moo
 COPY --from=weights --link /src/checkpoints /src/checkpoints
 COPY --from=weights --link /src/models /src/models


### PR DESCRIPTION
There's this error that can happen

```
 => ERROR [stage-1 6/7] RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages                                                                                 0.5s
------
 > [stage-1 6/7] RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages:
0.390 ln: /root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/_distutils_hack: cannot overwrite directory
0.391 ln: /root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/pkg_resources: cannot overwrite directory
0.392 ln: /root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/setuptools: cannot overwrite directory
0.392 ln: /root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/wheel: cannot overwrite directory
0.392 ln: /root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/wheel-0.41.2.dist-info: cannot overwrite directory
------
```

It's caused by some basic packages already being installed and ln not willing to do directories even with --force. It will still process everything else, so ||true seems like a good enough fix, but `rm -rf $(pyenv prefix)/lib/python*/site-packages/*` would work just as well.
