### PR TITLE
Add support for Markdown file inputs and outputs

### DIFF
--- a/pkg/util/mime/mime.go
+++ b/pkg/util/mime/mime.go
@@ -73,6 +73,7 @@ var typeToExtension = map[string]string{
 	"text/csv":        ".csv",
 	"text/html":       ".html",
 	"text/javascript": ".js",
+	"text/markdown":   ".md",
 	"text/plain":      ".txt",
 
 	"video/3gpp":      ".3gp",


### PR DESCRIPTION
Currently, models do not support [Markdown files](https://en.wikipedia.org/wiki/Markdown). Instead, they must be converted to and from plain text (`text/plain` / `.txt`) files.

This PR adds a new entry to Cog's MIME / content type mapping for Markdown files (content type `text/markdown` with file extension `.md`) so they can be supported directly.