### PR TITLE
Fix usage description for `--dockerfile` option

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -89,5 +89,5 @@ func addUseCudaBaseImageFlag(cmd *cobra.Command) {
 }
 
 func addDockerfileFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&buildDockerfileFile, "dockerfile", "", "Path to a Dockerfile. If the flag is passed but no value is provided, defaults to the Dockerfile in the working directory.")
+	cmd.Flags().StringVar(&buildDockerfileFile, "dockerfile", "", "Path to a Dockerfile. If set, cog will use this Dockerfile instead of generating one from cog.yaml")
 }


### PR DESCRIPTION
Follow-up to #1229 

This PR corrects the usage description for `--dockerfile` option to reflect the actual behavior. I introduced this mistake with https://github.com/replicate/cog/pull/1229/commits/ffe657f652444215bd30ea9b666ea1818de2dba6.