### PR TITLE
Hide `--dockerfile` flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/term v0.5.0
 	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	github.com/vincent-petithory/dataurl v1.0.0
 	github.com/xeipuuv/gojsonschema v1.2.0
@@ -174,7 +175,6 @@ require (
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.13.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.1.1 // indirect

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/image"
@@ -90,4 +91,9 @@ func addUseCudaBaseImageFlag(cmd *cobra.Command) {
 
 func addDockerfileFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&buildDockerfileFile, "dockerfile", "", "Path to a Dockerfile. If set, cog will use this Dockerfile instead of generating one from cog.yaml")
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Name == "dockerfile" {
+			f.Hidden = true
+		}
+	})
 }


### PR DESCRIPTION
Follow-up to #1229

The `--dockerfile` flag is intended primarily for debugging, and shouldn't be advertised in command usage output. This PR marks the flag as hidden.

```console
$ cog build --help
Build an image from cog.yaml

Usage:
  cog build [flags]

Flags:
  -h, --help                         help for build
      --no-cache                     Do not use cache when building the image
      --openapi-schema string        Load OpenAPI schema from a file
      --progress string              Set type of build progress output, 'auto' (default), 'tty' or 'plain' (default "auto")
      --secret stringArray           Secrets to pass to the build environment in the form 'id=foo,src=/path/to/file'
      --separate-weights             Separate model weights from code in image layers
  -t, --tag string                   A name for the built image in the form 'repository:tag'
      --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")

Global Flags:
      --debug     Show debugging output
      --version   Show version of Cog
```