### PR TITLE
increase pipe size to maybe improve large output handling

### DIFF
--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -24,7 +24,7 @@ from .exceptions import (
     FatalWorkerException,
     InvalidStateException,
 )
-from .helpers import StreamRedirector, WrappedStream
+from .helpers import StreamRedirector, WrappedStream, increase_conn_size
 
 _spawn = multiprocessing.get_context("spawn")
 

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -47,6 +47,9 @@ class Worker:
 
         # A pipe with which to communicate with the child worker.
         self._events, child_events = _spawn.Pipe()
+        # just increasing our end's rcv buffer might be sufficient?🤷‍
+        increase_conn_size(self._events)
+        increase_conn_size(child_events)
         self._child = _ChildWorker(predictor_ref, child_events, tee_output)
         self._terminating = False
 

--- a/python/tests/server/fixtures/large_output.py
+++ b/python/tests/server/fixtures/large_output.py
@@ -1,0 +1,10 @@
+from typing import List
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def predict(
+        self, n: int = 2**20
+    ) -> List[int]:
+        return [1] * n

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -62,6 +62,7 @@ OUTPUT_FIXTURES = [
         lambda x: list(range(x["upto"])),
     ),
     ("complex_output", {}, lambda _: {"number": 42, "text": "meaning of life"}),
+    ("large_output", {"n": st.sampled_from([2**25])}, lambda _: [1] * 2**25),
 ]
 
 SETUP_LOGS_FIXTURES = [


### PR DESCRIPTION
lifted from https://github.com/coreweave/tensorizer/blob/main/tensorizer/_wide_pipes.py

Models that return a large batch of vectors have errors. https://replicate.com/p/ksmnnytbfsx7zbbfdeuyhkndva

```
{"logger": "cog.server.runner", "timestamp": "2023-09-23T06:42:37.904471Z", "exception": "Traceback (most recent call last):\n  File \"/root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/cog/server/runner.py\", line 113, in handle_error\n    raise error\n  File \"/root/.pyenv/versions/3.11.5/lib/python3.11/multiprocessing/pool.py\", line 125, in worker\n    result = (True, func(*args, **kwds))\n                    ^^^^^^^^^^^^^^^^^^^\n  File \"/root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/cog/server/runner.py\", line 334, in predict\n    return _predict(\n           ^^^^^^^^^\n  File \"/root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/cog/server/runner.py\", line 370, in _predict\n    for event in worker.predict(input_dict, poll=0.1):\n  File \"/root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/cog/server/worker.py\", line 118, in _wait\n    ev = self._events.recv()\n         ^^^^^^^^^^^^^^^^^^^\n  File \"/root/.pyenv/versions/3.11.5/lib/python3.11/multiprocessing/connection.py\", line 250, in recv\n    return _ForkingPickler.loads(buf.getbuffer())\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n_pickle.UnpicklingError: invalid load key, '\\x00'.", "severity": "ERROR", "message": "caught exception while running prediction"}
```

This seems to be a null byte where pickle is expecting an opcode ([load key](https://github.com/python/cpython/blob/3.11/Modules/_pickle.c#L6993)). I don't know that this error specifically related to pipe size, but we've had problems with large outputs before, and we may as well try this. 

I'm uncertain if I've put the fcntl in the right place though. 