### PR TITLE
Unhide dockerfile commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/term v0.5.0
 	github.com/spf13/cobra v1.7.0
-	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	github.com/vincent-petithory/dataurl v1.0.0
 	github.com/xeipuuv/gojsonschema v1.2.0
@@ -175,6 +174,7 @@ require (
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.13.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.1.1 // indirect

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/image"
@@ -91,9 +90,4 @@ func addUseCudaBaseImageFlag(cmd *cobra.Command) {
 
 func addDockerfileFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&buildDockerfileFile, "dockerfile", "", "Path to a Dockerfile. If set, cog will use this Dockerfile instead of generating one from cog.yaml")
-	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		if f.Name == "dockerfile" {
-			f.Hidden = true
-		}
-	})
 }

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -16,7 +16,7 @@ var imageName string
 func newDebugCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "debug",
-		Hidden: true,
+		Hidden: false,
 		Short:  "Generate a Dockerfile from " + global.ConfigFilename,
 		RunE:   cmdDockerfile,
 	}


### PR DESCRIPTION
As per https://github.com/replicate/cog/pull/1315#issuecomment-1733358324, cog debug is very useful as a starting point for --dockerfile. We should make both visible. 