### PR TITLE
fix updating pip in multistage cuda images

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -377,12 +377,7 @@ func (g *Generator) pipInstalls() string {
 	// ...except it's actually /root/.pyenv/versions/3.8.17/lib/python3.8/site-packages
 	py := g.Config.Build.PythonVersion
 	if g.Config.Build.GPU && g.useCudaBaseImage {
-		return strings.Join(
-			[]string{
-				"COPY --from=deps --link /dep /dep",
-				"RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages || true",
-			},
-			"\n")
+		return "RUN --mount=type=bind,from=deps,source=/dep,target=/dep cp -rf /dep/* $(pyenv prefix)/lib/python*/site-packages || true"
 	}
 	return "COPY --from=deps --link /dep /usr/local/lib/python" + py + "/site-packages"
 }

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -377,6 +377,9 @@ func (g *Generator) pipInstalls() string {
 	// ...except it's actually /root/.pyenv/versions/3.8.17/lib/python3.8/site-packages
 	py := g.Config.Build.PythonVersion
 	if g.Config.Build.GPU && g.useCudaBaseImage {
+		// this requires buildkit!
+		// we should check for buildkit and otherwise revert to symlinks or copying into /src
+		// we mount to avoid copying, which avoids having two copies in this layer
 		return "RUN --mount=type=bind,from=deps,source=/dep,target=/dep cp -rf /dep/* $(pyenv prefix)/lib/python*/site-packages || true"
 	}
 	return "COPY --from=deps --link /dep /usr/local/lib/python" + py + "/site-packages"

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -120,8 +120,7 @@ FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
-` + testTini() + testInstallPython("3.8") + `COPY --from=deps --link /dep /dep
-RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages || true
+` + testTini() + testInstallPython("3.8") + `RUN --mount=type=bind,from=deps,source=/dep,target=/dep cp -rf /dep/* $(pyenv prefix)/lib/python*/site-packages || true
 WORKDIR /src
 EXPOSE 5000
 CMD ["python", "-m", "cog.server.http"]
@@ -214,8 +213,7 @@ ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
 ` + testTini() +
 		testInstallPython("3.8") + `RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
-COPY --from=deps --link /dep /dep
-RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages || true
+RUN --mount=type=bind,from=deps,source=/dep,target=/dep cp -rf /dep/* $(pyenv prefix)/lib/python*/site-packages || true
 RUN cowsay moo
 WORKDIR /src
 EXPOSE 5000
@@ -366,8 +364,7 @@ ENV PYTHONUNBUFFERED=1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin
 ` + testTini() +
 		testInstallPython("3.8") + `RUN --mount=type=cache,target=/var/cache/apt apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
-COPY --from=deps --link /dep /dep
-RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages || true
+RUN --mount=type=bind,from=deps,source=/dep,target=/dep cp -rf /dep/* $(pyenv prefix)/lib/python*/site-packages || true
 RUN cowsay moo
 COPY --from=weights --link /src/checkpoints /src/checkpoints
 COPY --from=weights --link /src/models /src/models


### PR DESCRIPTION
### This PR

this replaces symlinks with hard copies using a buildkit feature, RUN --mount=type=bind,from=stage. the readme tells people they need buildx, but we should maybe still verify that buildkit is actually available (#1322), or find a different solution (e.g. somehow force pyenv to use a knowable site-packages location, or copy packages directly into /src)

I noted other options for resolving minor versions here: https://github.com/replicate/cog/pull/1233/commits/94ce8f046328249a6073b68eca67e2f5bd58e343

https://docs.docker.com/engine/reference/builder/#run---mounttypebind

---

### Error information

this is the relevant part of the previous dockerfile

```Dockerfile
FROM python:3.11 as deps
COPY .cog/tmp/build2042880849/cog-0.0.1.dev-py3-none-any.whl /tmp/cog-0.0.1.dev-py3-none-any.whl
RUN --mount=type=cache,target=/root/.cache/pip pip install -t /dep /tmp/cog-0.0.1.dev-py3-none-any.whl

FROM nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
...
COPY --from=deps --link /dep /dep
RUN ln --force -s /dep/* $(pyenv prefix)/lib/python*/site-packages || true
```

this error message when updating cog
```
# pip install -U cog==0.9.0b7
Installing collected packages: cog
  Attempting uninstall: cog
    Found existing installation: cog 0.9.0b7.dev0+gac3e15c.d20230928
    Uninstalling cog-0.9.0b7.dev0+gac3e15c.d20230928:
      Successfully uninstalled cog-0.9.0b7.dev0+gac3e15c.d20230928
      Rolling back uninstall of cog
  Moving to /dep/cog-0.9.0b7.dev0+gac3e15c.d20230928.dist-info/
   from /dep/~og-0.9.0b7.dev0+gac3e15c.d20230928.dist-info
  Moving to /dep/cog/
   from /dep/~og
  Moving to /dep/tests/
   from /dep/~ests
ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: '/root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/cog/.gitignore'
```

/root/.pyenv/versions/3.11.5/lib/python3.11/site-packages/cog is a symlink pointing to /dep/cog, and /dep/cog/.gitignore exists, so it's weird