### PR TITLE
support async predict functions 

### DIFF
--- a/python/cog/command/ast_openapi_schema.py
+++ b/python/cog/command/ast_openapi_schema.py
@@ -345,7 +345,7 @@ def get_call_name(call: ast.Call) -> str:
 def parse_args(tree: ast.AST) -> "list[tuple[ast.arg, ast.expr | Ellipsis]]":
     """Parse argument, default pairs from a file with a predict function"""
     predict = find(tree, "predict")
-    assert isinstance(predict, ast.FunctionDef)
+    assert isinstance(predict, (ast.FunctionDef, ast.AsyncFunctionDef))
     args = predict.args.args  # [-len(defaults) :]
     # use Ellipsis instead of None here to distinguish a default of None
     defaults = [...] * (len(args) - len(predict.args.defaults)) + predict.args.defaults
@@ -413,7 +413,7 @@ def resolve_name(node: ast.expr) -> str:
 
 def parse_return_annotation(tree: ast.AST, fn: str = "predict") -> "tuple[dict, dict]":
     predict = find(tree, fn)
-    if not isinstance(predict, ast.FunctionDef):
+    if not isinstance(predict, (ast.FunctionDef, ast.AsyncFunctionDef)):
         raise ValueError("Could not find predict function")
     annotation = predict.returns
     if not annotation:

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -5,7 +5,7 @@ import io
 import os.path
 import sys
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import Iterator, AsyncIterator
 from pathlib import Path
 from typing import (
     Any,
@@ -324,7 +324,7 @@ For example:
         OutputType = signature.return_annotation
 
     # The type that goes in the response is a list of the yielded type
-    if get_origin(OutputType) is Iterator:
+    if get_origin(OutputType) in {Iterator, AsyncIterator}:
         # Annotated allows us to attach Field annotations to the list, which we use to mark that this is an iterator
         # https://pydantic-docs.helpmanual.io/usage/schema/#typingannotated-fields
         OutputType = Annotated[List[get_args(OutputType)[0]], Field(**{"x-cog-array-type": "iterator"})]  # type: ignore

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -173,12 +173,7 @@ class _ChildWorker(_spawn.Process):  # type: ignore
         self._stream_redirector.start()
 
         self._setup()
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-        loop.run_until_complete(self._loop())
-
+        asyncio.run(self._loop())
         self._stream_redirector.shutdown()
 
     def _setup(self) -> None:

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import multiprocessing
 import os
@@ -125,9 +126,8 @@ class Worker:
         if done:
             if done.error and raise_on_error:
                 raise FatalWorkerException(raise_on_error + ": " + done.error_detail)
-            else:
-                self._state = WorkerState.READY
-                self._allow_cancel = False
+            self._state = WorkerState.READY
+            self._allow_cancel = False
 
         # If we dropped off the end off the end of the loop, check if it's
         # because the child process died.
@@ -208,7 +208,7 @@ class _ChildWorker(_spawn.Process):  # type: ignore
             ev = self._events.recv()
             if isinstance(ev, Shutdown):
                 break
-            elif isinstance(ev, PredictionInput):
+            if isinstance(ev, PredictionInput):
                 await self._predict(ev.payload)
             else:
                 print(f"Got unexpected event: {ev}", file=sys.stderr)

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -1,3 +1,4 @@
+import inspect
 import multiprocessing
 import os
 import signal
@@ -172,7 +173,11 @@ class _ChildWorker(_spawn.Process):  # type: ignore
         self._stream_redirector.start()
 
         self._setup()
-        self._loop()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+        loop.run_until_complete(self._loop())
 
         self._stream_redirector.shutdown()
 
@@ -198,17 +203,17 @@ class _ChildWorker(_spawn.Process):  # type: ignore
             self._stream_redirector.drain()
             self._events.send(done)
 
-    def _loop(self) -> None:
+    async def _loop(self) -> None:
         while True:
             ev = self._events.recv()
             if isinstance(ev, Shutdown):
                 break
             elif isinstance(ev, PredictionInput):
-                self._predict(ev.payload)
+                await self._predict(ev.payload)
             else:
                 print(f"Got unexpected event: {ev}", file=sys.stderr)
 
-    def _predict(self, payload: Dict[str, Any]) -> None:
+    async def _predict(self, payload: Dict[str, Any]) -> None:
         assert self._predictor
         done = Done()
         self._cancelable = True
@@ -217,10 +222,18 @@ class _ChildWorker(_spawn.Process):  # type: ignore
             result = predict(**payload)
 
             if result:
-                if isinstance(result, types.GeneratorType):
+                if inspect.isasyncgen(result):
+                    self._events.send(PredictionOutputType(multi=True))
+                    async for r in result:
+                        self._events.send(PredictionOutput(payload=make_encodeable(r)))
+                elif inspect.isgenerator(result):
                     self._events.send(PredictionOutputType(multi=True))
                     for r in result:
                         self._events.send(PredictionOutput(payload=make_encodeable(r)))
+                elif inspect.isawaitable(result):
+                    result = await result
+                    self._events.send(PredictionOutputType(multi=False))
+                    self._events.send(PredictionOutput(payload=make_encodeable(result)))
                 else:
                     self._events.send(PredictionOutputType(multi=False))
                     self._events.send(PredictionOutput(payload=make_encodeable(result)))

--- a/python/tests/server/fixtures/async_hello.py
+++ b/python/tests/server/fixtures/async_hello.py
@@ -1,0 +1,7 @@
+class Predictor:
+    def setup(self) -> None:
+        print("did setup")
+
+    async def predict(self, name: str) -> str:
+        print(f"hello, {name}")
+        return f"hello, {name}"

--- a/python/tests/server/fixtures/async_yield.py
+++ b/python/tests/server/fixtures/async_yield.py
@@ -1,0 +1,9 @@
+from typing import AsyncIterator
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    async def predict(self) -> AsyncIterator[str]:
+        yield "foo"
+        yield "bar"
+        yield "baz"

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -259,6 +259,22 @@ def test_openapi_specification_with_yield(client, static_schema):
     }
 
 
+@uses_predictor("async_yield")
+def test_openapi_specification_with_async_yield(client, static_schema):
+    resp = client.get("/openapi.json")
+    assert resp.status_code == 200
+    schema = resp.json()
+    assert schema == static_schema
+    assert schema["components"]["schemas"]["Output"] == {
+        "title": "Output",
+        "type": "array",
+        "items": {
+            "type": "string",
+        },
+        "x-cog-array-type": "iterator",
+    }
+
+
 @uses_predictor("yield_concatenate_iterator")
 def test_openapi_specification_with_yield_with_concatenate_iterator(
     client, static_schema
@@ -314,6 +330,15 @@ def test_openapi_specification_with_int_choices(client, static_schema):
         "title": "pick_a_number_any_number",
         "type": "integer",
     }
+
+
+@uses_predictor("async_yield")
+def test_yielding_strings_from_async_generator_predictors(client, match):
+    resp = client.post("/predictions")
+    assert resp.status_code == 200
+    assert resp.json() == match(
+        {"status": "succeeded", "output": ["foo", "bar", "baz"]}
+    )
 
 
 @uses_predictor("yield_strings")

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -56,6 +56,11 @@ OUTPUT_FIXTURES = [
         lambda x: f"hello, {x['name']}",
     ),
     (
+        "async_hello",
+        {"name": ST_NAMES},
+        lambda x: f"hello, {x['name']}",
+    ),
+    (
         "count_up",
         {"upto": st.integers(min_value=0, max_value=100)},
         lambda x: list(range(x["upto"])),


### PR DESCRIPTION
this is the first step towards supporting continuous batching and concurrent predictions. eventually, you will be configure it so your predict function will be called concurrently. this will work with engines that implement batching internally like vLLM and TRT, and allow users to implement things like microbatching on their own. it may also be possible to have truly concurrent predictions without batching at all by using cuda streams. 