### PR TITLE
Add support for `.glb`, `.mtl` and `.obj` files

### DIFF
--- a/pkg/util/mime/mime.go
+++ b/pkg/util/mime/mime.go
@@ -68,6 +68,10 @@ var typeToExtension = map[string]string{
 	"image/vnd.microsoft.icon": ".ico",
 	"image/webp":               ".webp",
 
+	"model/gltf-binary": ".glb",
+	"model/mtl":         ".mtl",
+	"model/obj":         ".obj",
+
 	"text/calendar":   ".ics",
 	"text/css":        ".css",
 	"text/csv":        ".csv",

--- a/pkg/util/mime/mime_test.go
+++ b/pkg/util/mime/mime_test.go
@@ -10,6 +10,7 @@ func TestExtensionByType(t *testing.T) {
 	require.Equal(t, ".txt", ExtensionByType("text/plain"))
 	require.Equal(t, ".jpg", ExtensionByType("image/jpeg"))
 	require.Equal(t, ".png", ExtensionByType("image/png"))
+	require.Equal(t, ".obj", ExtensionByType("model/obj"))
 	require.Equal(t, ".json", ExtensionByType("application/json"))
 	require.Equal(t, "", ExtensionByType("asdfasdf"))
 }
@@ -18,6 +19,7 @@ func TestTypeByExtension(t *testing.T) {
 	require.Equal(t, "text/plain", TypeByExtension(".txt"))
 	require.Equal(t, "image/jpeg", TypeByExtension(".jpg"))
 	require.Equal(t, "image/png", TypeByExtension(".png"))
+	require.Equal(t, "model/obj", TypeByExtension(".obj"))
 	require.Equal(t, "application/json", TypeByExtension(".json"))
 	require.Equal(t, "application/octet-stream", TypeByExtension(".asdfasdf"))
 }


### PR DESCRIPTION
This PR adds MIME type definitions some 3D assets.

| Content type | File extension |
|-|-|
| `model/gltf-binary` | `.glb` |
| `model/mtl` |         `.mtl` |
| `model/obj` |          `.obj`|