### PR TITLE
create event loop before predictor setup

### DIFF
--- a/python/cog/command/ast_openapi_schema.py
+++ b/python/cog/command/ast_openapi_schema.py
@@ -309,10 +309,15 @@ def find(obj: ast.AST, name: str) -> ast.AST:
     """Find a particular named node in a tree"""
     return next(node for node in ast.walk(obj) if getattr(node, "name", "") == name)
 
+
 if typing.TYPE_CHECKING:
-    AstVal: "typing.TypeAlias" = "int | float | complex | str | list[AstVal] | bytes | None"
+    AstVal: "typing.TypeAlias" = (
+        "int | float | complex | str | list[AstVal] | bytes | None"
+    )
     AstValNoBytes: "typing.TypeAlias" = "int | float | str | list[AstValNoBytes]"
-    JSONObject: "typing.TypeAlias" = "int | float | str | list[JSONObject] | JSONDict | None"
+    JSONObject: "typing.TypeAlias" = (
+        "int | float | str | list[JSONObject] | JSONDict | None"
+    )
     JSONDict: "typing.TypeAlias" = "dict[str, JSONObject]"
 
 
@@ -327,6 +332,7 @@ def to_serializable(val: "AstVal") -> "JSONObject":
     else:
         return val
 
+
 def get_value(node: ast.AST) -> "AstVal":
     """Return the value of constant or list of constants"""
     if isinstance(node, ast.Constant):
@@ -339,7 +345,7 @@ def get_value(node: ast.AST) -> "AstVal":
     if isinstance(node, (ast.List, ast.Tuple)):
         return [get_value(e) for e in node.elts]
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
-            return -typing.cast(typing.Union[int, float, complex], get_value(node.operand))
+        return -typing.cast(typing.Union[int, float, complex], get_value(node.operand))
     raise ValueError("Unexpected node type", type(node))
 
 
@@ -372,6 +378,7 @@ def parse_args(tree: ast.AST) -> "list[tuple[ast.arg, ast.expr | types.EllipsisT
     defaults = [...] * (len(args) - len(predict.args.defaults)) + predict.args.defaults
     return list(zip(args, defaults))
 
+
 def parse_assignment(assignment: ast.AST) -> "None | tuple[str, JSONObject]":
     """Parse an assignment into an OpenAPI object property"""
     if isinstance(assignment, ast.AnnAssign):
@@ -403,7 +410,9 @@ def parse_class(classdef: ast.AST) -> "JSONDict":
     """Parse a class definition into an OpenAPI object"""
     assert isinstance(classdef, ast.ClassDef)
     properties = {
-        assignment[0]: assignment[1] for assignment in map(parse_assignment, classdef.body) if assignment
+        assignment[0]: assignment[1]
+        for assignment in map(parse_assignment, classdef.body)
+        if assignment
     }
     return {
         "title": classdef.name,
@@ -428,7 +437,7 @@ def resolve_name(node: ast.expr) -> str:
         return node.id
     if isinstance(node, ast.Index):
         # deprecated, but needed for py3.8
-        return resolve_name(node.value) # type: ignore
+        return resolve_name(node.value)  # type: ignore
     if isinstance(node, ast.Attribute):
         return node.attr
     if isinstance(node, ast.Subscript):
@@ -436,7 +445,9 @@ def resolve_name(node: ast.expr) -> str:
     raise ValueError("Unexpected node type", type(node), ast.unparse(node))
 
 
-def parse_return_annotation(tree: ast.AST, fn: str = "predict") -> "tuple[JSONDict, JSONDict]":
+def parse_return_annotation(
+    tree: ast.AST, fn: str = "predict"
+) -> "tuple[JSONDict, JSONDict]":
     predict = find(tree, fn)
     if not isinstance(predict, (ast.FunctionDef, ast.AsyncFunctionDef)):
         raise ValueError("Could not find predict function")
@@ -550,7 +561,7 @@ def extract_info(code: str) -> "JSONDict":
         **return_schema,
     }
     # trust me, typechecker, I know BASE_SCHEMA
-    x: "JSONDict" = schema["components"]["schemas"] # type: ignore
+    x: "JSONDict" = schema["components"]["schemas"]  # type: ignore
     x.update(components)
     return schema
 

--- a/python/cog/command/ast_openapi_schema.py
+++ b/python/cog/command/ast_openapi_schema.py
@@ -366,7 +366,7 @@ def get_call_name(call: ast.Call) -> str:
 def parse_args(tree: ast.AST) -> "list[tuple[ast.arg, ast.expr | types.EllipsisType]]":
     """Parse argument, default pairs from a file with a predict function"""
     predict = find(tree, "predict")
-    assert isinstance(predict, ast.FunctionDef)
+    assert isinstance(predict, (ast.FunctionDef, ast.AsyncFunctionDef))
     args = predict.args.args  # [-len(defaults) :]
     # use Ellipsis instead of None here to distinguish a default of None
     defaults = [...] * (len(args) - len(predict.args.defaults)) + predict.args.defaults
@@ -438,7 +438,7 @@ def resolve_name(node: ast.expr) -> str:
 
 def parse_return_annotation(tree: ast.AST, fn: str = "predict") -> "tuple[JSONDict, JSONDict]":
     predict = find(tree, fn)
-    if not isinstance(predict, ast.FunctionDef):
+    if not isinstance(predict, (ast.FunctionDef, ast.AsyncFunctionDef)):
         raise ValueError("Could not find predict function")
     annotation = predict.returns
     if not annotation:

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -80,7 +80,7 @@ async def run_setup_async(predictor: BasePredictor) -> None:
         return await maybe_coro
 
 
-def get_weights_argument(predictor: BasePredictor) -> Union[io.IOBase, CogPath, None]:
+def get_weights_argument(predictor: BasePredictor) -> Union[CogFile, CogPath, None]:
     # by the time we get here we assume predictor has a setup method
     weights_type = get_weights_type(predictor.setup)
     if weights_type is None:
@@ -112,7 +112,7 @@ def get_weights_argument(predictor: BasePredictor) -> Union[io.IOBase, CogPath, 
     return None
 
 
-def get_weights_type(setup_function: Callable) -> Optional[Any]:
+def get_weights_type(setup_function: Callable[[Any], Optional[Awaitable[None]]]) -> Optional[Any]:
     signature = inspect.signature(setup_function)
     if "weights" not in signature.parameters:
         return None

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -6,7 +6,7 @@ import os.path
 import sys
 import types
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import Iterator, AsyncIterator
 from pathlib import Path
 from typing import (
     Any,
@@ -329,7 +329,7 @@ For example:
         OutputType = signature.return_annotation
 
     # The type that goes in the response is a list of the yielded type
-    if get_origin(OutputType) is Iterator:
+    if get_origin(OutputType) in {Iterator, AsyncIterator}:
         # Annotated allows us to attach Field annotations to the list, which we use to mark that this is an iterator
         # https://pydantic-docs.helpmanual.io/usage/schema/#typingannotated-fields
         OutputType: Type[BaseModel] = Annotated[List[get_args(OutputType)[0]], Field(**{"x-cog-array-type": "iterator"})]  # type: ignore

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -56,13 +56,16 @@ class Health(Enum):
     BUSY = auto()
     SETUP_FAILED = auto()
 
+
 class State:
     health: Health
     setup_result: "Optional[asyncio.Task[schema.PredictionResponse]]"
     setup_result_payload: Optional[schema.PredictionResponse]
 
+
 class MyFastAPI(FastAPI):
     state: State
+
 
 def create_app(
     config: Dict[str, Any],
@@ -95,6 +98,7 @@ def create_app(
 
     class PredictionRequest(schema.PredictionRequest.with_types(input_type=InputType)):
         pass
+
     PredictionResponse = schema.PredictionResponse.with_types(
         input_type=InputType, output_type=OutputType
     )
@@ -104,6 +108,7 @@ def create_app(
     if TYPE_CHECKING:
         P = ParamSpec("P")
         T = TypeVar("T")
+
     def limited(f: "Callable[P, Awaitable[T]]") -> "Callable[P, Awaitable[T]]":
         @functools.wraps(f)
         async def wrapped(*args: "P.args", **kwargs: "P.kwargs") -> "T":
@@ -148,7 +153,10 @@ def create_app(
         response_model=PredictionResponse,
         response_model_exclude_unset=True,
     )
-    async def predict(request: PredictionRequest = Body(default=None), prefer: Union[str, None] = Header(default=None)) -> Any:  # type: ignore
+    async def predict(
+        request: PredictionRequest = Body(default=None),
+        prefer: Union[str, None] = Header(default=None),
+    ) -> Any:  # type: ignore
         """
         Run a single prediction on the model
         """

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -35,7 +35,9 @@ class RunnerBusyError(Exception):
 class UnknownPredictionError(Exception):
     pass
 
+
 PredictionTask: "typing.TypeAlias" = "Task[schema.PredictionResponse]"
+
 
 class PredictionRunner:
     def __init__(
@@ -318,7 +320,7 @@ async def setup(*, worker: Worker) -> schema.PredictionResponse:
         logs="".join(logs),
         error=None,
         metrics=None,
-        status=status
+        status=status,
     )
 
 
@@ -405,7 +407,7 @@ async def _predict(
             else:
                 event_handler.set_output(event.payload)
 
-        elif isinstance(event, Done): # pyright: ignore reportUnnecessaryIsinstance
+        elif isinstance(event, Done):  # pyright: ignore reportUnnecessaryIsinstance
             if event.canceled:
                 event_handler.canceled()
             elif event.error:
@@ -413,7 +415,7 @@ async def _predict(
             else:
                 event_handler.succeeded()
 
-        else: # shouldn't happen, exhausted the type
+        else:  # shouldn't happen, exhausted the type
             log.warn("received unexpected event from worker", data=event)
 
     return event_handler.response

--- a/python/cog/server/webhook.py
+++ b/python/cog/server/webhook.py
@@ -37,7 +37,8 @@ SKIP_START_EVENT = _response_interval < 0.1
 
 
 def webhook_caller_filtered(
-    webhook: str, webhook_events_filter: Set[WebhookEvent],
+    webhook: str,
+    webhook_events_filter: Set[WebhookEvent],
 ) -> Callable[[Any, WebhookEvent], None]:
     upstream_caller = webhook_caller(webhook)
 

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import inspect
 import multiprocessing
 import os
@@ -8,7 +9,7 @@ import traceback
 import types
 from enum import Enum, auto, unique
 from multiprocessing.connection import Connection
-from typing import Any, Dict, Iterable, Optional, TextIO, Union
+from typing import Any, Dict, Iterator, Optional, TextIO, Union
 
 from ..json import make_encodeable
 from ..predictor import (
@@ -58,7 +59,7 @@ class Worker:
         self._child = _ChildWorker(predictor_ref, child_events, tee_output)
         self._terminating = False
 
-    def setup(self) -> Iterable[_PublicEventType]:
+    def setup(self) -> Iterator[_PublicEventType]:
         self._assert_state(WorkerState.NEW)
         self._state = WorkerState.STARTING
         self._child.start()
@@ -67,7 +68,7 @@ class Worker:
 
     def predict(
         self, payload: Dict[str, Any], poll: Optional[float] = None
-    ) -> Iterable[_PublicEventType]:
+    ) -> Iterator[_PublicEventType]:
         self._assert_state(WorkerState.READY)
         self._state = WorkerState.PROCESSING
         self._allow_cancel = True
@@ -108,7 +109,7 @@ class Worker:
 
     def _wait(
         self, poll: Optional[float] = None, raise_on_error: Optional[str] = None
-    ) -> Iterable[_PublicEventType]:
+    ) -> Iterator[_PublicEventType]:
         done = None
 
         if poll:
@@ -178,15 +179,21 @@ class _ChildWorker(_spawn.Process):  # type: ignore
             [ws_stdout, ws_stderr], self._stream_write_hook
         )
         self._stream_redirector.start()
-
         self._setup()
-        asyncio.run(self._loop())
+        self._loop()
         self._stream_redirector.shutdown()
 
     def _setup(self) -> None:
-        done = Done()
-        try:
+        with self._handle_setup_error():
+            # we need to load the predictor to know if setup is async
             self._predictor = load_predictor_from_ref(self._predictor_ref)
+            # if users want to access the same event loop from setup and predict,
+            # both have to be async. if setup isn't async, it doesn't matter if we
+            # create the event loop here or after setup
+            #
+            # otherwise, if setup is sync and the user does new_event_loop to use a ClientSession,
+            # then tries to use the same session from async predict, they would get an error.
+            # that's significant if connections are open and would need to be discarded
             if is_async_predictor(self._predictor):
                 self.loop = get_loop()
             # Could be a function or a class
@@ -195,6 +202,12 @@ class _ChildWorker(_spawn.Process):  # type: ignore
                     self.loop.run_until_complete(run_setup_async(self._predictor))
                 else:
                     run_setup(self._predictor)
+
+    @contextlib.contextmanager
+    def _handle_setup_error(self) -> Iterator[None]:
+        done = Done()
+        try:
+            yield
         except Exception as e:
             traceback.print_exc()
             done.error = True
@@ -210,40 +223,39 @@ class _ChildWorker(_spawn.Process):  # type: ignore
             self._stream_redirector.drain()
             self._events.send(done)
 
-    async def _loop(self) -> None:
+    def _loop_sync(self) -> None:
         while True:
             ev = self._events.recv()
             if isinstance(ev, Shutdown):
                 break
             if isinstance(ev, PredictionInput):
-                await self._predict(ev.payload)
+                self._predict_sync(ev.payload)
             else:
                 print(f"Got unexpected event: {ev}", file=sys.stderr)
 
-    async def _predict(self, payload: Dict[str, Any]) -> None:
+    async def _loop_async(self) -> None:
+        while True:
+            ev = self._events.recv()
+            if isinstance(ev, Shutdown):
+                break
+            if isinstance(ev, PredictionInput):
+                await self._predict_async(ev.payload)
+            else:
+                print(f"Got unexpected event: {ev}", file=sys.stderr)
+
+    def _loop(self) -> None:
+        if is_async(get_predict(self._predictor)):
+            self.loop.run_until_complete(self._loop_async())
+        else:
+            self._loop_sync()
+
+    @contextlib.contextmanager
+    def _handle_predict_error(self) -> Iterator[None]:
         assert self._predictor
         done = Done()
         self._cancelable = True
         try:
-            predict = get_predict(self._predictor)
-            result = predict(**payload)
-
-            if result:
-                if inspect.isasyncgen(result):
-                    self._events.send(PredictionOutputType(multi=True))
-                    async for r in result:
-                        self._events.send(PredictionOutput(payload=make_encodeable(r)))
-                elif inspect.isgenerator(result):
-                    self._events.send(PredictionOutputType(multi=True))
-                    for r in result:
-                        self._events.send(PredictionOutput(payload=make_encodeable(r)))
-                elif inspect.isawaitable(result):
-                    result = await result
-                    self._events.send(PredictionOutputType(multi=False))
-                    self._events.send(PredictionOutput(payload=make_encodeable(result)))
-                else:
-                    self._events.send(PredictionOutputType(multi=False))
-                    self._events.send(PredictionOutput(payload=make_encodeable(result)))
+            yield
         except CancelationException:
             done.canceled = True
         except Exception as e:
@@ -254,6 +266,33 @@ class _ChildWorker(_spawn.Process):  # type: ignore
             self._cancelable = False
         self._stream_redirector.drain()
         self._events.send(done)
+
+    async def _predict_async(self, payload: Dict[str, Any]) -> None:
+        with self._handle_predict_error():
+            predict = get_predict(self._predictor)
+            result = predict(**payload)
+            if result:
+                if inspect.isasyncgen(result):
+                    self._events.send(PredictionOutputType(multi=True))
+                    async for r in result:
+                        self._events.send(PredictionOutput(payload=make_encodeable(r)))
+                elif inspect.isawaitable(result):
+                    result = await result
+                    self._events.send(PredictionOutputType(multi=False))
+                    self._events.send(PredictionOutput(payload=make_encodeable(result)))
+
+    def _predict_sync(self, payload: Dict[str, Any]) -> None:
+        with self._handle_predict_error():
+            predict = get_predict(self._predictor)
+            result = predict(**payload)
+            if result:
+                if inspect.isgenerator(result):
+                    self._events.send(PredictionOutputType(multi=True))
+                    for r in result:
+                        self._events.send(PredictionOutput(payload=make_encodeable(r)))
+                else:
+                    self._events.send(PredictionOutputType(multi=False))
+                    self._events.send(PredictionOutput(payload=make_encodeable(result)))
 
     def _signal_handler(self, signum: int, frame: Optional[types.FrameType]) -> None:
         if signum == signal.SIGUSR1 and self._cancelable:
@@ -270,13 +309,16 @@ class _ChildWorker(_spawn.Process):  # type: ignore
 
 def get_loop() -> asyncio.AbstractEventLoop:
     try:
+        # just in case something else created an event loop already
         return asyncio.get_running_loop()
     except RuntimeError:
         return asyncio.new_event_loop()
 
 
+def is_async(fn: Any) -> bool:
+    return inspect.iscoroutinefunction(fn) or inspect.isasyncgenfunction(fn)
+
+
 def is_async_predictor(predictor: BasePredictor) -> bool:
-    predict = get_predict(predictor)
-    if inspect.iscoroutinefunction(predict) or inspect.isasyncgenfunction(predict):
-        return True
-    return inspect.iscoroutinefunction(getattr(predictor, "setup", None))
+    setup = getattr(predictor, "setup", None)
+    return is_async(setup) or is_async(get_predict(predictor))

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -1,3 +1,5 @@
+import asyncio
+import inspect
 import multiprocessing
 import os
 import signal
@@ -125,9 +127,8 @@ class Worker:
         if done:
             if done.error and raise_on_error:
                 raise FatalWorkerException(raise_on_error + ": " + done.error_detail)
-            else:
-                self._state = WorkerState.READY
-                self._allow_cancel = False
+            self._state = WorkerState.READY
+            self._allow_cancel = False
 
         # If we dropped off the end off the end of the loop, check if it's
         # because the child process died.
@@ -173,8 +174,7 @@ class _ChildWorker(_spawn.Process):  # type: ignore
         self._stream_redirector.start()
 
         self._setup()
-        self._loop()
-
+        asyncio.run(self._loop())
         self._stream_redirector.shutdown()
 
     def _setup(self) -> None:
@@ -199,17 +199,17 @@ class _ChildWorker(_spawn.Process):  # type: ignore
             self._stream_redirector.drain()
             self._events.send(done)
 
-    def _loop(self) -> None:
+    async def _loop(self) -> None:
         while True:
             ev = self._events.recv()
             if isinstance(ev, Shutdown):
                 break
-            elif isinstance(ev, PredictionInput):
-                self._predict(ev.payload)
+            if isinstance(ev, PredictionInput):
+                await self._predict(ev.payload)
             else:
                 print(f"Got unexpected event: {ev}", file=sys.stderr)
 
-    def _predict(self, payload: Dict[str, Any]) -> None:
+    async def _predict(self, payload: Dict[str, Any]) -> None:
         assert self._predictor
         done = Done()
         self._cancelable = True
@@ -218,10 +218,18 @@ class _ChildWorker(_spawn.Process):  # type: ignore
             result = predict(**payload)
 
             if result:
-                if isinstance(result, types.GeneratorType):
+                if inspect.isasyncgen(result):
+                    self._events.send(PredictionOutputType(multi=True))
+                    async for r in result:
+                        self._events.send(PredictionOutput(payload=make_encodeable(r)))
+                elif inspect.isgenerator(result):
                     self._events.send(PredictionOutputType(multi=True))
                     for r in result:
                         self._events.send(PredictionOutput(payload=make_encodeable(r)))
+                elif inspect.isawaitable(result):
+                    result = await result
+                    self._events.send(PredictionOutputType(multi=False))
+                    self._events.send(PredictionOutput(payload=make_encodeable(result)))
                 else:
                     self._events.send(PredictionOutputType(multi=False))
                     self._events.send(PredictionOutput(payload=make_encodeable(result)))

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -97,7 +97,11 @@ class Worker:
             self._child.join()
 
     def cancel(self) -> None:
-        if self._allow_cancel and self._child.is_alive() and self._child.pid is not None:
+        if (
+            self._allow_cancel
+            and self._child.is_alive()
+            and self._child.pid is not None
+        ):
             os.kill(self._child.pid, signal.SIGUSR1)
             self._allow_cancel = False
 

--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -261,11 +261,11 @@ class ConcatenateIterator(Iterator[Item]):
         return value
 
 
-def _len_bytes(s: str, encoding: str="utf-8") -> int:
+def _len_bytes(s: str, encoding: str = "utf-8") -> int:
     return len(s.encode(encoding))
 
 
-def _truncate_filename_bytes(s: str, length: int, encoding: str="utf-8") -> str:
+def _truncate_filename_bytes(s: str, length: int, encoding: str = "utf-8") -> str:
     """
     Truncate a filename to at most `length` bytes, preserving file extension
     and avoiding text encoding corruption from truncation.

--- a/python/tests/server/fixtures/async_hello.py
+++ b/python/tests/server/fixtures/async_hello.py
@@ -1,0 +1,7 @@
+class Predictor:
+    def setup(self) -> None:
+        print("did setup")
+
+    async def predict(self, name: str) -> str:
+        print(f"hello, {name}")
+        return f"hello, {name}"

--- a/python/tests/server/fixtures/async_setup_uses_same_loop_as_predict.py
+++ b/python/tests/server/fixtures/async_setup_uses_same_loop_as_predict.py
@@ -1,0 +1,8 @@
+import asyncio
+
+class Predictor:
+    async def setup(self) -> None:
+        self.loop = asyncio.get_running_loop()
+
+    async def predict(self) -> bool:
+        return self.loop == asyncio.get_running_loop()

--- a/python/tests/server/fixtures/async_yield.py
+++ b/python/tests/server/fixtures/async_yield.py
@@ -1,0 +1,9 @@
+from typing import AsyncIterator
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    async def predict(self) -> AsyncIterator[str]:
+        yield "foo"
+        yield "bar"
+        yield "baz"

--- a/python/tests/server/fixtures/setup_uses_async.py
+++ b/python/tests/server/fixtures/setup_uses_async.py
@@ -1,0 +1,11 @@
+import asyncio
+
+class Predictor:
+    async def download(self) -> None:
+        print("setup used asyncio.run! it's not very effective...")
+
+    def setup(self) -> None:
+        asyncio.run(self.download())
+
+    def predict(self) -> str:
+        return "output"

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -259,6 +259,22 @@ def test_openapi_specification_with_yield(client, static_schema):
     }
 
 
+@uses_predictor("async_yield")
+def test_openapi_specification_with_async_yield(client, static_schema):
+    resp = client.get("/openapi.json")
+    assert resp.status_code == 200
+    schema = resp.json()
+    assert schema == static_schema
+    assert schema["components"]["schemas"]["Output"] == {
+        "title": "Output",
+        "type": "array",
+        "items": {
+            "type": "string",
+        },
+        "x-cog-array-type": "iterator",
+    }
+
+
 @uses_predictor("yield_concatenate_iterator")
 def test_openapi_specification_with_yield_with_concatenate_iterator(
     client, static_schema
@@ -314,6 +330,15 @@ def test_openapi_specification_with_int_choices(client, static_schema):
         "title": "pick_a_number_any_number",
         "type": "integer",
     }
+
+
+@uses_predictor("async_yield")
+def test_yielding_strings_from_async_generator_predictors(client, match):
+    resp = client.post("/predictions")
+    assert resp.status_code == 200
+    assert resp.json() == match(
+        {"status": "succeeded", "output": ["foo", "bar", "baz"]}
+    )
 
 
 @uses_predictor("yield_strings")

--- a/python/tests/server/test_runner.py
+++ b/python/tests/server/test_runner.py
@@ -199,6 +199,7 @@ def fake_worker(events):
 
     return FakeWorker()
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("events,calls", PREDICT_TESTS)
 async def test_predict(events, calls):

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -56,6 +56,11 @@ OUTPUT_FIXTURES = [
         lambda x: f"hello, {x['name']}",
     ),
     (
+        "async_hello",
+        {"name": ST_NAMES},
+        lambda x: f"hello, {x['name']}",
+    ),
+    (
         "count_up",
         {"upto": st.integers(min_value=0, max_value=100)},
         lambda x: list(range(x["upto"])),

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -66,6 +66,7 @@ OUTPUT_FIXTURES = [
         lambda x: list(range(x["upto"])),
     ),
     ("complex_output", {}, lambda _: {"number": 42, "text": "meaning of life"}),
+    ("async_setup_uses_same_loop_as_predict", {}, lambda _: True),
 ]
 
 SETUP_LOGS_FIXTURES = [
@@ -77,7 +78,8 @@ SETUP_LOGS_FIXTURES = [
             "setting up predictor\n"
         ),
         "writing to stderr at import time\n",
-    )
+    ),
+    ("setup_uses_async", "setup used asyncio.run! it's not very effective...\n", ""),
 ]
 
 PREDICT_LOGS_FIXTURES = [


### PR DESCRIPTION
The current implementation (prior to #1350)  throws an error:
```
Traceback (most recent call last):
File "/usr/local/lib/python3.11/site-packages/cog/server/worker.py", line 226, in _predict
for r in result:
...
File "/src/src/download.py", line 118, in sync_download_file
return self.loop.run_until_complete(self.download_file(url))
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/asyncio/base_events.py", line 629, in run_until_complete
self._check_running()
File "/usr/local/lib/python3.11/asyncio/base_events.py", line 590, in _check_running
raise RuntimeError(
RuntimeError: Cannot run the event loop while another loop is running
```

The problem is that llama's [setup()](https://github.com/replicate/cog-llama-template/blob/main/predict.py#L35) creates a Downloader, which [can't find an event loop and creates one](https://github.com/replicate/cog-llama-template/blob/main/src/download.py#L21-L24), then tries to use that loop in predict, and by that time `_ChildWorker.run` has used `asyncio.run`

This solves that specific problem, and since we didn't see any other errors besides llama maybe few other models use an event loop. However, we may want/need to consider moving the check where we inspect if `predict()` is async earlier, and have more separate code paths so that we don't need to be async if the user isn't using the async feature. On the other hand, doing that could get messy and involve a lot of duplicated code, so if we're sure our users use `asyncio.get_running_loop` and not `asyncio.create_event_loop`, it would be best to not do that.