### PR TITLE
tweak schema file console message

### DIFF
--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -89,10 +89,9 @@ func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache,
 		}
 	}
 
-	console.Info("Validating model schema...")
-
 	var schemaJSON []byte
 	if schemaFile != "" {
+		console.Infof("Validating model schema from %s...", schemaFile)
 		data, err := os.ReadFile(schemaFile)
 		if err != nil {
 			return fmt.Errorf("Failed to read schema file: %w", err)
@@ -100,6 +99,7 @@ func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache,
 
 		schemaJSON = data
 	} else {
+		console.Info("Validating model schema...")
 		schema, err := GenerateOpenAPISchema(imageName, cfg.Build.GPU)
 		if err != nil {
 			return fmt.Errorf("Failed to get type signature: %w", err)


### PR DESCRIPTION
"Validating model schema..." is a kind of confusing message when we're reading from a file. The llama repo uses several schema files, logging which one is being used is a better use of that line in the progress output
