### PR TITLE
Get faster initial output from latency-sensitive models

### DIFF
--- a/python/cog/server/webhook.py
+++ b/python/cog/server/webhook.py
@@ -32,6 +32,11 @@ def _get_version() -> str:
 _user_agent = f"cog-worker/{_get_version()}"
 _response_interval = float(os.environ.get("COG_THROTTLE_RESPONSE_INTERVAL", 0.5))
 
+# HACK: signal that we should skip the start webhook when the response interval
+# is tuned below 100ms. This should help us get output sooner for models that
+# are latency sensitive.
+SKIP_START_EVENT = _response_interval < 0.1
+
 
 def webhook_caller_filtered(
     webhook: str, webhook_events_filter: Set[WebhookEvent]


### PR DESCRIPTION
This is a bit of a hack, but it should help us get output sooner from models that are latency-sensitive and return their first output very shortly after prediction start.

If COG_THROTTLE_RESPONSE_INTERVAL is set to a value below 0.1 (i.e. <100ms), don't sent the initial "start" webhook. This should mean that the first output webhook will be sent as soon as it is received. Without this, there is a risk that it will be throttled by the ResponseThrottler.