### PR TITLE
Makefile: don't hardcode bash path and use the one from PATH instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := bash
 
 DESTDIR ?=
 PREFIX = /usr/local


### PR DESCRIPTION
My `bash` doesn't live in `/bin`, so the Makefile doesn't work for me. However, `bash` is in the `PATH`, so look it up from there.