### PR TITLE
cog predict: check output path writability before predict/train

### DIFF
--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -221,7 +221,7 @@ func predictIndividualInputs(predictor predict.Predictor, inputFlags []string, o
 
 	prediction, err := predictor.Predict(inputs)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to predict: %w", err)
 	}
 
 	if isURI(outputSchema) {

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -336,16 +336,19 @@ func writeDataURLOutput(outputString string, outputPath string, addExtension boo
 	if err != nil {
 		return fmt.Errorf("Failed to decode dataurl: %w", err)
 	}
-	out := dataurlObj.Data
+	output := dataurlObj.Data
+
 	if addExtension {
 		extension := mime.ExtensionByType(dataurlObj.ContentType())
 		if extension != "" {
 			outputPath += extension
 		}
 	}
-	if err := writeOutput(outputPath, out); err != nil {
+
+	if err := writeOutput(outputPath, output); err != nil {
 		return err
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
`cog train` failed after 30 minutes with "weights: is a directory".
I refactored `predictIndividualInputs` so it checks output file writability if the path is known.