### PR TITLE
[#1349] Show information about `cog debug` in output of `cog help`

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -15,9 +15,9 @@ var imageName string
 
 func newDebugCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "debug",
-		Short:  "Generate a Dockerfile from " + global.ConfigFilename,
-		RunE:   cmdDockerfile,
+		Use:   "debug",
+		Short: "Generate a Dockerfile from " + global.ConfigFilename,
+		RunE:  cmdDockerfile,
 	}
 
 	addSeparateWeightsFlag(cmd)

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -16,7 +16,6 @@ var imageName string
 func newDebugCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "debug",
-		Hidden: true,
 		Short:  "Generate a Dockerfile from " + global.ConfigFilename,
 		RunE:   cmdDockerfile,
 	}


### PR DESCRIPTION
Minor; one-liner: Unhide CLI documentation about `cog debug` when running `cog help|-h`.