### PR TITLE
use a more realistic registry URL in cog push usage

### DIFF
--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -18,7 +18,7 @@ func newPushCommand() *cobra.Command {
 		Use: "push [IMAGE]",
 
 		Short:   "Build and push model in current directory to a Docker registry",
-		Example: `cog push registry.hooli.corp/hotdog-detector`,
+		Example: `cog push r8.im/your-username/hotdog-detector`,
 		RunE:    push,
 		Args:    cobra.MaximumNArgs(1),
 	}
@@ -45,7 +45,7 @@ func push(cmd *cobra.Command, args []string) error {
 	}
 
 	if imageName == "" {
-		return fmt.Errorf("To push images, you must either set the 'image' option in cog.yaml or pass an image name as an argument. For example, 'cog push registry.hooli.corp/hotdog-detector'")
+		return fmt.Errorf("To push images, you must either set the 'image' option in cog.yaml or pass an image name as an argument. For example, 'cog push r8.im/your-username/hotdog-detector'")
 	}
 
 	if err := image.Build(cfg, projectDir, imageName, buildSecrets, buildNoCache, buildSeparateWeights, buildUseCudaBaseImage, buildProgressOutput, buildSchemaFile, buildDockerfileFile); err != nil {


### PR DESCRIPTION
It's nice that Cog can push to any Docker registry, so it makes sense that this could be "any URL", but most users will be pushing to Replicate's model registry. This change updates the usage to give more of a hint of what kind of URL they should be constructing.