### PR TITLE
Mux prediction events

### DIFF
--- a/python/cog/server/eventtypes.py
+++ b/python/cog/server/eventtypes.py
@@ -1,3 +1,4 @@
+import secrets
 from typing import Any, Dict
 
 from attrs import define, field, validators
@@ -8,6 +9,7 @@ from attrs import define, field, validators
 @define
 class PredictionInput:
     payload: Dict[str, Any]
+    id: str = field(factory=lambda: secrets.token_hex(4))
 
 
 @define

--- a/python/cog/server/helpers.py
+++ b/python/cog/server/helpers.py
@@ -196,8 +196,11 @@ async def race(
 # functionally this is the exact same thing as aioprocessing but 0.1% the code
 # however it's still worse than just using actual asynchronous io
 class AsyncPipe(Generic[X]):
-    def __init__(self, conn: Connection) -> None:
+    def __init__(
+        self, conn: Connection, alive: Callable[[], bool] = lambda: True
+    ) -> None:
         self.conn = conn
+        self.alive = alive
         self.exiting = threading.Event()
         self.executor = concurrent.futures.ThreadPoolExecutor(1)
 
@@ -216,8 +219,11 @@ class AsyncPipe(Generic[X]):
     def _recv(self) -> Optional[X]:
         # this ugly mess could easily be avoided with loop.connect_read_pipe
         # even loop.add_reader would help but we don't want to mess with a thread-local loop
-        while not self.exiting.is_set():
+        while not self.exiting.is_set() and not self.conn.closed and self.alive():
             if self.conn.poll(0.01):
+                if self.conn.closed or not self.alive():
+                    print("caught conn closed or unalive")
+                    return
                 return self.conn.recv()
         return None
 

--- a/python/cog/server/helpers.py
+++ b/python/cog/server/helpers.py
@@ -206,7 +206,7 @@ class AsyncPipe(Generic[X]):
 
     def shutdown(self) -> None:
         self.exiting.set()
-        self.executor.shutdown(wait=False)
+        self.executor.shutdown(wait=True)
         # if we ever need cancel_futures (introduced 3.9), we can copy it in from
         # https://github.com/python/cpython/blob/3.11/Lib/concurrent/futures/thread.py#L216-L235
 

--- a/python/cog/server/helpers.py
+++ b/python/cog/server/helpers.py
@@ -225,3 +225,8 @@ class AsyncPipe(Generic[X]):
         loop = asyncio.get_running_loop()
         # believe it or not this can still deadlock!
         return await loop.run_in_executor(self.executor, self._recv)
+
+    async def coro_recv_with_exit(self, exit: asyncio.Event) -> Optional[X]:
+        result = await race(self.coro_recv(), exit.wait())
+        if result is not True:  # wait() would return True
+            return result

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -157,7 +157,7 @@ class Worker:
         return self._state not in {WorkerState.PROCESSING, WorkerState.IDLE}
 
     @contextlib.asynccontextmanager
-    async def prediction_ctx(self, input: PredictionInput) -> AsyncIterator[None]:
+    async def _prediction_ctx(self, input: PredictionInput) -> AsyncIterator[None]:
         async with self._semaphore:
             self._predictions_in_flight.add(input.id)  # idempotent ig
             self._state = self.state_from_predictions_in_flight()
@@ -184,7 +184,7 @@ class Worker:
         self._state = self.state_from_predictions_in_flight()
 
         async def inner() -> AsyncIterator[_PublicEventType]:
-            async with self.prediction_ctx(input):
+            async with self._prediction_ctx(input):
                 self._events.send(input)
                 async for event in self._mux.read(input.id, poll=poll):
                     yield event

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -46,7 +46,7 @@ _PublicEventType = Union[Done, Heartbeat, Log, PredictionOutput, PredictionOutpu
 class WorkerState(Enum):
     NEW = auto()
     STARTING = auto()
-    READY = auto()
+    IDLE = auto()
     PROCESSING = auto()
     DEFUNCT = auto()
 
@@ -87,9 +87,13 @@ class Mux:
 
 
 class Worker:
-    def __init__(self, predictor_ref: str, tee_output: bool = True) -> None:
+    def __init__(
+        self, predictor_ref: str, tee_output: bool = True, concurrent: int = 1
+    ) -> None:
         self._state = WorkerState.NEW
         self._allow_cancel = False
+        self._semaphore = asyncio.Semaphore(concurrent)
+        self._concurrent = concurrent
 
         # A pipe with which to communicate with the child worker.
         events, child_events = _spawn.Pipe()
@@ -110,10 +114,24 @@ class Worker:
             self._ensure_event_reader()
             async for event in self._mux.read("SETUP", poll=0.1):
                 yield event
-                if isinstance(event, Done) and event.error:
-                    raise FatalWorkerException(
-                        "Predictor errored during setup: " + event.error_detail
-                    )
+                if isinstance(event, Done):
+                    if event.error:
+                        raise FatalWorkerException(
+                            "Predictor errored during setup: " + event.error_detail
+                        )
+                    self._state = WorkerState.IDLE
+                    self._allow_cancel = False
+
+        return inner()
+
+    @contextlib.asynccontextmanager
+    async def prediction_ctx(self) -> AsyncIterator[None]:
+        async with self._semaphore:
+            self._allow_cancel = True
+            yield
+        if self._semaphore._value == self._concurrent:
+            self._state = WorkerState.IDLE
+            self._allow_cancel = False
 
     def predict(
         self, payload: Dict[str, Any], poll: Optional[float] = None
@@ -124,11 +142,16 @@ class Worker:
             )
         self._assert_state(WorkerState.READY)
         self._state = WorkerState.PROCESSING
-        self._allow_cancel = True
-        input = PredictionInput(payload=payload)
-        self._events.send(input)
 
-        return self._wait(poll=poll)
+        async def inner() -> AsyncIterator[_PublicEventType]:
+            async with self.prediction_ctx():
+                input = PredictionInput(payload=payload)
+                self._events.send(input)
+                self._ensure_event_reader()
+                async for event in self._mux.read(input.id, poll=poll):
+                    yield event
+
+        return inner()
 
     def shutdown(self) -> None:
         if self._state == WorkerState.DEFUNCT:

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -100,8 +100,10 @@ class Worker:
 
         # A pipe with which to communicate with the child worker.
         events, child_events = _spawn.Pipe()
-        self._events: "AsyncPipe[tuple[str, _PublicEventType]]" = AsyncPipe(events)
         self._child = _ChildWorker(predictor_ref, child_events, tee_output)
+        self._events: "AsyncPipe[tuple[str, _PublicEventType]]" = AsyncPipe(
+            events, self._child.is_alive
+        )
         # shutdown requested
         self._shutting_down = False
         # stop reading events

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -52,10 +52,11 @@ class WorkerState(Enum):
 
 
 class Mux:
-    def __init__(self) -> None:
-        self.outs: defaultdict[str, asyncio.Queue[_PublicEventType]] = defaultdict(
+    def __init__(self, terminating: asyncio.Event) -> None:
+        self.outs: "defaultdict[str, asyncio.Queue[_PublicEventType]]" = defaultdict(
             asyncio.Queue
         )
+        self.terminating = terminating
 
     async def write(self, id: str, item: _PublicEventType) -> None:
         await self.outs[id].put(item)
@@ -78,8 +79,8 @@ class Worker:
         events, child_events = _spawn.Pipe()
         self._events: "AsyncPipe[tuple[str, _PublicEventType]]" = AsyncPipe(events)
         self._child = _ChildWorker(predictor_ref, child_events, tee_output)
-        self._terminating = False
-        self._mux = Mux()
+        self._terminating = asyncio.Event()
+        self._mux = Mux(self._terminating)
 
     def setup(self) -> AsyncIterator[_PublicEventType]:
         self._assert_state(WorkerState.NEW)
@@ -103,7 +104,7 @@ class Worker:
         if self._state == WorkerState.DEFUNCT:
             return
 
-        self._terminating = True
+        self._terminating.set()
 
         if self._child.is_alive():
             self._events.send(Shutdown())
@@ -112,7 +113,7 @@ class Worker:
         if self._state == WorkerState.DEFUNCT:
             return
 
-        self._terminating = True
+        self._terminating.set()
         self._state = WorkerState.DEFUNCT
 
         if self._child.is_alive():
@@ -188,7 +189,7 @@ class Worker:
 
         # If we dropped off the end off the end of the loop, check if it's
         # because the child process died.
-        if not self._child.is_alive() and not self._terminating:
+        if not self._child.is_alive() and not self._terminating.is_set():
             exitcode = self._child.exitcode
             raise FatalWorkerException(
                 f"Prediction failed for an unknown reason. It might have run out of memory? (exitcode {exitcode})"

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -117,6 +117,11 @@ class Worker:
         self._state = WorkerState.STARTING
 
         async def inner() -> AsyncIterator[_PublicEventType]:
+            # in 3.10 Event started doing get_running_loop
+            # previously it stored the loop when created, which causes an error in tests
+            if sys.version_info < (3, 10):
+                self._terminating = self._mux.terminating = asyncio.Event()
+
             self._child.start()
             self._ensure_event_reader()
             async for event in self._mux.read("SETUP", poll=0.1):
@@ -228,12 +233,6 @@ class Worker:
             self._read_events_task.add_done_callback(handle_error)
 
     async def _read_events(self) -> None:
-        # in 3.10 Event started doing get_running_loop
-        # previously it stored the loop when created, which causes an error in tests
-        if sys.version_info < (3, 10):
-            self._terminating = asyncio.Event()
-            self._mux.terminating = self._terminating
-
         while self._child.is_alive() and not self._terminating.is_set():
             # this can still be running when the task is destroyed
             result = await self._events.coro_recv_with_exit(self._terminating)

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -48,6 +48,7 @@ class WorkerState(Enum):
     STARTING = auto()
     IDLE = auto()
     PROCESSING = auto()
+    BUSY = auto()
     DEFUNCT = auto()
 
 
@@ -132,6 +133,9 @@ class Worker:
     @contextlib.asynccontextmanager
     async def prediction_ctx(self, input: PredictionInput) -> AsyncIterator[None]:
         async with self._semaphore:
+            if self._semaphore._value == 0:
+                # maybe this will fix hypothesis
+                self._state = WorkerState.BUSY
             self._allow_cancel = True
             self._predictions_in_flight.add(input.id)
             try:
@@ -141,6 +145,9 @@ class Worker:
         if self._semaphore._value == self._concurrent:
             self._state = WorkerState.IDLE
             self._allow_cancel = False
+        else:
+            # we just finished a prediction, so if we were BUSY we aren't anymore
+            self._state = WorkerState.PROCESSING
 
     def predict(
         self, payload: Dict[str, Any], poll: Optional[float] = None

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -209,6 +209,12 @@ class Worker:
             self._read_events_task.add_done_callback(handle_error)
 
     async def _read_events(self) -> None:
+        # in 3.10 Event started doing get_running_loop
+        # previously it stored the loop when created, which causes an error in tests
+        if sys.version_info < (3, 10):
+            self._terminating = asyncio.Event()
+            self._mux.terminating = self._terminating
+
         while self._child.is_alive() and not self._terminating.is_set():
             # this can still be running when the task is destroyed
             result = await self._events.coro_recv_with_exit(self._terminating)

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -285,6 +285,7 @@ class _ChildWorker(_spawn.Process):  # type: ignore
         self._setup()
         self._loop()
         self._stream_redirector.shutdown()
+        self._events.close()
 
     def _setup(self) -> None:
         with self._handle_setup_error():

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -57,6 +57,7 @@ class Mux:
             asyncio.Queue
         )
         self.terminating = terminating
+        self.fatal: "Optional[FatalWorkerException]" = None
 
     async def write(self, id: str, item: _PublicEventType) -> None:
         await self.outs[id].put(item)
@@ -72,7 +73,7 @@ class Mux:
         while 1:
             try:
                 event = await race(
-                    self.outs[id].get(), self.shutdown.wait(), timeout=poll
+                    self.outs[id].get(), self.terminating.wait(), timeout=poll
                 )
             except TimeoutError:
                 if send_heartbeats:
@@ -84,6 +85,8 @@ class Mux:
             if isinstance(event, Done):
                 self.outs.pop(id)
                 break
+        if self.fatal:
+            raise self.fatal
 
 
 class Worker:
@@ -215,6 +218,16 @@ class Worker:
             if id == "LOG" and self._state == WorkerState.STARTING:
                 id = "SETUP"
             await self._mux.write(id, event)
+        # If we dropped off the end off the end of the loop, check if it's
+        # because the child process died.
+        if not self._child.is_alive() and not self._terminating.is_set():
+            exitcode = self._child.exitcode
+            self._mux.fatal = FatalWorkerException(
+                f"Prediction failed for an unknown reason. It might have run out of memory? (exitcode {exitcode})"
+            )
+        # this is the same event as _terminating
+        # we need to set it so mux.reads wake up and throw an error if needed
+        self._mux.terminating.set()
 
 
 class _ChildWorker(_spawn.Process):  # type: ignore

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -126,7 +126,6 @@ class Worker:
                             "Predictor errored during setup: " + event.error_detail
                         )
                     self._state = WorkerState.IDLE
-                    self._allow_cancel = False
 
         return inner()
 
@@ -146,12 +145,15 @@ class Worker:
     def predict(
         self, payload: Dict[str, Any], poll: Optional[float] = None
     ) -> AsyncIterator[_PublicEventType]:
+        # this has to be eager just for hypothesis
+        if self._state not in {WorkerState.PROCESSING, WorkerState.IDLE}:
+            raise InvalidStateException(
+                f"Invalid operation: state is {self._state} (must be processing or idle)"
+            )
         if self._shutting_down:
             raise InvalidStateException(
                 "cannot accept new predictions because shutdown requested"
             )
-        self._assert_state(WorkerState.READY)
-        # this has to be eager for hypothesis...
         self._state = WorkerState.PROCESSING
 
         async def inner() -> AsyncIterator[_PublicEventType]:
@@ -195,6 +197,7 @@ class Worker:
             and self._child.pid is not None
         ):
             os.kill(self._child.pid, signal.SIGUSR1)
+            # this should probably check self._semaphore._value == self._concurrent
             self._allow_cancel = False
 
     def _assert_state(self, state: WorkerState) -> None:

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -149,13 +149,13 @@ class Worker:
                 "cannot accept new predictions because shutdown requested"
             )
         self._assert_state(WorkerState.READY)
+        # this has to be eager for hypothesis...
         self._state = WorkerState.PROCESSING
 
         async def inner() -> AsyncIterator[_PublicEventType]:
             input = PredictionInput(payload=payload)
             async with self.prediction_ctx(input):
                 self._events.send(input)
-                self._ensure_event_reader()
                 async for event in self._mux.read(input.id, poll=poll):
                     yield event
 
@@ -205,6 +205,8 @@ class Worker:
 
     def _ensure_event_reader(self) -> None:
         def handle_error(task: "asyncio.Task[None]") -> None:
+            if task.cancelled():
+                return
             exc = task.exception()
             if exc:
                 logging.error("caught exception", exc_info=exc)

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -575,7 +575,6 @@ class WorkerState(RuleBasedStateMachine):
 
     def teardown(self):
         self.worker.shutdown()
-        # really make sure everything is shut down and cleaned up
         self.worker.terminate()
 
 

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -478,6 +478,7 @@ class WorkerState(RuleBasedStateMachine):
     def __init__(self):
         super().__init__()
         self.loop = asyncio.new_event_loop()
+        # it would be nice to parameterize this with the async equivalent
         self.worker = Worker(_fixture_path("steps"), tee_output=False)
 
         self.setup_generator = None


### PR DESCRIPTION
A critical part of concurrent predictions is multiplexing several prediction outputs over the same pipe. This takes a stab at that. Once this is done, we might be able to drop some parts of runner.

We tag each _PublicEventType with a prediction id, introduce a `Mux`, and have a `_read_events` task responsible for reading events from the pipe and writing them to the mux. The mux adds it to the right queue, and then the places that previously called `_wait` instead call `Mux.read`. 

We also add a semaphore and keep track of predictions in flight. READY is renamed to IDLE, but that may need to be reworked further. 

---

Some challenges
* contextvar to tag logs that were emitted from inside a predict() 
  * however, logs emitted from cross-prediction stuff (like the actual batching code) have to be discarded to not leak information
* aioprocessing uses a threadpool and "does _not_ re-implement multiprocessing using asynchronous I/O". it hangs at shutdown. it's still useful for getting the rest of the code in shape for now. 
  * aioprocessing itself, especially the part we use, is extremely small (730 loc) so we could vendor/fix it if we wanted to. 
  * https://github.com/kchmck/aiopipe/tree/master is closest to what we would need, but looks a little awkward. 
  * I also have an example that uses loop.connect_read_pipe correctly but it's a little wordy and would take some hacking to be suitable for duplex use
* I don't know what to do with the hypothesis tests

---
[x] mux events
[x] doesn't deadlock
[x] hypothesis tests mostly pass
[ ] serious pipe implementation (future PR?)
[ ] cancellation
[x] READY /  PROCESSING semaphore 
[~] route predict logs to prediction if only one prediction is running