### PR TITLE
Stricter image cleanup

### DIFF
--- a/test-integration/test_integration/conftest.py
+++ b/test-integration/test_integration/conftest.py
@@ -11,7 +11,15 @@ def pytest_sessionstart(session):
 
 
 @pytest.fixture
-def docker_image():
-    image = "cog-test-" + random_string(10)
-    yield image
-    subprocess.run(["docker", "rmi", "-f", image], check=False)
+def docker_image_name():
+    return "cog-test-" + random_string(10)
+
+
+@pytest.fixture
+def docker_image(docker_image_name):
+    yield docker_image_name
+    # We expect the image to exist by this point and will fail if it doesn't.
+    # If you just need a name, use docker_image_name.
+    subprocess.run(
+        ["docker", "rmi", docker_image_name], check=True, capture_output=True
+    )

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -95,10 +95,8 @@ def test_build_invalid_schema(docker_image):
     assert "invalid default: number must be at least 2" in build_process.stderr.decode()
 
 
+@pytest.mark.skipif(os.environ.get("CI") != "true", reason="only runs in CI")
 def test_build_gpu_model_on_cpu(tmpdir, docker_image):
-    if os.environ.get("CI") != "true":
-        pytest.skip("only runs on CI environment")
-
     with open(tmpdir / "cog.yaml", "w") as f:
         cog_yaml = """
 build:

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -113,28 +113,24 @@ def test_predict_writes_strings_to_files(tmpdir_factory):
         assert f.read() == "hello world"
 
 
-def test_predict_runs_an_existing_image(tmpdir_factory):
+def test_predict_runs_an_existing_image(docker_image, tmpdir_factory):
     project_dir = Path(__file__).parent / "fixtures/string-project"
-    image_name = "cog-test-" + random_string(10)
 
-    try:
-        subprocess.run(
-            ["cog", "build", "-t", image_name],
-            cwd=project_dir,
-            check=True,
-        )
+    subprocess.run(
+        ["cog", "build", "-t", docker_image],
+        cwd=project_dir,
+        check=True,
+    )
 
-        # Run in another directory to ensure it doesn't use cog.yaml
-        another_directory = tmpdir_factory.mktemp("project")
-        result = subprocess.run(
-            ["cog", "predict", image_name, "-i", "s=world"],
-            cwd=another_directory,
-            check=True,
-            capture_output=True,
-        )
-        assert result.stdout == b"hello world\n"
-    finally:
-        subprocess.run(["docker", "rmi", image_name], check=True)
+    # Run in another directory to ensure it doesn't use cog.yaml
+    another_directory = tmpdir_factory.mktemp("project")
+    result = subprocess.run(
+        ["cog", "predict", docker_image, "-i", "s=world"],
+        cwd=another_directory,
+        check=True,
+        capture_output=True,
+    )
+    assert result.stdout == b"hello world\n"
 
 
 # https://github.com/replicate/cog/commit/28202b12ea40f71d791e840b97a51164e7be3b3c
@@ -142,7 +138,7 @@ def test_predict_runs_an_existing_image(tmpdir_factory):
 @pytest.mark.skip("incredibly slow")
 def test_predict_with_remote_image(tmpdir_factory):
     image_name = "r8.im/replicate/hello-world@sha256:5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa"
-    subprocess.run(["docker", "rmi", image_name], check=False)
+    subprocess.run(["docker", "rmi", "-f", image_name], check=True)
 
     # Run in another directory to ensure it doesn't use cog.yaml
     another_directory = tmpdir_factory.mktemp("project")


### PR DESCRIPTION
Ensures that images that we expect to clean up are cleaned up correctly. With check=True in the call to `docker rmi ...` we will raise if the call fails, and the exception will include the command output.