### PR TITLE
Fix FastAPI state hack, freeze pyright version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ optional-dependencies = { "dev" = [
   'numpy<1.22.0; python_version < "3.8"',
   'numpy; python_version >= "3.8"',
   "pillow",
-  "pyright",
+  "pyright==1.1.339",
   "pytest",
   "pytest-asyncio",
   "pytest-httpserver",

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -57,14 +57,17 @@ class Health(Enum):
     SETUP_FAILED = auto()
 
 
-class State:
+class MyState:
     health: Health
     setup_result: "Optional[asyncio.Task[schema.PredictionResponse]]"
     setup_result_payload: Optional[schema.PredictionResponse]
 
 
 class MyFastAPI(FastAPI):
-    state: State
+    # TODO: not, strictly speaking, legal
+    # https://github.com/microsoft/pyright/issues/5933
+    # but it'd need a FastAPI patch to fix
+    state: MyState # type: ignore
 
 
 def create_app(


### PR DESCRIPTION
Yeah, overriding `State` like that wasn't legal to do, so it's right to complain. However, it's really nice so I'll keep doing it. Long term there should maybe be a type variable to `FastAPI`?

https://github.com/microsoft/pyright/issues/5933