### PR TITLE
fix(test): 'docker' 'rmi' failed in python integration tests

### DIFF
--- a/test-integration/test_integration/conftest.py
+++ b/test-integration/test_integration/conftest.py
@@ -1,9 +1,8 @@
 import os
-import subprocess
-
 import pytest
 
 from .util import random_string
+from .util import remove_docker_image
 
 
 def pytest_sessionstart(session):
@@ -20,6 +19,4 @@ def docker_image(docker_image_name):
     yield docker_image_name
     # We expect the image to exist by this point and will fail if it doesn't.
     # If you just need a name, use docker_image_name.
-    subprocess.run(
-        ["docker", "rmi", docker_image_name], check=True, capture_output=True
-    )
+    remove_docker_image(docker_image_name)

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -5,8 +5,6 @@ from pathlib import Path
 
 import pytest
 
-from .util import random_string
-
 
 def test_predict_takes_string_inputs_and_returns_strings_to_stdout():
     project_dir = Path(__file__).parent / "fixtures/string-project"

--- a/test-integration/test_integration/util.py
+++ b/test-integration/test_integration/util.py
@@ -1,6 +1,20 @@
 import random
 import string
-
+import time
+import subprocess
 
 def random_string(length):
     return "".join(random.choice(string.ascii_lowercase) for i in range(length))
+
+
+def remove_docker_image(image_name, max_attempts=5, wait_seconds=1):
+    for attempt in range(max_attempts):
+        try:
+            subprocess.run(["docker", "rmi", image_name], check=True, capture_output=True)
+            print(f"Image {image_name} successfully removed.")
+            break
+        except subprocess.CalledProcessError as e:
+            print(f"Attempt {attempt + 1} failed: {e.stderr.decode()}")
+            time.sleep(wait_seconds)
+    else:
+        print(f"Failed to remove image {image_name} after {max_attempts} attempts.")


### PR DESCRIPTION
- fixes the case when "make test-integration" fails intermittently in test cleanup that removes image
- added def remove_docker_image(image_name, max_attempts=5, wait_seconds=1):

