### PR TITLE
fix: handle early exceptions in model setup

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -99,6 +99,8 @@ def create_app(
     try:
         # TODO: avoid loading predictor code in this process
         predictor = load_predictor_from_ref(predictor_ref)
+        InputType = get_input_type(predictor)
+        OutputType = get_output_type(predictor)
     except Exception as ex:
         app.state.health = Health.SETUP_FAILED
         response = schema.PredictionResponse(input={},
@@ -118,7 +120,7 @@ def create_app(
         async def healthcheck_startup_failed() -> Any:
             return jsonable_encoder(
                 {
-                    "status": app.state.health,
+                    "status": app.state.health.name,
                     "setup": app.state.setup_result_payload,
                 }
             )
@@ -130,9 +132,6 @@ def create_app(
         shutdown_event=shutdown_event,
         upload_url=upload_url,
     )
-
-    InputType = get_input_type(predictor)
-    OutputType = get_output_type(predictor)
 
     class PredictionRequest(schema.PredictionRequest.with_types(input_type=InputType)):
         pass

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -125,6 +125,10 @@ def create_app(
                 }
             )
 
+        @app.on_event("shutdown")
+        def shutdown_startup_failed() -> None:
+            pass
+
         return app
 
     runner = PredictionRunner(

--- a/python/tests/server/test_http_input.py
+++ b/python/tests/server/test_http_input.py
@@ -1,8 +1,12 @@
 import base64
 import os
+import threading
 
 import pytest
 import responses
+from cog import schema
+from cog.server.http import create_app, Health
+from tests.server.conftest import _fixture_path
 
 from .conftest import make_client, uses_predictor
 
@@ -239,10 +243,24 @@ def test_union_integers(client):
 
 
 def test_untyped_inputs():
-    with pytest.raises(TypeError):
-        make_client("input_untyped")
+    config = {"predict": _fixture_path("input_untyped")}
+    app = create_app(
+        config=config,
+        shutdown_event=threading.Event(),
+        upload_url="input_untyped",
+    )
+    assert app.state.health == Health.SETUP_FAILED
+    assert app.state.setup_result_payload.status == schema.Status.FAILED
+    assert app.state.setup_result_payload.error.startswith("TypeError('No input type provided for parameter `input`")
 
 
 def test_input_with_unsupported_type():
-    with pytest.raises(TypeError):
-        make_client("input_unsupported_type")
+    config = {"predict": _fixture_path("input_unsupported_type")}
+    app = create_app(
+        config=config,
+        shutdown_event=threading.Event(),
+        upload_url="input_untyped",
+    )
+    assert app.state.health == Health.SETUP_FAILED
+    assert app.state.setup_result_payload.status == schema.Status.FAILED
+    assert app.state.setup_result_payload.error.startswith("TypeError('Unsupported input type input_unsupported_type.Input for parameter `input`")

--- a/python/tests/server/test_http_input.py
+++ b/python/tests/server/test_http_input.py
@@ -251,7 +251,7 @@ def test_untyped_inputs():
     )
     assert app.state.health == Health.SETUP_FAILED
     assert app.state.setup_result.status == schema.Status.FAILED
-    assert app.state.setup_result.logs.find("TypeError: No input type provided for parameter") != -1
+    assert "TypeError: No input type provided for parameter" in app.state.setup_result.logs
 
 
 def test_input_with_unsupported_type():
@@ -263,4 +263,4 @@ def test_input_with_unsupported_type():
     )
     assert app.state.health == Health.SETUP_FAILED
     assert app.state.setup_result.status == schema.Status.FAILED
-    assert app.state.setup_result.logs.find("TypeError: Unsupported input type input_unsupported_type.") != -1
+    assert "TypeError: Unsupported input type input_unsupported_type" in app.state.setup_result.logs

--- a/python/tests/server/test_http_input.py
+++ b/python/tests/server/test_http_input.py
@@ -250,8 +250,8 @@ def test_untyped_inputs():
         upload_url="input_untyped",
     )
     assert app.state.health == Health.SETUP_FAILED
-    assert app.state.setup_result_payload.status == schema.Status.FAILED
-    assert app.state.setup_result_payload.error.startswith("TypeError('No input type provided for parameter `input`")
+    assert app.state.setup_result.status == schema.Status.FAILED
+    assert app.state.setup_result.logs.find("TypeError: No input type provided for parameter") != -1
 
 
 def test_input_with_unsupported_type():
@@ -262,5 +262,5 @@ def test_input_with_unsupported_type():
         upload_url="input_untyped",
     )
     assert app.state.health == Health.SETUP_FAILED
-    assert app.state.setup_result_payload.status == schema.Status.FAILED
-    assert app.state.setup_result_payload.error.startswith("TypeError('Unsupported input type input_unsupported_type.Input for parameter `input`")
+    assert app.state.setup_result.status == schema.Status.FAILED
+    assert app.state.setup_result.logs.find("TypeError: Unsupported input type input_unsupported_type.") != -1


### PR DESCRIPTION
- handle early exceptions during model container setup
- catch exceptions during creation of Pydantic validators
- propagate error message to health checks w/o creation of predictor

Ref: https://github.com/replicate/infra/issues/21