### PR TITLE
Add note for naming `Output` class

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -158,7 +158,7 @@ class Predictor(BasePredictor):
         return Output(text="hello", file=io.StringIO("hello"))
 ```
 
-Each of the output object's properties must be one of the supported output types. For the full list, see [Input and output types](#input-and-output-types).
+Each of the output object's properties must be one of the supported output types. For the full list, see [Input and output types](#input-and-output-types). Also, make sure to name the output class as `Output` and nothing else.
 
 ### Returning a list
 


### PR DESCRIPTION
It seems there's some [confusion with custom return objects](https://github.com/replicate/cog/issues/1275). This PR intends to avoid this confusion by adding a not in the docs.