### PR TITLE
Capitalize OS name in release artifacts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,10 @@ builds:
 archives:
   - format: binary
     name_template: >-
-      {{ .ProjectName }}_{{ .Os }}_
+      {{ .ProjectName }}_
+      {{- if eq .Os "darwin" }}Darwin
+      {{- else if eq .Os "linux" }}Linux
+      {{- else }}{{ .Os }}{{ end -}}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end -}}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,9 +19,7 @@ archives:
   - format: binary
     name_template: >-
       {{ .ProjectName }}_
-      {{- if eq .Os "darwin" }}Darwin
-      {{- else if eq .Os "linux" }}Linux
-      {{- else }}{{ .Os }}{{ end -}}_
+      {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end -}}


### PR DESCRIPTION
This is a partial fix for https://github.com/replicate/cog/issues/1465

This PR updates the Goreleaser config to capitalize OS names like `Darwin` and `Linux` so they match the output of `uname -s`, which we've long used for the [installation instructions in the README](https://github.com/replicate/cog?tab=readme-ov-file#install).

@caarlos0 does this look right? I did a dry run locally and I see this:

```
$ goreleaser release --snapshot --skip=publish --clean              
...
• archives
  • skip archiving                                 binary=cog name=cog_Darwin_arm64
  • skip archiving                                 binary=cog name=cog_Darwin_x86_64
  • skip archiving                                 binary=cog name=cog_Linux_x86_64
  • skip archiving                                 binary=cog name=cog_Linux_arm64
```