### PR TITLE
remove upgrade anchor from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,6 @@ Hit us up if you're interested in using it or want to collaborate with us. [We'r
 
 ## Install
 
-<a id="upgrade"></a>
-
 If you're using macOS, you can install Cog using Homebrew:
 
 ```console


### PR DESCRIPTION
There's now a separate section in the README with upgrading instructions (See #315), so we don't need this anchor any more.