### PR TITLE
Revert batching changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ optional-dependencies = { "dev" = [
   "pillow",
   "pyright==1.1.345",
   "pytest",
-  "pytest-asyncio",
   "pytest-httpserver",
   "pytest-rerunfailures",
   "pytest-xdist",

--- a/python/cog/command/ast_openapi_schema.py
+++ b/python/cog/command/ast_openapi_schema.py
@@ -309,15 +309,10 @@ def find(obj: ast.AST, name: str) -> ast.AST:
     """Find a particular named node in a tree"""
     return next(node for node in ast.walk(obj) if getattr(node, "name", "") == name)
 
-
 if typing.TYPE_CHECKING:
-    AstVal: "typing.TypeAlias" = (
-        "int | float | complex | str | list[AstVal] | bytes | None"
-    )
+    AstVal: "typing.TypeAlias" = "int | float | complex | str | list[AstVal] | bytes | None"
     AstValNoBytes: "typing.TypeAlias" = "int | float | str | list[AstValNoBytes]"
-    JSONObject: "typing.TypeAlias" = (
-        "int | float | str | list[JSONObject] | JSONDict | None"
-    )
+    JSONObject: "typing.TypeAlias" = "int | float | str | list[JSONObject] | JSONDict | None"
     JSONDict: "typing.TypeAlias" = "dict[str, JSONObject]"
 
 
@@ -332,7 +327,6 @@ def to_serializable(val: "AstVal") -> "JSONObject":
     else:
         return val
 
-
 def get_value(node: ast.AST) -> "AstVal":
     """Return the value of constant or list of constants"""
     if isinstance(node, ast.Constant):
@@ -345,7 +339,7 @@ def get_value(node: ast.AST) -> "AstVal":
     if isinstance(node, (ast.List, ast.Tuple)):
         return [get_value(e) for e in node.elts]
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
-        return -typing.cast(typing.Union[int, float, complex], get_value(node.operand))
+            return -typing.cast(typing.Union[int, float, complex], get_value(node.operand))
     raise ValueError("Unexpected node type", type(node))
 
 
@@ -372,12 +366,11 @@ def get_call_name(call: ast.Call) -> str:
 def parse_args(tree: ast.AST) -> "list[tuple[ast.arg, ast.expr | types.EllipsisType]]":
     """Parse argument, default pairs from a file with a predict function"""
     predict = find(tree, "predict")
-    assert isinstance(predict, (ast.FunctionDef, ast.AsyncFunctionDef))
+    assert isinstance(predict, ast.FunctionDef)
     args = predict.args.args  # [-len(defaults) :]
     # use Ellipsis instead of None here to distinguish a default of None
     defaults = [...] * (len(args) - len(predict.args.defaults)) + predict.args.defaults
     return list(zip(args, defaults))
-
 
 def parse_assignment(assignment: ast.AST) -> "None | tuple[str, JSONObject]":
     """Parse an assignment into an OpenAPI object property"""
@@ -410,9 +403,7 @@ def parse_class(classdef: ast.AST) -> "JSONDict":
     """Parse a class definition into an OpenAPI object"""
     assert isinstance(classdef, ast.ClassDef)
     properties = {
-        assignment[0]: assignment[1]
-        for assignment in map(parse_assignment, classdef.body)
-        if assignment
+        assignment[0]: assignment[1] for assignment in map(parse_assignment, classdef.body) if assignment
     }
     return {
         "title": classdef.name,
@@ -437,7 +428,7 @@ def resolve_name(node: ast.expr) -> str:
         return node.id
     if isinstance(node, ast.Index):
         # deprecated, but needed for py3.8
-        return resolve_name(node.value)  # type: ignore
+        return resolve_name(node.value) # type: ignore
     if isinstance(node, ast.Attribute):
         return node.attr
     if isinstance(node, ast.Subscript):
@@ -445,11 +436,9 @@ def resolve_name(node: ast.expr) -> str:
     raise ValueError("Unexpected node type", type(node), ast.unparse(node))
 
 
-def parse_return_annotation(
-    tree: ast.AST, fn: str = "predict"
-) -> "tuple[JSONDict, JSONDict]":
+def parse_return_annotation(tree: ast.AST, fn: str = "predict") -> "tuple[JSONDict, JSONDict]":
     predict = find(tree, fn)
-    if not isinstance(predict, (ast.FunctionDef, ast.AsyncFunctionDef)):
+    if not isinstance(predict, ast.FunctionDef):
         raise ValueError("Could not find predict function")
     annotation = predict.returns
     if not annotation:
@@ -561,7 +550,7 @@ def extract_info(code: str) -> "JSONDict":
         **return_schema,
     }
     # trust me, typechecker, I know BASE_SCHEMA
-    x: "JSONDict" = schema["components"]["schemas"]  # type: ignore
+    x: "JSONDict" = schema["components"]["schemas"] # type: ignore
     x.update(components)
     return schema
 

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -73,13 +73,11 @@ class MyState:
     setup_task: Optional[SetupTask]
     setup_result: Optional[SetupResult]
 
-
 class MyFastAPI(FastAPI):
     # TODO: not, strictly speaking, legal
     # https://github.com/microsoft/pyright/issues/5933
     # but it'd need a FastAPI patch to fix
     state: MyState  # type: ignore
-
 
 def create_app(
     config: Dict[str, Any],
@@ -137,7 +135,6 @@ def create_app(
 
     class PredictionRequest(schema.PredictionRequest.with_types(input_type=InputType)):
         pass
-
     PredictionResponse = schema.PredictionResponse.with_types(
         input_type=InputType, output_type=OutputType
     )
@@ -147,7 +144,6 @@ def create_app(
     if TYPE_CHECKING:
         P = ParamSpec("P")
         T = TypeVar("T")
-
     def limited(f: "Callable[P, Awaitable[T]]") -> "Callable[P, Awaitable[T]]":
         @functools.wraps(f)
         async def wrapped(*args: "P.args", **kwargs: "P.kwargs") -> "T":
@@ -228,10 +224,7 @@ def create_app(
         response_model=PredictionResponse,
         response_model_exclude_unset=True,
     )
-    async def predict(
-        request: PredictionRequest = Body(default=None),
-        prefer: Union[str, None] = Header(default=None),
-    ) -> Any:  # type: ignore
+    async def predict(request: PredictionRequest = Body(default=None), prefer: Union[str, None] = Header(default=None)) -> Any:  # type: ignore
         """
         Run a single prediction on the model
         """

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -1,9 +1,10 @@
-import asyncio
 import io
+import sys
 import threading
 import traceback
 import typing  # TypeAlias, py3.10
 from datetime import datetime, timezone
+from multiprocessing.pool import AsyncResult, ThreadPool
 from typing import Any, Callable, Optional, Tuple, Union, cast
 
 import requests
@@ -44,8 +45,11 @@ class SetupResult:
     status: schema.Status
 
 
-PredictionTask: "typing.TypeAlias" = "asyncio.Task[schema.PredictionResponse]"
-SetupTask: "typing.TypeAlias" = "asyncio.Task[SetupResult]"
+PredictionTask: "typing.TypeAlias" = "AsyncResult[schema.PredictionResponse]"
+SetupTask: "typing.TypeAlias" = "AsyncResult[SetupResult]"
+if sys.version_info < (3, 9):
+    PredictionTask = AsyncResult
+    SetupTask = AsyncResult
 RunnerTask: "typing.TypeAlias" = Union[PredictionTask, SetupTask]
 
 
@@ -57,37 +61,38 @@ class PredictionRunner:
         shutdown_event: Optional[threading.Event],
         upload_url: Optional[str] = None,
     ) -> None:
+        self._thread = None
+        self._threadpool = ThreadPool(processes=1)
+
         self._response: Optional[schema.PredictionResponse] = None
         self._result: Optional[RunnerTask] = None
 
         self._worker = Worker(predictor_ref=predictor_ref)
-        self._should_cancel = asyncio.Event()
+        self._should_cancel = threading.Event()
 
         self._shutdown_event = shutdown_event
         self._upload_url = upload_url
 
-    def make_error_handler(self, activity: str) -> Callable[[RunnerTask], None]:
-        def handle_error(task: RunnerTask) -> None:
-            exc = task.exception()
-            if not exc:
-                return
+    def setup(self) -> SetupTask:
+        if self.is_busy():
+            raise RunnerBusyError()
+
+        def handle_error(error: BaseException) -> None:
             # Re-raise the exception in order to more easily capture exc_info,
             # and then trigger shutdown, as we have no easy way to resume
             # worker state if an exception was thrown.
             try:
-                raise exc
+                raise error
             except Exception:
-                log.error(f"caught exception while running {activity}", exc_info=True)
+                log.error("caught exception while running setup", exc_info=True)
                 if self._shutdown_event is not None:
                     self._shutdown_event.set()
 
-        return handle_error
-
-    def setup(self) -> SetupTask:
-        if self.is_busy():
-            raise RunnerBusyError()
-        self._result = asyncio.create_task(setup(worker=self._worker))
-        self._result.add_done_callback(self.make_error_handler("setup"))
+        self._result = self._threadpool.apply_async(
+            func=setup,
+            kwds={"worker": self._worker},
+            error_callback=handle_error,
+        )
         return self._result
 
     # TODO: Make the return type AsyncResult[schema.PredictionResponse] when we
@@ -116,21 +121,34 @@ class PredictionRunner:
         upload_url = self._upload_url if upload else None
         event_handler = create_event_handler(prediction, upload_url=upload_url)
 
-        def handle_cleanup(_: PredictionTask) -> None:
+        def cleanup(_: schema.PredictionResponse = None) -> None:
             input = cast(Any, prediction.input)
             if hasattr(input, "cleanup"):
                 input.cleanup()
 
+        def handle_error(error: BaseException) -> None:
+            # Re-raise the exception in order to more easily capture exc_info,
+            # and then trigger shutdown, as we have no easy way to resume
+            # worker state if an exception was thrown.
+            try:
+                raise error
+            except Exception:
+                log.error("caught exception while running prediction", exc_info=True)
+                if self._shutdown_event is not None:
+                    self._shutdown_event.set()
+
         self._response = event_handler.response
-        coro = predict(
-            worker=self._worker,
-            request=prediction,
-            event_handler=event_handler,
-            should_cancel=self._should_cancel,
+        self._result = self._threadpool.apply_async(
+            func=predict,
+            kwds={
+                "worker": self._worker,
+                "request": prediction,
+                "event_handler": event_handler,
+                "should_cancel": self._should_cancel,
+            },
+            callback=cleanup,
+            error_callback=handle_error,
         )
-        self._result = asyncio.create_task(coro)
-        self._result.add_done_callback(handle_cleanup)
-        self._result.add_done_callback(self.make_error_handler("prediction"))
 
         return (self._response, self._result)
 
@@ -138,7 +156,7 @@ class PredictionRunner:
         if self._result is None:
             return False
 
-        if not self._result.done():
+        if not self._result.ready():
             return True
 
         self._response = None
@@ -146,9 +164,9 @@ class PredictionRunner:
         return False
 
     def shutdown(self) -> None:
-        if self._result:
-            self._result.cancel()
         self._worker.terminate()
+        self._threadpool.terminate()
+        self._threadpool.join()
 
     def cancel(self, prediction_id: Optional[str] = None) -> None:
         if not self.is_busy():
@@ -290,15 +308,13 @@ class PredictionEventHandler:
             raise FileUploadError("Got error trying to upload output files") from error
 
 
-async def setup(*, worker: Worker) -> SetupResult:
+def setup(*, worker: Worker) -> SetupResult:
     logs = []
     status = None
     started_at = datetime.now(tz=timezone.utc)
 
     try:
-        # will be async
         for event in worker.setup():
-            await asyncio.sleep(0)
             if isinstance(event, Log):
                 logs.append(event.message)
             elif isinstance(event, Done):
@@ -328,19 +344,19 @@ async def setup(*, worker: Worker) -> SetupResult:
     )
 
 
-async def predict(
+def predict(
     *,
     worker: Worker,
     request: schema.PredictionRequest,
     event_handler: PredictionEventHandler,
-    should_cancel: asyncio.Event,
+    should_cancel: threading.Event,
 ) -> schema.PredictionResponse:
     # Set up logger context within prediction thread.
     structlog.contextvars.clear_contextvars()
     structlog.contextvars.bind_contextvars(prediction_id=request.id)
 
     try:
-        return await _predict(
+        return _predict(
             worker=worker,
             request=request,
             event_handler=event_handler,
@@ -353,12 +369,12 @@ async def predict(
         raise
 
 
-async def _predict(
+def _predict(
     *,
     worker: Worker,
     request: schema.PredictionRequest,
     event_handler: PredictionEventHandler,
-    should_cancel: asyncio.Event,
+    should_cancel: threading.Event,
 ) -> schema.PredictionResponse:
     initial_prediction = request.dict()
 
@@ -375,9 +391,8 @@ async def _predict(
                 event_handler.failed(error=str(e))
                 log.warn("failed to download url path from input", exc_info=True)
                 return event_handler.response
-    # will be async
+
     for event in worker.predict(input_dict, poll=0.1):
-        await asyncio.sleep(0)
         if should_cancel.is_set():
             worker.cancel()
             should_cancel.clear()

--- a/python/cog/server/webhook.py
+++ b/python/cog/server/webhook.py
@@ -37,8 +37,7 @@ SKIP_START_EVENT = _response_interval < 0.1
 
 
 def webhook_caller_filtered(
-    webhook: str,
-    webhook_events_filter: Set[WebhookEvent],
+    webhook: str, webhook_events_filter: Set[WebhookEvent],
 ) -> Callable[[Any, WebhookEvent], None]:
     upstream_caller = webhook_caller(webhook)
 

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -114,8 +114,7 @@ class Worker:
                 if send_heartbeats:
                     yield Heartbeat()
                 continue
-            # this needs aioprocessing.Pipe or similar
-            # multiprocessing.Pipe is not async
+
             ev = self._events.recv()
             yield ev
 

--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -257,11 +257,11 @@ class ConcatenateIterator(Iterator[Item]):
         return value
 
 
-def _len_bytes(s: str, encoding: str = "utf-8") -> int:
+def _len_bytes(s: str, encoding: str="utf-8") -> int:
     return len(s.encode(encoding))
 
 
-def _truncate_filename_bytes(s: str, length: int, encoding: str = "utf-8") -> str:
+def _truncate_filename_bytes(s: str, length: int, encoding: str="utf-8") -> str:
     """
     Truncate a filename to at most `length` bytes, preserving file extension
     and avoiding text encoding corruption from truncation.

--- a/python/tests/server/fixtures/async_hello.py
+++ b/python/tests/server/fixtures/async_hello.py
@@ -1,7 +1,0 @@
-class Predictor:
-    def setup(self) -> None:
-        print("did setup")
-
-    async def predict(self, name: str) -> str:
-        print(f"hello, {name}")
-        return f"hello, {name}"

--- a/python/tests/server/fixtures/async_yield.py
+++ b/python/tests/server/fixtures/async_yield.py
@@ -1,9 +1,0 @@
-from typing import AsyncIterator
-from cog import BasePredictor
-
-
-class Predictor(BasePredictor):
-    async def predict(self) -> AsyncIterator[str]:
-        yield "foo"
-        yield "bar"
-        yield "baz"

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -272,22 +272,6 @@ def test_openapi_specification_with_yield(client, static_schema):
     }
 
 
-@uses_predictor("async_yield")
-def test_openapi_specification_with_async_yield(client, static_schema):
-    resp = client.get("/openapi.json")
-    assert resp.status_code == 200
-    schema = resp.json()
-    assert schema == static_schema
-    assert schema["components"]["schemas"]["Output"] == {
-        "title": "Output",
-        "type": "array",
-        "items": {
-            "type": "string",
-        },
-        "x-cog-array-type": "iterator",
-    }
-
-
 @uses_predictor("yield_concatenate_iterator")
 def test_openapi_specification_with_yield_with_concatenate_iterator(
     client, static_schema
@@ -343,15 +327,6 @@ def test_openapi_specification_with_int_choices(client, static_schema):
         "title": "pick_a_number_any_number",
         "type": "integer",
     }
-
-
-@uses_predictor("async_yield")
-def test_yielding_strings_from_async_generator_predictors(client, match):
-    resp = client.post("/predictions")
-    assert resp.status_code == 200
-    assert resp.json() == match(
-        {"status": "succeeded", "output": ["foo", "bar", "baz"]}
-    )
 
 
 @uses_trainer("train.py:train")

--- a/python/tests/server/test_http_input.py
+++ b/python/tests/server/test_http_input.py
@@ -2,13 +2,13 @@ import base64
 import os
 import threading
 
-import pytest
 import responses
 from cog import schema
-from cog.server.http import create_app, Health
+from cog.server.http import Health, create_app
+
 from tests.server.conftest import _fixture_path
 
-from .conftest import make_client, uses_predictor
+from .conftest import uses_predictor
 
 
 @uses_predictor("input_none")
@@ -251,7 +251,9 @@ def test_untyped_inputs():
     )
     assert app.state.health == Health.SETUP_FAILED
     assert app.state.setup_result.status == schema.Status.FAILED
-    assert "TypeError: No input type provided for parameter" in app.state.setup_result.logs
+    assert (
+        "TypeError: No input type provided for parameter" in app.state.setup_result.logs
+    )
 
 
 def test_input_with_unsupported_type():
@@ -263,4 +265,7 @@ def test_input_with_unsupported_type():
     )
     assert app.state.health == Health.SETUP_FAILED
     assert app.state.setup_result.status == schema.Status.FAILED
-    assert "TypeError: Unsupported input type input_unsupported_type" in app.state.setup_result.logs
+    assert (
+        "TypeError: Unsupported input type input_unsupported_type"
+        in app.state.setup_result.logs
+    )

--- a/python/tests/server/test_runner.py
+++ b/python/tests/server/test_runner.py
@@ -199,7 +199,6 @@ def fake_worker(events):
 
     return FakeWorker()
 
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize("events,calls", PREDICT_TESTS)
 async def test_predict(events, calls):

--- a/python/tests/server/test_runner.py
+++ b/python/tests/server/test_runner.py
@@ -1,11 +1,9 @@
-import asyncio
 import os
 import threading
 from datetime import datetime
 from unittest import mock
 
 import pytest
-import pytest_asyncio
 from cog.schema import PredictionRequest, PredictionResponse, Status, WebhookEvent
 from cog.server.eventtypes import (
     Done,
@@ -28,25 +26,24 @@ def _fixture_path(name):
     return os.path.join(test_dir, f"fixtures/{name}.py") + ":Predictor"
 
 
-@pytest_asyncio.fixture
-async def runner():
+@pytest.fixture
+def runner():
     runner = PredictionRunner(
         predictor_ref=_fixture_path("sleep"), shutdown_event=threading.Event()
     )
     try:
-        await runner.setup()
+        runner.setup().get(5)
         yield runner
     finally:
         runner.shutdown()
 
 
-@pytest.mark.asyncio
-async def test_prediction_runner_setup():
+def test_prediction_runner_setup():
     runner = PredictionRunner(
         predictor_ref=_fixture_path("sleep"), shutdown_event=threading.Event()
     )
     try:
-        result = await runner.setup()
+        result = runner.setup().get(5)
 
         assert result.status == Status.SUCCEEDED
         assert result.logs == ""
@@ -56,11 +53,10 @@ async def test_prediction_runner_setup():
         runner.shutdown()
 
 
-@pytest.mark.asyncio
-async def test_prediction_runner(runner):
+def test_prediction_runner(runner):
     request = PredictionRequest(input={"sleep": 0.1})
     _, async_result = runner.predict(request)
-    response = await async_result
+    response = async_result.get(timeout=1)
     assert response.output == "done in 0.1 seconds"
     assert response.status == "succeeded"
     assert response.error is None
@@ -69,37 +65,33 @@ async def test_prediction_runner(runner):
     assert isinstance(response.completed_at, datetime)
 
 
-@pytest.mark.asyncio
-async def test_prediction_runner_called_while_busy(runner):
+def test_prediction_runner_called_while_busy(runner):
     request = PredictionRequest(input={"sleep": 0.1})
     _, async_result = runner.predict(request)
 
     assert runner.is_busy()
     with pytest.raises(RunnerBusyError):
-        _, task = runner.predict(request)
-        await task
+        runner.predict(request)
 
-    # Await to ensure that the first prediction is scheduled before we
+    # Call .get() to ensure that the first prediction is scheduled before we
     # attempt to shut down the runner.
-    await async_result
+    async_result.get()
 
 
-@pytest.mark.asyncio
-async def test_prediction_runner_called_while_busy_idempotent(runner):
+def test_prediction_runner_called_while_busy_idempotent(runner):
     request = PredictionRequest(id="abcd1234", input={"sleep": 0.1})
 
     runner.predict(request)
     runner.predict(request)
     _, async_result = runner.predict(request)
 
-    response = await asyncio.wait_for(async_result, timeout=1)
+    response = async_result.get(timeout=1)
     assert response.id == "abcd1234"
     assert response.output == "done in 0.1 seconds"
     assert response.status == "succeeded"
 
 
-@pytest.mark.asyncio
-async def test_prediction_runner_called_while_busy_idempotent_wrong_id(runner):
+def test_prediction_runner_called_while_busy_idempotent_wrong_id(runner):
     request1 = PredictionRequest(id="abcd1234", input={"sleep": 0.1})
     request2 = PredictionRequest(id="5678efgh", input={"sleep": 0.1})
 
@@ -107,20 +99,19 @@ async def test_prediction_runner_called_while_busy_idempotent_wrong_id(runner):
     with pytest.raises(RunnerBusyError):
         runner.predict(request2)
 
-    response = await async_result
+    response = async_result.get(timeout=1)
     assert response.id == "abcd1234"
     assert response.output == "done in 0.1 seconds"
     assert response.status == "succeeded"
 
 
-@pytest.mark.asyncio
-async def test_prediction_runner_cancel(runner):
+def test_prediction_runner_cancel(runner):
     request = PredictionRequest(input={"sleep": 0.5})
     _, async_result = runner.predict(request)
 
     runner.cancel()
 
-    response = await async_result
+    response = async_result.get(timeout=1)
     assert response.output is None
     assert response.status == "canceled"
     assert response.error is None
@@ -129,27 +120,25 @@ async def test_prediction_runner_cancel(runner):
     assert isinstance(response.completed_at, datetime)
 
 
-@pytest.mark.asyncio
-async def test_prediction_runner_cancel_matching_id(runner):
+def test_prediction_runner_cancel_matching_id(runner):
     request = PredictionRequest(id="abcd1234", input={"sleep": 0.5})
     _, async_result = runner.predict(request)
 
     runner.cancel(prediction_id="abcd1234")
 
-    response = await async_result
+    response = async_result.get(timeout=1)
     assert response.output is None
     assert response.status == "canceled"
 
 
-@pytest.mark.asyncio
-async def test_prediction_runner_cancel_by_mismatched_id(runner):
+def test_prediction_runner_cancel_by_mismatched_id(runner):
     request = PredictionRequest(id="abcd1234", input={"sleep": 0.5})
     _, async_result = runner.predict(request)
 
     with pytest.raises(UnknownPredictionError):
         runner.cancel(prediction_id="5678efgh")
 
-    response = await async_result
+    response = async_result.get(timeout=1)
     assert response.output == "done in 0.5 seconds"
     assert response.status == "succeeded"
 
@@ -199,15 +188,15 @@ def fake_worker(events):
 
     return FakeWorker()
 
-@pytest.mark.asyncio
+
 @pytest.mark.parametrize("events,calls", PREDICT_TESTS)
-async def test_predict(events, calls):
+def test_predict(events, calls):
     worker = fake_worker(events)
     request = PredictionRequest(input={"text": "hello"}, foo="bar")
     event_handler = mock.Mock()
     should_cancel = threading.Event()
 
-    await predict(
+    predict(
         worker=worker,
         request=request,
         event_handler=event_handler,

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -57,17 +57,11 @@ OUTPUT_FIXTURES = [
         lambda x: f"hello, {x['name']}",
     ),
     (
-        "async_hello",
-        {"name": ST_NAMES},
-        lambda x: f"hello, {x['name']}",
-    ),
-    (
         "count_up",
         {"upto": st.integers(min_value=0, max_value=100)},
         lambda x: list(range(x["upto"])),
     ),
     ("complex_output", {}, lambda _: {"number": 42, "text": "meaning of life"}),
-    ("async_setup_uses_same_loop_as_predict", {}, lambda _: True),
 ]
 
 SETUP_LOGS_FIXTURES = [
@@ -79,8 +73,7 @@ SETUP_LOGS_FIXTURES = [
             "setting up predictor\n"
         ),
         "writing to stderr at import time\n",
-    ),
-    ("setup_uses_async", "setup used asyncio.run! it's not very effective...\n", ""),
+    )
 ]
 
 PREDICT_LOGS_FIXTURES = [


### PR DESCRIPTION
Revert "add test cases for shared loop across setup and predict + asyncio.run in setup"
Revert "don't use async for predict loop if predict is not async"
Revert "conditionally create the event loop if predictor is async, and add a path for hypothetical async setup"
Revert "Revert "Revert "support async predict functions  (#1350)" (#1373)""

This reverts commit 8b8bbac9989a04bb7d3e1843d2a998b647cb7b02.
This reverts commit 0ca552108fd549e63b0a9ad6dfdb8b1a328a4259.
This reverts commit dcf5ac4656f4f93173b5c85b4cfbcdb544e8a8a7.
This reverts commit 47f3fa590145ef103ec46a95c054303df2d7c7a9.

Revert "review changes to tests and server"
Revert "delete remaining runner thread code :)"
Revert "make tests async and fix them"
Revert "have runner return asyncio.Task instead of AsyncFuture"

This reverts commit https://github.com/replicate/cog/commit/b002d542ac68e010c20247416c3c64cd8779a12f.
This reverts commit https://github.com/replicate/cog/commit/087f4824d1864382ff09cc780708ba8122c3d0ce.
This reverts commit https://github.com/replicate/cog/commit/6729d53d00e555accf023c42bee9b06eac21eaa0.
This reverts commit https://github.com/replicate/cog/commit/dc5ef44d5212f987d0080b752ad87207c7a6fb45.