### PR TITLE
fix: add handling of early setup exceptions on "train" path in cog predict/build

### DIFF
--- a/python/cog/command/openapi_schema.py
+++ b/python/cog/command/openapi_schema.py
@@ -5,8 +5,9 @@ This prints a JSON object describing the inputs of the model.
 """
 import json
 
-from ..errors import ConfigDoesNotExist, PredictorNotSet
+from ..errors import CogError, ConfigDoesNotExist, PredictorNotSet
 from ..predictor import load_config
+from ..schema import Status
 from ..server.http import create_app
 from ..suppress_output import suppress_output
 
@@ -16,6 +17,8 @@ if __name__ == "__main__":
         with suppress_output():
             config = load_config()
             app = create_app(config, shutdown_event=None)
+            if app.state.setup_result and app.state.setup_result.status == Status.FAILED:
+                raise CogError(app.state.setup_result.logs)
             schema = app.openapi()
     except (ConfigDoesNotExist, PredictorNotSet):
         # If there is no cog.yaml or 'predict' has not been set, then there is no type signature.

--- a/test-integration/test_integration/conftest.py
+++ b/test-integration/test_integration/conftest.py
@@ -1,8 +1,8 @@
 import os
+
 import pytest
 
-from .util import random_string
-from .util import remove_docker_image
+from .util import random_string, remove_docker_image
 
 
 def pytest_sessionstart(session):

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -14,7 +14,7 @@ def test_build_without_predictor(docker_image):
         capture_output=True,
     )
     assert build_process.returncode > 0
-    assert "Model schema is invalid" in build_process.stderr.decode()
+    assert "Can't run predictions: 'predict' option not found" in build_process.stderr.decode()
 
 
 def test_build_names_uses_image_option_in_cog_yaml(tmpdir, docker_image):

--- a/test-integration/test_integration/util.py
+++ b/test-integration/test_integration/util.py
@@ -1,7 +1,8 @@
 import random
 import string
-import time
 import subprocess
+import time
+
 
 def random_string(length):
     return "".join(random.choice(string.ascii_lowercase) for i in range(length))


### PR DESCRIPTION
- added handling of early setup exceptions on "train" path in cog predict/build
- skip calling setup() on early setup errors, and optionally initiate shutdown in interactive mode 
- added check for setup() errors in cog build (in openapi_schema.py)

Testing:
- use simple model with predict & train
- change input type in train to a bad type
- run cog predict or build

Expected:
- cog prints bad input type error

Ref:  https://github.com/replicate/infra/issues/25
