### PR TITLE
Use cheaper runner for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
   # cannot run this on mac due to licensing issues: https://github.com/actions/virtual-environments/issues/2150
   test-integration:
     name: "Test integration"
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
16-cores costs $0.064/minute. 8-cores costs $0.032/minute. The default 2-cores costs $0.008/minute.