### PR TITLE
fix: ignore "train" part of schema errors during predict runs

### DIFF
--- a/python/cog/command/openapi_schema.py
+++ b/python/cog/command/openapi_schema.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     try:
         with suppress_output():
             config = load_config()
-            app = create_app(config, shutdown_event=None)
+            app = create_app(config, shutdown_event=None, is_build=True)
             if app.state.setup_result and app.state.setup_result.status == Status.FAILED:
                 raise CogError(app.state.setup_result.logs)
             schema = app.openapi()


### PR DESCRIPTION
- ignore "train" part of schema errors during predict runs for backward compatibility with existing "bad" models already in use
- expected: cog shall not trigger exception/error  when "train" is present in config but "train.py" is missing.


