### PR TITLE
feat: eliminate redundant loads of predict.py and train.py in early setup of cog predict

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test-integration: cog
 
 .PHONY: test-python
 test-python:
-	$(PYTEST) -n auto -vv python/tests $(if $(FILTER),-k "$(FILTER)",)
+	$(PYTEST) -n auto -vv --cov=python/cog  --cov-report term-missing  python/tests $(if $(FILTER),-k "$(FILTER)",)
 
 .PHONY: test
 test: test-go test-python test-integration

--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -76,7 +76,7 @@ func BuildAddLabelsAndSchemaToImage(image string, labels map[string]string, bund
 
 	dockerfile := "FROM " + image + "\n"
 	dockerfile += "COPY " + bundledSchemaFile + " .cog\n"
-	const env_path = "/tmp/venv/tools/"
+	env_path := "/tmp/venv/tools/"
 	dockerfile += "RUN python -m venv --symlinks " + env_path + " && " +
 		env_path + "/bin/python -m pip install 'datamodel-code-generator>=0.25' && " +
 		env_path + "/bin/datamodel-codegen --version && " +

--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -49,7 +49,7 @@ func Build(dir, dockerfile, imageName string, secrets []string, noCache bool, pr
 	return cmd.Run()
 }
 
-func BuildAddLabelsAndSchemaToImage(image string, labels map[string]string, schemaFile string) error {
+func BuildAddLabelsAndSchemaToImage(image string, labels map[string]string, bundledSchemaFile string, bundledSchemaPy string) error {
 	var args []string
 
 	args = append(args,
@@ -75,7 +75,13 @@ func BuildAddLabelsAndSchemaToImage(image string, labels map[string]string, sche
 	cmd := exec.Command("docker", args...)
 
 	dockerfile := "FROM " + image + "\n"
-	dockerfile += "COPY " + schemaFile + " .cog"
+	dockerfile += "COPY " + bundledSchemaFile + " .cog\n"
+	const env_path = "/tmp/venv/tools/"
+	dockerfile += "RUN python -m venv --symlinks " + env_path + " && " +
+		env_path + "/bin/python -m pip install 'datamodel-code-generator>=0.25' && " +
+		env_path + "/bin/datamodel-codegen --version && " +
+		env_path + "/bin/datamodel-codegen --input-file-type openapi --input " + bundledSchemaFile +
+		" --output " + bundledSchemaPy + " && rm -rf " + env_path
 	cmd.Stdin = strings.NewReader(dockerfile)
 
 	console.Debug("$ " + strings.Join(cmd.Args, " "))

--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -49,7 +49,7 @@ func Build(dir, dockerfile, imageName string, secrets []string, noCache bool, pr
 	return cmd.Run()
 }
 
-func BuildAddLabelsToImage(image string, labels map[string]string) error {
+func BuildAddLabelsAndSchemaToImage(image string, labels map[string]string, schemaFile string) error {
 	var args []string
 
 	args = append(args,
@@ -74,7 +74,8 @@ func BuildAddLabelsToImage(image string, labels map[string]string) error {
 	args = append(args, ".")
 	cmd := exec.Command("docker", args...)
 
-	dockerfile := "FROM " + image
+	dockerfile := "FROM " + image + "\n"
+	dockerfile += "COPY " + schemaFile + " .cog"
 	cmd.Stdin = strings.NewReader(dockerfile)
 
 	console.Debug("$ " + strings.Join(cmd.Args, " "))

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -21,6 +21,7 @@ import (
 const dockerignoreBackupPath = ".dockerignore.cog.bak"
 const weightsManifestPath = ".cog/cache/weights_manifest.json"
 const bundledSchemaFile = ".cog/openapi_schema.json"
+const bundledSchemaPy = ".cog/openapi_schema.py"
 
 // Build a Cog model from a config
 //
@@ -28,8 +29,9 @@ const bundledSchemaFile = ".cog/openapi_schema.json"
 func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache, separateWeights bool, useCudaBaseImage string, progressOutput string, schemaFile string, dockerfileFile string) error {
 	console.Infof("Building Docker image from environment in cog.yaml as %s...", imageName)
 
-	// remove bundled schema file that may be left from previous runs
+	// remove bundled schema files that may be left from previous builds
 	_ = os.Remove(bundledSchemaFile)
+	_ = os.Remove(bundledSchemaPy)
 
 	if dockerfileFile != "" {
 		dockerfileContents, err := os.ReadFile(dockerfileFile)
@@ -117,6 +119,7 @@ func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache,
 		schemaJSON = data
 	}
 
+	// save open_api schema file
 	err := os.WriteFile(bundledSchemaFile, schemaJSON, 0o644)
 	if err != nil {
 		return fmt.Errorf("Failed to store bundled schema file #{bundledSchemaFile}: %w", err)
@@ -172,7 +175,7 @@ func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache,
 		}
 	}
 
-	if err := docker.BuildAddLabelsAndSchemaToImage(imageName, labels, bundledSchemaFile); err != nil {
+	if err := docker.BuildAddLabelsAndSchemaToImage(imageName, labels, bundledSchemaFile, bundledSchemaPy); err != nil {
 		return fmt.Errorf("Failed to add labels to image: %w", err)
 	}
 	return nil

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -20,12 +20,16 @@ import (
 
 const dockerignoreBackupPath = ".dockerignore.cog.bak"
 const weightsManifestPath = ".cog/cache/weights_manifest.json"
+const bundledSchemaFile = ".cog/openapi_schema.json"
 
 // Build a Cog model from a config
 //
 // This is separated out from docker.Build(), so that can be as close as possible to the behavior of 'docker build'.
 func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache, separateWeights bool, useCudaBaseImage string, progressOutput string, schemaFile string, dockerfileFile string) error {
 	console.Infof("Building Docker image from environment in cog.yaml as %s...", imageName)
+
+	// remove bundled schema file that may be left from previous runs
+	_ = os.Remove(bundledSchemaFile)
 
 	if dockerfileFile != "" {
 		dockerfileContents, err := os.ReadFile(dockerfileFile)
@@ -113,6 +117,11 @@ func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache,
 		schemaJSON = data
 	}
 
+	err := os.WriteFile(bundledSchemaFile, schemaJSON, 0o644)
+	if err != nil {
+		return fmt.Errorf("Failed to store bundled schema file #{bundledSchemaFile}: %w", err)
+	}
+
 	loader := openapi3.NewLoader()
 	loader.IsExternalRefsAllowed = true
 	doc, err := loader.LoadFromData(schemaJSON)
@@ -163,7 +172,7 @@ func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache,
 		}
 	}
 
-	if err := docker.BuildAddLabelsToImage(imageName, labels); err != nil {
+	if err := docker.BuildAddLabelsAndSchemaToImage(imageName, labels, bundledSchemaFile); err != nil {
 		return fmt.Errorf("Failed to add labels to image: %w", err)
 	}
 	return nil

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -21,7 +21,7 @@ import (
 const dockerignoreBackupPath = ".dockerignore.cog.bak"
 const weightsManifestPath = ".cog/cache/weights_manifest.json"
 const bundledSchemaFile = ".cog/openapi_schema.json"
-const bundledSchemaPy = ".cog/openapi_schema.py"
+const bundledSchemaPy = ".cog/schema.py"
 
 // Build a Cog model from a config
 //
@@ -122,7 +122,7 @@ func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache,
 	// save open_api schema file
 	err := os.WriteFile(bundledSchemaFile, schemaJSON, 0o644)
 	if err != nil {
-		return fmt.Errorf("Failed to store bundled schema file #{bundledSchemaFile}: %w", err)
+		return fmt.Errorf("failed to store bundled schema file %s: %w", bundledSchemaFile, err)
 	}
 
 	loader := openapi3.NewLoader()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
   'typing-compat; python_version < "3.8"',
   "typing_extensions>=4.4.0",
   "uvicorn[standard]>=0.12,<1",
-  "datamodel-code-generator >=0.25",
 ]
 
 optional-dependencies = { "dev" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ optional-dependencies = { "dev" = [
   "pytest-httpserver",
   "pytest-rerunfailures",
   "pytest-xdist",
+  "pytest-cov",
   "responses",
   "ruff",
 ] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   'typing-compat; python_version < "3.8"',
   "typing_extensions>=4.4.0",
   "uvicorn[standard]>=0.12,<1",
+  "datamodel-code-generator >=0.25",
 ]
 
 optional-dependencies = { "dev" = [

--- a/python/cog/files.py
+++ b/python/cog/files.py
@@ -2,7 +2,6 @@ import base64
 import io
 import mimetypes
 import os
-import sys
 from urllib.parse import urlparse
 
 import requests
@@ -74,18 +73,3 @@ def ensure_trailing_slash(url: str) -> str:
         return url
     else:
         return url + "/"
-
-
-def get_site_packages_bin_path() -> str:
-    """
-    Returns python site packages bin path
-    """
-    site_packages_path = os.path.join(
-        os.path.dirname(next(p for p in sys.path if "site-packages" in p)),
-        "site-packages/bin",
-    )
-    exec_prefix_path = os.path.join(sys.exec_prefix, "bin")
-    bin_path = (
-        exec_prefix_path if exec_prefix_path != "/usr/local/bin" else site_packages_path
-    )
-    return bin_path

--- a/python/cog/files.py
+++ b/python/cog/files.py
@@ -2,6 +2,7 @@ import base64
 import io
 import mimetypes
 import os
+import sys
 from urllib.parse import urlparse
 
 import requests
@@ -73,3 +74,18 @@ def ensure_trailing_slash(url: str) -> str:
         return url
     else:
         return url + "/"
+
+
+def get_site_packages_bin_path() -> str:
+    """
+    Returns python site packages bin path
+    """
+    site_packages_path = os.path.join(
+        os.path.dirname(next(p for p in sys.path if "site-packages" in p)),
+        "site-packages/bin",
+    )
+    exec_prefix_path = os.path.join(sys.exec_prefix, "bin")
+    bin_path = (
+        exec_prefix_path if exec_prefix_path != "/usr/local/bin" else site_packages_path
+    )
+    return bin_path

--- a/python/cog/schema.py
+++ b/python/cog/schema.py
@@ -9,7 +9,7 @@ from types import ModuleType
 
 import pydantic
 
-OPENAPI_SCHEMA_PY = ".cog/openapi_schema.py"
+BUNDLED_SCHEMA_PATH = ".cog/schema.py"
 
 
 class Status(str, Enum):
@@ -101,12 +101,14 @@ class TrainingResponse(PredictionResponse):
     pass
 
 
-def create_schema_model(openapi_model_py: str) -> ModuleType:
-    module_name = os.path.basename(openapi_model_py).rstrip(".py")
-    spec = importlib.util.spec_from_file_location(module_name, openapi_model_py)
+def create_schema_module() -> t.Optional[ModuleType]:
+    if not os.path.exists(BUNDLED_SCHEMA_PATH):
+        return None
+    name = "cog.bundled_schema"
+    spec = importlib.util.spec_from_file_location(name, BUNDLED_SCHEMA_PATH)
     assert spec is not None
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
-    sys.modules[module_name] = module
+    sys.modules[name] = module
     spec.loader.exec_module(module)
     return module

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -128,9 +128,9 @@ def create_app(
     try:
         predictor_ref = get_predictor_ref(config, mode)
         # use openapi schema if schema file exists in model dir (cloud/k8s run)
-        if os.path.exists(schema.OPENAPI_SCHEMA_FILE):
-            log.info(f"using {schema.OPENAPI_SCHEMA_FILE} file")
-            schema_model = schema.create_schema_model(schema.OPENAPI_SCHEMA_FILE)
+        if os.path.exists(schema.OPENAPI_SCHEMA_PY):
+            log.info(f"using {schema.OPENAPI_SCHEMA_PY}")
+            schema_model = schema.create_schema_model(schema.OPENAPI_SCHEMA_PY)
             InputType = schema_model.Input
             OutputType = schema_model.Output
         else:
@@ -173,9 +173,9 @@ def create_app(
         try:
             trainer_ref = get_predictor_ref(config, "train")
             # use openapi schema if schema file exists in model dir (cloud/k8s run)
-            if os.path.exists(schema.OPENAPI_SCHEMA_FILE):
-                log.info(f"using {schema.OPENAPI_SCHEMA_FILE} file")
-                schema_model = schema.create_schema_model(schema.OPENAPI_SCHEMA_FILE)
+            if os.path.exists(schema.OPENAPI_SCHEMA_PY):
+                log.info(f"using {schema.OPENAPI_SCHEMA_PY}")
+                schema_model = schema.create_schema_model(schema.OPENAPI_SCHEMA_PY)
                 TrainingInputType = schema_model.TrainingInputType
                 TrainingOutputType = schema_model.TrainingOutputType
             else:

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -127,12 +127,12 @@ def create_app(
 
     try:
         predictor_ref = get_predictor_ref(config, mode)
-        # use openapi schema if schema file exists in model dir (cloud/k8s run)
-        if os.path.exists(schema.OPENAPI_SCHEMA_PY):
-            log.info(f"using {schema.OPENAPI_SCHEMA_PY}")
-            schema_model = schema.create_schema_model(schema.OPENAPI_SCHEMA_PY)
-            InputType = schema_model.Input
-            OutputType = schema_model.Output
+        # use bundled schema if it exists
+        schema_module = schema.create_schema_module()
+        if schema_module is not None:
+            log.info("using bundled schema")
+            InputType = schema_module.Input
+            OutputType = schema_module.Output
         else:
             predictor = load_predictor_from_ref(predictor_ref)
             InputType = get_input_type(predictor)
@@ -172,12 +172,12 @@ def create_app(
     if "train" in config:
         try:
             trainer_ref = get_predictor_ref(config, "train")
-            # use openapi schema if schema file exists in model dir (cloud/k8s run)
-            if os.path.exists(schema.OPENAPI_SCHEMA_PY):
-                log.info(f"using {schema.OPENAPI_SCHEMA_PY}")
-                schema_model = schema.create_schema_model(schema.OPENAPI_SCHEMA_PY)
-                TrainingInputType = schema_model.TrainingInputType
-                TrainingOutputType = schema_model.TrainingOutputType
+            # use bundled schema if it exists
+            schema_module = schema.create_schema_module()
+            if schema_module is not None:
+                log.info("using bundled schema")
+                TrainingInputType = schema_module.TrainingInputType
+                TrainingOutputType = schema_module.TrainingOutputType
             else:
                 trainer = load_predictor_from_ref(trainer_ref)
                 TrainingInputType = get_training_input_type(trainer)


### PR DESCRIPTION
- store openapi schema file json & py files in .cog subdir during cog build;
- conditionally create Input & Output schema types from openapi schema file;
- conditionally create TrainingInput & TrainingOutput schema types from openapi schema file;

Migration:
- optimization will work for new  models, old models are unaffected

Ref: https://github.com/replicate/infra/issues/23