### PR TITLE
Fix a formatting typo in yaml.md

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -60,7 +60,7 @@ build:
 
 To install Git-hosted Python packages, add `git` to the `system_packages` list, then use the `git+https://` syntax to specify the package name. For example:
 
-````yaml
+```yaml
 build:
   system_packages:
     - "git"
@@ -75,7 +75,7 @@ A pip requirements file specifying the Python packages to install. For example:
 ```yaml
 build:
   python_requirements: requirements.txt
-````
+```
 
 Your `cog.yaml` file can set either `python_packages` or `python_requirements`, but not both. Use `python_requirements` when you need to configure options like `--extra-index-url` or `--trusted-host` to fetch Python package dependencies.
 


### PR DESCRIPTION
Removed a redundant backtick that was causing the `python requirements` section to be displayed as a code excerpt.

@allcontributors please add @JacekDuszenko for doc