### PR TITLE
Make cog local runner match /tmp/shm size on Replicate

### DIFF
--- a/pkg/docker/run.go
+++ b/pkg/docker/run.go
@@ -54,7 +54,9 @@ func generateDockerArgs(options internalRunOptions) []string {
 	dockerArgs := []string{
 		"run",
 		"--rm",
-		"--shm-size", "8G", // https://github.com/pytorch/pytorch/issues/2244
+		"--shm-size", "6G",
+		// https://github.com/pytorch/pytorch/issues/2244
+		// https://github.com/replicate/cog/issues/1293
 		// TODO: relative to pwd and cog.yaml
 	}
 


### PR DESCRIPTION
Followup on https://github.com/replicate/cog/issues/1293#issuecomment-1952954820