### PR TITLE
Update VSCode workspace settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,7 @@
 {
   "recommendations": [
     "charliermarsh.ruff",
-    "esbenp.prettier-vscode",
     "golang.go",
-    "ms-python.black-formatter",
     "ms-python.python",
     "ms-python.vscode-pylance"
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,12 +13,14 @@
   "go.lintTool": "golangci-lint",
   "go.formatTool": "goimports",
   "go.testOnSave": true,
-  "gopls": { "formatting.local": "github.com/replicate/cog" },
+  "gopls": {
+    "formatting.local": "github.com/replicate/cog"
+  },
   "[json]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "vscode.json-language-features"
   },
   "[jsonc]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "vscode.json-language-features"
   },
   "[python]": {
     "editor.formatOnSave": true,
@@ -29,8 +31,13 @@
     "editor.defaultFormatter": null
   },
   "python.languageServer": "Pylance",
-  "python.testing.pytestArgs": ["-vvv", "python"],
+  "python.testing.pytestArgs": [
+    "-vvv",
+    "python"
+  ],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
-  "ruff.lint.args": ["--config=pyproject.toml"]
+  "ruff.lint.args": [
+    "--config=pyproject.toml"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,8 +23,8 @@
   "[python]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll": true,
-      "source.organizeImports": true
+      "source.fixAll": "explicit",
+      "source.organizeImports": "explicit"
     },
     "editor.defaultFormatter": null
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,5 +35,5 @@
   "python.formatting.provider": "black",
   "python.linting.mypyEnabled": true,
   "python.linting.mypyArgs": ["--show-column-numbers", "--no-pretty"],
-  "ruff.args": ["--config=pyproject.toml"]
+  "ruff.lint.args": ["--config=pyproject.toml"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,8 +32,5 @@
   "python.testing.pytestArgs": ["-vvv", "python"],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
-  "python.formatting.provider": "black",
-  "python.linting.mypyEnabled": true,
-  "python.linting.mypyArgs": ["--show-column-numbers", "--no-pretty"],
   "ruff.lint.args": ["--config=pyproject.toml"]
 }


### PR DESCRIPTION
Prompted by getting a `All settings starting with "python.linting." are deprecated and can be removed from settings.` warning at startup. This PR resolves the handful of other issues discovered along the way.