### PR TITLE
feat: deprecate python 3.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     defaults:
       run:
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ lint-go:
 lint-python:
 	$(RUFF) python/cog
 	$(RUFF) format --check python
+	@$(PYTHON) -c 'import sys; sys.exit("Warning: python >=3.10 is needed (not installed) to pass linting (pyright)") if sys.version_info < (3, 10) else None'
 	$(PYRIGHT)
 
 .PHONY: lint
@@ -106,7 +107,6 @@ mod-tidy:
 
 .PHONY: install-python # install dev dependencies
 install-python:
-	$(PYTHON) -c 'import sys; exit(0) if sys.version_info >= (3, 10) else print("\n\nWarning: python >=3.10 is needed (not installed) to pass linting (pyright)\n\n")'
 	$(PYTHON) -m pip install '.[dev]'
 
 

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -88,7 +88,7 @@ build:
   python_version: "3.11.1"
 ```
 
-Cog supports all active branches of Python: 3.8, 3.9, 3.10, 3.11.
+Cog supports all active branches of Python: 3.8, 3.9, 3.10, 3.11, 3.12.
 
 Note that these are the versions supported **in the Docker container**, not your host machine. You can run any version(s) of Python you wish on your host machine.
 

--- a/test-integration/test_integration/fixtures/python_37/cog.yaml
+++ b/test-integration/test_integration/fixtures/python_37/cog.yaml
@@ -1,0 +1,5 @@
+build:
+  gpu: false
+  python_version: "3.7"
+
+predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/python_37/predict.py
+++ b/test-integration/test_integration/fixtures/python_37/predict.py
@@ -1,0 +1,6 @@
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def predict(self, num: int) -> int:
+        return num * 2

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -208,3 +208,15 @@ def test_build_with_cog_init_templates(tmpdir, docker_image):
 
     assert build_process.returncode == 0
     assert "Image built as cog-" in build_process.stderr.decode()
+
+
+def test_python_37_depricated(docker_image):
+    def test_build_invalid_schema(docker_image):
+        project_dir = Path(__file__).parent / "fixtures/python_37"
+        build_process = subprocess.run(
+            ["cog", "build", "-t", docker_image],
+            cwd=project_dir,
+            capture_output=True,
+        )
+        assert build_process.returncode > 0
+        assert "ERROR: Package 'cog' requires a different Python" in build_process.stderr.decode()


### PR DESCRIPTION
- do not allow python 3.7 in models
- added python 3.12 to CI verification
- added test:  test_integration/test_build.py::test_python_37_depricated

Ref: issue #1431