### PR TITLE
Remove deprecated labels

### DIFF
--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -153,12 +153,6 @@ func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache,
 		// Mark the image as having an appropriate init entrypoint. We can use this
 		// to decide how/if to shim the image.
 		global.LabelNamespace + "has_init": "true",
-
-		// Backwards compatibility. Remove for 1.0.
-		"org.cogmodel.deprecated":     "The org.cogmodel labels are deprecated. Use run.cog.",
-		"org.cogmodel.cog_version":    global.Version,
-		"org.cogmodel.config":         string(bytes.TrimSpace(configJSON)),
-		"org.cogmodel.openapi_schema": string(schemaJSON),
 	}
 
 	if isGitRepo(dir) {

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -14,7 +14,10 @@ def test_build_without_predictor(docker_image):
         capture_output=True,
     )
     assert build_process.returncode > 0
-    assert "Can't run predictions: 'predict' option not found" in build_process.stderr.decode()
+    assert (
+        "Can't run predictions: 'predict' option not found"
+        in build_process.stderr.decode()
+    )
 
 
 def test_build_names_uses_image_option_in_cog_yaml(tmpdir, docker_image):
@@ -64,9 +67,6 @@ def test_build_with_model(docker_image):
     )
     labels = image[0]["Config"]["Labels"]
     schema = json.loads(labels["run.cog.openapi_schema"])
-
-    # Backwards compatibility
-    assert "org.cogmodel.openapi_schema" in labels
 
     assert schema["components"]["schemas"]["Input"] == {
         "title": "Input",
@@ -174,19 +174,6 @@ class Predictor(BasePredictor):
     }
     assert "run.cog.openapi_schema" in labels
 
-    # Deprecated. Remove for 1.0.
-    assert len(labels["org.cogmodel.cog_version"]) > 0
-    assert json.loads(labels["org.cogmodel.config"]) == {
-        "build": {
-            "python_version": "3.8",
-            "gpu": True,
-            "cuda": "11.8",
-            "cudnn": "8",
-        },
-        "predict": "predict.py:Predictor",
-    }
-    assert "org.cogmodel.openapi_schema" in labels
-
     assert len(labels["org.opencontainers.image.version"]) > 0
     assert len(labels["org.opencontainers.image.revision"]) > 0
 
@@ -219,4 +206,7 @@ def test_python_37_depricated(docker_image):
             capture_output=True,
         )
         assert build_process.returncode > 0
-        assert "ERROR: Package 'cog' requires a different Python" in build_process.stderr.decode()
+        assert (
+            "ERROR: Package 'cog' requires a different Python"
+            in build_process.stderr.decode()
+        )


### PR DESCRIPTION
We have been warning that these are deprecated for a long, long time
now, and we probably have the liberty to make breaking changes <1.0.

Signed-off-by: Ben Firshman <ben@firshman.com>
