### PR TITLE
Increase timeout of flakey test to 1.5s

### DIFF
--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -22,7 +22,7 @@ from hypothesis.stateful import (
 )
 
 # Set a longer deadline on CI as the instances are a bit slower.
-settings.register_profile("ci", max_examples=100, deadline=1000)
+settings.register_profile("ci", max_examples=100, deadline=1500)
 settings.register_profile("default", max_examples=10, deadline=1000)
 settings.register_profile("slow", max_examples=10, deadline=2000)
 settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))


### PR DESCRIPTION
this PR attempts to debug why hypothesis tests are flaking