### PR TITLE
use shorter cog.run URLs in `cog init` templates

### DIFF
--- a/pkg/cli/init-templates/cog.yaml
+++ b/pkg/cli/init-templates/cog.yaml
@@ -1,5 +1,5 @@
 # Configuration for Cog ⚙️
-# Reference: https://github.com/replicate/cog/blob/main/docs/yaml.md
+# Reference: https://cog.run/yaml
 
 build:
   # set to true if your model requires a GPU

--- a/pkg/cli/init-templates/predict.py
+++ b/pkg/cli/init-templates/predict.py
@@ -1,5 +1,5 @@
 # Prediction interface for Cog ⚙️
-# https://github.com/replicate/cog/blob/main/docs/python.md
+# https://cog.run/python
 
 from cog import BasePredictor, Input, Path
 


### PR DESCRIPTION
💅🏼 