### PR TITLE
update compatibility matrices: support torch 2.2

### DIFF
--- a/pkg/config/torch_compatibility_matrix.json
+++ b/pkg/config/torch_compatibility_matrix.json
@@ -1,44 +1,182 @@
 [
   {
-    "Torch": "2.1.1+cpu",
-    "Torchvision": "0.16.1",
-    "Torchaudio": "2.1.1",
+    "Torch": "2.2.1+cpu",
+    "Torchvision": "0.17.1",
+    "Torchaudio": "2.2.1",
     "FindLinks": "",
     "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
     "CUDA": null,
     "Pythons": [
       "3.10",
       "3.11",
+      "3.12",
       "3.8",
       "3.9"
     ]
   },
   {
-    "Torch": "2.1.1+cu118",
-    "Torchvision": "0.16.1",
-    "Torchaudio": "2.1.1",
+    "Torch": "2.2.1+cu118",
+    "Torchvision": "0.17.1",
+    "Torchaudio": "2.2.1",
     "FindLinks": "",
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu118",
     "CUDA": "11.8",
     "Pythons": [
       "3.10",
       "3.11",
+      "3.12",
       "3.8",
       "3.9"
     ]
   },
   {
-    "Torch": "2.1.1+cu121",
-    "Torchvision": "0.16.1",
-    "Torchaudio": "2.1.1",
+    "Torch": "2.2.1+cu121",
+    "Torchvision": "0.17.1",
+    "Torchaudio": "2.2.1",
     "FindLinks": "",
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu121",
     "CUDA": "12.1",
     "Pythons": [
       "3.10",
       "3.11",
+      "3.12",
       "3.8",
       "3.9"
+    ]
+  },
+  {
+    "Torch": "2.2.0",
+    "Torchvision": "0.17.0",
+    "Torchaudio": "2.2.0",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cu118",
+    "CUDA": "11.8",
+    "Pythons": [
+      "3.7",
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
+    ]
+  },
+  {
+    "Torch": "2.2.0",
+    "Torchvision": "0.17.0",
+    "Torchaudio": "2.2.0",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cu121",
+    "CUDA": "12.1",
+    "Pythons": [
+      "3.7",
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
+    ]
+  },
+  {
+    "Torch": "2.2.0",
+    "Torchvision": "0.17.0",
+    "Torchaudio": "2.2.0",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
+    "CUDA": null,
+    "Pythons": [
+      "3.7",
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
+    ]
+  },
+  {
+    "Torch": "2.1.2",
+    "Torchvision": "0.16.2",
+    "Torchaudio": "2.1.2",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cu118",
+    "CUDA": "11.8",
+    "Pythons": [
+      "3.7",
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
+    ]
+  },
+  {
+    "Torch": "2.1.2",
+    "Torchvision": "0.16.2",
+    "Torchaudio": "2.1.2",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cu121",
+    "CUDA": "12.1",
+    "Pythons": [
+      "3.7",
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
+    ]
+  },
+  {
+    "Torch": "2.1.2",
+    "Torchvision": "0.16.2",
+    "Torchaudio": "2.1.2",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
+    "CUDA": null,
+    "Pythons": [
+      "3.7",
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
+    ]
+  },
+  {
+    "Torch": "2.1.1",
+    "Torchvision": "0.16.1",
+    "Torchaudio": "2.1.1",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cu118",
+    "CUDA": "11.8",
+    "Pythons": [
+      "3.7",
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
+    ]
+  },
+  {
+    "Torch": "2.1.1",
+    "Torchvision": "0.16.1",
+    "Torchaudio": "2.1.1",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cu121",
+    "CUDA": "12.1",
+    "Pythons": [
+      "3.7",
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
+    ]
+  },
+  {
+    "Torch": "2.1.1",
+    "Torchvision": "0.16.1",
+    "Torchaudio": "2.1.1",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
+    "CUDA": null,
+    "Pythons": [
+      "3.7",
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
     ]
   },
   {
@@ -49,7 +187,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu118",
     "CUDA": "11.8",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -65,7 +202,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu121",
     "CUDA": "12.1",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -81,7 +217,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -97,7 +232,6 @@
     "ExtraIndexURL": "",
     "CUDA": "11.7",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -113,7 +247,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu118",
     "CUDA": "11.8",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -129,7 +262,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -145,7 +277,6 @@
     "ExtraIndexURL": "",
     "CUDA": "11.7",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -161,7 +292,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu118",
     "CUDA": "11.8",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -177,7 +307,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -193,7 +322,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu116",
     "CUDA": "11.6",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -209,7 +337,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu117",
     "CUDA": "11.7",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -225,7 +352,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -241,7 +367,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu116",
     "CUDA": "11.6",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -257,7 +382,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu117",
     "CUDA": "11.7",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -273,7 +397,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -289,7 +412,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu116",
     "CUDA": "11.6",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -305,7 +427,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu113",
     "CUDA": "11.3",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -321,7 +442,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu102",
     "CUDA": "10.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -337,7 +457,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -353,7 +472,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu116",
     "CUDA": "11.6",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -369,7 +487,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu113",
     "CUDA": "11.3",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -385,7 +502,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu102",
     "CUDA": "10.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -401,7 +517,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -417,7 +532,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu113",
     "CUDA": "11.3",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -433,7 +547,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu102",
     "CUDA": "10.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -449,7 +562,6 @@
     "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -465,7 +577,6 @@
     "ExtraIndexURL": "",
     "CUDA": "11.1",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -481,7 +592,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -497,7 +607,6 @@
     "ExtraIndexURL": "",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -513,7 +622,6 @@
     "ExtraIndexURL": "",
     "CUDA": "11.1",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -529,7 +637,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -545,7 +652,6 @@
     "ExtraIndexURL": "",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -561,7 +667,6 @@
     "ExtraIndexURL": "",
     "CUDA": "11.1",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -577,7 +682,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -593,7 +697,6 @@
     "ExtraIndexURL": "",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -609,7 +712,6 @@
     "ExtraIndexURL": "",
     "CUDA": "11.1",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -625,7 +727,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -641,7 +742,6 @@
     "ExtraIndexURL": "",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -657,7 +757,6 @@
     "ExtraIndexURL": "",
     "CUDA": "11.1",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -673,7 +772,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -689,7 +787,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.1",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -705,7 +802,6 @@
     "ExtraIndexURL": "",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -721,7 +817,6 @@
     "ExtraIndexURL": "",
     "CUDA": "11.1",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -737,7 +832,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -753,7 +847,6 @@
     "ExtraIndexURL": "",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -769,7 +862,6 @@
     "ExtraIndexURL": "",
     "CUDA": "11.0",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -785,7 +877,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -801,7 +892,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.1",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -817,7 +907,6 @@
     "ExtraIndexURL": "",
     "CUDA": "9.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -833,7 +922,6 @@
     "ExtraIndexURL": "",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -849,7 +937,6 @@
     "ExtraIndexURL": "",
     "CUDA": "11.0",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -865,7 +952,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -881,7 +967,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.1",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -897,7 +982,6 @@
     "ExtraIndexURL": "",
     "CUDA": "9.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -913,7 +997,6 @@
     "ExtraIndexURL": "",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -929,7 +1012,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -945,7 +1027,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.1",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -961,7 +1042,6 @@
     "ExtraIndexURL": "",
     "CUDA": "9.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -977,7 +1057,6 @@
     "ExtraIndexURL": "",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -993,7 +1072,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -1009,7 +1087,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.1",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -1025,7 +1102,6 @@
     "ExtraIndexURL": "",
     "CUDA": "9.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -1041,7 +1117,6 @@
     "ExtraIndexURL": "",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -1057,7 +1132,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -1073,7 +1147,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.1",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -1089,7 +1162,6 @@
     "ExtraIndexURL": "",
     "CUDA": "9.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -1105,7 +1177,6 @@
     "ExtraIndexURL": "",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -1121,7 +1192,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.1",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -1137,7 +1207,6 @@
     "ExtraIndexURL": "",
     "CUDA": "9.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -1153,7 +1222,6 @@
     "ExtraIndexURL": "",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -1169,7 +1237,6 @@
     "ExtraIndexURL": "",
     "CUDA": "10.0",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -1185,7 +1252,6 @@
     "ExtraIndexURL": "",
     "CUDA": "9.2",
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",
@@ -1201,7 +1267,6 @@
     "ExtraIndexURL": "",
     "CUDA": null,
     "Pythons": [
-      "3.6",
       "3.7",
       "3.8",
       "3.9",


### PR DESCRIPTION
I ran the compatgen tool with `go run tools/compatgen/main.go torch`, and used the output to update the compatibility matrix for torch.

- adds support for Torch 2.2.*
- removes Python 3.6 from compatibilities matrix

Judging from [this merged PR](https://github.com/replicate/cog/pull/1550), should we maybe also remove mentions of Python 3.7 and add Python 3.12?