### PR TITLE
feat: deprecate python 3.7 #2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     defaults:
       run:
         shell: bash

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -52,6 +52,11 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 		imageName = config.DockerImageName(projectDir)
 	}
 
+	err = config.ValidateModelPythonVersion(cfg.Build.PythonVersion)
+	if err != nil {
+		return err
+	}
+
 	if err := image.Build(cfg, projectDir, imageName, buildSecrets, buildNoCache, buildSeparateWeights, buildUseCudaBaseImage, buildProgressOutput, buildSchemaFile, buildDockerfileFile); err != nil {
 		return err
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -480,3 +480,14 @@ func TestBlankBuild(t *testing.T) {
 	require.NotNil(t, config.Build)
 	require.Equal(t, false, config.Build.GPU)
 }
+
+func TestModelPythonVersionValidation(t *testing.T) {
+	err := ValidateModelPythonVersion("3.8")
+	require.NoError(t, err)
+	err = ValidateModelPythonVersion("3.8.1")
+	require.NoError(t, err)
+	err = ValidateModelPythonVersion("3.7")
+	require.Equal(t, "minimum supported Python version is 3.8. requested 3.7", err.Error())
+	err = ValidateModelPythonVersion("3.7.1")
+	require.Equal(t, "minimum supported Python version is 3.8. requested 3.7.1", err.Error())
+}

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -22,7 +22,7 @@ from hypothesis.stateful import (
 )
 
 # Set a longer deadline on CI as the instances are a bit slower.
-settings.register_profile("ci", max_examples=100, deadline=1000)
+settings.register_profile("ci", max_examples=100, deadline=1300)
 settings.register_profile("default", max_examples=10, deadline=1000)
 settings.register_profile("slow", max_examples=10, deadline=2000)
 settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -208,16 +208,15 @@ def test_build_with_complex_output(tmpdir, docker_image):
     assert "Image built as cog-" in build_process.stderr.decode()
 
 
-def test_python_37_depricated(docker_image):
-    def test_build_invalid_schema(docker_image):
-        project_dir = Path(__file__).parent / "fixtures/python_37"
-        build_process = subprocess.run(
-            ["cog", "build", "-t", docker_image],
-            cwd=project_dir,
-            capture_output=True,
-        )
-        assert build_process.returncode > 0
-        assert (
-            "ERROR: Package 'cog' requires a different Python"
-            in build_process.stderr.decode()
-        )
+def test_python_37_deprecated(docker_image):
+    project_dir = Path(__file__).parent / "fixtures/python_37"
+    build_process = subprocess.run(
+        ["cog", "build", "-t", docker_image],
+        cwd=project_dir,
+        capture_output=True,
+    )
+    assert build_process.returncode > 0
+    assert (
+        "minimum supported Python version is 3.8. requested 3.7"
+        in build_process.stderr.decode()
+    )


### PR DESCRIPTION
- previous deprecation of Ptyhon 3.7 in models did not have actual check (https://github.com/replicate/cog/pull/1550)
- now the model python minimum version is checked in `cog build` only
- this new approach is compatible with existing already built and/or uploaded models
- fixed integration test
- keep running CI tests on python 3.7
