### PR TITLE
Cog build instructions and cog dockerfile generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,7 @@ sudo chmod +x /usr/local/bin/cog
 Alternatively, you can build Cog from source and install it with these commands:
 
 ```console
-make
-sudo make install
+make cog
 ```
 
 ## Upgrade

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ sudo chmod +x /usr/local/bin/cog
 Alternatively, you can build Cog from source and install it with these commands:
 
 ```console
-make cog
+make
+sudo make install
 ```
 
 ## Upgrade

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/weights"
@@ -66,8 +67,9 @@ func NewGenerator(config *config.Config, dir string) (*Generator, error) {
 	if err := os.MkdirAll(rootTmp, 0o755); err != nil {
 		return nil, err
 	}
-	// tmpDir ends up being something like dir/.cog/tmp/build123456789
-	tmpDir, err := os.MkdirTemp(rootTmp, "build")
+	// tmpDir ends up being something like dir/.cog/tmp/build20230731
+	now := time.Now().Format("20060102150405")
+	tmpDir, err := os.MkdirTemp(rootTmp, "build"+now)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -67,8 +67,8 @@ func NewGenerator(config *config.Config, dir string) (*Generator, error) {
 	if err := os.MkdirAll(rootTmp, 0o755); err != nil {
 		return nil, err
 	}
-	// tmpDir ends up being something like dir/.cog/tmp/build20230731
-	now := time.Now().Format("20060102150405")
+	// tmpDir ends up being something like dir/.cog/tmp/build20240319021234.000000
+	now := time.Now().Format("20060102150405.000000")
 	tmpDir, err := os.MkdirTemp(rootTmp, "build"+now)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Use datetime instead of random for dockerfile generation to distinguish older .cog/tmp/buildX from newer .cog/tmp/buildY