### PR TITLE
Add workflow to build cog-base images

### DIFF
--- a/.github/workflows/build-bases.yaml
+++ b/.github/workflows/build-bases.yaml
@@ -1,0 +1,64 @@
+name: Build Base Images
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+jobs:
+  setmatrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - id: set-matrix
+        run: echo "::set-output name=matrix::$(jq -c . < cog-bases/matrix.json)"
+        shell: bash
+
+  build:
+    name: Build Image
+    runs-on: ubuntu-latest-8-cores
+    strategy:
+      matrix: ${{fromJson(needs.setmatrix.outputs.matrix)}}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      - uses: actions/checkout@v4
+        name: 'Checkout Repository'
+
+      - name: 'Set up Buildx'
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - id: auth
+        name: 'Authenticate to Google Cloud'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity: 'projects/1025538909507/locations/global/workloadIdentityPools/github/providers/github-actions'
+          service_account: 'builder@replicate-production.iam.gserviceaccount.com'
+          token_format: 'access_token'
+
+      - name: 'Login to US Artifact Registry'
+        uses: docker/login-action@v3
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.token }}
+
+      - name: 'Build and Push Base Images'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          registry: us-docker.pkg.dev/replicate-production/replicate-us/cog-base
+          push: true
+          file: ./cog-bases/${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ matrix.imagename }}:latest, ${{ matrix.imagename }}:${{ github.sha }}

--- a/cog-bases/matrix.json
+++ b/cog-bases/matrix.json
@@ -1,0 +1,4 @@
+{
+  "dockerfile": ["Dockerfile1", "Dockerfile2"],
+  "imagename": ["image1", "image2"]
+}


### PR DESCRIPTION
This PR adds a manual dispatch workflow that will build the cog base images. The dockerfiles and imagenames are defined in `cog-bases/matrix.json`.

The intent is to make it easy to build/add and support a variety of base images that cog can rely on for building more consistent and reusable images. This will improve cache hit when run in environments with a node cache of images.