### PR TITLE
deprecate `cog.File` in docs

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -230,6 +230,9 @@ Each parameter of the `predict()` method must be annotated with a type. The meth
 
 ## `File()`
 
+> [!WARNING]  
+> `cog.File` is deprecated and will be removed in a future version of Cog. Use [`cog.Path`](#path) instead.
+
 The `cog.File` object is used to get files in and out of models. It represents a _file handle_.
 
 For models that return a `cog.File` object, the prediction output returned by Cog's built-in HTTP server will be a URL.


### PR DESCRIPTION
The `cog.File` object was intended to be an alternative to `cog.Path` that represents a file handle rather than a path to a file, but it's confusing, the differences are not clear, it's not well documented, and nearly everyone uses `cog.Path` instead.

This PR updates the docs to warn people that `cog.File` is deprecated, will be removed, and that they should use `cog.Path` instead.

---

Here is the tiny list of public models I was able to find that use `cog.File`

- [bfirsh/segformer-b0-finetuned-ade-512-512](https://replicate.com/bfirsh/segformer-b0-finetuned-ade-512-512)
- [center/-curriculum-redesign---bge_1-5_query_embeddings](https://replicate.com/center/-curriculum-redesign---bge_1-5_query_embeddings)
- [cszn/scunet](https://replicate.com/cszn/scunet)
- [cudanexus/nougat](https://replicate.com/cudanexus/nougat)
- [fire/v-sekai.mediapipe-labeler](https://replicate.com/fire/v-sekai.mediapipe-labeler)
- [flores/---sd-x2-latent-upscaler](https://replicate.com/flores/---sd-x2-latent-upscaler)
- [holywalley/bel-tts](https://replicate.com/holywalley/bel-tts)
- [krthr/clip-embeddings](https://replicate.com/krthr/clip-embeddings)
- [mchong6/gans-n-roses](https://replicate.com/mchong6/gans-n-roses)
- [nicholascelestin/dalle-mega](https://replicate.com/nicholascelestin/dalle-mega)
- [nicholascelestin/glid-3](https://replicate.com/nicholascelestin/glid-3)
- [ocg2347/sam-pointprompt](https://replicate.com/ocg2347/sam-pointprompt)
- [satani99/van-gogh](https://replicate.com/satani99/van-gogh)
- [thomasmol/whisper-diarization](https://replicate.com/thomasmol/whisper-diarization)
