### PR TITLE
Always pass `--load` flag to `docker buildx build` command

### DIFF
--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -17,12 +17,12 @@ func Build(dir, dockerfile, imageName string, secrets []string, noCache bool, pr
 	var args []string
 
 	args = append(args,
-		"buildx", "build",
+		"buildx", "build", "--load",
 	)
 
 	if util.IsAppleSiliconMac(runtime.GOOS, runtime.GOARCH) {
 		// Fixes "WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested"
-		args = append(args, "--platform", "linux/amd64", "--load")
+		args = append(args, "--platform", "linux/amd64")
 	}
 
 	for _, secret := range secrets {


### PR DESCRIPTION
Related to https://github.com/replicate/cog/issues/1620

Some customers have observed the [`replicate/setup-cog` action](https://github.com/replicate/setup-cog) failing to push new versions of images to Replicate.

In logs for such failing GitHub Actions runs, the following is printed:

> No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load

We currently _do_ pass `--load`, but only when building on macOS:

https://github.com/replicate/cog/blob/03216b69e2f0aa2b93fe42e00f752fae5b576a78/pkg/docker/build.go#L25

I believe this code was leftover from when `cog build` didn't always imply `docker buildx build`, and BuildKit was used only when building `linux/amd64` on `linux/arm64/v8`.

From https://docs.docker.com/reference/cli/docker/buildx/create/#docker-driver:

> `docker driver` - Uses the builder that is built into the Docker daemon. With this driver, the --load flag is implied by default on buildx build. However, building multi-platform images or exporting cache is not currently supported.

> `docker-container driver` - Uses a BuildKit container that will be spawned via Docker. With this driver, both building multi-platform images and exporting cache are supported.

This PR adds the `--load` flag to the `docker buildx build` command invocation for all code paths. Since that's the implied default for the `docker` driver, this change shouldn't affect anyone getting the correct behavior.