### PR TITLE
fix: 🐛 Failed to Load Docker Image Metadata in Github Action

### DIFF
--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -71,7 +71,7 @@ func Build(dir, dockerfile, imageName string, secrets []string, noCache bool, pr
 	return cmd.Run()
 }
 
-func BuildAddLabelsAndSchemaToImage(image string, labels map[string]string, bundledSchemaFile string, bundledSchemaPy string) error {
+func BuildAddLabelsAndSchemaToImage(dir, image string, labels map[string]string, bundledSchemaFile string, bundledSchemaPy string) error {
 	var args []string
 
 	args = append(args,
@@ -95,6 +95,7 @@ func BuildAddLabelsAndSchemaToImage(image string, labels map[string]string, bund
 	// We're not using context, but Docker requires we pass a context
 	args = append(args, ".")
 	cmd := exec.Command("docker", args...)
+	cmd.Dir = dir
 
 	dockerfile := "FROM " + image + "\n"
 	dockerfile += "COPY " + bundledSchemaFile + " .cog\n"

--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -75,12 +75,12 @@ func BuildAddLabelsAndSchemaToImage(dir, image string, labels map[string]string,
 	var args []string
 
 	args = append(args,
-		"buildx", "build",
+		"buildx", "build", "--load",
 	)
 
 	if util.IsAppleSiliconMac(runtime.GOOS, runtime.GOARCH) {
 		// Fixes "WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested"
-		args = append(args, "--platform", "linux/amd64", "--load")
+		args = append(args, "--platform", "linux/amd64")
 	}
 
 	args = append(args,

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -170,7 +170,7 @@ func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache,
 		}
 	}
 
-	if err := docker.BuildAddLabelsAndSchemaToImage(imageName, labels, bundledSchemaFile, bundledSchemaPy); err != nil {
+	if err := docker.BuildAddLabelsAndSchemaToImage(dir, imageName, labels, bundledSchemaFile, bundledSchemaPy); err != nil {
 		return fmt.Errorf("Failed to add labels to image: %w", err)
 	}
 	return nil


### PR DESCRIPTION
Related to #1635 and #1631

PR #1621 attempts to address this issue, but passing the ```--load``` parameter in each build only partially solves the problem.