### PR TITLE
Fix Getting Started Link returns 404

### DIFF
--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -68,7 +68,7 @@ func initCommand(args []string) error {
 		console.Infof("✅ Created %s", filePath)
 	}
 
-	console.Infof("\nDone! For next steps, check out the docs at https://cog.run/docs/getting-started")
+	console.Infof("\nDone! For next steps, check out the docs at https://cog.run/getting-started")
 
 	return nil
 }


### PR DESCRIPTION
The correct link on cog.run is https://cog.run/getting-started/

Alternatively we could add a redirect to cog.run/docs/getting-started to redirect back.