### PR TITLE
implement mp.Connection with async streams

### DIFF
--- a/python/cog/server/connection.py
+++ b/python/cog/server/connection.py
@@ -8,9 +8,10 @@ from multiprocessing.connection import Connection
 from typing import Any, Generic, TypeVar
 
 X = TypeVar("X")
-_ForkingPickler = connection._ForkingPickler
+_ForkingPickler = connection._ForkingPickler  # type: ignore
 
 # based on https://github.com/python/cpython/blob/main/Lib/multiprocessing/connection.py#L364
+
 
 class AsyncConnection(Generic[X]):
     def __init__(self, conn: Connection) -> None:

--- a/python/cog/server/connection.py
+++ b/python/cog/server/connection.py
@@ -1,0 +1,85 @@
+import asyncio
+import io
+import os
+import socket
+import struct
+from multiprocessing import connection
+from multiprocessing.connection import Connection
+from typing import Any, Generic, TypeVar
+
+X = TypeVar("X")
+_ForkingPickler = connection._ForkingPickler
+
+
+class AsyncConnection(Generic[X]):
+    def __init__(self, conn: Connection) -> None:
+        self.wrapped_conn = conn
+        self.started = False
+
+    async def async_init(self) -> None:
+        fd = self.wrapped_conn.fileno()
+        # mp may have handled something already but let's dup so exit is clean
+        dup_fd = os.dup(fd)
+        sock = socket.socket(fileno=dup_fd)
+        sock.setblocking(False)
+        # make the pipe bigger probably
+        self._reader, self._writer = await asyncio.open_connection(sock=sock)
+        self.started = True
+
+    async def _recv(self, size: int) -> io.BytesIO:
+        if not self.started:
+            await self.async_init()
+        buf = io.BytesIO()
+        remaining = size
+        while remaining > 0:
+            chunk = await self._reader.read(remaining)
+            n = len(chunk)
+            if n == 0:
+                if remaining == size:
+                    raise EOFError
+                else:
+                    raise OSError("got end of file during message")
+            buf.write(chunk)
+            remaining -= n
+        return buf
+
+    async def _recv_bytes(self) -> io.BytesIO:
+        buf = await self._recv(4)
+        (size,) = struct.unpack("!i", buf.getvalue())
+        if size == -1:
+            buf = await self._recv(8)
+            (size,) = struct.unpack("!Q", buf.getvalue())
+        return await self._recv(size)
+
+    async def recv(self) -> X:
+        buf = await self._recv_bytes()
+        return _ForkingPickler.loads(buf.getbuffer())
+
+    def _send_bytes(self, buf: bytes) -> None:
+        n = len(buf)
+        if n > 0x7FFFFFFF:
+            pre_header = struct.pack("!i", -1)
+            header = struct.pack("!Q", n)
+            self._writer.write(pre_header)
+            self._writer.write(header)
+            self._writer.write(buf)
+        else:
+            header = struct.pack("!i", n)
+            if n > 16384:
+                self._writer.write(header)
+                self._writer.write(buf)
+            else:
+                self._writer.write(header + buf)
+
+    def send(self, obj: Any) -> None:
+        self._send_bytes(_ForkingPickler.dumps(obj, protocol=5))
+
+    def close(self) -> None:
+        self.wrapped_conn.close()
+        self._writer.close()
+
+    def __enter__(self) -> "AsyncConnection[X]":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
+        self.close()

--- a/python/cog/server/helpers.py
+++ b/python/cog/server/helpers.py
@@ -1,22 +1,13 @@
-import asyncio
-import concurrent.futures
 import io
 import os
 import selectors
-import sys
 import threading
 import uuid
-from multiprocessing.connection import Connection
 from typing import (
-    Any,
     Callable,
-    Coroutine,
-    Generic,
     Optional,
     Sequence,
     TextIO,
-    TypeVar,
-    Union,
 )
 
 
@@ -162,77 +153,3 @@ class StreamRedirector(threading.Thread):
                     if drain_tokens_seen >= drain_tokens_needed:
                         self.drain_event.set()
                         drain_tokens_seen = 0
-
-
-X = TypeVar("X")
-Y = TypeVar("Y")
-
-
-async def race(
-    x: Coroutine[None, None, X],
-    y: Coroutine[None, None, Y],
-    timeout: Optional[float] = None,
-) -> Union[X, Y]:
-    tasks = [asyncio.create_task(x), asyncio.create_task(y)]
-    wait = asyncio.wait(tasks, timeout=timeout, return_when=asyncio.FIRST_COMPLETED)
-    done, pending = await wait
-    for task in pending:
-        task.cancel()
-    if not done:
-        raise TimeoutError
-    # done is an unordered set but we want to preserve original order
-    result_task, *others = (t for t in tasks if t in done)
-    # during shutdown, some of the other completed tasks might be an error
-    # cancel them instead of handling the error to avoid the warning
-    # "Task exception was never retrieved"
-    for task in others:
-        msg = "was completed at the same time as another selected task, canceling"
-        # FIXME: ues a logger?
-        print(task, msg, file=sys.stderr)
-        task.cancel()
-    return result_task.result()
-
-
-# functionally this is the exact same thing as aioprocessing but 0.1% the code
-# however it's still worse than just using actual asynchronous io
-class AsyncPipe(Generic[X]):
-    def __init__(
-        self, conn: Connection, alive: Callable[[], bool] = lambda: True
-    ) -> None:
-        self.conn = conn
-        self.alive = alive
-        self.exiting = threading.Event()
-        self.executor = concurrent.futures.ThreadPoolExecutor(1)
-
-    def send(self, obj: Any) -> None:
-        self.conn.send(obj)
-
-    def shutdown(self) -> None:
-        self.exiting.set()
-        self.executor.shutdown(wait=True)
-        # if we ever need cancel_futures (introduced 3.9), we can copy it in from
-        # https://github.com/python/cpython/blob/3.11/Lib/concurrent/futures/thread.py#L216-L235
-
-    def poll(self, timeout: float = 0.0) -> bool:
-        return self.conn.poll(timeout)
-
-    def _recv(self) -> Optional[X]:
-        # this ugly mess could easily be avoided with loop.connect_read_pipe
-        # even loop.add_reader would help but we don't want to mess with a thread-local loop
-        while not self.exiting.is_set() and not self.conn.closed and self.alive():
-            if self.conn.poll(0.01):
-                if self.conn.closed or not self.alive():
-                    print("caught conn closed or unalive")
-                    return
-                return self.conn.recv()
-        return None
-
-    async def coro_recv(self) -> Optional[X]:
-        loop = asyncio.get_running_loop()
-        # believe it or not this can still deadlock!
-        return await loop.run_in_executor(self.executor, self._recv)
-
-    async def coro_recv_with_exit(self, exit: asyncio.Event) -> Optional[X]:
-        result = await race(self.coro_recv(), exit.wait())
-        if result is not True:  # wait() would return True
-            return result

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -108,7 +108,7 @@ class PredictionRunner:
             if self._response is None:
                 raise RunnerBusyError()
             assert self._result is not None
-            if request.id is not None and request.id == self._response.id:
+            if request.id is not None and request.id == self._response.id:  # type: ignore
                 result = cast(PredictionTask, self._result)
                 return (self._response, result)
             raise RunnerBusyError()

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -246,8 +246,9 @@ class Worker:
     async def _read_events(self) -> None:
         while self._child.is_alive() and not self._terminating.is_set():
             # this can still be running when the task is destroyed
-            result = await self._events.recv() # this might be kind of risky
-            if result is None:  # event loop closed or child died
+            result = await self._events.recv()  # this might be kind of risky
+            # event loop closed or child died
+            if result is None:  # type: ignore
                 break
             id, event = result
             if id == "LOG" and self._state == WorkerState.STARTING:

--- a/python/tests/server/test_connection.py
+++ b/python/tests/server/test_connection.py
@@ -1,0 +1,18 @@
+import multiprocessing as mp
+
+import pytest
+from cog.server import eventtypes
+from cog.server.connection import AsyncConnection
+
+
+@pytest.mark.asyncio
+async def test_async_connection_rt():
+    item = ("asdf", eventtypes.PredictionOutput({"x": 3}))
+    c1, c2 = mp.Pipe()
+    ac = AsyncConnection(c1)
+    await ac.async_init()
+    ac.send(item)
+    # we expect the binary format to be compatible
+    assert c2.recv() == item
+    c2.send(item)
+    assert await ac.recv() == item

--- a/python/tests/server/test_webhook.py
+++ b/python/tests/server/test_webhook.py
@@ -2,7 +2,6 @@ import pytest
 import requests
 import responses
 from cog.schema import WebhookEvent
-
 from responses import registries
 
 pytest.skip(allow_module_level=True)


### PR DESCRIPTION
Yet Another Step towards merging #1530 into #1512. this drops that stupid `race()` function and the threaded mp.Connection setup, because those were found to be somewhat slow when profiling and it's generally simpler and less deadlock-prone to do it this way. we instead just implement most of the same stuff as mp.Connection, including a test that it matches the same binary format implemented by mp.Connection