### PR TITLE
time_share metric

### DIFF
--- a/python/cog/schema.py
+++ b/python/cog/schema.py
@@ -79,7 +79,7 @@ class PredictionResponse(PredictionBaseModel):
     error: t.Optional[str]
     status: t.Optional[Status]
 
-    metrics: t.Optional[t.Dict[str, t.Any]]
+    metrics: t.Dict[str, t.Any] = pydantic.Field(default_factory=dict)
 
     @classmethod
     def with_types(cls, input_type: t.Type[t.Any], output_type: t.Type[t.Any]) -> t.Any:

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -307,12 +307,8 @@ class PredictionRunner:
                     event_stream = self._mux.read(prediction_input.id, poll=poll)
                     result = await event_handler.handle_event_stream(event_stream)
                     self.update_time_shares()
-                    if not result.metrics:
-                        result.metrics = {}
-                    predict_time_share = self._time_shares_per_prediction.pop(
-                        request.id
-                    )
-                    result.metrics["predict_time_share"] = predict_time_share
+                    time_share = self._time_shares_per_prediction.pop(request.id)
+                    result.metrics["predict_time_share"] = time_share
                     return result
             except httpx.HTTPError as e:
                 tb = traceback.format_exc()

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -309,8 +309,10 @@ class PredictionRunner:
                     self.update_time_shares()
                     if not result.metrics:
                         result.metrics = {}
-                    time_share = self._time_shares_per_prediction.pop(request.id)
-                    result.metrics["time_share"] = time_share
+                    predict_time_share = self._time_shares_per_prediction.pop(
+                        request.id
+                    )
+                    result.metrics["predict_time_share"] = predict_time_share
                     return result
             except httpx.HTTPError as e:
                 tb = traceback.format_exc()


### PR DESCRIPTION
it might be helpful to account for the cost of individual predictions in a batch, including the changes in batch size over the course of the prediction. this would add a metric representing that. it can also be used to determine the average batch size (`batch_size = predict_time / time_share`).

if there are two predictions that take 1 second, they would both cost 0.5s. if there's one prediction that takes 3 seconds and another one that takes 1 second (overlapping with the first prediction), the first will cost 2.5 (1 + 1/2 + 1) seconds and the second will cost 0.5 (1/2) seconds.

```
AAA***
*BBBB*
**CC**
***DDD
```
job A is running for the first 3 seconds, job B is running from second 2 to 5, job C runs seconds 3–4, job D runs seconds 4–6. suppose each second costs $1. A costs $1 + $.5 + $.3, B costs 0.5 + 0.3 + 0.3 + 0.5, C costs 0.3 + 0.3, etc.