### PR TITLE
function to emit metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,14 @@
+# Metrics
+
+Prediction objects have a `metrics` field. This normally includes `predict_time` and `total_time`. Official language models have metrics like `input_token_count`, `output_token_count`, `tokens_per_second`, and `time_to_first_token`. Currently, custom metrics from Cog are ignored when running on Replicate. Official Replicate-published models are the only exception to this. When running outside of Replicate, you can emit custom metrics like this:
+
+
+```python
+import cog
+from cog import BasePredictor, Path
+
+class Predictor(BasePredictor):
+    def predict(self, width: int, height: int) -> Path:
+        """Run a single prediction on the model"""
+        cog.emit_metric(name="pixel_count", value=width * height)
+```

--- a/python/cog/__init__.py
+++ b/python/cog/__init__.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 
 from .predictor import BasePredictor
+from .server.worker import emit_metric
 from .types import AsyncConcatenateIterator, ConcatenateIterator, File, Input, Path
 
 try:
@@ -18,4 +19,5 @@ __all__ = [
     "File",
     "Input",
     "Path",
+    "emit_metric",
 ]

--- a/python/cog/server/eventtypes.py
+++ b/python/cog/server/eventtypes.py
@@ -39,6 +39,12 @@ class Log:
 
 
 @define
+class PredictionMetric:
+    name: str
+    value: "float | int"
+
+
+@define
 class PredictionOutput:
     payload: Any
 

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -26,6 +26,7 @@ from .eventtypes import (
     Heartbeat,
     Log,
     PredictionInput,
+    PredictionMetric,
     PredictionOutput,
     PredictionOutputType,
     PublicEventType,
@@ -438,6 +439,7 @@ class PredictionEventHandler:
         self.logger.info("starting prediction")
         # maybe this should be a deep copy to not share File state with child worker
         self.p = schema.PredictionResponse(**request.dict())
+        self.p.metrics = {}
         self.p.status = schema.Status.PROCESSING
         self.p.output = None
         self.p.logs = ""
@@ -489,9 +491,9 @@ class PredictionEventHandler:
         # that...
         assert self.p.completed_at is not None
         assert self.p.started_at is not None
-        self.p.metrics = {
-            "predict_time": (self.p.completed_at - self.p.started_at).total_seconds()
-        }
+        self.p.metrics["predict_time"] = (
+            self.p.completed_at - self.p.started_at
+        ).total_seconds()
         await self._send_webhook(schema.WebhookEvent.COMPLETED)
 
     async def failed(self, error: str) -> None:
@@ -551,6 +553,9 @@ class PredictionEventHandler:
             self._output_type = event
             if self._output_type.multi:
                 return self.set_output([])
+            return self.noop()
+        if isinstance(event, PredictionMetric):
+            self.p.metrics[event.name] = event.value
             return self.noop()
         if isinstance(event, PredictionOutput):
             if self._output_type is None:

--- a/python/tests/server/test_runner.py
+++ b/python/tests/server/test_runner.py
@@ -4,8 +4,10 @@ import threading
 import time
 from datetime import datetime
 from unittest import mock
+
 import pytest
 import pytest_asyncio
+
 from cog.schema import PredictionRequest, PredictionResponse, Status, WebhookEvent
 from cog.server.clients import ClientManager
 from cog.server.eventtypes import (
@@ -21,7 +23,6 @@ from cog.server.runner import (
     RunnerBusyError,
     UnknownPredictionError,
 )
-
 
 # TODO
 # - setup logs


### PR DESCRIPTION
we need the model code to emit accurate input token counts using the correct prompt formatting and tokenizer for the model in question. after some internal discussion `from cog import emit_metric` seems similar to the best approach for this. presently these metrics are ignored for non-official models and shouldn't really matter anywhere else, so it shouldn't be a concern with billing. this particular approach is janky but should unblock us for now. 

usage:
```python
     async def predict(self, ...) -> ...:
        ...
        formatted_prompt = prompt_template.format(prompt=prompt, system_prompt=system_prompt)
        input_token_count = len(self.tokenizer(formatted_prompt )["input_ids"])
        cog.emit_metric(name="input_token_count", value=input_token_count)
        ...
```