### PR TITLE
fix: 🐛 a better fix for #1635

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GO ?= go
 GOOS := $(shell $(GO) env GOOS)
 GOARCH := $(shell $(GO) env GOARCH)
 
-PYTHON ?= python
+PYTHON ?= python3
 PYTEST := $(PYTHON) -m pytest
 PYRIGHT := $(PYTHON) -m pyright
 RUFF := $(PYTHON) -m ruff

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GO ?= go
 GOOS := $(shell $(GO) env GOOS)
 GOARCH := $(shell $(GO) env GOARCH)
 
-PYTHON ?= python3
+PYTHON ?= python
 PYTEST := $(PYTHON) -m pytest
 PYRIGHT := $(PYTHON) -m pyright
 RUFF := $(PYTHON) -m ruff

--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -17,12 +17,12 @@ func Build(dir, dockerfile, imageName string, secrets []string, noCache bool, pr
 	var args []string
 
 	args = append(args,
-		"buildx", "build", "--load",
+		"buildx", "build",
 	)
 
 	if util.IsAppleSiliconMac(runtime.GOOS, runtime.GOARCH) {
 		// Fixes "WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested"
-		args = append(args, "--platform", "linux/amd64")
+		args = append(args, "--platform", "linux/amd64", "--load")
 	}
 
 	for _, secret := range secrets {
@@ -71,16 +71,16 @@ func Build(dir, dockerfile, imageName string, secrets []string, noCache bool, pr
 	return cmd.Run()
 }
 
-func BuildAddLabelsAndSchemaToImage(dir, image string, labels map[string]string, bundledSchemaFile string, bundledSchemaPy string) error {
+func BuildAddLabelsAndSchemaToImage(image string, labels map[string]string, bundledSchemaFile string, bundledSchemaPy string) error {
 	var args []string
 
 	args = append(args,
-		"buildx", "build", "--load",
+		"buildx", "build",
 	)
 
 	if util.IsAppleSiliconMac(runtime.GOOS, runtime.GOARCH) {
 		// Fixes "WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested"
-		args = append(args, "--platform", "linux/amd64")
+		args = append(args, "--platform", "linux/amd64", "--load")
 	}
 
 	args = append(args,
@@ -95,7 +95,6 @@ func BuildAddLabelsAndSchemaToImage(dir, image string, labels map[string]string,
 	// We're not using context, but Docker requires we pass a context
 	args = append(args, ".")
 	cmd := exec.Command("docker", args...)
-	cmd.Dir = dir
 
 	dockerfile := "FROM " + image + "\n"
 	dockerfile += "COPY " + bundledSchemaFile + " .cog\n"

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -170,7 +170,7 @@ func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache,
 		}
 	}
 
-	if err := docker.BuildAddLabelsAndSchemaToImage(dir, imageName, labels, bundledSchemaFile, bundledSchemaPy); err != nil {
+	if err := docker.BuildAddLabelsAndSchemaToImage(imageName, labels, bundledSchemaFile, bundledSchemaPy); err != nil {
 		return fmt.Errorf("Failed to add labels to image: %w", err)
 	}
 	return nil


### PR DESCRIPTION
Related to #1635

PR #1638 solved this issue by ```load``` the image, but this solution took too long. 

```
2024-05-03T15:46:10.8805623Z #22 [stage-1 10/10] COPY . /src
2024-05-03T15:48:13.0347903Z #22 DONE 122.3s
2024-05-03T15:48:13.1585476Z 
2024-05-03T15:48:13.1587553Z #23 exporting to docker image format
2024-05-03T15:48:13.1588225Z #23 exporting layers
2024-05-03T15:56:24.3242181Z #23 exporting layers 491.2s done
2024-05-03T15:56:24.4767343Z #23 preparing layers for inline cache
2024-05-03T15:56:24.4943072Z #23 preparing layers for inline cache 0.2s done
2024-05-03T15:56:24.6204175Z #23 exporting manifest sha256:7b10fa087624266b84eb57facf450e2dc767b009b56436bd3c028779a4cc67f6 0.1s done
2024-05-03T15:56:24.6206394Z #23 exporting config sha256:38d47fc393ad525a1d25a91b9c1e648135472ac63f020470a4c188d0b4e1a961 0.1s done
2024-05-03T15:56:24.7764816Z #23 sending tarball
2024-05-03T16:00:07.2301375Z #23 ...
2024-05-03T16:00:07.2301605Z 
2024-05-03T16:00:07.2301791Z #24 importing to docker
2024-05-03T16:00:07.3643158Z #24 loading layer 1cde2b4dc996 32.77kB / 1.38MB
2024-05-03T16:00:07.3643801Z #24 loading layer 28f5903dfbd2 557.06kB / 100.94MB
2024-05-03T16:00:09.4743365Z #24 loading layer 28f5903dfbd2 99.71MB / 100.94MB 2.1s
2024-05-03T16:00:09.8255467Z #24 loading layer 3482a0714270 557.06kB / 87.55MB
2024-05-03T16:00:11.8367026Z #24 loading layer 3482a0714270 52.92MB / 87.55MB 2.0s
2024-05-03T16:00:13.7084115Z #24 loading layer 566cf2e36219 557.06kB / 171.75MB
2024-05-03T16:00:15.7395988Z #24 loading layer 566cf2e36219 115.87MB / 171.75MB 2.0s
2024-05-03T16:00:17.4028542Z #24 loading layer ae6ca9281f45 557.06kB / 3.17GB
2024-05-03T16:00:21.5107514Z #24 loading layer ae6ca9281f45 183.27MB / 3.17GB 4.1s
2024-05-03T16:00:25.6782155Z #24 loading layer ae6ca9281f45 408.88MB / 3.17GB 8.3s
2024-05-03T16:00:29.8381849Z #24 loading layer ae6ca9281f45 659.00MB / 3.17GB 12.4s
2024-05-03T16:00:33.9766994Z #24 loading layer ae6ca9281f45 1.02GB / 3.17GB 16.6s
2024-05-03T16:00:36.0661563Z #24 loading layer ae6ca9281f45 1.23GB / 3.17GB 18.7s
2024-05-03T16:00:38.1266979Z #24 loading layer ae6ca9281f45 1.41GB / 3.17GB 20.7s
2024-05-03T16:00:40.1923607Z #24 loading layer ae6ca9281f45 1.60GB / 3.17GB 22.8s
2024-05-03T16:00:42.2548782Z #24 loading layer ae6ca9281f45 1.82GB / 3.17GB 24.9s
2024-05-03T16:00:46.4134173Z #24 loading layer ae6ca9281f45 1.98GB / 3.17GB 29.0s
2024-05-03T16:00:52.6119664Z #24 loading layer ae6ca9281f45 2.15GB / 3.17GB 35.2s
2024-05-03T16:00:56.7480662Z #24 loading layer ae6ca9281f45 2.45GB / 3.17GB 39.3s
2024-05-03T16:00:58.8074572Z #24 loading layer ae6ca9281f45 2.68GB / 3.17GB 41.4s
2024-05-03T16:01:02.8259055Z #24 loading layer ae6ca9281f45 2.87GB / 3.17GB 45.4s
2024-05-03T16:01:06.9058459Z #24 loading layer ae6ca9281f45 3.15GB / 3.17GB 49.5s
2024-05-03T16:01:07.6885529Z #24 loading layer c76af8f74ef7 557.06kB / 72.19MB
2024-05-03T16:01:08.6584024Z #24 loading layer 95a863b35bca 65.54kB / 4.02MB
2024-05-03T16:01:08.8398985Z #24 loading layer cacf46ce3fd0 92B / 92B
2024-05-03T16:01:08.8399624Z #24 loading layer 8a2bf9f15a15 557.06kB / 12.80GB
2024-05-03T16:01:15.0016826Z #24 loading layer 8a2bf9f15a15 608.31MB / 12.80GB 6.2s
2024-05-03T16:01:21.1912787Z #24 loading layer 8a2bf9f15a15 1.00GB / 12.80GB 12.4s
2024-05-03T16:01:27.3174168Z #24 loading layer 8a2bf9f15a15 1.38GB / 12.80GB 18.5s
2024-05-03T16:01:33.4551100Z #24 loading layer 8a2bf9f15a15 2.13GB / 12.80GB 24.6s
2024-05-03T16:01:39.6126247Z #24 loading layer 8a2bf9f15a15 2.85GB / 12.80GB 30.8s
2024-05-03T16:01:45.7700363Z #24 loading layer 8a2bf9f15a15 3.58GB / 12.80GB 36.9s
2024-05-03T16:01:51.9148877Z #24 loading layer 8a2bf9f15a15 4.29GB / 12.80GB 43.1s
2024-05-03T16:01:58.1806450Z #24 loading layer 8a2bf9f15a15 4.75GB / 12.80GB 49.3s
2024-05-03T16:02:04.3451134Z #24 loading layer 8a2bf9f15a15 5.14GB / 12.80GB 55.5s
2024-05-03T16:02:10.4423061Z #24 loading layer 8a2bf9f15a15 5.77GB / 12.80GB 61.6s
2024-05-03T16:02:16.5809751Z #24 loading layer 8a2bf9f15a15 6.52GB / 12.80GB 67.7s
2024-05-03T16:02:22.7292243Z #24 loading layer 8a2bf9f15a15 7.26GB / 12.80GB 73.9s
2024-05-03T16:02:28.8679457Z #24 loading layer 8a2bf9f15a15 7.97GB / 12.80GB 80.0s
2024-05-03T16:02:34.9831777Z #24 loading layer 8a2bf9f15a15 8.45GB / 12.80GB 86.1s
2024-05-03T16:02:41.2012232Z #24 loading layer 8a2bf9f15a15 8.84GB / 12.80GB 92.4s
2024-05-03T16:02:47.3622021Z #24 loading layer 8a2bf9f15a15 9.41GB / 12.80GB 98.5s
2024-05-03T16:02:53.5188331Z #24 loading layer 8a2bf9f15a15 10.12GB / 12.80GB 104.7s
2024-05-03T16:02:59.6758109Z #24 loading layer 8a2bf9f15a15 10.88GB / 12.80GB 110.8s
2024-05-03T16:03:05.8188022Z #24 loading layer 8a2bf9f15a15 11.62GB / 12.80GB 117.0s
2024-05-03T16:03:11.9888352Z #24 loading layer 8a2bf9f15a15 12.22GB / 12.80GB 123.1s
2024-05-03T16:03:18.0788233Z #24 loading layer 8a2bf9f15a15 12.57GB / 12.80GB 129.2s
2024-05-03T16:03:23.6569059Z #24 loading layer 1cde2b4dc996 32.77kB / 1.38MB 196.4s done
2024-05-03T16:03:23.8113371Z #24 loading layer 28f5903dfbd2 99.71MB / 100.94MB 196.3s done
2024-05-03T16:03:23.8114105Z #24 loading layer 3482a0714270 52.92MB / 87.55MB 193.8s done
2024-05-03T16:03:23.8114747Z #24 loading layer 566cf2e36219 115.87MB / 171.75MB 189.9s done
2024-05-03T16:03:23.8115377Z #24 loading layer ae6ca9281f45 3.15GB / 3.17GB 186.3s done
2024-05-03T16:03:23.8116004Z #24 loading layer c76af8f74ef7 557.06kB / 72.19MB 136.0s done
2024-05-03T16:03:23.8116751Z #24 loading layer 95a863b35bca 65.54kB / 4.02MB 135.0s done
2024-05-03T16:03:23.8117344Z #24 loading layer cacf46ce3fd0 92B / 92B 134.9s done
2024-05-03T16:03:23.8117925Z #24 loading layer 8a2bf9f15a15 12.80GB / 12.80GB 134.8s done
2024-05-03T16:03:23.8118431Z #24 DONE 196.4s
2024-05-03T16:03:23.8118670Z 
2024-05-03T16:03:23.8118831Z #23 exporting to docker image format
2024-05-03T16:03:23.8119279Z #23 sending tarball 419.0s done
2024-05-03T16:03:23.8119663Z #23 DONE 910.5s
2024-05-03T16:03:57.6760767Z Validating model schema...
```

Changing the input of the ```setup-buildx-action``` script executed by the ```setup-cog``` script can better resolve the issue.

Please see https://github.com/replicate/setup-cog/pull/36