### PR TITLE
Update CUDA compatibility matrix for CUDA 12.3 / PyTorch 2.3.0

### DIFF
--- a/pkg/config/cuda_base_images.json
+++ b/pkg/config/cuda_base_images.json
@@ -1,5 +1,33 @@
 [
   {
+    "Tag": "12.4.1-cudnn-devel-ubuntu22.04",
+    "CUDA": "12.4.1",
+    "CuDNN": "",
+    "IsDevel": true,
+    "Ubuntu": "22.04"
+  },
+  {
+    "Tag": "12.4.1-cudnn-devel-ubuntu20.04",
+    "CUDA": "12.4.1",
+    "CuDNN": "",
+    "IsDevel": true,
+    "Ubuntu": "20.04"
+  },
+  {
+    "Tag": "12.3.2-cudnn9-devel-ubuntu22.04",
+    "CUDA": "12.3.2",
+    "CuDNN": "9",
+    "IsDevel": true,
+    "Ubuntu": "22.04"
+  },
+  {
+    "Tag": "12.3.2-cudnn9-devel-ubuntu20.04",
+    "CUDA": "12.3.2",
+    "CuDNN": "9",
+    "IsDevel": true,
+    "Ubuntu": "20.04"
+  },
+  {
     "Tag": "12.2.2-cudnn8-devel-ubuntu22.04",
     "CUDA": "12.2.2",
     "CuDNN": "8",
@@ -138,6 +166,13 @@
     "CuDNN": "8",
     "IsDevel": true,
     "Ubuntu": "18.04"
+  },
+  {
+    "Tag": "11.6.1-cudnn8-devel-ubuntu20.04",
+    "CUDA": "11.6.1",
+    "CuDNN": "8",
+    "IsDevel": true,
+    "Ubuntu": "20.04"
   },
   {
     "Tag": "11.5.2-cudnn8-devel-ubuntu20.04",

--- a/pkg/config/tf_compatibility_matrix.json
+++ b/pkg/config/tf_compatibility_matrix.json
@@ -1,10 +1,23 @@
 [
   {
+    "TF": "2.16.1",
+    "TFCPUPackage": "tensorflow==2.16.1",
+    "TFGPUPackage": "tensorflow==2.16.1",
+    "CUDA": "12.3",
+    "CuDNN": "8.9",
+    "Pythons": [
+      "3.9",
+      "3.10",
+      "3.11",
+      "3.12"
+    ]
+  },
+  {
     "TF": "2.15.0",
     "TFCPUPackage": "tensorflow==2.15.0",
     "TFGPUPackage": "tensorflow==2.15.0",
     "CUDA": "12.2",
-    "CuDNN": "8.8",
+    "CuDNN": "8.9",
     "Pythons": [
       "3.9",
       "3.10",

--- a/pkg/config/torch_compatibility_matrix.json
+++ b/pkg/config/torch_compatibility_matrix.json
@@ -1,8 +1,8 @@
 [
   {
-    "Torch": "2.2.1+cpu",
-    "Torchvision": "0.17.1",
-    "Torchaudio": "2.2.1",
+    "Torch": "2.3.0+cpu",
+    "Torchvision": "0.18.0",
+    "Torchaudio": "2.3.0",
     "FindLinks": "",
     "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
     "CUDA": null,
@@ -15,9 +15,9 @@
     ]
   },
   {
-    "Torch": "2.2.1+cu118",
-    "Torchvision": "0.17.1",
-    "Torchaudio": "2.2.1",
+    "Torch": "2.3.0+cu118",
+    "Torchvision": "0.18.0",
+    "Torchaudio": "2.3.0",
     "FindLinks": "",
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu118",
     "CUDA": "11.8",
@@ -30,9 +30,9 @@
     ]
   },
   {
-    "Torch": "2.2.1+cu121",
-    "Torchvision": "0.17.1",
-    "Torchaudio": "2.2.1",
+    "Torch": "2.3.0+cu121",
+    "Torchvision": "0.18.0",
+    "Torchaudio": "2.3.0",
     "FindLinks": "",
     "ExtraIndexURL": "https://download.pytorch.org/whl/cu121",
     "CUDA": "12.1",
@@ -42,6 +42,96 @@
       "3.12",
       "3.8",
       "3.9"
+    ]
+  },
+  {
+    "Torch": "2.2.2",
+    "Torchvision": "0.17.2",
+    "Torchaudio": "2.2.2",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cu118",
+    "CUDA": "11.8",
+    "Pythons": [
+      "3.7",
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
+    ]
+  },
+  {
+    "Torch": "2.2.2",
+    "Torchvision": "0.17.2",
+    "Torchaudio": "2.2.2",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cu121",
+    "CUDA": "12.1",
+    "Pythons": [
+      "3.7",
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
+    ]
+  },
+  {
+    "Torch": "2.2.2",
+    "Torchvision": "0.17.2",
+    "Torchaudio": "2.2.2",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
+    "CUDA": null,
+    "Pythons": [
+      "3.7",
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
+    ]
+  },
+  {
+    "Torch": "2.2.1",
+    "Torchvision": "0.17.1",
+    "Torchaudio": "2.2.1",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cu118",
+    "CUDA": "11.8",
+    "Pythons": [
+      "3.7",
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
+    ]
+  },
+  {
+    "Torch": "2.2.1",
+    "Torchvision": "0.17.1",
+    "Torchaudio": "2.2.1",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cu121",
+    "CUDA": "12.1",
+    "Pythons": [
+      "3.7",
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
+    ]
+  },
+  {
+    "Torch": "2.2.1",
+    "Torchvision": "0.17.1",
+    "Torchaudio": "2.2.1",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
+    "CUDA": null,
+    "Pythons": [
+      "3.7",
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
     ]
   },
   {


### PR DESCRIPTION
Release Notes:

- https://docs.nvidia.com/cuda/archive/12.3.2/
- https://github.com/pytorch/pytorch/releases/tag/v2.3.0
- https://github.com/tensorflow/tensorflow/releases/tag/v2.16.1