### PR TITLE
document pinning python package installations to commit SHAs

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -65,8 +65,20 @@ build:
   system_packages:
     - "git"
   python_packages:
-    - "git+https://github.com/m-bain/whisperX.git"
+    - "git+https://github.com/huggingface/transformers"
 ```
+
+You can also pin Python package installations to a specific git commit:
+
+```yaml
+build:
+  system_packages:
+    - "git"
+  python_packages:
+    - "git+https://github.com/huggingface/transformers@2d1602a"
+```
+
+Note that you can use a shortened prefix of the 40-character git commit SHA, but you must use at least six characters, like `2d1602a` above.
 
 ### `python_requirements`
 


### PR DESCRIPTION
This PR adds some docs about how to pin to a specific git commit when installing Python packages directly from a GitHub repo.

cc @fofr @lucataco 