### PR TITLE
initial sketch of consuming a new file upload API

### DIFF
--- a/python/cog/files.py
+++ b/python/cog/files.py
@@ -3,6 +3,7 @@ import io
 import json
 import mimetypes
 import os
+from typing import Optional
 from urllib.parse import urlparse
 
 import requests
@@ -40,7 +41,7 @@ def guess_filename(obj: io.IOBase) -> str:
 
 
 def upload_file_via_signed_endpoint(
-    fh: io.IOBase, endpoint: str, client: requests.Session
+    fh: io.IOBase, endpoint: str, client: requests.Session, prediction_id: Optional[str]
 ) -> str:
     fh.seek(0)
 
@@ -56,7 +57,7 @@ def upload_file_via_signed_endpoint(
     length = requests.models.utils.super_len(fh)
     request_body = json.dumps(
         {
-            "prediction_id": "TODO",
+            "prediction_id": prediction_id,
             "file_name": filename,
             "file_size": length,
             "content_type": content_type,

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -346,7 +346,8 @@ def create_app(
         response_object = response.dict()
         response_object["output"] = upload_files(
             response_object["output"],
-            upload_file=lambda fh: upload_file(fh, request.output_file_prefix),  # type: ignore
+            upload_file=lambda fh, _: upload_file(fh, request.output_file_prefix),  # type: ignore
+            prediction_id=request.id,
         )
 
         # FIXME: clean up output files

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -15,7 +15,7 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry  # type: ignore
 
 from .. import schema, types
-from ..files import put_file_to_signed_endpoint
+from ..files import upload_file_via_signed_endpoint
 from ..json import upload_files
 from .eventtypes import Done, Heartbeat, Log, PredictionOutput, PredictionOutputType
 from .probes import ProbeHelper
@@ -207,7 +207,7 @@ def generate_file_uploader(upload_url: str) -> Callable[[Any], Any]:
 
     def file_uploader(output: Any) -> Any:
         def upload_file(fh: io.IOBase) -> str:
-            return put_file_to_signed_endpoint(fh, upload_url, client=client)
+            return upload_file_via_signed_endpoint(fh, upload_url, client=client)
 
         return upload_files(output, upload_file=upload_file)
 

--- a/python/tests/server/test_runner.py
+++ b/python/tests/server/test_runner.py
@@ -351,7 +351,7 @@ def test_prediction_event_handler_webhook_sender_intermediate(match):
 
 def test_prediction_event_handler_file_uploads():
     u = mock.Mock()
-    p = PredictionResponse(input={"hello": "there"})
+    p = PredictionResponse(input={"hello": "there"}, id="fakeid")
     h = PredictionEventHandler(p, file_uploader=u)
 
     # in reality this would be a Path object, but in this test we just care it
@@ -360,7 +360,7 @@ def test_prediction_event_handler_file_uploads():
     u.return_value = "http://example.com/output-image.png"
     h.set_output("Path(to/my/file)")
 
-    u.assert_called_once_with("Path(to/my/file)")
+    u.assert_called_once_with("Path(to/my/file)", "fakeid")
     assert p.output == "http://example.com/output-image.png"
 
     # cheat and reset output behind event handler's back
@@ -376,5 +376,11 @@ def test_prediction_event_handler_file_uploads():
     u.return_value = "http://example.com/world.jpg"
     h.append_output("world.jpg")
 
-    u.assert_has_calls([mock.call([]), mock.call("hello.jpg"), mock.call("world.jpg")])
+    u.assert_has_calls(
+        [
+            mock.call([], "fakeid"),
+            mock.call("hello.jpg", "fakeid"),
+            mock.call("world.jpg", "fakeid"),
+        ]
+    )
     assert p.output == ["http://example.com/hello.jpg", "http://example.com/world.jpg"]

--- a/python/tests/test_json.py
+++ b/python/tests/test_json.py
@@ -43,9 +43,9 @@ def test_upload_files():
     with open(temp_path, "w") as fh:
         fh.write("file content")
     obj = {"path": cog.Path(temp_path)}
-    assert upload_files(obj, upload_file) == {
-        "path": "data:text/plain;base64,ZmlsZSBjb250ZW50"
-    }
+    assert upload_files(
+        obj, lambda fh, _: upload_file(fh, None), "fakepredictionid"
+    ) == {"path": "data:text/plain;base64,ZmlsZSBjb250ZW50"}
 
 
 def test_numpy():


### PR DESCRIPTION
The idea here is that a new file upload API has two stages:

- first, we call a JSON endpoint to explicitly ask for a presigned upload URL for a particular file with a particular length
- then, we upload to that URL.

Contrast this with the current file upload API where we just PUT the file to an endpoint and potentially get (308) redirected to a presigned URL.

In future this could support other formats of upload such as S3 multipart uploads.