### PR TITLE
update `cog init` to include a GitHub Actions workflow file

### DIFF
--- a/pkg/cli/init-templates/.github/workflows/push.yaml
+++ b/pkg/cli/init-templates/.github/workflows/push.yaml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       model_name:
-        description: 'Enter the model name, like "alice/bunny-detector"'
-        required: true
+        description: 'Enter the model name, like "alice/bunny-detector". If unset, this will default to the value of `image` in cog.yaml.'
   # # Uncomment these lines to trigger the workflow on every push to the main branch
   # push:
   #   branches:
@@ -42,9 +41,14 @@ jobs:
           # the action will authenticate with Replicate automatically so you
           # can push your model
           token: ${{ secrets.REPLICATE_API_TOKEN }}
-        
-      # If you run the action manually using workflow dispatch, you'll enter
-      # the model name manually. If the workflow is run automatically (say on
-      # a push to main), the model name will be derived from Repsoitory Variables.
+
+      # If you trigger the workflow manually, you can specify the model name.
+      # If you leave it blank (or if the workflow is triggered by a push), the 
+      # model name will be derived from the `image` value in cog.yaml.
       - name: Push to Replicate
-        run: cog push r8.im/${{ inputs.model_name || vars.DEFAULT_MODEL_NAME }}
+        run: |
+          if [ -n "${{ inputs.model_name }}" ]; then
+            cog push r8.im/${{ inputs.model_name }}
+          else
+            cog push
+          fi

--- a/pkg/cli/init-templates/.github/workflows/push.yaml
+++ b/pkg/cli/init-templates/.github/workflows/push.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # This action cleans up disk space to make more room for your
       # model code, weights, etc.
-      - name: Free disk pace
+      - name: Free disk space
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false

--- a/pkg/cli/init-templates/.github/workflows/push.yaml
+++ b/pkg/cli/init-templates/.github/workflows/push.yaml
@@ -1,0 +1,50 @@
+name: Push to Replicate
+
+on:
+  # Workflow dispatch allows you to manually trigger the workflow from GitHub.com
+  # Go to your repo, click "Actions", click "Push to Replicate", click "Run workflow"
+  workflow_dispatch:
+    inputs:
+      model_name:
+        description: 'Enter the model name, like "alice/bunny-detector"'
+        required: true
+  # # Uncomment these lines to trigger the workflow on every push to the main branch
+  # push:
+  #   branches:
+  #     - main
+
+jobs:
+  push_to_replicate:
+    name: Push to Replicate
+
+    # If your model is large, the default GitHub Actions runner may not 
+    # have enough disk space. If you need more space you can set up a 
+    # bigger runner on GitHub.
+    runs-on: ubuntu-latest
+
+    steps:
+      # This action cleans up disk space to make more room for your
+      # model code, weights, etc.
+      - name: Free disk pace
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          docker-images: false
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # This action installs Docker buildx and Cog (and optionally CUDA)
+      - name: Setup Cog
+        uses: replicate/setup-cog@v2
+        with:
+          # If you set REPLICATE_API_TOKEN in your GitHub repository secrets,
+          # the action will authenticate with Replicate automatically so you
+          # can push your model
+          token: ${{ secrets.REPLICATE_API_TOKEN }}
+        
+      # If you run the action manually using workflow dispatch, you'll enter
+      # the model name manually. If the workflow is run automatically (say on
+      # a push to main), the model name will be derived from Repsoitory Variables.
+      - name: Push to Replicate
+        run: cog push r8.im/${{ inputs.model_name || vars.DEFAULT_MODEL_NAME }}

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -22,6 +22,9 @@ var cogYamlContent []byte
 //go:embed init-templates/predict.py
 var predictPyContent []byte
 
+//go:embed init-templates/.github/workflows/push.yaml
+var actionsWorkflowContent []byte
+
 func newInitCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:        "init",
@@ -45,9 +48,10 @@ func initCommand(args []string) error {
 	}
 
 	fileContentMap := map[string][]byte{
-		"cog.yaml":      cogYamlContent,
-		"predict.py":    predictPyContent,
-		".dockerignore": dockerignoreContent,
+		"cog.yaml":                    cogYamlContent,
+		"predict.py":                  predictPyContent,
+		".dockerignore":               dockerignoreContent,
+		".github/workflows/push.yaml": actionsWorkflowContent,
 	}
 
 	for filename, content := range fileContentMap {
@@ -59,6 +63,12 @@ func initCommand(args []string) error {
 
 		if fileExists {
 			return fmt.Errorf("Found an existing %s.\nExiting without overwriting (to be on the safe side!)", filename)
+		}
+
+		dirPath := path.Dir(filePath)
+		err = os.MkdirAll(dirPath, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("Error creating directory %s: %w", dirPath, err)
 		}
 
 		err = os.WriteFile(filePath, content, 0o644)


### PR DESCRIPTION
This PR adds a "Push to Replicate" GitHub Actions workflow file to the `cog init` template, so users will have a smoother path to continuous delivery.

The workflow is configured to start users off with a manual "repository dispatch" so pushes are explicit and intentional. It also has some commented-out settings to support a more continuous workflow once they've kicked the tires, plus some pointers for common issues like running out of disk space.

```
$ ~/go/bin/cog init     

Setting up the current directory for use with Cog...

✅ Created /Users/z/Desktop/cog-init-test/cog.yaml
✅ Created /Users/z/Desktop/cog-init-test/predict.py
✅ Created /Users/z/Desktop/cog-init-test/.dockerignore
✅ Created /Users/z/Desktop/cog-init-test/.github/workflows/push.yaml

Done! For next steps, check out the docs at https://cog.run/getting-started
```