### PR TITLE
allow setting both max and target concurrency in cog.yaml

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,17 +44,22 @@ type Build struct {
 	pythonRequirementsContent []string
 }
 
+type Concurrency struct {
+	Max           int `json:"max,omitempty" yaml:"max"`
+	DefaultTarget int `json:"default_target,omitempty" yaml:"default_target"`
+}
+
 type Example struct {
 	Input  map[string]string `json:"input" yaml:"input"`
 	Output string            `json:"output" yaml:"output"`
 }
 
 type Config struct {
-	Build       *Build `json:"build" yaml:"build"`
-	Image       string `json:"image,omitempty" yaml:"image"`
-	Predict     string `json:"predict,omitempty" yaml:"predict"`
-	Train       string `json:"train,omitempty" yaml:"train"`
-	Concurrency int    `json:"concurrency,omitempty" yaml:"concurrency"`
+	Build       *Build       `json:"build" yaml:"build"`
+	Image       string       `json:"image,omitempty" yaml:"image"`
+	Predict     string       `json:"predict,omitempty" yaml:"predict"`
+	Train       string       `json:"train,omitempty" yaml:"train"`
+	Concurrency *Concurrency `json:"concurrency,omitempty" yaml:"concurrency"`
 }
 
 func DefaultConfig() *Config {

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -131,7 +131,7 @@ def create_app(
         add_setup_failed_routes(app, started_at, msg)
         return app
 
-    concurrency = os.getenv("COG_CONCURRENCY_OVERRIDE", config.get("concurrency", "1"))
+    concurrency = config.get("concurrency", {}).get("max", "1")
 
     runner = PredictionRunner(
         predictor_ref=predictor_ref,


### PR DESCRIPTION
we need users to be able to set target metric. after discussion in #1668, this seems like the simplest approach for now and could be reconsidered later.
