### PR TITLE
Rename `DefaultTarget` to `Target`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,8 +45,8 @@ type Build struct {
 }
 
 type Concurrency struct {
-	Max           int `json:"max,omitempty" yaml:"max"`
-	DefaultTarget int `json:"default_target,omitempty" yaml:"default_target"`
+	Max    int `json:"max,omitempty" yaml:"max"`
+	Target int `json:"target,omitempty" yaml:"target"`
 }
 
 type Example struct {


### PR DESCRIPTION
Follow-up to #1672

Both max and target concurrency levels can be overridden by web, so in effect both are default values.