### PR TITLE
document how cog.yaml `image` works with `cog push`

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -211,7 +211,6 @@ cog push
 # Building r8.im/replicate/resnet...
 # Pushing r8.im/replicate/resnet...
 # Pushed!
-
 ```
 
 The Docker image is now accessible to anyone or any system that has access to this Docker registry.

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -156,7 +156,11 @@ image: "r8.im/your-username/your-model"
 
 r8.im is Replicate's registry, but this can be any Docker registry.
 
-If you don't provide this, a name will be generated from the directory name.
+If you don't set this, then a name will be generated from the directory name.
+
+If you set this, then you can run `cog push` without specifying the model name. 
+
+If you specify an image name argument when pushing (like `cog push your-username/custom-model-name`), the argument will be used and the value of `image` in cog.yaml will be ignored.
 
 ## `predict`
 


### PR DESCRIPTION
This PR clarifies that you can run `cog push r8.im/foo/bar` to override the `image` in cog.yaml.