### PR TITLE
[async] Include prediction id upload request

### DIFF
--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -518,7 +518,9 @@ class PredictionEventHandler:
     async def _upload_files(self, output: Any) -> Any:
         try:
             # TODO: clean up output files
-            return await self._client_manager.upload_files(output, self._upload_url)
+            return await self._client_manager.upload_files(
+                output, self._upload_url, self.p.id
+            )
         except Exception as error:
             # If something goes wrong uploading a file, it's irrecoverable.
             # The re-raised exception will be caught and cause the prediction


### PR DESCRIPTION
httpx version of #1667 

> We now allow downstream services to include the destination of the asset in a Location header, rather than assuming that it's the same as the final upload url (either the one passed via --upload-url or the result of a 307 redirect response.
> We now include the X-Prediction-Id header in upload request, this allows the downstream client to potentially do configuration/routing based on the prediction ID. This ID should be considered unsafe and needs to be validated by the downstream service.
