### PR TITLE
fixing install logic to reenable no cuda base image

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -440,7 +440,7 @@ func (g *Generator) copyPipPackagesFromInstallStage() string {
 	// return "COPY --from=deps --link /dep COPY --from=deps /src"
 	// ...except it's actually /root/.pyenv/versions/3.8.17/lib/python3.8/site-packages
 	py := g.Config.Build.PythonVersion
-	if g.Config.Build.GPU {
+	if g.Config.Build.GPU && (g.useCudaBaseImage || g.useCogBaseImage) {
 		// this requires buildkit!
 		// we should check for buildkit and otherwise revert to symlinks or copying into /src
 		// we mount to avoid copying, which avoids having two copies in this layer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ ignore = [
   "ANN101", # Missing type annotation for self in method
   "ANN102", # Missing type annotation for cls in classmethod
   "ANN401", # Dynamically typed expressions are disallowed
+  # recently ruff added checks for pyupgrade, which is bad for back-compat
+  "UP037", # Remove quotes from type annotation
 ]
 extend-exclude = [
   "python/tests/server/fixtures/*",


### PR DESCRIPTION
As of cog v0.9.7, setting the `--use-cuda-base-image=false` flag fails b/c we changed the logic below around copying python packages to the staging images. This fixes that logic for the case when we have that flag set and aren't using cog base images. 