### PR TITLE
Fix linter errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ lint-go:
 
 .PHONY: lint-python
 lint-python:
-	$(RUFF) python/cog
+	$(RUFF) check python/cog
 	$(RUFF) format --check python
 	@$(PYTHON) -c 'import sys; sys.exit("Warning: python >=3.10 is needed (not installed) to pass linting (pyright)") if sys.version_info < (3, 10) else None'
 	$(PYRIGHT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ reportUnusedExpression = "warning"
 package-dir = { "" = "python" }
 
 [tool.ruff]
-select = [
+lint.select = [
   "E",   # pycodestyle error
   "F",   # Pyflakes
   "I",   # isort
@@ -77,7 +77,7 @@ select = [
   "B",   # flake8-bugbear
   "ANN", # flake8-annotations
 ]
-ignore = [
+lint.ignore = [
   "E501",   # Line too long
   "S101",   # Use of `assert` detected"
   "S113",   # Probable use of requests call without timeout
@@ -94,7 +94,7 @@ extend-exclude = [
   "test-integration/test_integration/fixtures/*",
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "python/cog/server/http.py" = [
   "S104", # Possible binding to all interfaces
 ]

--- a/python/cog/command/ast_openapi_schema.py
+++ b/python/cog/command/ast_openapi_schema.py
@@ -493,7 +493,7 @@ For example:
         format = {"format": "uri"} if name in ("Path", "File") else {}
         return {}, {"title": "Output", "type": OPENAPI_TYPES.get(name, name), **format}
     # it must be a custom object
-    schema: "JSONDict" = {name: parse_class(find(tree, name))}
+    schema: JSONDict = {name: parse_class(find(tree, name))}
     return schema, {
         "title": "Output",
         "$ref": f"#/components/schemas/{name}",
@@ -506,10 +506,10 @@ KEPT_ATTRS = ("description", "default", "ge", "le", "max_length", "min_length", 
 def extract_info(code: str) -> "JSONDict":
     """Parse the schemas from a file with a predict function"""
     tree = ast.parse(code)
-    properties: "JSONDict" = {}
-    inputs: "JSONDict" = {"title": "Input", "type": "object", "properties": properties}
-    required: "list[str]" = []
-    schemas: "JSONDict" = {}
+    properties: JSONDict = {}
+    inputs: JSONDict = {"title": "Input", "type": "object", "properties": properties}
+    required: list[str] = []
+    schemas: JSONDict = {}
     for arg, default in parse_args(tree):
         if arg.arg == "self":
             continue
@@ -526,7 +526,7 @@ def extract_info(code: str) -> "JSONDict":
             kws = {}
         else:
             raise ValueError("Unexpected default value", default)
-        input: "JSONDict" = {"x-order": len(properties)}
+        input: JSONDict = {"x-order": len(properties)}
         # need to handle other types?
         arg_type = OPENAPI_TYPES.get(get_annotation(arg.annotation), "string")
         if get_annotation(arg.annotation) in ("Path", "File"):
@@ -553,15 +553,15 @@ def extract_info(code: str) -> "JSONDict":
         inputs["required"] = list(required)
     # List[Path], list[Path], str, Iterator[str], MyOutput, Output
     return_schema, output = parse_return_annotation(tree, "predict")
-    schema: "JSONDict" = json.loads(BASE_SCHEMA)
-    components: "JSONDict" = {
+    schema: JSONDict = json.loads(BASE_SCHEMA)
+    components: JSONDict = {
         "Input": inputs,
         "Output": output,
         **schemas,
         **return_schema,
     }
     # trust me, typechecker, I know BASE_SCHEMA
-    x: "JSONDict" = schema["components"]["schemas"]  # type: ignore
+    x: JSONDict = schema["components"]["schemas"]  # type: ignore
     x.update(components)
     return schema
 

--- a/python/tests/cog/test_files.py
+++ b/python/tests/cog/test_files.py
@@ -1,8 +1,8 @@
-import requests
 import io
-import responses
-from cog.files import put_file_to_signed_endpoint
 from unittest.mock import Mock
+
+import requests
+from cog.files import put_file_to_signed_endpoint
 
 
 def test_put_file_to_signed_endpoint():

--- a/python/tests/server/test_code_xforms.py
+++ b/python/tests/server/test_code_xforms.py
@@ -1,8 +1,9 @@
 import os
-import pytest
 import sys
 import uuid
+
 import cog.code_xforms as code_xforms
+import pytest
 
 g_module_dir = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
The latest version of Ruff enabled new errors, causing regressions in our codebase. This PR fixes those errors and updates the `pyproject.toml` file to use the new `tool.ruff.lint` namespace.