### PR TITLE
Forward on trace context to upstream services

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
   # intentionally loose. perhaps these should be vendored to not collide with user code?
   "attrs>=20.1,<24",
   "fastapi>=0.75.2,<0.99.0",
+  "opentelemetry-api",
+  "opentelemetry-sdk",
+  "opentelemetry-instrumentation-requests",
   "pydantic>=1.9,<2",
   "PyYAML",
   "requests>=2,<3",

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -19,6 +19,7 @@ from ..files import put_file_to_signed_endpoint
 from ..json import upload_files
 from .eventtypes import Done, Heartbeat, Log, PredictionOutput, PredictionOutputType
 from .probes import ProbeHelper
+from .telemetry import requests_session
 from .webhook import SKIP_START_EVENT, webhook_caller_filtered
 from .worker import Worker
 
@@ -451,7 +452,7 @@ def _predict(
 
 
 def _make_file_upload_http_client() -> requests.Session:
-    session = requests.Session()
+    session = requests_session()
     adapter = HTTPAdapter(
         max_retries=Retry(
             total=3,

--- a/python/cog/server/telemetry.py
+++ b/python/cog/server/telemetry.py
@@ -1,0 +1,41 @@
+import os
+
+import requests
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+
+
+def requests_session() -> requests.Session:
+    """
+    Creates a :code:`requests.Session` with opentelementry tracing
+    configured so that tracing context is propagated to downstream
+    services.
+    """
+    # NOTE: We just ensure that outgoing requests propagate tracing
+    # information, currently we don't perform any tracing or collection
+    # within cog itself.
+    if "OTEL_SERVICE_NAME" in os.environ:
+        tp = TracerProvider()
+
+        # RequestsInstrumentor patches the global `requests.Session` object
+        # which includes the global `requests.get` etc. as well as any child
+        # sessions created.
+        #
+        # As we only want specific sessions to be instrumented we need to do
+        # some juggling to get things to work, namely we capture the patched
+        # `send()` method created as part of `instrument()` and then remove
+        # the patch from the Session, before applying it again to the newly
+        # created session instance.
+        RequestsInstrumentor().instrument(tracer_provider=tp)
+
+        session = requests.Session()
+        instrumented_send = session.send
+
+        # Unpatch requests.Session
+        RequestsInstrumentor().uninstrument()
+
+        session.send = instrumented_send
+    else:
+        session = requests.Session()
+
+    return session

--- a/python/cog/server/webhook.py
+++ b/python/cog/server/webhook.py
@@ -8,6 +8,7 @@ from requests.packages.urllib3.util.retry import Retry  # type: ignore
 
 from ..schema import Status, WebhookEvent
 from .response_throttler import ResponseThrottler
+from .telemetry import requests_session as otel_requests_session
 
 log = structlog.get_logger(__name__)
 
@@ -74,7 +75,7 @@ def webhook_caller(webhook: str) -> Callable[[Any], None]:
 
 
 def requests_session() -> requests.Session:
-    session = requests.Session()
+    session = otel_requests_session()
     session.headers["user-agent"] = (
         _user_agent + " " + str(session.headers["user-agent"])
     )

--- a/python/tests/cog/server/test_telemetry.py
+++ b/python/tests/cog/server/test_telemetry.py
@@ -1,0 +1,53 @@
+import os
+from unittest import mock
+
+import requests
+from cog.server.telemetry import requests_session
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+
+
+def test_otel_requests_session():
+    os.environ["OTEL_SERVICE_NAME"] = "cog"
+    session = requests_session()
+    assert hasattr(session.send, "opentelemetry_instrumentation_requests_applied")
+    assert session.send.opentelemetry_instrumentation_requests_applied
+    os.environ.pop("OTEL_SERVICE_NAME")
+
+    RequestsInstrumentor.uninstrument_session(session)
+    assert not hasattr(
+        requests.Session.send, "opentelemetry_instrumentation_requests_applied"
+    )
+
+    RequestsInstrumentor.uninstrument_session(session)
+    assert not hasattr(session.send, "opentelemetry_instrumentation_requests_applied")
+
+
+def test_otel_requests_session_without_environment():
+    session = requests_session()
+    assert not hasattr(session, "opentelemetry_instrumentation_requests_applied")
+
+
+def test_otel_requests_session_default_client():
+    os.environ["OTEL_SERVICE_NAME"] = "cog"
+    _ = requests_session()
+    assert not hasattr(
+        requests.Session.send, "opentelemetry_instrumentation_requests_applied"
+    )
+    assert not hasattr(
+        requests.Session().send, "opentelemetry_instrumentation_requests_applied"
+    )
+    os.unsetenv("OTEL_SERVICE_NAME")
+
+
+@mock.patch(
+    "requests.Session.send",
+)
+def test_header_propagation(mock_send: mock.Mock):
+    os.environ["OTEL_SERVICE_NAME"] = "cog"
+    session = requests_session()
+
+    session.get("http://example.com")
+    assert mock_send.call_count == 1
+    assert "traceparent" in mock_send.call_args.args[-1].headers
+
+    os.environ.pop("OTEL_SERVICE_NAME")


### PR DESCRIPTION
When the `OTEL_SERVICE_NAME` environment variable is provided, we use the Open Telemetry `requests` library to instrument the `requests.Session` to ensure trace context is forwarded on to upstream services for functionality like webhooks and uploads.

As we only want the internal sessions used by cog to be instrumented rather than the global session available via `request.get` etc, we do some awkward monkey patching in the new `telemetry.requests_session()` method.

Tests have been added to verify the telemetry is added to the correct clients and not the globals.

> [!NOTE]
> Currently there is no support for configuring any exporters, and no telemetry will be collected for cog. This PR is primarily about ensuring that the trace context is properly propagated.