### PR TITLE
Propagate trace context to webhook and upload requests

### DIFF
--- a/python/cog/code_xforms.py
+++ b/python/cog/code_xforms.py
@@ -7,8 +7,8 @@ COG_IMPORT_MODULES = {"cog", "typing", "sys", "os", "functools", "pydantic", "nu
 
 
 def load_module_from_string(
-    name: str, source: Union[str, None]
-) -> Union[types.ModuleType, None]:
+    name: str, source: Optional[str]
+) -> Optional[types.ModuleType]:
     if not source or not name:
         return None
     module = types.ModuleType(name)

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -203,7 +203,7 @@ def load_full_predictor_from_file(
 
 def load_slim_predictor_from_file(
     module_path: str, class_name: str, method_name: str
-) -> Union[types.ModuleType, None]:
+) -> Optional[types.ModuleType]:
     with open(module_path, encoding="utf-8") as file:
         source_code = file.read()
     stripped_source = code_xforms.strip_model_source_code(

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -185,7 +185,7 @@ def create_app(
             )
             def train(
                 request: TrainingRequest = Body(default=None),
-                prefer: Union[str, None] = Header(default=None),
+                prefer: Optional[str] = Header(default=None),
             ) -> Any:  # type: ignore
                 return predict(request, prefer)
 
@@ -197,7 +197,7 @@ def create_app(
             def train_idempotent(
                 training_id: str = Path(..., title="Training ID"),
                 request: TrainingRequest = Body(..., title="Training Request"),
-                prefer: Union[str, None] = Header(default=None),
+                prefer: Optional[str] = Header(default=None),
             ) -> Any:
                 return predict_idempotent(training_id, request, prefer)
 
@@ -259,7 +259,7 @@ def create_app(
     )
     async def predict(
         request: PredictionRequest = Body(default=None),
-        prefer: Union[str, None] = Header(default=None),
+        prefer: Optional[str] = Header(default=None),
     ) -> Any:  # type: ignore
         """
         Run a single prediction on the model
@@ -283,7 +283,7 @@ def create_app(
     async def predict_idempotent(
         prediction_id: str = Path(..., title="Prediction ID"),
         request: PredictionRequest = Body(..., title="Prediction Request"),
-        prefer: Union[str, None] = Header(default=None),
+        prefer: Optional[str] = Header(default=None),
     ) -> Any:
         """
         Run a single prediction on the model (idempotent creation).

--- a/python/cog/server/telemetry.py
+++ b/python/cog/server/telemetry.py
@@ -1,11 +1,16 @@
-from typing import TypedDict, Union, Optional
 from contextlib import contextmanager
 from contextvars import ContextVar
+from typing import Generator, Optional
+
+# TypedDict was added in 3.8
+from typing_extensions import TypedDict
+
 
 # See: https://www.w3.org/TR/trace-context/
-TraceContext = TypedDict(
-    "TraceContext", {"traceparent": Optional[str], "tracestate": Optional[str]}
-)
+class TraceContext(TypedDict, total=False):
+    traceparent: str
+    tracestate: str
+
 
 TRACE_CONTEXT: ContextVar[Optional[TraceContext]] = ContextVar(
     "trace_context", default=None
@@ -19,10 +24,15 @@ def make_trace_context(
     Creates a trace context dictionary from the given traceparent and tracestate
     headers. This is used to pass the trace context between services.
     """
-    return {"traceparent": traceparent, "tracestate": tracestate}
+    ctx: TraceContext = {}
+    if traceparent:
+        ctx["traceparent"] = traceparent
+    if tracestate:
+        ctx["tracestate"] = tracestate
+    return ctx
 
 
-def current_trace_context() -> Union[TraceContext, None]:
+def current_trace_context() -> Optional[TraceContext]:
     """
     Returns the current trace context, this needs to be added via HTTP headers
     to all outgoing HTTP requests.
@@ -31,7 +41,7 @@ def current_trace_context() -> Union[TraceContext, None]:
 
 
 @contextmanager
-def trace_context(ctx: TraceContext):
+def trace_context(ctx: TraceContext) -> Generator[None, None, None]:
     """
     A helper for managing the current trace context provided by the inbound
     HTTP request. This context is used to link requests across the system and

--- a/python/cog/server/telemetry.py
+++ b/python/cog/server/telemetry.py
@@ -1,0 +1,44 @@
+from typing import TypedDict, Union, Optional
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+# See: https://www.w3.org/TR/trace-context/
+TraceContext = TypedDict(
+    "TraceContext", {"traceparent": Optional[str], "tracestate": Optional[str]}
+)
+
+TRACE_CONTEXT: ContextVar[Optional[TraceContext]] = ContextVar(
+    "trace_context", default=None
+)
+
+
+def make_trace_context(
+    traceparent: Optional[str] = None, tracestate: Optional[str] = None
+) -> TraceContext:
+    """
+    Creates a trace context dictionary from the given traceparent and tracestate
+    headers. This is used to pass the trace context between services.
+    """
+    return {"traceparent": traceparent, "tracestate": tracestate}
+
+
+def current_trace_context() -> Union[TraceContext, None]:
+    """
+    Returns the current trace context, this needs to be added via HTTP headers
+    to all outgoing HTTP requests.
+    """
+    return TRACE_CONTEXT.get()
+
+
+@contextmanager
+def trace_context(ctx: TraceContext):
+    """
+    A helper for managing the current trace context provided by the inbound
+    HTTP request. This context is used to link requests across the system and
+    needs to be added to all internal outgoing HTTP requests.
+    """
+    t = TRACE_CONTEXT.set(ctx)
+    try:
+        yield
+    finally:
+        TRACE_CONTEXT.reset(t)

--- a/python/cog/server/useragent.py
+++ b/python/cog/server/useragent.py
@@ -1,0 +1,17 @@
+def _get_version() -> str:
+    try:
+        try:
+            from importlib.metadata import version
+        except ImportError:
+            pass
+        else:
+            return version("cog")
+        import pkg_resources
+
+        return pkg_resources.get_distribution("cog").version
+    except Exception:
+        return "unknown"
+
+
+def get_user_agent() -> str:
+    return f"cog-worker/{_get_version()}"

--- a/python/cog/server/webhook.py
+++ b/python/cog/server/webhook.py
@@ -8,26 +8,11 @@ from requests.packages.urllib3.util.retry import Retry  # type: ignore
 
 from ..schema import Status, WebhookEvent
 from .response_throttler import ResponseThrottler
+from .telemetry import current_trace_context
+from .useragent import get_user_agent
 
 log = structlog.get_logger(__name__)
 
-
-def _get_version() -> str:
-    try:
-        try:
-            from importlib.metadata import version
-        except ImportError:
-            pass
-        else:
-            return version("cog")
-        import pkg_resources
-
-        return pkg_resources.get_distribution("cog").version
-    except Exception:
-        return "unknown"
-
-
-_user_agent = f"cog-worker/{_get_version()}"
 _response_interval = float(os.environ.get("COG_THROTTLE_RESPONSE_INTERVAL", 0.5))
 
 # HACK: signal that we should skip the start webhook when the response interval
@@ -76,8 +61,13 @@ def webhook_caller(webhook: str) -> Callable[[Any], None]:
 def requests_session() -> requests.Session:
     session = requests.Session()
     session.headers["user-agent"] = (
-        _user_agent + " " + str(session.headers["user-agent"])
+        get_user_agent() + " " + str(session.headers["user-agent"])
     )
+
+    ctx = current_trace_context() or {}
+    for key, value in ctx.items():
+        session.headers[key] = str(value)
+
     auth_token = os.environ.get("WEBHOOK_AUTH_TOKEN")
     if auth_token:
         session.headers["authorization"] = "Bearer " + auth_token

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -531,6 +531,75 @@ def test_asynchronous_prediction_endpoint(client, match):
         time.sleep(0.1)
         n += 1
 
+
+# End-to-end test for passing tracing headers on to downstream services.
+@responses.activate
+@uses_predictor_with_client_options(
+    "output_file", upload_url="https://example.com/upload"
+)
+def test_asynchronous_prediction_endpoint_with_trace_context(client, match):
+    webhook = responses.post(
+        "https://example.com/webhook",
+        match=[
+            matchers.json_params_matcher(
+                {
+                    "id": "12345abcde",
+                    "status": "succeeded",
+                    "output": "https://example.com/upload/file",
+                },
+                strict_match=False,
+            ),
+            matchers.header_matcher(
+                {
+                    "traceparent": "traceparent-123",
+                    "tracestate": "tracestate-123",
+                },
+                strict_match=False,
+            ),
+        ],
+        status=200,
+    )
+    uploader = responses.put(
+        "https://example.com/upload/file",
+        match=[
+            matchers.header_matcher(
+                {
+                    "traceparent": "traceparent-123",
+                    "tracestate": "tracestate-123",
+                },
+                strict_match=False,
+            ),
+        ],
+        status=200,
+    )
+
+    resp = client.post(
+        "/predictions",
+        json={
+            "id": "12345abcde",
+            "input": {},
+            "webhook": "https://example.com/webhook",
+            "webhook_events_filter": ["completed"],
+        },
+        headers={
+            "Prefer": "respond-async",
+            "traceparent": "traceparent-123",
+            "tracestate": "tracestate-123",
+        },
+    )
+    assert resp.status_code == 202
+
+    assert resp.json() == match(
+        {"status": "processing", "output": None, "started_at": mock.ANY}
+    )
+    assert resp.json()["started_at"] is not None
+
+    n = 0
+    while webhook.call_count < 1 and n < 10:
+        time.sleep(0.1)
+        n += 1
+
+    assert uploader.call_count == 1
     assert webhook.call_count == 1
 
 

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -86,11 +86,7 @@ def test_predict_writes_multiple_files_to_files(tmpdir_factory):
     out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
     shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
     result = subprocess.run(
-        [
-            "cog",
-            "predict",
-            "--debug"
-        ],
+        ["cog", "predict", "--debug"],
         cwd=out_dir,
         check=True,
         capture_output=True,


### PR DESCRIPTION
If the request to /predict contains headers `traceparent` and `tracestate` defined by w3c Trace Context[^1] then these headers are forwarded on to the webhook and upload calls.

This allows observability systems to link requests passing through cog.

[^1]: https://www.w3.org/TR/trace-context/