### PR TITLE
Improve cog base image handling

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -25,10 +25,11 @@ var buildUseCogBaseImage bool
 
 func newBuildCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "build",
-		Short: "Build an image from cog.yaml",
-		Args:  cobra.NoArgs,
-		RunE:  buildCommand,
+		Use:     "build",
+		Short:   "Build an image from cog.yaml",
+		Args:    cobra.NoArgs,
+		RunE:    buildCommand,
+		PreRunE: checkMutuallyExclusiveFlags,
 	}
 	addBuildProgressOutputFlag(cmd)
 	addSecretsFlag(cmd)
@@ -55,11 +56,6 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 	}
 	if imageName == "" {
 		imageName = config.DockerImageName(projectDir)
-	}
-
-	err = checkMutuallyExclusiveFlags(cmd)
-	if err != nil {
-		return err
 	}
 
 	err = config.ValidateModelPythonVersion(cfg.Build.PythonVersion)
@@ -122,7 +118,7 @@ func addBuildTimestampFlag(cmd *cobra.Command) {
 	_ = cmd.Flags().MarkHidden("timestamp")
 }
 
-func checkMutuallyExclusiveFlags(cmd *cobra.Command) error {
+func checkMutuallyExclusiveFlags(cmd *cobra.Command, args []string) error {
 	flags := []string{"use-cog-base-image", "use-cuda-base-image", "dockerfile"}
 	var flagsSet []string
 	for _, flag := range flags {

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -131,7 +131,7 @@ func checkMutuallyExclusiveFlags(cmd *cobra.Command) error {
 		}
 	}
 	if len(flagsSet) > 1 {
-		return fmt.Errorf("the flags %s are mutually exclusive, you can only set one of them", strings.Join(flagsSet, " and "))
+		return fmt.Errorf("The flags %s are mutually exclusive: you can only set one of them.", strings.Join(flagsSet, " and "))
 	}
 	return nil
 }

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -114,7 +114,7 @@ func addDockerfileFlag(cmd *cobra.Command) {
 }
 
 func addUseCogBaseImageFlag(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&buildUseCogBaseImage, "use-cog-base-image", true, "Use pre-built Cog base image for faster cold boots")
+	cmd.Flags().BoolVar(&buildUseCogBaseImage, "use-cog-base-image", false, "Use pre-built Cog base image for faster cold boots")
 }
 
 func addBuildTimestampFlag(cmd *cobra.Command) {

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -57,7 +57,7 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 		imageName = config.DockerImageName(projectDir)
 	}
 
-	err = checkMutuallyExclusiveFlags(cmd, "use-cog-base-image", "use-cuda-base-image", "dockerfile")
+	err = checkMutuallyExclusiveFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -122,7 +122,8 @@ func addBuildTimestampFlag(cmd *cobra.Command) {
 	_ = cmd.Flags().MarkHidden("timestamp")
 }
 
-func checkMutuallyExclusiveFlags(cmd *cobra.Command, flags ...string) error {
+func checkMutuallyExclusiveFlags(cmd *cobra.Command) error {
+	flags := []string{"use-cog-base-image", "use-cuda-base-image", "dockerfile"}
 	var flagsSet []string
 	for _, flag := range flags {
 		if cmd.Flag(flag).Changed {
@@ -130,12 +131,7 @@ func checkMutuallyExclusiveFlags(cmd *cobra.Command, flags ...string) error {
 		}
 	}
 	if len(flagsSet) > 1 {
-		flagNames := strings.Join(flagsSet, ", ")
-		lastComma := strings.LastIndex(flagNames, ",")
-		if lastComma != -1 {
-			flagNames = flagNames[:lastComma] + " and" + flagNames[lastComma+1:]
-		}
-		return fmt.Errorf("the flags %s are mutually exclusive, you can only set one of them", flagNames)
+		return fmt.Errorf("the flags %s are mutually exclusive, you can only set one of them", strings.Join(flagsSet, " and "))
 	}
 	return nil
 }

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -111,6 +111,11 @@ func addDockerfileFlag(cmd *cobra.Command) {
 
 func addUseCogBaseImageFlag(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&buildUseCogBaseImage, "use-cog-base-image", false, "Use pre-built Cog base image for faster cold boots")
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Name == "use-cog-base-image" {
+			f.Hidden = true
+		}
+	})
 }
 
 func addBuildTimestampFlag(cmd *cobra.Command) {

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -54,12 +54,6 @@ func run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	//err = checkMutuallyExclusiveFlags(cmd)
-	if err != nil {
-		return err
-	}
-
 	imageName, err := image.BuildBase(cfg, projectDir, buildUseCudaBaseImage, buildUseCogBaseImage, buildProgressOutput)
 	if err != nil {
 		return err

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -25,10 +25,11 @@ func addGpusFlag(cmd *cobra.Command) {
 
 func newRunCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "run <command> [arg...]",
-		Short: "Run a command inside a Docker environment",
-		RunE:  run,
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "run <command> [arg...]",
+		Short:   "Run a command inside a Docker environment",
+		RunE:    run,
+		PreRunE: checkMutuallyExclusiveFlags,
+		Args:    cobra.MinimumNArgs(1),
 	}
 	addBuildProgressOutputFlag(cmd)
 	addDockerfileFlag(cmd)
@@ -54,7 +55,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = checkMutuallyExclusiveFlags(cmd)
+	//err = checkMutuallyExclusiveFlags(cmd)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -54,6 +54,11 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	err = checkMutuallyExclusiveFlags(cmd)
+	if err != nil {
+		return err
+	}
+
 	imageName, err := image.BuildBase(cfg, projectDir, buildUseCudaBaseImage, buildUseCogBaseImage, buildProgressOutput)
 	if err != nil {
 		return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -483,10 +483,6 @@ Compatible cuDNN version is: %s`,
 				return fmt.Errorf("Cog doesn't know what CUDA version is compatible with torch==%s. You might need to upgrade Cog: https://github.com/replicate/cog#upgrade\n\nIf that doesn't work, you need to set the 'cuda' option in cog.yaml to set what version to use. You might be able to find this out from https://pytorch.org/", torchVersion)
 			}
 			c.Build.CUDA = latestCUDAFrom(torchCUDAs)
-			c.Build.CUDA, err = resolveMinorToPatch(c.Build.CUDA)
-			if err != nil {
-				return err
-			}
 			console.Debugf("Setting CUDA to version %s from Torch version", c.Build.CUDA)
 		} else if !slices.ContainsString(torchCUDAs, c.Build.CUDA) {
 			// TODO: can we suggest a CUDA version known to be compatible?
@@ -511,6 +507,13 @@ Compatible cuDNN version is: %s`,
 				return err
 			}
 			console.Debugf("Setting CuDNN to version %s", c.Build.CUDA)
+		}
+	}
+
+	if c.Build.CUDA != "" {
+		c.Build.CUDA, err = resolveMinorToPatch(c.Build.CUDA)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -483,6 +483,10 @@ Compatible cuDNN version is: %s`,
 				return fmt.Errorf("Cog doesn't know what CUDA version is compatible with torch==%s. You might need to upgrade Cog: https://github.com/replicate/cog#upgrade\n\nIf that doesn't work, you need to set the 'cuda' option in cog.yaml to set what version to use. You might be able to find this out from https://pytorch.org/", torchVersion)
 			}
 			c.Build.CUDA = latestCUDAFrom(torchCUDAs)
+			c.Build.CUDA, err = resolveMinorToPatch(c.Build.CUDA)
+			if err != nil {
+				return err
+			}
 			console.Debugf("Setting CUDA to version %s from Torch version", c.Build.CUDA)
 		} else if !slices.ContainsString(torchCUDAs, c.Build.CUDA) {
 			// TODO: can we suggest a CUDA version known to be compatible?
@@ -507,13 +511,6 @@ Compatible cuDNN version is: %s`,
 				return err
 			}
 			console.Debugf("Setting CuDNN to version %s", c.Build.CUDA)
-		}
-	}
-
-	if c.Build.CUDA != "" {
-		c.Build.CUDA, err = resolveMinorToPatch(c.Build.CUDA)
-		if err != nil {
-			return err
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
@@ -107,6 +108,24 @@ func TestValidateCudaVersion(t *testing.T) {
 				require.NoError(t, err)
 			}
 		})
+	}
+}
+
+func assertMinorVersion(t *testing.T, expected, actual string) {
+	expectedVersion, err := version.NewVersion(expected)
+	if err != nil {
+		t.Errorf("Error parsing version: %v", err)
+		return
+	}
+	actualVersion, err := version.NewVersion(actual)
+	if err != nil {
+		t.Errorf("Error parsing version: %v", err)
+		return
+	}
+
+	// Compare only the major and minor parts
+	if expectedVersion.Segments()[0] != actualVersion.Segments()[0] || expectedVersion.Segments()[1] != actualVersion.Segments()[1] {
+		t.Errorf("Expected %s but got %s", expected, actual)
 	}
 }
 
@@ -237,7 +256,7 @@ func TestValidateAndCompleteCUDAForAllTF(t *testing.T) {
 
 		err := config.ValidateAndComplete("")
 		require.NoError(t, err)
-		require.Equal(t, compat.CUDA, config.Build.CUDA)
+		assertMinorVersion(t, compat.CUDA, config.Build.CUDA)
 		require.Equal(t, compat.CuDNN, config.Build.CuDNN)
 	}
 }
@@ -319,7 +338,7 @@ func TestUnsupportedTorch(t *testing.T) {
 	}
 	err = config.ValidateAndComplete("")
 	require.NoError(t, err)
-	require.Equal(t, "11.8", config.Build.CUDA)
+	assertMinorVersion(t, "11.8", config.Build.CUDA)
 	require.Equal(t, "8", config.Build.CuDNN)
 }
 
@@ -356,7 +375,7 @@ func TestUnsupportedTensorflow(t *testing.T) {
 	}
 	err = config.ValidateAndComplete("")
 	require.NoError(t, err)
-	require.Equal(t, "11.8", config.Build.CUDA)
+	assertMinorVersion(t, "11.8", config.Build.CUDA)
 	require.Equal(t, "8", config.Build.CuDNN)
 }
 
@@ -376,7 +395,7 @@ func TestPythonPackagesForArchTorchGPU(t *testing.T) {
 	}
 	err := config.ValidateAndComplete("")
 	require.NoError(t, err)
-	require.Equal(t, "11.8", config.Build.CUDA)
+	assertMinorVersion(t, "11.8", config.Build.CUDA)
 	require.Equal(t, "8", config.Build.CuDNN)
 
 	requirements, err := config.PythonRequirementsForArch("", "", []string{})
@@ -429,7 +448,7 @@ func TestPythonPackagesForArchTensorflowGPU(t *testing.T) {
 	}
 	err := config.ValidateAndComplete("")
 	require.NoError(t, err)
-	require.Equal(t, "11.8", config.Build.CUDA)
+	assertMinorVersion(t, "11.8", config.Build.CUDA)
 	require.Equal(t, "8", config.Build.CuDNN)
 
 	// tensorflow and tensorflow-gpu have been the same package since TensorFlow 2.1, released in September 2019.

--- a/pkg/dockerfile/base.go
+++ b/pkg/dockerfile/base.go
@@ -80,11 +80,15 @@ func BaseImageConfigurations() []BaseImageConfiguration {
 	// versions, and a subset of combinations for older but
 	// popular combinations.
 	return []BaseImageConfiguration{
+		{"", "3.12", ""},
+		{"", "3.12", "2.3.0"},
+		{"", "3.11", ""},
+		{"", "3.11", "2.3.0"},
 		{"", "3.10", ""},
 		{"", "3.10", "1.12.1"},
-		{"", "3.11", ""},
 		{"", "3.8", ""},
 		{"", "3.9", ""},
+		{"11.8", "3.12", "2.3.0"},
 		{"11.0.3", "3.8", "1.7.1"},
 		{"11.1", "3.8", "1.8.0"},
 		{"11.1.1", "3.8", "1.8.0"},

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -256,7 +256,12 @@ func (g *Generator) baseImage() (string, error) {
 			return "", err
 		}
 		torchVersion, _ := g.Config.TorchVersion()
-		baseImage := BaseImageName(cudaVersion, pythonVersion, torchVersion)
+		// validate that we base image configuration exists
+		imageGenerator, err := NewBaseImageGenerator(cudaVersion, pythonVersion, torchVersion)
+		if err != nil {
+			return "", err
+		}
+		baseImage := BaseImageName(imageGenerator.cudaVersion, imageGenerator.pythonVersion, imageGenerator.torchVersion)
 		return baseImage, nil
 	}
 

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -256,7 +256,7 @@ func (g *Generator) baseImage() (string, error) {
 			return "", err
 		}
 		torchVersion, _ := g.Config.TorchVersion()
-		// validate that we base image configuration exists
+		// validate that the base image configuration exists
 		imageGenerator, err := NewBaseImageGenerator(cudaVersion, pythonVersion, torchVersion)
 		if err != nil {
 			return "", err

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -542,7 +542,7 @@ build:
     - ffmpeg
     - cowsay
   python_packages:
-    - torch==2.0.1
+    - torch==2.3.0
     - pandas==2.0.3
   run:
     - "cowsay moo"
@@ -558,7 +558,7 @@ predict: predict.py:Predictor
 	require.NoError(t, err)
 
 	expected := `#syntax=docker/dockerfile:1.4
-FROM r8.im/cog-base:cuda11.8-python3.12-torch2.0.1
+FROM r8.im/cog-base:cuda11.8-python3.12-torch2.3.0
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq && apt-get install -qqy cowsay && rm -rf /var/lib/apt/lists/*
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -496,6 +496,7 @@ build:
   system_packages:
     - ffmpeg
     - cowsay
+  python_version: "3.12"
   python_packages:
     - torch==2.3.0
     - pandas==1.2.0.12


### PR DESCRIPTION
In preparation for making `--use-cog-base-image` flag the default behavior, we are adding better
handling for invalid configuration.

* Check that the combination of cuda, python and pytorch is valid before attempting to run/build the image
* Check that we are not missing flags that don't work together
