### PR TITLE
Increase Hypothesis test deadlines

### DIFF
--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -22,8 +22,8 @@ from hypothesis.stateful import (
 )
 
 # Set a longer deadline on CI as the instances are a bit slower.
-settings.register_profile("ci", max_examples=100, deadline=1500)
-settings.register_profile("default", max_examples=10, deadline=1000)
+settings.register_profile("ci", max_examples=100, deadline=2000)
+settings.register_profile("default", max_examples=10, deadline=1500)
 settings.register_profile("slow", max_examples=10, deadline=2000)
 settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))
 


### PR DESCRIPTION
Recently we have been hitting the timings deadline in the python integration tests.

I didn't investigate if the regression is expected or not.