### PR TITLE
Quick fix for Apple Silicon M1 support in `run`

### DIFF
--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -74,7 +75,7 @@ func run(cmd *cobra.Command, args []string) error {
 		Workdir: "/src",
 	}
 
-	if util.IsAppleSiliconMac(os.GOOS, os.GOARCH) {
+	if util.IsAppleSiliconMac(runtime.GOOS, runtime.GOARCH) {
 		runOptions.Platform = "linux/amd64"
 	}
 

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -9,6 +9,7 @@ import (
 	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/docker"
 	"github.com/replicate/cog/pkg/image"
+	"github.com/replicate/cog/pkg/util"
 	"github.com/replicate/cog/pkg/util/console"
 )
 
@@ -71,6 +72,10 @@ func run(cmd *cobra.Command, args []string) error {
 		Image:   imageName,
 		Volumes: []docker.Volume{{Source: projectDir, Destination: "/src"}},
 		Workdir: "/src",
+	}
+
+	if util.IsAppleSiliconMac(os.GOOS, os.GOARCH) {
+		runOptions.Platform = "linux/amd64"
 	}
 
 	for _, portString := range runPorts {

--- a/pkg/docker/run.go
+++ b/pkg/docker/run.go
@@ -30,13 +30,14 @@ type Volume struct {
 }
 
 type RunOptions struct {
-	Args    []string
-	Env     []string
-	GPUs    string
-	Image   string
-	Ports   []Port
-	Volumes []Volume
-	Workdir string
+	Args     []string
+	Env      []string
+	GPUs     string
+	Image    string
+	Ports    []Port
+	Volumes  []Volume
+	Workdir  string
+	Platform string
 }
 
 // used for generating arguments, with a few options not exposed by public API
@@ -83,6 +84,9 @@ func generateDockerArgs(options internalRunOptions) []string {
 	}
 	if options.Workdir != "" {
 		dockerArgs = append(dockerArgs, "--workdir", options.Workdir)
+	}
+	if options.Platform != "" {
+		dockerArgs = append(dockerArgs, "--platform", options.Platform)
 	}
 	dockerArgs = append(dockerArgs, options.Image)
 	dockerArgs = append(dockerArgs, options.Args...)


### PR DESCRIPTION
This commit fixes the `run` command for Apple Silicon M1 support. The `run` command now uses the `docker run` command with the `--platform` flag set to `linux/amd64` to ensure that the container runs on the correct architecture. This behavior matches the `build` command, which also uses the `--platform` flag to ensure that the image is built for the correct architecture.