### PR TITLE
Fix upload logging

### DIFF
--- a/python/cog/server/clients.py
+++ b/python/cog/server/clients.py
@@ -187,7 +187,7 @@ class ClientManager:
         # if we get multipart uploads working or a separate API route
         # then we could drop this
         if url and ".internal" in url:
-            log.info("doing test upload to", url)
+            log.info("doing test upload to %s", url)
             resp1 = await self.file_client.put(
                 url,
                 content=b"",


### PR DESCRIPTION
Fixes an error that occurs when uploading the results of a training run.

```
File "/root/.pyenv/versions/3.11.9/lib/python3.11/site-packages/cog/server/clients.py", line 190, in upload_file
    [log.info](http://log.info/)("doing test upload to", url)
  File "/root/.pyenv/versions/3.11.9/lib/python3.11/site-packages/structlog/_native.py", line 136, in meth
    return self._proxy_to_logger(name, event % args, **kw)
                                       ~~~~~~^~~~~~
TypeError: not all arguments converted during string formatting
```