### PR TITLE
Set missing `Env` argument in call to `NewPredictor` on retry

### DIFF
--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -145,6 +145,7 @@ func cmdPredict(cmd *cobra.Command, args []string) error {
 			predictor = predict.NewPredictor(docker.RunOptions{
 				Image:   imageName,
 				Volumes: volumes,
+				Env:     envFlags,
 			})
 
 			if err := predictor.Start(os.Stderr); err != nil {


### PR DESCRIPTION
Follow-up to #1253 

This PR fixes a bug where environment variables wouldn't be set on the second attempt to run `cog predict` when no GPUs are available (such as on macOS).