### PR TITLE
Add `--env`/`-e` flags to cog train subcommand

### DIFF
--- a/pkg/cli/train.go
+++ b/pkg/cli/train.go
@@ -36,6 +36,7 @@ It will build the model in the current directory and train it.`,
 	addUseCogBaseImageFlag(cmd)
 
 	cmd.Flags().StringArrayVarP(&trainInputFlags, "input", "i", []string{}, "Inputs, in the form name=value. if value is prefixed with @, then it is read from a file on disk. E.g. -i path=@image.jpg")
+	cmd.Flags().StringArrayVarP(&envFlags, "env", "e", []string{}, "Environment variables, in the form name=value")
 
 	return cmd
 }
@@ -74,6 +75,7 @@ func cmdTrain(cmd *cobra.Command, args []string) error {
 		GPUs:    gpus,
 		Image:   imageName,
 		Volumes: volumes,
+		Env:     envFlags,
 		Args:    []string{"python", "-m", "cog.server.http", "--x-mode", "train"},
 	})
 


### PR DESCRIPTION
Follow-up to #1253

While I was working on #1709, I noticed that we don't support passing environment variables to `cog train`. This PR makes that change.