### PR TITLE
Run predictions off main thread to avoid blocking health check

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -271,7 +271,7 @@ def create_app(
         response_model=PredictionResponse,
         response_model_exclude_unset=True,
     )
-    async def predict(
+    def predict(
         request: PredictionRequest = Body(default=None),
         prefer: Optional[str] = Header(default=None),
         traceparent: Optional[str] = Header(default=None, include_in_schema=False),
@@ -300,7 +300,7 @@ def create_app(
         response_model=PredictionResponse,
         response_model_exclude_unset=True,
     )
-    async def predict_idempotent(
+    def predict_idempotent(
         prediction_id: str = Path(..., title="Prediction ID"),
         request: PredictionRequest = Body(..., title="Prediction Request"),
         prefer: Optional[str] = Header(default=None),


### PR DESCRIPTION
Fixes https://github.com/replicate/cog/issues/1719

Defining the prediction endpoints with `async def` runs them on the main thread per [FastAPI docs](https://fastapi.tiangolo.com/async/#path-operation-functions), which is problematic because it blocks the server from responding to the health check endpoint. Converting these to `def` allows health checks to run and fixes the problem I described in the above issue.