### PR TITLE
Validate minor version for CUDA and Python

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -25,13 +25,13 @@ This stanza describes how to build the Docker image your model runs in. It conta
 
 ### `cuda`
 
-Cog automatically picks the correct version of CUDA to install, but this lets you override it for whatever reason.
+Cog automatically picks the correct version of CUDA to install, but this lets you override it for whatever reason by specifying the minor (`11.8`) or patch (`11.8.0`) version of CUDA to use.
 
 For example:
 
 ```yaml
 build:
-  cuda: "11.1"
+  cuda: "11.8"
 ```
 
 ### `gpu`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,6 +22,16 @@ func TestValidateModelPythonVersion(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			name:        "MinimumVersion",
+			input:       "3.8",
+			expectedErr: false,
+		},
+		{
+			name:        "FullyQualifiedVersion",
+			input:       "3.12.1",
+			expectedErr: false,
+		},
+		{
 			name:        "InvalidFormat",
 			input:       "3-12",
 			expectedErr: true,
@@ -35,16 +45,6 @@ func TestValidateModelPythonVersion(t *testing.T) {
 			name:        "LessThanMinimum",
 			input:       "3.7",
 			expectedErr: true,
-		},
-		{
-			name:        "EqualToMinimum",
-			input:       "3.8",
-			expectedErr: false,
-		},
-		{
-			name:        "GreaterThanMinimum",
-			input:       "3.11",
-			expectedErr: false,
 		},
 	}
 
@@ -68,7 +68,17 @@ func TestValidateCudaVersion(t *testing.T) {
 	}{
 		{
 			name:        "ValidVersion",
-			input:       "11.2",
+			input:       "12.4",
+			expectedErr: false,
+		},
+		{
+			name:        "MinimumVersion",
+			input:       "11.0",
+			expectedErr: false,
+		},
+		{
+			name:        "FullyQualifiedVersion",
+			input:       "12.4.1",
 			expectedErr: false,
 		},
 		{
@@ -85,11 +95,6 @@ func TestValidateCudaVersion(t *testing.T) {
 			name:        "LessThanMinimum",
 			input:       "9.1",
 			expectedErr: true,
-		},
-		{
-			name:        "GreaterThanMinimum",
-			input:       "11.0",
-			expectedErr: false,
 		},
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -10,6 +10,101 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+func TestValidateModelPythonVersion(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       string
+		expectedErr bool
+	}{
+		{
+			name:        "ValidVersion",
+			input:       "3.12",
+			expectedErr: false,
+		},
+		{
+			name:        "InvalidFormat",
+			input:       "3-12",
+			expectedErr: true,
+		},
+		{
+			name:        "InvalidMissingMinor",
+			input:       "3",
+			expectedErr: true,
+		},
+		{
+			name:        "LessThanMinimum",
+			input:       "3.7",
+			expectedErr: true,
+		},
+		{
+			name:        "EqualToMinimum",
+			input:       "3.8",
+			expectedErr: false,
+		},
+		{
+			name:        "GreaterThanMinimum",
+			input:       "3.11",
+			expectedErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateModelPythonVersion(tc.input)
+			if tc.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateCudaVersion(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       string
+		expectedErr bool
+	}{
+		{
+			name:        "ValidVersion",
+			input:       "11.2",
+			expectedErr: false,
+		},
+		{
+			name:        "InvalidFormat",
+			input:       "11-2",
+			expectedErr: true,
+		},
+		{
+			name:        "InvalidMissingMinor",
+			input:       "11",
+			expectedErr: true,
+		},
+		{
+			name:        "LessThanMinimum",
+			input:       "9.1",
+			expectedErr: true,
+		},
+		{
+			name:        "GreaterThanMinimum",
+			input:       "11.0",
+			expectedErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateCudaVersion(tc.input)
+			if tc.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestPythonPackagesAndRequirementsCantBeUsedTogether(t *testing.T) {
 	config := &Config{
 		Build: &Build{


### PR DESCRIPTION
When the user specifies a CUDA or Python version in the cog.yaml, we now ensure that at least the minor version is set. This validation ensures that our compatibility version logic works properly.

Additionally, this commit adds logic to the CUDA version selection process, enabling it to pick the latest versions of both CUDA and Ubuntu that satisfy the major.minor constraints.

It also fixes a bug in the config parsing that caused a panic if the user defined only the major version of Python.