### PR TITLE
Unhide the use-cog-base-image-flag

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -108,11 +108,6 @@ func addDockerfileFlag(cmd *cobra.Command) {
 
 func addUseCogBaseImageFlag(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&buildUseCogBaseImage, "use-cog-base-image", false, "Use pre-built Cog base image for faster cold boots")
-	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		if f.Name == "use-cog-base-image" {
-			f.Hidden = true
-		}
-	})
 }
 
 func addBuildTimestampFlag(cmd *cobra.Command) {


### PR DESCRIPTION
Unhide the flags that control if we should use base images by default.

That should allow more testing of the functionality before we make it the default behavior.

Moved out from https://github.com/replicate/cog/pull/1699