### PR TITLE
Implement pre-build repository check for Replicate images

### DIFF
--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -51,11 +51,8 @@ func push(cmd *cobra.Command, args []string) error {
 
 	replicatePrefix := fmt.Sprintf("%s/", global.ReplicateRegistryHost)
 	if strings.HasPrefix(imageName, replicatePrefix) {
-		err := ManifestInspect(imageName)
-		if err != nil {
-			if strings.Contains(err.Error(), `"code":"NAME_UNKNOWN"`) {
-				return err
-			}
+		if err := ManifestInspect(imageName); err != nil && strings.Contains(err.Error(), `"code":"NAME_UNKNOWN"`) {
+			return fmt.Errorf("Unable to find Replicate existing model for %s. Go to replicate.com and create a new model before pushing.", imageName)
 		}
 	}
 

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -65,7 +65,6 @@ func push(cmd *cobra.Command, args []string) error {
 	exitStatus := docker.Push(imageName)
 	if exitStatus == nil {
 		console.Infof("Image '%s' pushed", imageName)
-		// replicatePrefix := fmt.Sprintf("%s/", global.ReplicateRegistryHost)
 		if strings.HasPrefix(imageName, replicatePrefix) {
 			replicatePage := fmt.Sprintf("https://%s", strings.Replace(imageName, global.ReplicateRegistryHost, global.ReplicateWebsiteHost, 1))
 			console.Infof("\nRun your model on Replicate:\n    %s", replicatePage)

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -49,6 +49,16 @@ func push(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("To push images, you must either set the 'image' option in cog.yaml or pass an image name as an argument. For example, 'cog push r8.im/your-username/hotdog-detector'")
 	}
 
+	replicatePrefix := fmt.Sprintf("%s/", global.ReplicateRegistryHost)
+	if strings.HasPrefix(imageName, replicatePrefix) {
+		err := ManifestInspect(imageName)
+		if err != nil {
+			if strings.Contains(err.Error(), `"code":"NAME_UNKNOWN"`) {
+				return err
+			}
+		}
+	}
+
 	if err := image.Build(cfg, projectDir, imageName, buildSecrets, buildNoCache, buildSeparateWeights, buildUseCudaBaseImage, buildProgressOutput, buildSchemaFile, buildDockerfileFile, buildUseCogBaseImage); err != nil {
 		return err
 	}
@@ -58,7 +68,7 @@ func push(cmd *cobra.Command, args []string) error {
 	exitStatus := docker.Push(imageName)
 	if exitStatus == nil {
 		console.Infof("Image '%s' pushed", imageName)
-		replicatePrefix := fmt.Sprintf("%s/", global.ReplicateRegistryHost)
+		// replicatePrefix := fmt.Sprintf("%s/", global.ReplicateRegistryHost)
 		if strings.HasPrefix(imageName, replicatePrefix) {
 			replicatePage := fmt.Sprintf("https://%s", strings.Replace(imageName, global.ReplicateRegistryHost, global.ReplicateWebsiteHost, 1))
 			console.Infof("\nRun your model on Replicate:\n    %s", replicatePage)

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -51,7 +51,7 @@ func push(cmd *cobra.Command, args []string) error {
 
 	replicatePrefix := fmt.Sprintf("%s/", global.ReplicateRegistryHost)
 	if strings.HasPrefix(imageName, replicatePrefix) {
-		if err := ManifestInspect(imageName); err != nil && strings.Contains(err.Error(), `"code":"NAME_UNKNOWN"`) {
+		if err := docker.ManifestInspect(imageName); err != nil && strings.Contains(err.Error(), `"code":"NAME_UNKNOWN"`) {
 			return fmt.Errorf("Unable to find Replicate existing model for %s. Go to replicate.com and create a new model before pushing.", imageName)
 		}
 	}

--- a/pkg/docker/manifest_inspect.go
+++ b/pkg/docker/manifest_inspect.go
@@ -1,0 +1,27 @@
+package docker
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/replicate/cog/pkg/util/console"
+)
+
+func ManifestInspect(image string) error {
+	cmd := exec.Command("docker", "manifest", "inspect", image)
+	var out strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	console.Debug("$ " + strings.Join(cmd.Args, " "))
+	err := cmd.Run()
+
+	if err != nil {
+		output := out.String()
+		if strings.Contains(output, "no such manifest") || strings.Contains(output, "manifest unknown") || strings.Contains(output, "not found") {
+			return nil
+		}
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
- Added the `ManifestInspect` function in `pkg/docker` to verify if a Docker image exists on a registry using the `docker manifest inspect` command.
- Updated the `push` function in `pkg/cli/push.go` to include a check for the existence of a model on the Replicate registry before initiating the build process.
- The validation step is conditionally executed only for images with the Replicate registry prefix, preventing unnecessary checks for other registries.
- This change ensures that if a model does not exist on Replicate, the process stops early with a clear error message, avoiding the waste of time and resources on building and attempting to push a non-existent model.

References:
- Issue #1678
