### PR TITLE
Revert "Bump goreleaser/goreleaser-action from 4 to 6"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,7 @@ jobs:
           go-version-file: go.mod
       - name: Build
         run: make cog
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
Reverts replicate/cog#1731

Inadvertently merged this before migrating incompatible changes.