### PR TITLE
Update HTTP server to make host configurable

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -546,7 +546,7 @@ if __name__ == "__main__":
 
     server_config = uvicorn.Config(
         app,
-        host="0.0.0.0",
+        host="::",
         port=port,
         log_config=None,
         # This is the default, but to be explicit: only run a single worker

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -484,6 +484,13 @@ def _cpu_count() -> int:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Cog HTTP server")
     parser.add_argument(
+        "--host",
+        dest="host",
+        type=str,
+        default="0.0.0.0",
+        help="Host to bind to",
+    )
+    parser.add_argument(
         "--threads",
         dest="threads",
         type=int,
@@ -539,6 +546,8 @@ if __name__ == "__main__":
         mode=args.mode,
     )
 
+    host: str = args.host
+
     port = int(os.getenv("PORT", 5000))
     if is_port_in_use(port):
         log.error(f"Port {port} is already in use")
@@ -546,7 +555,7 @@ if __name__ == "__main__":
 
     server_config = uvicorn.Config(
         app,
-        host="::",
+        host=host,
         port=port,
         log_config=None,
         # This is the default, but to be explicit: only run a single worker


### PR DESCRIPTION
Resolves #1735 

By default `http.server` binds to `0.0.0.0`. To support IPv6, you can specify `--host="::"`.

Defaulting to `::` breaks integration tests, as it requires Docker to enable IPv6 support. Making the host configurable seems like a better solution.