### PR TITLE
add batch size metric

### DIFF
--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -511,6 +511,7 @@ class PredictionEventHandler:
         if self.time_share_tracker and self.p.id:
             time_share = self.time_share_tracker.end_tracking(self.p.id)
             self.p.metrics["predict_time_share"] = time_share
+            self.p.metrics["batch_size"] = self.p.metrics["predict_time"] / time_share
         await self._send_webhook(schema.WebhookEvent.COMPLETED)
 
     async def failed(self, error: str) -> None:


### PR DESCRIPTION
seemingly director or some other part of the system introduces enough change to predict_time as recorded in web that predict_time/predict_time_share gives implausible values for batch size. recording batch_size *should* be redundant given predict_time_share, but everything will probably be simpler to just record it explicitly.
