### PR TITLE
add necessary headers to curl

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -27,6 +27,7 @@ Port 5000 is now serving the API:
 To run a prediction on the model, call the `/predictions` endpoint, passing input in the format expected by your model:
 
     curl http://localhost:5000/predictions -X POST \
+        --header "Content-Type:application/json" \
         --data '{"input": {"image": "https://.../input.jpg"}}'
 
 To view the API documentation in browser for the model that is running, open [http://localhost:5000/docs](http://localhost:5000/docs).

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -27,7 +27,7 @@ Port 5000 is now serving the API:
 To run a prediction on the model, call the `/predictions` endpoint, passing input in the format expected by your model:
 
     curl http://localhost:5000/predictions -X POST \
-        --header "Content-Type:application/json" \
+        --header "Content-Type: application/json" \
         --data '{"input": {"image": "https://.../input.jpg"}}'
 
 To view the API documentation in browser for the model that is running, open [http://localhost:5000/docs](http://localhost:5000/docs).


### PR DESCRIPTION
The example curl to `/predict` does not include the necessary headers shown in [https://github.com/replicate/cog/blob/main/docs/http.md#post-predictions-synchronous](https://github.com/replicate/cog/blob/main/docs/http.md#post-predictions-synchronous)