### PR TITLE
Set 10 minute timeout for test-integration CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,6 +89,7 @@ jobs:
   test-integration:
     name: "Test integration"
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
I noticed that `test-integration` sometimes fails after 6 hours. This corresponds to the 360 minute [default timeout](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) for GitHub Actions jobs.

`test-integration` typically completes in <5 minutes. If it hasn't finished by then, then it's unlikely to finish at all. So this PR sets an explicit 10 minute timeout.