### PR TITLE
Update install script instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,16 @@ brew install cog
 You can also download and install the latest release using our 
 [install script](https://cog.run/install):
 
-```
-# via curl
-curl -fsSL https://cog.run/install | sh
-# or via wget:
-wget -qO- https://cog.run/install | sh
-# or via fetch:
-fetch -o - https://cog.run/install | sh
+```console
+# fish shell
+sh (curl -fsSL https://cog.run/install.sh | psub)
+
+# bash, zsh, and other shells
+sh <(curl -fsSL https://cog.run/install.sh)
+
+# download with wget and run in a separate command
+wget -qO- https://cog.run/install.sh
+sh ./install.sh
 ```
 
 You can manually install the latest release of Cog directly from GitHub 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -138,9 +138,9 @@ print_success() {
 
 main() {
 
-  # Check if OS X
+  # Check if macOS
   if [ "$(uname -s)" = "Darwin" ]; then
-    echo "On OS X, it is recommended to install cog using Homebrew instead:"
+    echo "On macOS, it is recommended to install cog using Homebrew instead:"
     echo \`brew install cog\`
     echo "Do you want to continue with this installation anyway?"
     


### PR DESCRIPTION
Follow up to #1558 

Trying this out myself, I noticed that it wasn't being run interactively. To make that work, you need to redirect the source directly into a `sh` process. Piped execution doesn't support interactivity.

```console
$ curl -fsSL https://cog.run/install.sh | sh
On OS X, it is recommended to install cog using Homebrew instead:
`brew install cog`
Do you want to continue with this installation anyway?
```

This PR updates to use process substitution syntax. As discussed in https://github.com/fish-shell/fish-shell/issues/5181, fish (my preferred shell) uses a different syntax, so I added special instructions for that. I also removed instructions for `fetch`, because I think `wget` and `curl` cover the vast majority of use cases.