### PR TITLE
Reduce unnecessary work in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,8 +46,7 @@ jobs:
 
   test-python:
     needs:
-      - typecheck-python
-      - test-go
+      - lint-python
     name: "Test Python ${{ matrix.python-version }}"
     runs-on: ubuntu-latest-8-cores
     strategy:
@@ -70,8 +69,8 @@ jobs:
         env:
           HYPOTHESIS_PROFILE: ci
 
-  typecheck-python:
-    name: "Typecheck and lint Python"
+  lint-python:
+    name: "Lint Python"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -84,7 +83,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install '.[dev]'
-      - name: Run typechecking
+      - name: Lint
         run: |
           make lint-python
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
       - test-go
       - test-python
     name: "Test integration"
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,9 @@ jobs:
 
   # cannot run this on mac due to licensing issues: https://github.com/actions/virtual-environments/issues/2150
   test-integration:
+    needs:
+      - test-go
+      - test-python
     name: "Test integration"
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,9 @@ jobs:
         run: make test-go
 
   test-python:
+    needs:
+      - typecheck-python
+      - test-go
     name: "Test Python ${{ matrix.python-version }}"
     runs-on: ubuntu-latest-8-cores
     strategy:


### PR DESCRIPTION
Cog's CI workflow consists of unit tests for Go, unit tests for Python, and integration tests. When Go unit tests fail, CI continues to run Python and integration tests, leading to wasted effort.

This PR sets up job dependencies to reduce wasted effort. First, it tests Go unit tests, since those run faster and only target 2 platforms. Once that finishes, it runs Python unit tests across our supported Python versions. And then, only when all of that finishes does it run integration tests.

<img width="1051" alt="Screenshot 2024-06-22 at 06 38 38" src="https://github.com/replicate/cog/assets/7659/551e9e8b-e9aa-4cde-b196-2c7bcfde9fd0">


This PR also removes Python 3.7 from the build matrix, as support for that was dropped in #1582.