### PR TITLE
Rewrite HTTP API documentation

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -51,13 +51,9 @@ call the `/predictions` endpoint,
 passing input in the format expected by your model:
 
 ```console
-curl http://localhost:5000/predictions -X POST \
+curl http://localhost:5001/predictions -X POST \
     --header "Content-Type: application/json" \
     --data '{"input": {"image": "https://.../input.jpg"}}'
-```
-
-To view the API documentation in browser for the model that is running, 
-open [http://localhost:5000/docs](http://localhost:5000/docs).
 
 For more details about the HTTP API, 
 see the [HTTP API reference documentation](http.md).

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,38 +1,66 @@
 # Deploy models with Cog
 
-Cog containers are Docker containers that serve an HTTP server for running predictions on your model. You can deploy them anywhere that Docker containers run.
+Cog containers are Docker containers that serve an HTTP server 
+for running predictions on your model. 
+You can deploy them anywhere that Docker containers run.
 
-This guide assumes you have a model packaged with Cog. If you don't, [follow our getting started guide](getting-started-own-model.md), or use [an example model](https://github.com/replicate/cog-examples).
+This guide assumes you have a model packaged with Cog. 
+If you don't, [follow our getting started guide](getting-started-own-model.md), 
+or use [an example model](https://github.com/replicate/cog-examples).
 
 ## Getting started
 
 First, build your model:
 
-    cog build -t my-model
+```console
+cog build -t my-model
+```
 
 Then, start the Docker container:
 
-    docker run -d -p 5000:5000 my-model
+```shell
+# If your model uses a CPU:
+docker run -d -p 5001:5000 my-model
 
-    # If your model uses a GPU:
-    docker run -d -p 5000:5000 --gpus all my-model
+# If your model uses a GPU:
+docker run -d -p 5001:5000 --gpus all my-model
 
-    # If you're on an M1 Mac:
-    docker run -d -p 5000:5000 --platform=linux/amd64 my-model
+# If you're on an M1 Mac:
+docker run -d -p 5001:5000 --platform=linux/amd64 my-model
+```
 
-Port 5000 is now serving the API:
+The server is now running locally on port 5001.
 
-    curl http://localhost:5000
+To view the OpenAPI schema, 
+open [localhost:5001/openapi.json](http://localhost:5001/openapi.json) 
+in your browser 
+or use cURL to make a request:
 
-To run a prediction on the model, call the `/predictions` endpoint, passing input in the format expected by your model:
+```console
+curl http://localhost:5001/openapi.json
+```
 
-    curl http://localhost:5000/predictions -X POST \
-        --header "Content-Type: application/json" \
-        --data '{"input": {"image": "https://.../input.jpg"}}'
+To stop the server, run:
 
-To view the API documentation in browser for the model that is running, open [http://localhost:5000/docs](http://localhost:5000/docs).
+```console
+docker kill my-model
+```
 
-For more details about the HTTP API, see the [HTTP API reference documentation](http.md).
+To run a prediction on the model, 
+call the `/predictions` endpoint, 
+passing input in the format expected by your model:
+
+```console
+curl http://localhost:5000/predictions -X POST \
+    --header "Content-Type: application/json" \
+    --data '{"input": {"image": "https://.../input.jpg"}}'
+```
+
+To view the API documentation in browser for the model that is running, 
+open [http://localhost:5000/docs](http://localhost:5000/docs).
+
+For more details about the HTTP API, 
+see the [HTTP API reference documentation](http.md).
 
 ## Options
 

--- a/docs/http.md
+++ b/docs/http.md
@@ -26,7 +26,7 @@ with `202 Accepted` status and a prediction object in status `processing`.
 > started asynchronously is using [webhooks](#webhooks). 
 > Polling for prediction status is not currently supported.
 
-The server also provides a way to create predictions idempotently,
+You can also use certain server endpoints to create predictions idempotently,
 such that if a client calls this endpoint more than once with the same ID 
 (for example, due to a network interruption) 
 while the prediction is still running, 
@@ -55,7 +55,7 @@ Choose the endpoint that best fits your needs:
 
 ## Webhooks
 
-The client can provide a `webhook` parameter in the request body 
+You can provide a `webhook` parameter in the client request body
 when creating a prediction.
 
 ```http

--- a/docs/http.md
+++ b/docs/http.md
@@ -1,147 +1,62 @@
 # HTTP API
 
-When a Cog Docker image is run, it serves an HTTP API for making predictions. For more information, take a look at [the documentation for deploying models](deploy.md).
+> [!TIP]
+> For information about how to run the HTTP server, 
+> see [our documentation to deploying models](deploy.md).
 
-## Contents
+When you run a Docker image built by Cog, 
+it serves an HTTP API for making predictions.
 
-- [Contents](#contents)
-- [Running the server](#running-the-server)
-- [Stopping the server](#stopping-the-server)
-- [API](#api)
-  - [`GET /openapi.json`](#get-openapijson)
-  - [`POST /predictions` (synchronous)](#post-predictions-synchronous)
-  - [`POST /predictions` (asynchronous)](#post-predictions-asynchronous)
-    - [Webhooks](#webhooks)
-  - [`PUT /predictions/<prediction_id>` (synchronous)](#put-predictionsprediction_id-synchronous)
-  - [`PUT /predictions/<prediction_id>` (asynchronous)](#put-predictionsprediction_id-asynchronous)
-  - [`POST /predictions/<prediction_id>/cancel`](#post-predictionsprediction_idcancel)
+The server supports both synchronous and asynchronous prediction creation:
 
-## Running the server
+- **Synchronous**: 
+  The server waits until the prediction is completed
+  and responds with the result.
+- **Asynchronous**: 
+  The server immediately returns a response 
+  and processes the prediction in the background. 
 
-First, build your model:
+The client can create a prediction asynchronously
+by setting the `Prefer: respond-async` header in their request.
+When provided, the server responds immediately after starting the prediction 
+with `202 Accepted` status and a prediction object in status `processing`.
 
-```
-cog build -t my-model
-```
+> [!NOTE]
+> The only supported way to receive updates on the status of predictions
+> started asynchronously is using [webhooks](#webhooks). 
+> Polling for prediction status is not currently supported.
 
-Then, start the Docker container:
+The server also provides a way to create predictions idempotently,
+such that if a client calls this endpoint more than once with the same ID 
+(for example, due to a network interruption) 
+while the prediction is still running, 
+no new prediction is created. 
+Instead, the client receives a `202 Accepted` response
+with the initial state of the prediction.
 
-```console
-# If your model uses a CPU:
-docker run -d -p 5001:5000 my-model
+---
 
-# If your model uses a GPU:
-docker run -d -p 5001:5000 --gpus all my-model
+Here's a summary of the prediction creation endpoints:
 
-# If you're on an M1 Mac:
-docker run -d -p 5001:5000 --platform=linux/amd64 my-model
-```
+| Endpoint                           | Header                  | Behavior                     |
+| ---------------------------------- | ----------------------- | ---------------------------- |
+| `POST /predictions`                | -                       | Synchronous, non-idempotent  |
+| `POST /predictions`                | `Prefer: respond-async` | Asynchronous, non-idempotent |
+| `PUT /predictions/<prediction_id>` | -                       | Synchronous, idempotent      |
+| `PUT /predictions/<prediction_id>` | `Prefer: respond-async` | Asynchronous, idempotent     |
 
-The server is now running locally on port 5001.
+Choose the endpoint that best fits your needs:
 
-To view the OpenAPI schema, open [localhost:5001/openapi.json](http://localhost:5001/openapi.json) in your browser or use cURL to make requests:
+- Use synchronous endpoints when you want to wait for the prediction result.
+- Use asynchronous endpoints when you want to start a prediction 
+  and receive updates via webhooks.
+- Use idempotent endpoints when you need to safely retry requests 
+  without creating duplicate predictions.
 
-```console
-curl http://localhost:5001/openapi.json
-```
+## Webhooks
 
-## Stopping the server
-
-To stop the server, run:
-
-```console
-docker kill my-model
-```
-
-## API
-
-### `GET /openapi.json`
-
-The [OpenAPI](https://swagger.io/specification/) specification of the API, which is derived from the input and output types specified in your model's [Predictor](python.md) and [Training](training.md) objects.
-
-### `POST /predictions` (synchronous)
-
-Make a single prediction. The request body should be a JSON object with the following fields:
-
-- `input`: a JSON object with the same keys as the [arguments to the `predict()` function](python.md). Any `File` or `Path` inputs are passed as URLs.
-- `output_file_prefix`: A base URL to upload output files to. <!-- link to file handling documentation -->
-
-The response is a JSON object with the following fields:
-
-- `status`: Either `succeeded` or `failed`.
-- `output`: The return value of the `predict()` function.
-- `error`: If `status` is `failed`, the error message.
-
-For example:
-
-```http
-POST /predictions HTTP/1.1
-Content-Type: application/json; charset=utf-8
-
-{
-    "input": {
-        "image": "https://example.com/image.jpg",
-        "text": "Hello world!"
-    }
-}
-```
-
-Responds with:
-
-```
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{
-    "status": "succeeded",
-    "output": "data:image/png;base64,..."
-}
-```
-
-Or, with curl:
-
-    curl -X POST -H "Content-Type: application/json" -d '{"input": {"image": "https://example.com/image.jpg", "text": "Hello world!"}}' http://localhost:5000/predictions
-
-### `POST /predictions` (asynchronous)
-
-Make a single prediction without waiting for the prediction to complete.
-
-Callers can specify an HTTP header of `Prefer: respond-async` when calling the
-`POST /predictions` endpoint. If provided, the request will return immediately
-after starting the prediction with an HTTP `202 Accepted` status and a
-prediction object in status `processing`.
-
-```http
-POST /predictions HTTP/1.1
-Content-Type: application/json; charset=utf-8
-Prefer: respond-async
-
-{
-    "input": {"prompt": "A picture of an onion with sunglasses"}
-}
-```
-
-The only supported mechanism for receiving updates on the status of predictions
-started asynchronously is via webhooks. There is as yet no support for polling
-for prediction status.
-
-**Note 1:** that while this allows clients to create predictions
-"asynchronously," Cog can only run one prediction at a time, and it is currently
-the caller's responsibility to make sure that earlier predictions are complete
-before new ones are created.
-
-**Note 2:** predictions created asynchronously use a different mechanism for
-file upload than those created using the synchronous API. You must specify an
-`--upload-url` when running the Cog server process. All uploads will be `PUT`
-using the provided `--upload-url` as a prefix, in much the same way that
-`output_file_prefix` worked. There is currently no single upload mechanism which
-works the same way for both synchronous and asynchronous prediction creation.
-This will be addressed in a future version of Cog.
-
-#### Webhooks
-
-Clients can (and should, if a prediction is created asynchronously) provide a
-`webhook` parameter at the top level of the prediction request, e.g.
+The client can provide a `webhook` parameter in the request body 
+when creating a prediction.
 
 ```http
 POST /predictions HTTP/1.1
@@ -154,23 +69,34 @@ Prefer: respond-async
 }
 ```
 
-Cog will make requests to the URL supplied with the state of the prediction
-object in the request body. Requests are made when specific events occur during
-the prediction, namely:
+The server makes requests to the provided URL
+with the current state of the prediction object in the request body
+at the following times.
 
-- `start`: immediately on prediction start
-- `output`: each time a prediction generates an output (note that predictions can generate multiple outputs)
-- `logs`: each time log output is generated by a prediction
-- `completed`: when the prediction reaches a terminal state (succeeded/canceled/failed)
+- `start`: 
+  Once, when the prediction starts
+  (`status` is `starting`).
+- `output`: 
+  Each time a predict function generates an output 
+  (either once using `return` or multiple times using `yield`)
+- `logs`: 
+  Each time the predict function writes to `stdout`
+- `completed`: 
+  Once, when the prediction reaches a terminal state 
+  (`status` is `succeeded`, `canceled`, or `failed`)
 
-Requests for event types `output` and `logs` will be sent at most once every
-500ms. This interval is currently not configurable. Requests for event types
-`start` and `completed` will be sent immediately.
+Webhook requests for `start` and `completed` event types 
+are sent immediately.
+Webhook requests for `output` and `logs` event types 
+are sent at most once every 500ms.
+This interval is not configurable.
 
-By default, Cog will send requests for all event types. Clients can change which
-events trigger webhook requests by specifying `webhook_events_filter` in the
-prediction request. For example, if you only wanted requests to be sent at the
-start and end of the prediction, you would provide:
+By default, the server sends requests for all event types. 
+Clients can specify which events trigger webhook requests 
+with the `webhook_events_filter` parameter in the prediction request body. 
+For example,
+the following request specifies that webhooks are sent by the server
+only at the start and end of the prediction:
 
 ```http
 POST /predictions HTTP/1.1
@@ -184,43 +110,222 @@ Prefer: respond-async
 }
 ```
 
-### `PUT /predictions/<prediction_id>` (synchronous)
+## Generating unique prediction IDs
+
+Endpoints for creating and canceling a prediction idempotently
+accept a `prediction_id` parameter in their path.
+The server can run only one prediction at a time.
+The client must ensure that running prediction is complete
+before creating a new one with a different ID.
+
+Clients are responsible for providing unique prediction IDs.
+We recommend generating a UUIDv4 or [UUIDv7](https://uuid7.com),
+base32-encoding that value,
+and removing padding characters (`==`).
+This produces a random identifier that is 26 ASCII characters long.
+
+```python
+>> from uuid import uuid4
+>> from base64 import b32encode
+>> b32encode(uuid4().bytes).decode('utf-8').lower().rstrip('=')
+'wjx3whax6rf4vphkegkhcvpv6a'
+```
+
+## File uploads
+
+A model's `predict` function can produce file output by yielding or returning
+a `cog.Path` or `cog.File` value.
+
+By default,
+files are returned as a base64-encoded 
+[data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
+
+```http
+POST /predictions HTTP/1.1
+Content-Type: application/json; charset=utf-8
+
+{
+    "input": {"prompt": "A picture of an onion with sunglasses"},
+}
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "status": "succeeded",
+    "output": "data:image/png;base64,..."
+}
+```
+
+When creating a prediction synchronously,
+the client can configure a base URL to upload output files to instead
+by setting the `output_file_prefix` parameter in the request body:
+
+```http
+POST /predictions HTTP/1.1
+Content-Type: application/json; charset=utf-8
+
+{
+    "input": {"prompt": "A picture of an onion with sunglasses"},
+    "output_file_prefix": "https://example.com/upload",
+}
+```
+
+When the model produces a file output,
+the server sends the following request to upload the file to the configured URL:
+
+```http
+PUT /upload HTTP/1.1
+Host: example.com
+Content-Type: multipart/form-data
+
+--boundary
+Content-Disposition: form-data; name="file"; filename="image.png"
+Content-Type: image/png
+
+<binary data>
+--boundary--
+```
+
+If the upload succeeds, the server responds with output:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "status": "succeeded",
+    "output": "http://example.com/upload/image.png"
+}
+```
+
+If the upload fails, the server responds with an error.
+
+> [!IMPORTANT]  
+> File uploads for predictions created asynchronously 
+> require `--upload-url` to be specified when starting the HTTP server.
+
+<a id="api"></a>
+
+## Endpoints
+
+### `GET /openapi.json`
+
+The [OpenAPI](https://swagger.io/specification/) specification of the API, 
+which is derived from the input and output types specified in your model's 
+[Predictor](python.md) and [Training](training.md) objects.
+
+### `POST /predictions`
+
+Makes a single prediction.
+
+The request body is a JSON object with the following fields:
+
+- `input`: 
+  A JSON object with the same keys as the 
+  [arguments to the `predict()` function](python.md).
+  Any `File` or `Path` inputs are passed as URLs.
+
+The response body is a JSON object with the following fields:
+
+- `status`: Either `succeeded` or `failed`.
+- `output`: The return value of the `predict()` function.
+- `error`: If `status` is `failed`, the error message.
+
+```http
+POST /predictions HTTP/1.1
+Content-Type: application/json; charset=utf-8
+
+{
+    "input": {
+        "image": "https://example.com/image.jpg",
+        "text": "Hello world!"
+    }
+}
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "status": "succeeded",
+    "output": "data:image/png;base64,..."
+}
+```
+
+If the client sets the `Prefer: respond-async` header in their request,
+the server responds immediately after starting the prediction 
+with `202 Accepted` status and a prediction object in status `processing`.
+
+```http
+POST /predictions HTTP/1.1
+Content-Type: application/json; charset=utf-8
+Prefer: respond-async
+
+{
+    "input": {"prompt": "A picture of an onion with sunglasses"}
+}
+```
+
+```http
+HTTP/1.1 202 Accepted
+Content-Type: application/json
+
+{
+    "status": "starting",
+}
+```
+
+### `PUT /predictions/<prediction_id>`
 
 Make a single prediction.
+This is the idempotent version of the `POST /predictions` endpoint.
 
-This is the idempotent version of the `POST /predictions` endpoint. If you call
-it multiple times with the same ID (for example, because of a network
-interruption) and the prediction is still running, the request will not create
-further predictions but will wait for the original prediction to complete.
+```http
+PUT /predictions/wjx3whax6rf4vphkegkhcvpv6a HTTP/1.1
+Content-Type: application/json; charset=utf-8
 
-**Note:** It is currently the caller's responsibility to ensure that the
-supplied prediction ID is unique. We recommend you use base32-encoded UUID4s
-(stripped of any padding characters) to ensure forward compatibility: these will
-be 26 ASCII characters long.
+{
+    "input": {"prompt": "A picture of an onion with sunglasses"}
+}
+```
 
-### `PUT /predictions/<prediction_id>` (asynchronous)
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
 
-Make a single prediction without waiting for the prediction to complete.
+{
+    "status": "succeeded",
+    "output": "data:image/png;base64,..."
+}
+```
 
-Callers can specify an HTTP header of `Prefer: respond-async` when calling the
-`PUT /predictions/<prediction_id>` endpoint. If provided, the request will
-return immediately after starting the prediction with an HTTP `202 Accepted`
-status and a prediction object in status `processing`.
+If the client sets the `Prefer: respond-async` header in their request,
+the server responds immediately after starting the prediction 
+with `202 Accepted` status and a prediction object in status `processing`.
 
-This is the idempotent version of the asynchronous `POST /predictions` endpoint.
-If you call it multiple times with the same ID (for example, because of a
-network interruption) and the prediction is still running, the request will not
-create further predictions. The caller will receive a 202 Accepted response
-with the initial state of the prediction.
+```http
+PUT /predictions/wjx3whax6rf4vphkegkhcvpv6a HTTP/1.1
+Content-Type: application/json; charset=utf-8
+Prefer: respond-async
 
-**Note 1:** It is currently the caller's responsibility to ensure that the
-supplied prediction ID is unique. We recommend you use base32-encoded UUID4s
-(stripped of any padding characters) to ensure forward compatibility: these will
-be 26 ASCII characters long.
+{
+    "input": {"prompt": "A picture of an onion with sunglasses"}
+}
+```
 
-**Note 2:** As noted earlier, Cog can only run one prediction at a time, and it is
-the caller's responsibility to make sure that earlier predictions are complete
-before new ones (with new IDs) are created.
+```http
+HTTP/1.1 202 Accepted
+Content-Type: application/json
+
+{
+    "id": "wjx3whax6rf4vphkegkhcvpv6a",
+    "status": "starting"
+}
+```
 
 ### `POST /predictions/<prediction_id>/cancel`
 
@@ -228,7 +333,8 @@ A client can cancel an asynchronous prediction by making a
 `POST /predictions/<prediction_id>/cancel` request
 using the prediction `id` provided when the prediction was created.
 
-For example, if a prediction is created with:
+For example, 
+if the client creates a prediction by sending the request:
 
 ```http
 POST /predictions HTTP/1.1
@@ -241,19 +347,19 @@ Prefer: respond-async
 }
 ```
 
-It can be canceled with:
+The client can cancel the prediction by sending the request:
 
 ```http
 POST /predictions/abcd1234/cancel HTTP/1.1
 ```
 
-Predictions cannot be canceled if they're
-created without a provided `id`
-or synchronously, without the `Prefer: respond-async` header.
+A prediction cannot be canceled if it's
+created synchronously, without the `Prefer: respond-async` header,
+or created without a provided `id`.
 
-If no prediction exists with the provided `id`,
-then the server responds with status `404 Not Found`.
-Otherwise, the server responds with `200 OK`.
+If a prediction exists with the provided `id`,
+the server responds with status `200 OK`.
+Otherwise, the server responds with status `404 Not Found`.
 
 When a prediction is canceled,
 Cog raises `cog.server.exceptions.CancelationException`


### PR DESCRIPTION
I started documenting the HTTP server host parameter added by #1748, but one thing led to another, and I ended up rewriting the [HTTP API docs](https://github.com/replicate/cog/blob/main/docs/http.md).

At a high level, this PR reorganizes the document by extracting discussion of topics like sync/async, idempotency, and webhooks out of individual endpoints and into top-level sections. I also added missing discussion of how file uploads work, and removed information about running the HTTP server which were duplicated in the [deployment](https://github.com/replicate/cog/blob/main/docs/deploy.md) doc.