### PR TITLE
Allow `URLPath` files to be missing when cleaning up inputs

### DIFF
--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -266,15 +266,11 @@ class BaseInput(BaseModel):
         """
         for _, value in self:
             # Handle URLPath objects specially for cleanup.
-            if isinstance(value, URLPath):
-                value.unlink()
-            # Note this is pathlib.Path, which cog.Path is a subclass of. A pathlib.Path object shouldn't make its way here,
-            # but both have an unlink() method, so may as well be safe.
-            elif isinstance(value, Path):
-                try:
-                    value.unlink()
-                except FileNotFoundError:
-                    pass
+            # Also handle pathlib.Path objects, which cog.Path is a subclass of.
+            # A pathlib.Path object shouldn't make its way here,
+            # but both have an unlink() method, so we may as well be safe.
+            if isinstance(value, (URLPath, Path)):
+                value.unlink(missing_ok=True)
 
 
 def validate_input_type(type: Type[Any], name: str) -> None:

--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -157,12 +157,7 @@ class URLPath(pathlib.PosixPath):
 
     def unlink(self, missing_ok: bool = False) -> None:
         if self._path:
-            # TODO: use unlink(missing_ok=...) when we drop Python 3.7 support.
-            try:
-                self._path.unlink()
-            except FileNotFoundError:
-                if not missing_ok:
-                    raise
+            self._path.unlink(missing_ok=missing_ok)
 
     def __str__(self) -> str:
         # FastAPI's jsonable_encoder will encode subclasses of pathlib.Path by


### PR DESCRIPTION
Resolves #1736

This PR updates the `cleanup` method in `BaseInput` to specify `missing_ok=True` when unlinking `URLPath` values. 

This PR also follows a suggestion in a code comment to use the native `missing_ok` parameter of `pathlib.Path.unlink`, which was added in Python 3.8 (and which, as of #1582 is the minimum supported Python version.