### PR TITLE
Restructure CI workflow (again)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,9 @@ jobs:
           python -m uv pip install '.[dev]'
       - name: Lint
         run: |
-          make lint-python
+          if [[ $(python -c 'import sys; print(sys.version_info >= (3, 10))') == "True" ]]; then
+            make lint-python
+          fi
       - name: Test
         run: make test-python
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
-        platform: [ubuntu-latest-8-cores, macos-12]
+        platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     defaults:
       run:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,8 +46,6 @@ jobs:
         run: make test-go
 
   test-python:
-    needs:
-      - lint-python
     name: "Test Python ${{ matrix.python-version }}"
     runs-on: ubuntu-latest-8-cores
     strategy:
@@ -66,29 +64,13 @@ jobs:
         run: |
           python -m pip install --no-cache uv
           python -m uv pip install '.[dev]'
+      - name: Lint
+        run: |
+          make lint-python
       - name: Test
         run: make test-python
         env:
           HYPOTHESIS_PROFILE: ci
-
-  lint-python:
-    name: "Lint Python"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --no-cache uv
-          python -m uv pip install '.[dev]'
-      - name: Lint
-        run: |
-          make lint-python
 
   # cannot run this on mac due to licensing issues: https://github.com/actions/virtual-environments/issues/2150
   test-integration:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,9 +92,6 @@ jobs:
 
   # cannot run this on mac due to licensing issues: https://github.com/actions/virtual-environments/issues/2150
   test-integration:
-    needs:
-      - test-go
-      - test-python
     name: "Test integration"
     runs-on: ubuntu-latest-16-cores
     timeout-minutes: 10


### PR DESCRIPTION
Thanks to speedups in #1767, the slowdown from waiting for pending jobs to schedule a runner is now greater than the potential savings of not running integration tests.

This PR partially reverts #1760.