### PR TITLE
Fix `cog build --use-cog-base-image` with minor and patch versions of Python and Torch

### DIFF
--- a/pkg/cli/baseimage.go
+++ b/pkg/cli/baseimage.go
@@ -139,5 +139,4 @@ func baseImageGeneratorFromFlags() (*dockerfile.BaseImageGenerator, error) {
 		baseImagePythonVersion,
 		baseImageTorchVersion,
 	)
-
 }

--- a/pkg/dockerfile/base.go
+++ b/pkg/dockerfile/base.go
@@ -230,9 +230,29 @@ func BaseImageName(cudaVersion string, pythonVersion string, torchVersion string
 
 func BaseImageConfigurationExists(cudaVersion, pythonVersion, torchVersion string) bool {
 	for _, conf := range BaseImageConfigurations() {
-		if conf.CUDAVersion == cudaVersion && conf.PythonVersion == pythonVersion && conf.TorchVersion == torchVersion {
-			return true
+		// Check CUDA version compatibility
+		if !isVersionCompatible(conf.CUDAVersion, cudaVersion) {
+			continue
 		}
+
+		// Check Python version compatibility
+		if !isVersionCompatible(conf.PythonVersion, pythonVersion) {
+			continue
+		}
+
+		// Check Torch version compatibility
+		if !isVersionCompatible(conf.TorchVersion, torchVersion) {
+			continue
+		}
+
+		return true
 	}
 	return false
+}
+
+func isVersionCompatible(confVersion, requestedVersion string) bool {
+	if confVersion == "" || requestedVersion == "" {
+		return confVersion == requestedVersion
+	}
+	return version.Matches(confVersion, requestedVersion)
 }

--- a/pkg/dockerfile/base.go
+++ b/pkg/dockerfile/base.go
@@ -218,13 +218,22 @@ func (g *BaseImageGenerator) runStatements() []config.RunItem {
 }
 
 func BaseImageName(cudaVersion string, pythonVersion string, torchVersion string) string {
-	tag := "python" + pythonVersion
+	components := []string{}
 	if cudaVersion != "" {
-		tag = "cuda" + cudaVersion + "-" + tag
+		components = append(components, "cuda"+version.StripPatch(cudaVersion))
+	}
+	if pythonVersion != "" {
+		components = append(components, "python"+version.StripPatch(pythonVersion))
 	}
 	if torchVersion != "" {
-		tag += "-torch" + torchVersion
+		components = append(components, "torch"+version.StripPatch(torchVersion))
 	}
+
+	tag := strings.Join(components, "-")
+	if tag == "" {
+		tag = "latest"
+	}
+
 	return BaseImageRegistry + "/cog-base:" + tag
 }
 

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -254,14 +254,29 @@ func (g *Generator) Cleanup() error {
 
 func (g *Generator) BaseImage() (string, error) {
 	if g.useCogBaseImage {
-		cudaVersion := g.Config.Build.CUDA
-		pythonVersion := g.Config.Build.PythonVersion
+		var changed bool
 		var err error
-		pythonVersion, err = stripPatchVersion(pythonVersion)
+
+		cudaVersion := g.Config.Build.CUDA
+
+		pythonVersion := g.Config.Build.PythonVersion
+		pythonVersion, changed, err = stripPatchVersion(pythonVersion)
 		if err != nil {
 			return "", err
 		}
+		if changed {
+			console.Warnf("Stripping patch version from Python version %s to %s", g.Config.Build.PythonVersion, pythonVersion)
+		}
+
 		torchVersion, _ := g.Config.TorchVersion()
+		torchVersion, changed, err = stripPatchVersion(torchVersion)
+		if err != nil {
+			return "", err
+		}
+		if changed {
+			console.Warnf("Stripping patch version from Torch version %s to %s", g.Config.Build.PythonVersion, pythonVersion)
+		}
+
 		// validate that the base image configuration exists
 		imageGenerator, err := NewBaseImageGenerator(cudaVersion, pythonVersion, torchVersion)
 		if err != nil {
@@ -560,11 +575,18 @@ func (g *Generator) GenerateWeightsManifest() (*weights.Manifest, error) {
 	return m, nil
 }
 
-func stripPatchVersion(versionString string) (string, error) {
-	v, err := version.NewVersion(versionString)
-	if err != nil {
-		return "", fmt.Errorf("Invalid version: %s", versionString)
+func stripPatchVersion(versionString string) (string, bool, error) {
+	if versionString == "" {
+		return "", false, nil
 	}
 
-	return fmt.Sprintf("%d.%d", v.Major, v.Minor), nil
+	v, err := version.NewVersion(versionString)
+	if err != nil {
+		return "", false, fmt.Errorf("Invalid version: %s", versionString)
+	}
+
+	strippedVersion := fmt.Sprintf("%d.%d", v.Major, v.Minor)
+	changed := strippedVersion != versionString
+
+	return strippedVersion, changed, nil
 }


### PR DESCRIPTION
Follow-up to #1769 

This PR does the following:

* Adds (previously failing) test coverage for `cog.yaml` files with various minor and patch versions of Torch
* Updates logic for matching base images to pass aforementioned test case
* Strips patch from configured versions when generating `FROM` base image name

Now, when I run `cog build --use-cog-base-image` with either of the following configurations:

**With patch versions**

```yaml
build:
  gpu: true
  cuda: "12.1"
  python_version: "3.11.7"
  python_packages:
    - "torch==2.3.0"
predict: "predict.py:Predictor"
```

**Without patch versions**

```yaml
build:
  gpu: true
  cuda: "12.1"
  python_version: "3.11"
  python_packages:
    - "torch==2.3"
predict: "predict.py:Predictor"
```

...both attempt to pull `FROM r8.im/cog-base:cuda12.1-python3.11-torch2.3` [^1]

[^1]: However, this fails with `ERROR: failed to solve: failed to resolve source metadata for r8.im/cog-base:cuda12.1-python3.11-torch2.3: r8.im/cog-base:cuda12.1-python3.11-torch2.3: not found`

