### PR TITLE
Secure Prompt for API key

### DIFF
--- a/pkg/cli/login.go
+++ b/pkg/cli/login.go
@@ -106,7 +106,7 @@ func readTokenInteractively(registryHost string) (string, error) {
 	maybeOpenBrowser(url)
 
 	console.Info("")
-	console.Info("Once you've signed in, copy the authentication token from that web page, paste it here, then hit enter (input will be hidden):")
+	console.Info("Once you've signed in, copy the authentication token from that web page, paste it here, then hit enter:")
 
 	fmt.Print("API Key: ")
 	// Read the token securely, masking the input
@@ -114,10 +114,11 @@ func readTokenInteractively(registryHost string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Failed to read token: %w", err)
 	}
+
 	// Print a newline after the hidden input
 	fmt.Println()
-	return string(tokenBytes), nil
 
+	return string(tokenBytes), nil
 }
 
 func getDisplayTokenURL(registryHost string) (string, error) {

--- a/pkg/cli/login.go
+++ b/pkg/cli/login.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/replicate/cog/pkg/docker"
 	"github.com/replicate/cog/pkg/global"
@@ -105,12 +106,18 @@ func readTokenInteractively(registryHost string) (string, error) {
 	maybeOpenBrowser(url)
 
 	console.Info("")
-	console.Info("Once you've signed in, copy the authentication token from that web page, paste it here, then hit enter:")
-	token, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	console.Info("Once you've signed in, copy the authentication token from that web page, paste it here, then hit enter (input will be hidden):")
+
+	fmt.Print("API Key: ")
+	// Read the token securely, masking the input
+	tokenBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("Failed to read token: %w", err)
 	}
-	return token, nil
+	// Print a newline after the hidden input
+	fmt.Println()
+	return string(tokenBytes), nil
+
 }
 
 func getDisplayTokenURL(registryHost string) (string, error) {


### PR DESCRIPTION
This pull request changes `cog login` process by hiding the API key input from view ( using `term.ReadPassword` ) when the user pastes it into the terminal. Similar methods are used in for ex. `sudo` to prevent screen-sharing vulnerabilities.


Current behavior
  ```
This command will authenticate Docker with Replicate's 'r8.im' Docker registry. You will need a Replicate account.

Hit enter to get started. A browser will open with an authentication token that you need to paste here.

If it didn't open automatically, open this URL in a web browser:
https://replicate.com/auth/token

Once you've signed in, copy the authentication token from that web page, paste it here, then hit enter:
[API_KEY]
ⅹ User does not exist
   ```


Proposed behavior
  ```
This command will authenticate Docker with Replicate's 'r8.im' Docker registry. You will need a Replicate account.

Hit enter to get started. A browser will open with an authentication token that you need to paste here.

If it didn't open automatically, open this URL in a web browser:
https://replicate.com/auth/token

Once you've signed in, copy the authentication token from that web page, paste it here, then hit enter (input will be hidden):
API Key: 
You've successfully authenticated as shubhamai! You can now use the 'r8.im' registry.
   ```