### PR TITLE
`None` return in `predict` function results in panic error

### DIFF
--- a/pkg/cli/login.go
+++ b/pkg/cli/login.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/replicate/cog/pkg/docker"
 	"github.com/replicate/cog/pkg/global"
@@ -105,12 +106,18 @@ func readTokenInteractively(registryHost string) (string, error) {
 	maybeOpenBrowser(url)
 
 	console.Info("")
-	console.Info("Once you've signed in, copy the authentication token from that web page, paste it here, then hit enter:")
-	token, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	console.Info("Once you've signed in, copy the authentication token from that web page, paste it here, then hit enter (input will be hidden):")
+
+	fmt.Print("API Key: ")
+	// Read the token securely, masking the input
+	tokenBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("Failed to read token: %w", err)
 	}
-	return token, nil
+	// Print a newline after the hidden input
+	fmt.Println()
+	return string(tokenBytes), nil
+
 }
 
 func getDisplayTokenURL(registryHost string) (string, error) {

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -184,6 +184,10 @@ func predictIndividualInputs(predictor predict.Predictor, inputFlags []string, o
 		return err
 	}
 
+	if prediction.Output == nil {
+		return fmt.Errorf("Prediction output is None, return a valid output")
+	}
+
 	// Generate output depending on type in schema
 	var out []byte
 	responseSchema := schema.Paths.Value("/predictions").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value


### PR DESCRIPTION
If `None` is returned in the `predict` function of `predict.py`, it results it a panic error, with no clear error message to indicate what went wrong.

```
def predict(self) -> str:
        return None
```

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x8c3692]
```


The changes now check if none is returned, since `None` return is unintended, display an error message.

```
ⅹ Prediction output is none, return a valid output
```
