### PR TITLE
Fix Pyright `reportUnnecessaryComparison ` warning

### DIFF
--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -392,7 +392,7 @@ def get_output_type(predictor: BasePredictor) -> Type[BaseModel]:
     input_types = get_type_hints(predict)
 
     OutputType = input_types.pop("return", None)
-    if OutputType is None:
+    if not OutputType:
         raise TypeError(
             """You must set an output type. If your model can return multiple output types, you can explicitly set `Any` as the output type.
 

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -392,7 +392,7 @@ def get_output_type(predictor: BasePredictor) -> Type[BaseModel]:
     input_types = get_type_hints(predict)
 
     OutputType = input_types.pop("return", None)
-    if not OutputType:
+    if "return" not in input_types:
         raise TypeError(
             """You must set an output type. If your model can return multiple output types, you can explicitly set `Any` as the output type.
 

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -391,7 +391,6 @@ def get_output_type(predictor: BasePredictor) -> Type[BaseModel]:
 
     input_types = get_type_hints(predict)
 
-    OutputType = input_types.pop("return", None)
     if "return" not in input_types:
         raise TypeError(
             """You must set an output type. If your model can return multiple output types, you can explicitly set `Any` as the output type.
@@ -407,6 +406,7 @@ For example:
         ...
 """
         )
+    OutputType = input_types.pop("return")  # pylint: disable=invalid-name
 
     # The type that goes in the response is a list of the yielded type
     if get_origin(OutputType) is Iterator:


### PR DESCRIPTION
https://github.com/replicate/cog/blob/f7759a08ef89a39d06c287b0a279a2a6bb7e0ce8/python/cog/predictor.py#L395

```
python/cog/predictor.py:395:8 - warning: Condition will always evaluate to False since the types "type[BaseModel]" and "None" have no overlap (reportUnnecessaryComparison)
```