### PR TITLE
Make install docker friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pkg/dockerfile/embed/cog.whl
 .DS_Store
 docs/README.md
 docs/CONTRIBUTING.md
+venv

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ sudo make install
 Or if you are on docker:
 
 ```
-RUN sh -c "INSTALL_DIR=\"/usr/local/bin\" SUDO_CMD=\"\" $(curl -fsSL https://cog.run/install.sh)"
+RUN sh -c "INSTALL_DIR=\"/usr/local/bin\" SUDO=\"\" $(curl -fsSL https://cog.run/install.sh)"
 ```
 
 ## Upgrade

--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ make
 sudo make install
 ```
 
+Or if you are on docker:
+
+```
+RUN sh -c "INSTALL_DIR=\"/usr/local/bin\" SUDO_CMD=\"\" $(curl -fsSL https://cog.run/install.sh)"
+```
+
 ## Upgrade
 
 If you're using macOS and you previously installed Cog with Homebrew, run the following:

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -99,11 +99,11 @@ setup_cog() {
     esac
   fi
   if command_exists curl; then
-    $SUDO_CMD curl -o $COG_LOCATION -L $BINARY_URI
+    $SUDO curl -o $COG_LOCATION -L $BINARY_URI
   elif command_exists wget; then
-    $SUDO_CMD wget $BINARY_URI -O $COG_LOCATION
+    $SUDO wget $BINARY_URI -O $COG_LOCATION
   elif command_exists fetch; then
-    $SUDO_CMD fetch -o $COG_LOCATION $BINARY_URI
+    $SUDO fetch -o $COG_LOCATION $BINARY_URI
   else
     echo "One of curl, wget, or fetch must be present for this installer to work."
     exit 1
@@ -114,7 +114,7 @@ setup_cog() {
     exit 1
   fi
 
-  $SUDO_CMD chmod +x $COG_LOCATION
+  $SUDO chmod +x $COG_LOCATION
 
   SHELL_NAME=$(basename "$SHELL")
   if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
@@ -176,10 +176,10 @@ main() {
   fi
 
   # Check the users sudo priviledges
-  if [ -z "${SUDO_CMD}" ]; then
-    SUDO_CMD="sudo"
+  if [ -z "${SUDO}" ]; then
+    SUDO="sudo"
   fi
-  if [ ! user_can_sudo ] && [ "${SUDO_CMD}" != "" ]; then
+  if [ ! user_can_sudo ] && [ "${SUDO}" != "" ]; then
     echo "You need sudo permissions to run this install script. Please try again as a sudoer."
     exit 1
   fi

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -176,7 +176,7 @@ main() {
   fi
 
   # Check the users sudo priviledges
-  if [ -z "${SUDO}" ]; then
+  if [ -z "${SUDO+set}" ]; then
     SUDO="sudo"
   fi
   if [ ! user_can_sudo ] && [ "${SUDO}" != "" ]; then

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -152,7 +152,9 @@ main() {
   fi
 
   # Set install directory
-  read -p "Install location? [/usr/local/bin]: " INSTALL_DIR
+  if [ -z "${INSTALL_DIR}" ]; then
+    read -p "Install location? [/usr/local/bin]: " INSTALL_DIR
+  fi
   if [ ! -d "$INSTALL_DIR" ]; then
     echo "The directory $INSTALL_DIR does not exist. Please create it and re-run this script."
     # Ask user to manually create directory rather than making it for them,

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -82,8 +82,7 @@ check_docker() {
   fi
 
   if ! docker run hello-world >/dev/null 2>&1; then
-    echo "Docker engine is not running, or docker cannot be run without sudo. Please setup Docker so that your user has permission to run it: https://docs.docker.com/engine/install/linux-postinstall/"
-    exit 1
+    echo "WARNING: Docker engine is not running, or docker cannot be run without sudo. Please setup Docker so that your user has permission to run it: https://docs.docker.com/engine/install/linux-postinstall/"
   fi
 }
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -49,7 +49,7 @@ command_exists() {
 
 user_can_sudo() {
   # Check if sudo is installed
-  command_exists sudo || return 1
+  command_exists $SUDO || return 1
   # Termux can't run sudo, so we can detect it and exit the function early.
   case "$PREFIX" in
   *com.termux*) return 1 ;;
@@ -72,7 +72,7 @@ user_can_sudo() {
   #    to run `sudo` in the default locale (with `LANG=`) so that the message
   #    stays consistent regardless of the user's locale.
   #
-  ! LANG= sudo -n -v 2>&1 | grep -q "may not run sudo"
+  ! LANG= $SUDO -n -v 2>&1 | grep -q "may not run $SUDO"
 }
 
 check_docker() {
@@ -94,7 +94,7 @@ setup_cog() {
     echo "Do you want to delete this file and continue with this installation anyway?"
     read -p "Delete file? (y/N): " choice
     case "$choice" in 
-      y|Y ) echo "Deleting existing file and continuing with installation..."; sudo rm $COG_LOCATION;;
+      y|Y ) echo "Deleting existing file and continuing with installation..."; $SUDO rm $COG_LOCATION;;
       * ) echo "Exiting installation."; exit 1;;
     esac
   fi

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -100,11 +100,11 @@ setup_cog() {
     esac
   fi
   if command_exists curl; then
-    sudo curl -o $COG_LOCATION -L $BINARY_URI
+    $SUDO_CMD curl -o $COG_LOCATION -L $BINARY_URI
   elif command_exists wget; then
-    sudo wget $BINARY_URI -O $COG_LOCATION
+    $SUDO_CMD wget $BINARY_URI -O $COG_LOCATION
   elif command_exists fetch; then
-    sudo fetch -o $COG_LOCATION $BINARY_URI
+    $SUDO_CMD fetch -o $COG_LOCATION $BINARY_URI
   else
     echo "One of curl, wget, or fetch must be present for this installer to work."
     exit 1
@@ -115,7 +115,7 @@ setup_cog() {
     exit 1
   fi
 
-  sudo chmod +x $COG_LOCATION
+  $SUDO_CMD chmod +x $COG_LOCATION
 
   SHELL_NAME=$(basename "$SHELL")
   if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
@@ -175,7 +175,12 @@ main() {
       * ) echo "Exiting installation."; exit 1;;
     esac
   fi
-  if ! user_can_sudo; then
+
+  # Check the users sudo priviledges
+  if [ -z "${SUDO_CMD}" ]; then
+    SUDO_CMD="sudo"
+  fi
+  if [ ! user_can_sudo ] && [ "${SUDO_CMD}" != "" ]; then
     echo "You need sudo permissions to run this install script. Please try again as a sudoer."
     exit 1
   fi


### PR DESCRIPTION
* Fixes: https://github.com/replicate/cog/issues/1783
* Adds venv to gitignore (not strictly part of this issue but noticed it on my system)
* Add support for specifying the `INSTALL_DIR` via environment variable outside of the script to prevent a `read`
* Allow the user to specify `SUDO_CMD` via environment variable outside of the script incase they are operating on a docker that doesn't contain it
* Downgrades the docker run check to a warning, in docker this can't be running. I also feel this should be a runtime check rather than an install check.
* Updates the docs to add a docker install instruction.