### PR TITLE
fix send race by handling logs in the main thread when async

### DIFF
--- a/python/cog/server/connection.py
+++ b/python/cog/server/connection.py
@@ -17,8 +17,11 @@ class AsyncConnection(Generic[X]):
     def __init__(self, conn: Connection) -> None:
         self.wrapped_conn = conn
         self.started = False
+        print("init")
 
     async def async_init(self) -> None:
+        if self.started:
+            return
         fd = self.wrapped_conn.fileno()
         # mp may have handled something already but let's dup so exit is clean
         dup_fd = os.dup(fd)

--- a/python/cog/server/connection.py
+++ b/python/cog/server/connection.py
@@ -26,11 +26,12 @@ class AsyncConnection(Generic[X]):
         if self.started:
             return
         fd = self.wrapped_conn.fileno()
-        # # mp may have handled something already but let's dup so exit is clean
+        # mp may have handled something already but let's dup so exit is clean
         dup_fd = os.dup(fd)
         sock = socket.socket(fileno=dup_fd)
         # sock = socket.socket(fileno=fd)
         # we don't want to see EAGAIN, we'd rather wait
+        # however, perhaps this is wrong and in some cases this could still block terribly
         # sock.setblocking(False)
         # TODO: use /proc/sys/net/core/rmem_max, but special-case language models
         sz = 65536

--- a/python/cog/server/connection.py
+++ b/python/cog/server/connection.py
@@ -3,6 +3,7 @@ import io
 import os
 import socket
 import struct
+import threading
 from multiprocessing import connection
 from multiprocessing.connection import Connection
 from typing import Any, Generic, TypeVar
@@ -26,10 +27,11 @@ class AsyncConnection(Generic[X]):
             return
         fd = self.wrapped_conn.fileno()
         # # mp may have handled something already but let's dup so exit is clean
-        # dup_fd = os.dup(fd)
-        # sock = socket.socket(fileno=dup_fd)
-        sock = socket.socket(fileno=fd)
-        sock.setblocking(False)
+        dup_fd = os.dup(fd)
+        sock = socket.socket(fileno=dup_fd)
+        # sock = socket.socket(fileno=fd)
+        # we don't want to see EAGAIN, we'd rather wait
+        # sock.setblocking(False)
         # TODO: use /proc/sys/net/core/rmem_max, but special-case language models
         sz = 65536
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, sz)

--- a/python/cog/server/connection.py
+++ b/python/cog/server/connection.py
@@ -17,7 +17,7 @@ class AsyncConnection(Generic[X]):
     def __init__(self, conn: Connection) -> None:
         self.wrapped_conn = conn
         self.started = False
-        print("init")
+        print("conn __init__")
 
     async def async_init(self) -> None:
         if self.started:

--- a/python/cog/server/connection.py
+++ b/python/cog/server/connection.py
@@ -3,7 +3,6 @@ import io
 import os
 import socket
 import struct
-import threading
 from multiprocessing import connection
 from multiprocessing.connection import Connection
 from typing import Any, Generic, TypeVar
@@ -18,9 +17,6 @@ class AsyncConnection(Generic[X]):
     def __init__(self, conn: Connection) -> None:
         self.wrapped_conn = conn
         self.started = False
-        print("conn __init__")
-        # perhaps the lock should be here
-        # self.sync_lock = threading.Lock()
 
     async def async_init(self) -> None:
         if self.started:
@@ -29,10 +25,10 @@ class AsyncConnection(Generic[X]):
         # mp may have handled something already but let's dup so exit is clean
         dup_fd = os.dup(fd)
         sock = socket.socket(fileno=dup_fd)
-        # sock = socket.socket(fileno=fd)
         # we don't want to see EAGAIN, we'd rather wait
         # however, perhaps this is wrong and in some cases this could still block terribly
         # sock.setblocking(False)
+        sock.setblocking(True)
         # TODO: use /proc/sys/net/core/rmem_max, but special-case language models
         sz = 65536
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, sz)
@@ -93,11 +89,6 @@ class AsyncConnection(Generic[X]):
 
     def send(self, obj: Any) -> None:
         self._send_bytes(_ForkingPickler.dumps(obj, protocol=5))
-
-    # # perhaps we could do it like this
-    # def send_sync(self, obj: Any) -> None:
-    #     with self.sync_lock:
-    #         self.wrapped_conn.send(obj)
 
     # we could implement async def drain() but it's not really necessary for our purposes
 


### PR DESCRIPTION
If events can be written from an event loop and from a thread, some race conditions can occur. This PR tried to fix this by conditionally moving the stream redirector into the main thread when we switch to async, and registering the file descriptors with the main select loop instead of using epoll in a thread.

---

This solves a similar problem as #1758: in some cases, currently emitting a metric or yielding an output can result in an EAGAIN error, and we believe Done events are sometimes dropped. In async land, we shouldn't need a lock; multiple writers should be able to write to a [StreamWriter](https://docs.python.org/3/library/asyncio-stream.html#streamwriter) safely. We also keep a sync Lock when the predictor is not async.

<details><summary>However, I'm still not sure if StreamWriter is thread-safe. </summary>
After some research, StreamWriter.write calls self._transport.write and when StreamWriter is wrapping a unix socket and using the default selector, the _transport is a _SelectorSocketTransport, which calls [self._buffer.extend](https://github.com/python/cpython/blob/3.11/Lib/asyncio/selector_events.py#L1077), and self._buffer is a [bytearray](https://github.com/python/cpython/blob/3.11/Lib/asyncio/selector_events.py#L761). However, on 3.12, [append is called](https://github.com/python/cpython/blob/3.12/Lib/asyncio/selector_events.py#L1091) instead of extend.

After more soul-searching, I _think_ write should be basically thread-safe: the two critical calls, socket.send() and bytearray.append/extend should be represented as a single bytecode instruction and some native code which works on python objects and does not release the GIL. As far as I understand, [python threads are switched "between bytecodes"](https://stackoverflow.com/a/55197452). Even though the individual calls are thread-safe, the overall write method is not quite thread safe: a relevant thread switch could occur between the `if not self._buffer`, `_sock.send`, and `_buffer.extend` lines. However, in that case the race condition would result data could being sent out of order or incorrectly delayed/sent early, but it I think it shouldn't be corrupted, and we don't really care about the ordering of log lines vs outputs.
</details>

I can see two solutions:

1. Ideally, we would probably add an alternate implementation of StreamWriter that uses the main event loop and wraps stderr/stdout in StreamReaders, start a separate task for each stream, and use `await wrapped_stream.read()` so that threads are not necessary. there's a tricky moment where we need to use the threaded StreamRedirector to capture logs while the predictor is being imported, since we don't know if we're going to be async or not. 
2. Alternatively, we could try to use a queue or deque to communicate between threads, so instead of calling stream_write_hook StreamRedirector would do queue.put, the main event loop would do queue.get and not worry about thread safety for the pipe. The problem with this is that asyncio.Queue is not thread-safe and queue.Queue could block the event loop. You could use a busy wait or similar and get_nowait, but that has other downsides.