### PR TITLE
Fix cog base layer hash

### DIFF
--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -180,17 +180,22 @@ func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache,
 			return fmt.Errorf("Failed to fetch cog base image: %w", err)
 		}
 
-		manifest, err := img.Manifest()
+		layers, err := img.Layers()
 		if err != nil {
-			return fmt.Errorf("Failed to get manifest for cog base image: %w", err)
+			return fmt.Errorf("Failed to get layers for cog base image: %w", err)
 		}
 
-		if len(manifest.Layers) == 0 {
+		if len(layers) == 0 {
 			return fmt.Errorf("Cog base image has no layers: %s", cogBaseImageName)
 		}
 
-		lastLayerIndex := len(manifest.Layers) - 1
-		lastLayer := manifest.Layers[lastLayerIndex].Digest.String()
+		lastLayerIndex := len(layers) - 1
+		layerLayerDigest, err := layers[lastLayerIndex].DiffID()
+		if err != nil {
+			return fmt.Errorf("Failed to get last layer digest for cog base image: %w", err)
+		}
+
+		lastLayer := layerLayerDigest.String()
 		console.Debugf("Last layer of the cog base image: %s", lastLayer)
 
 		labels[global.LabelNamespace+"cog-base-image-last-layer-sha"] = lastLayer


### PR DESCRIPTION
* Fixes https://github.com/replicate/cog/issues/1822
* Adds a test case and develops against it, this test case creates a cog build, gets the labels from the docker image, and compares them against the layer hashes.
* Issue was the previous code was fetching the manifest, then the layers from the manifest, and the digest from those layers, but this was the hash for the layer manifest rather than the layer itself.
* Change to fetch layers rather than the manifest.
* Use the `DiffID` of the layers which is the uncompressed hash, this corresponds to what is in the docker inspect for the layers.