### PR TITLE
Print field in the validator error

### DIFF
--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -91,7 +91,7 @@ func getDescription(err validationError) string {
 	switch err.parent.Type() {
 	case "invalid_type":
 		if expectedType, ok := err.parent.Details()["expected"].(string); ok {
-			return fmt.Sprintf("must be a %s", humanReadableType(expectedType))
+			return fmt.Sprintf("%s must be a %s", err.parent.Field(), humanReadableType(expectedType))
 		}
 	case jsonschemaOneOf, jsonschemaAnyOf:
 		if err.child == nil {

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -91,3 +91,19 @@ func TestValidateNullListsAllowed(t *testing.T) {
 	err := Validate(config, "1.0")
 	require.NoError(t, err)
 }
+
+func TestValidateOutputsPropertyFromTypeError(t *testing.T) {
+	config := `build:
+  gpu: true
+  cuda: "11.8"
+  python_version: "3.11"
+  python_packages:
+    - "torch==2.0.1"
+
+predict: "predict.py:Predictor"
+concurrency: 54`
+
+	err := Validate(config, "1.0")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "concurrency must be a mapping.")
+}


### PR DESCRIPTION
* Currently we only know what the expected type was from validation error messages.
* Make sure we print the field as well to let the user know exactly which field is having issues.
* Add a test to confirm this error message.
* Fixes: https://github.com/replicate/cog/issues/1826