### PR TITLE
Extract release process into separate workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - "**"
+      - "v*"
   pull_request:
     branches:
       - main
@@ -93,45 +93,3 @@ jobs:
           python -m uv pip install '.[dev]'
       - name: Test
         run: make test-integration
-
-  release:
-    needs:
-      - test-go
-      - test-python
-      - test-integration
-    if: startsWith(github.ref, 'refs/tags/v')
-    outputs:
-      cog_version: ${{ steps.build-python-package.outputs.version }}
-    runs-on: ubuntu-latest-8-cores
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-      - name: Build
-        run: make cog
-      - uses: goreleaser/goreleaser-action@v4
-        with:
-          version: latest
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build Python package
-        id: build-python-package
-        run: |
-          # clean package built for go client
-          rm -rf dist
-          # install build
-          pip install build
-          # build package
-          python -m build --wheel
-          # set output
-          echo "version=$(ls dist/ | cut -d- -f2)" >> $GITHUB_OUTPUT
-      - name: Push Python package
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-          packages-dir: dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,6 @@ on:
       - completed
     branches:
       - main
-  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,71 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-tag:
+    name: "Check Tag"
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      is-release: ${{ steps.check-tag.outputs.is-release }}
+    steps:
+      - name: Check if commit has a version tag
+        id: check-tag
+        run: |
+          if [[ ${{ github.event.workflow_run.head_branch }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "is-release=true" >> $GITHUB_OUTPUT
+          else
+            echo "is-release=false" >> $GITHUB_OUTPUT
+          fi
+
+  release-cli:
+    name: "CLI"
+    needs: check-tag
+    if: needs.check-tag.outputs.is-release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build
+        run: make cog
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-python-package:
+    name: "Python Package"
+    needs: check-tag
+    if: needs.check-tag.outputs.is-release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Build Python package
+        run: |
+          pip install build
+          python -m build --wheel
+      - name: Push Python package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+          packages-dir: dist


### PR DESCRIPTION
The release job of the CI run for the latest release [failed](https://github.com/replicate/cog/actions/runs/10180772831/attempts/1) when building and pushing the Python package to PyPI. For some reason [^1], the package got built as `0.9.15.dev0+g592f768.d20240731` instead of `0.9.14`, and PyPI rejected that value.

[^1]: Any theories?

Our current CI/CD makes it impossible to re-run the failed release step without deleting or invalidating the GitHub release artifacts built by goreleaser. For sake of integrity, re-tagging or modifying artifacts after the fact is not an option.

This PR extracts the release step into its own workflow. It takes advantage of the [`workflow_run`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run) event to trigger after CI finishes. This has the same effect as a dependent job in a single workflow.
