### PR TITLE
Upload aarch64 cog binary release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,6 +118,13 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Copy arm64 to aarch64
+        run: mkdir -p dist/cog_linux_aarch64 && cp dist/cog_linux_arm64/cog dist/cog_linux_aarch64/cog
+      - name: Upload aarch64 cog binary to artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cog_Linux_aarch64
+          path: dist/cog_linux_aarch64/cog
       - name: Build Python package
         id: build-python-package
         run: |


### PR DESCRIPTION
* aarch64 is actually exactly the same as arm64
* Unfortunately because of uname sometimes the architecture is reported as aarch64
* This how most people download our binaries, so if we don’t provide this path we end up not
supporting this platform as well as we should.

As an aside, I'm a bit unsure how to test this because it lives in the release deployment.