### PR TITLE
Use uvloop for async event loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   'typing-compat; python_version < "3.8"',
   "typing_extensions>=4.4.0",
   "uvicorn[standard]>=0.12,<1",
+  "uvloop",
 ]
 
 optional-dependencies = { "dev" = [

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -587,6 +587,7 @@ if __name__ == "__main__":
         log_config=None,
         # This is the default, but to be explicit: only run a single worker
         workers=1,
+        loop="uvloop",
     )
 
     s = Server(config=server_config)


### PR DESCRIPTION
From https://github.com/MagicStack/uvloop:

> uvloop is a fast, drop-in replacement of the built-in asyncio event loop. uvloop is implemented in Cython and uses libuv under the hood.

Hard to argue with 2x speedup for a drop-in replacement. Curious to see whether that holds up.