### PR TITLE
call terminate after the last prediction or after a timeout if shutting down

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -449,7 +449,7 @@ class Server(uvicorn.Server):
 
         self._thread.join(timeout=5)
         if not self._thread.is_alive():
-            log.info("server thread is not running after join")
+            log.info("server has stopped gracefully, not forcing exit")
             return
 
         log.warn("failed to exit after 5 seconds, setting force_exit")

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -240,9 +240,12 @@ def create_app(
             app.state.setup_task = runner.setup()
 
     @app.on_event("shutdown")
-    def shutdown() -> None:
+    async def shutdown() -> None:
+        # this will fire when Server.stop sets should_exit
+        # the server and hence the server thread will not exit until this completes
+        # so we want runner.shutdown to block until everything is good
         log.info("app shutdown event has occurred")
-        runner.shutdown()
+        await runner.shutdown()
 
     @app.get("/")
     async def root() -> Any:
@@ -440,11 +443,17 @@ def _log_invalid_output(error: Any) -> None:
 
 class Server(uvicorn.Server):
     def start(self) -> None:
+        # run is a uvicorn.Server method that runs the server
+        # it will keep running until server shutdown handlers complete
         self._thread = threading.Thread(target=self.run)
         self._thread.start()
 
     def stop(self) -> None:
         log.info("stopping server")
+        # https://github.com/encode/uvicorn/blob/master/uvicorn/server.py#L250-L252
+        # https://github.com/encode/uvicorn/discussions/1103#discussioncomment-941739
+        # uvicorn's loop will check should_exit to see if it will exit
+        # once uvicorn starts exiting, the `shutdown` event will fire
         self.should_exit = True
 
         self._thread.join(timeout=5)
@@ -453,12 +462,26 @@ class Server(uvicorn.Server):
             return
 
         log.warn("failed to exit after 5 seconds, setting force_exit")
+        # as of uvicorn 0.30.5, force_exit does three things:
+        # 1. don't wait for connections to close. if force_exit becomes set
+        # while waiting for connections to close, uvicorn stops waiting
+        # https://github.com/encode/uvicorn/blob/master/uvicorn/server.py#L294-L298
+        # 2. don't wait for background tasks to complete.
+        # this respects force_exit becoming after the wait starts
+        # https://github.com/encode/uvicorn/blob/master/uvicorn/server.py#L300-L305
+        # 3. when shutdown starts, skip the shutdown event / lifecycle
+        # the shutdown handler is not interrupted by force_exit becoming set
+        # https://github.com/encode/uvicorn/blob/master/uvicorn/server.py#L289-L290
         self.force_exit = True
+        # this join is supposed to block until the shutdown handler completes
         self._thread.join(timeout=5)
         if not self._thread.is_alive():
             return
 
         log.warn("failed to exit after another 5 seconds, sending SIGKILL")
+        # because the child is created with spawn, it won't share a process group
+        # so killing the parent process will orphan the child
+        # FIXME: should we manually kill the child?
         os.kill(os.getpid(), signal.SIGKILL)
 
 
@@ -569,7 +592,7 @@ if __name__ == "__main__":
         shutdown_event.wait()
     except KeyboardInterrupt:
         pass
-
+    # this will try to shut down gracefully, then kill our process after 10s
     s.stop()
 
     # return error exit code when setup failed and cog is running in interactive mode (not k8s)

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -369,13 +369,6 @@ class PredictionRunner:
                 # since this is just before this coroutine exits
                 self._predictions.pop(request.id)
 
-                # all predictions in flight have been processed, we can exit
-                if self._shutting_down and not self._predictions:
-                    # note: this will do a bunch of work
-                    # and potentially slow down the coroutine completing
-                    # however, this should be okay
-                    self.terminate()
-
         # this is still a little silly
         result = asyncio.create_task(async_predict_handling_errors())
         # result.add_done_callback(self.make_error_handler("prediction"))
@@ -384,7 +377,8 @@ class PredictionRunner:
 
         return (response, result)
 
-    def shutdown(self) -> None:
+    async def shutdown(self) -> None:
+        # this is called by the app's shutdown handler. server won't exit until this is done
         self.log.info("runner.shutdown called")
         if self._state == WorkerState.DEFUNCT:
             return
@@ -394,32 +388,34 @@ class PredictionRunner:
         if self._child.is_alive():
             self.log.info("child is alive during shutdown, sending Shutdown event")
             self._events.send(Shutdown())
-            asyncio.create_task(self.terminate_later())
 
-    async def terminate_later(self) -> None:
-        self.log.info("scheduling termination in 10s")
-        await asyncio.sleep(10)
-        self.log.info("10s has passed, terminating")
-        self.terminate()
-
-    def terminate(self) -> None:
-        self.log.info("runner.terminate is called")
         if self._state == WorkerState.DEFUNCT:
             self.log.info("worker state is already defunct, no need to terminate")
             return
 
+        prediction_tasks = [task for _, task in self._predictions.values()]
+        try:
+            if prediction_tasks:
+                await asyncio.wait(prediction_tasks, timeout=9)
+        # should we do this?
+        except TimeoutError:
+            self.log.warn("runner timeout while waiting for predictions to complete")
+
         self._state = WorkerState.DEFUNCT
-        for _, task in self._predictions.values():
+        # in case we timed out, cancel everything
+        for task in prediction_tasks:
             task.cancel()
 
+        # tell _read_events and Mux to exit
         self._terminating.set()
 
         if self._child.is_alive():
             self._child.terminate()
             self.log.info("joining child worker")
             self._child.join()
+        # close the pipe
         self._events.close()
-
+        # stop reading events from the pipe
         if self._read_events_task:
             self._read_events_task.cancel()
 

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -202,10 +202,7 @@ class PredictionRunner:
                 self.log.info("caught CancelledError during setup")
                 logs.append(traceback.format_exc())
                 status = schema.Status.FAILED
-            except BaseException:
-                self.log.info("caught BaseException during setup")
-                logs.append(traceback.format_exc())
-                status = schema.Status.FAILED
+                # unclear if we should re-raise this
 
             # fixme: handle BaseException is mux.read times out and gets cancelled
 
@@ -246,6 +243,7 @@ class PredictionRunner:
                 )
                 if self._shutdown_event is not None:
                     self._shutdown_event.set()
+                raise
 
         result = asyncio.create_task(inner())
         result.add_done_callback(handle_error)

--- a/python/tests/server/test_runner.py
+++ b/python/tests/server/test_runner.py
@@ -42,7 +42,7 @@ async def runner():
         await runner.setup()
         yield runner
     finally:
-        runner.shutdown()
+        await runner.shutdown()
 
 
 @pytest.mark.asyncio
@@ -58,7 +58,7 @@ async def test_prediction_runner_setup():
         assert isinstance(result.started_at, datetime)
         assert isinstance(result.completed_at, datetime)
     finally:
-        runner.shutdown()
+        await runner.shutdown()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
this addresses the problem described in https://www.notion.so/replicate/Short-Term-Async-Fixes-9d11cfc15bb84878aedd9d8ddf31840d?pvs=4#8a86d46ada954ff5b509231224c24f2f

prior to https://github.com/replicate/cog/commit/974675f9#diff-136cc6506e8aaea24081862f89e1cb778251b7726180fe237c8aaf560ae7ec69R315-R338, runner.shutdown() would call worker.terminate(). as far as I understand, neither in that branch nor in main is worker.shutdown() ever called. in that commit, I split runner.shutdown into runner.shutdown and runner.terminate, but never made anything call terminate. because I also removed the `should_exit = True` line, the uvicorn server would never exit, so the shutdown handler would eventually notice this and kill the whole process, so we never noticed that terminate was never called.

runner.terminate does:
* cancel any predict tasks
* mark us as defunct
* if the child is alive, terminate it and then waitpid
* close the events pipe
* cancel the read events task