### PR TITLE
Add readiness check to HTTP server

### DIFF
--- a/python/cog/command/ast_openapi_schema.py
+++ b/python/cog/command/ast_openapi_schema.py
@@ -147,6 +147,30 @@ BASE_SCHEMA = """
         "summary": "Healthcheck"
       }
     },
+    "/ready": {
+      "get": {
+        "operationId": "readinesscheck_ready_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": { "title": "Response Readinesscheck Readiness Check Get" }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": { "title": "Response Readinesscheck Readiness Check Get" }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Readiness"
+      }
+    },
     "/predictions": {
       "post": {
         "description": "Run a single prediction on the model",

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -263,6 +263,13 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
         setup = attrs.asdict(app.state.setup_result) if app.state.setup_result else {}
         return jsonable_encoder({"status": health.name, "setup": setup})
 
+    @app.get("/ready")
+    async def readinesscheck() -> Any:
+        _check_setup_result()
+        if app.state.health == Health.READY:
+            return JSONResponse({}, status_code=200)
+        return JSONResponse({}, status_code=503)
+
     @limited
     @app.post(
         "/predictions",


### PR DESCRIPTION
This differs from the `/health-check` endpoint in that it _only_ returns 200 if the health status is `READY` — i.e. ready to make a prediction.

In my particular use-case, this will be useful when running Cog on Fly.io GPUs (see [here](https://github.com/kylemclaren/cog-flux), [here](https://github.com/fly-apps/cog-whisper) and [here](https://github.com/fly-apps/cog-sd3/)) with cold start requests; in my testing, I would regularly hit `409 - Conflict` ("Already running a prediction") when sending an HTTP request to Cog and starting the VM. This occurs even with the idempotent endpoint. I am not sure if I this is intended behaviour — but it's not working for my use-case.

A readiness endpoint would allow me to set a [health check](https://fly.io/docs/reference/configuration/#services-http_checks) to only forward the request to the Machine when it's ready to make a prediction:
```toml
  [[http_service.checks]]
    grace_period = "60s"
    interval = "30s"
    method = "GET"
    timeout = "5s"
    path = "/ready"
```

Happy to elaborate further!