### PR TITLE
Ignore git files everywhere in .dockerignore

### DIFF
--- a/pkg/cli/init-templates/.dockerignore
+++ b/pkg/cli/init-templates/.dockerignore
@@ -3,9 +3,9 @@
 # https://docs.docker.com/engine/reference/builder/#dockerignore-file
 
 # Exclude Git files
-.git
-.github
-.gitignore
+**/.git
+**/.github
+**/.gitignore
 
 # Exclude Python cache files
 __pycache__


### PR DESCRIPTION
Some models has nested model git repos with LFS which keeps copies of large files in `.git/lfs/objects` and leads to bloated image.