### PR TITLE
Bump pyright to 1.1.375

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ optional-dependencies = { "dev" = [
   'numpy<1.22.0; python_version < "3.8"',
   'numpy; python_version >= "3.8"',
   "pillow",
-  "pyright==1.1.347",
+  "pyright==1.1.375",
   "pytest",
   "pytest-httpserver",
   "pytest-rerunfailures",


### PR DESCRIPTION
We're working with `concurrent.futures.Future` on another branch and older pyright appears to have trouble with Future's type variables:

  error: Argument of type "(f: Future[Done]) -> None" cannot be assigned to parameter "fn" of type "(Future[_T@Future]) -> object" in function "add_done_callback"
      Type "(f: Future[Done]) -> None" cannot be assigned to type "(Future[_T@Future]) -> object"
        Parameter 1: type "Future[_T@Future]" cannot be assigned to type "Future[Done]"
          "Future[_T@Future]" is incompatible with "Future[Done]"
            Type parameter "_T@Future" is invariant, but "_T@Future" is
            not the same as "Done" (reportGeneralTypeIssues)Vkk