### PR TITLE
Simplify `PredictionRunner`

### DIFF
--- a/python/cog/schema.py
+++ b/python/cog/schema.py
@@ -80,6 +80,12 @@ class PredictionResponse(PredictionBaseModel):
 
     metrics: t.Optional[t.Dict[str, t.Any]]
 
+    # This is used to track a fatal exception that occurs during a prediction.
+    # "Fatal" means that we require the worker to be shut down to recover:
+    # regular exceptions raised during predict are handled and do not use this
+    # field.
+    _fatal_exception: t.Optional[BaseException] = pydantic.PrivateAttr(default=None)
+
     @classmethod
     def with_types(cls, input_type: t.Type[t.Any], output_type: t.Type[t.Any]) -> t.Any:
         # [compat] Input is implicitly optional -- previous versions of the

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -13,7 +13,6 @@ from datetime import datetime, timezone
 from enum import Enum, auto, unique
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional
 
-import attrs
 import structlog
 import uvicorn
 from fastapi import Body, FastAPI, Header, HTTPException, Path, Response
@@ -38,14 +37,15 @@ from ..predictor import (
     load_slim_predictor_from_ref,
 )
 from ..types import CogConfig
+from .probes import ProbeHelper
 from .runner import (
     PredictionRunner,
     RunnerBusyError,
     SetupResult,
-    SetupTask,
     UnknownPredictionError,
 )
 from .telemetry import make_trace_context, trace_context
+from .worker import Worker
 
 if TYPE_CHECKING:
     from typing import ParamSpec, TypeVar  # pylint: disable=import-outside-toplevel
@@ -63,11 +63,11 @@ class Health(Enum):
     READY = auto()
     BUSY = auto()
     SETUP_FAILED = auto()
+    DEFUNCT = auto()
 
 
 class MyState:
     health: Health
-    setup_task: Optional[SetupTask]
     setup_result: Optional[SetupResult]
 
 
@@ -87,7 +87,7 @@ def add_setup_failed_routes(
     result = SetupResult(
         started_at=started_at,
         completed_at=datetime.now(tz=timezone.utc),
-        logs=msg,
+        logs=[msg],
         status=schema.Status.FAILED,
     )
     app.state.setup_result = result
@@ -95,8 +95,13 @@ def add_setup_failed_routes(
 
     @app.get("/health-check")
     async def healthcheck_startup_failed() -> Any:
-        setup = attrs.asdict(app.state.setup_result)
-        return jsonable_encoder({"status": app.state.health.name, "setup": setup})
+        assert app.state.setup_result
+        return jsonable_encoder(
+            {
+                "status": app.state.health.name,
+                "setup": app.state.setup_result.to_dict(),
+            }
+        )
 
 
 def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-statements
@@ -114,7 +119,6 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
     )
 
     app.state.health = Health.STARTING
-    app.state.setup_task = None
     app.state.setup_result = None
     started_at = datetime.now(tz=timezone.utc)
 
@@ -122,7 +126,7 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
     @app.post("/shutdown")
     async def start_shutdown() -> Any:
         log.info("shutdown requested via http")
-        if shutdown_event is not None:
+        if shutdown_event:
             shutdown_event.set()
         return JSONResponse({}, status_code=200)
 
@@ -136,11 +140,8 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
         add_setup_failed_routes(app, started_at, msg)
         return app
 
-    runner = PredictionRunner(
-        predictor_ref=predictor_ref,
-        shutdown_event=shutdown_event,
-        upload_url=upload_url,
-    )
+    worker = Worker(predictor_ref=predictor_ref)
+    runner = PredictionRunner(worker=worker)
 
     class PredictionRequest(schema.PredictionRequest.with_types(input_type=InputType)):
         pass
@@ -235,15 +236,15 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
             and app.state.setup_result.status == schema.Status.FAILED
         ):
             # signal shutdown if interactive run
-            if not await_explicit_shutdown:
-                if shutdown_event is not None:
-                    shutdown_event.set()
+            if shutdown_event and not await_explicit_shutdown:
+                shutdown_event.set()
         else:
-            app.state.setup_task = runner.setup()
+            setup_task = runner.setup()
+            setup_task.add_done_callback(_handle_setup_done)
 
     @app.on_event("shutdown")
     def shutdown() -> None:
-        runner.shutdown()
+        worker.terminate()
 
     @app.get("/")
     async def root() -> Any:
@@ -255,12 +256,11 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
 
     @app.get("/health-check")
     async def healthcheck() -> Any:
-        _check_setup_result()
         if app.state.health == Health.READY:
             health = Health.BUSY if runner.is_busy() else Health.READY
         else:
             health = app.state.health
-        setup = attrs.asdict(app.state.setup_result) if app.state.setup_result else {}
+        setup = app.state.setup_result.to_dict() if app.state.setup_result else {}
         return jsonable_encoder({"status": health.name, "setup": setup})
 
     @limited
@@ -278,11 +278,6 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
         """
         Run a single prediction on the model
         """
-        if runner.is_busy():
-            return JSONResponse(
-                {"detail": "Already running a prediction"}, status_code=409
-            )
-
         # TODO: spec-compliant parsing of Prefer header.
         respond_async = prefer == "respond-async"
 
@@ -324,6 +319,16 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
         # set on the prediction object
         request.id = prediction_id
 
+        # If the prediction service is already running a prediction with a
+        # matching ID, return its current state.
+        if runner.is_busy():
+            task = runner.get_predict_task(request.id)
+            if task:
+                return JSONResponse(
+                    jsonable_encoder(task.result),
+                    status_code=202,
+                )
+
         # TODO: spec-compliant parsing of Prefer header.
         respond_async = prefer == "respond-async"
 
@@ -348,24 +353,37 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
         if request.input is None:
             request.input = {}  # pylint: disable=attribute-defined-outside-init
 
-        try:
-            # For now, we only ask PredictionRunner to handle file uploads for
+        task_kwargs = {}
+        if respond_async:
+            # For now, we only ask PredictionService to handle file uploads for
             # async predictions. This is unfortunate but required to ensure
             # backwards-compatible behaviour for synchronous predictions.
-            initial_response, async_result = runner.predict(
-                request,
-                upload=respond_async,
-            )
+            task_kwargs["upload_url"] = upload_url
+
+        try:
+            predict_task = runner.predict(request, task_kwargs=task_kwargs)
         except RunnerBusyError:
             return JSONResponse(
                 {"detail": "Already running a prediction"}, status_code=409
             )
 
-        if respond_async:
-            return JSONResponse(jsonable_encoder(initial_response), status_code=202)
+        if hasattr(request.input, "cleanup"):
+            predict_task.add_done_callback(lambda _: request.input.cleanup())
 
+        predict_task.add_done_callback(_handle_predict_done)
+
+        if respond_async:
+            return JSONResponse(
+                jsonable_encoder(predict_task.result),
+                status_code=202,
+            )
+
+        # Otherwise, wait for the prediction to complete...
+        predict_task.wait()
+
+        # ...and return the result.
         try:
-            response = PredictionResponse(**async_result.get().dict())
+            response = PredictionResponse(**predict_task.result.dict())
         except ValidationError as e:
             _log_invalid_output(e)
             raise HTTPException(status_code=500, detail=str(e)) from e
@@ -393,24 +411,30 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
             return JSONResponse({}, status_code=404)
         return JSONResponse({}, status_code=200)
 
-    def _check_setup_result() -> Any:
-        if app.state.setup_task is None:
-            return
+    def _handle_predict_done(response: schema.PredictionResponse) -> None:
+        if response._fatal_exception:
+            _maybe_shutdown(response._fatal_exception)
 
-        if not app.state.setup_task.ready():
-            return
+    def _handle_setup_done(setup_result: SetupResult) -> None:
+        app.state.setup_result = setup_result
 
-        result = app.state.setup_task.get()
-
-        if result.status == schema.Status.SUCCEEDED:
+        if app.state.setup_result.status == schema.Status.SUCCEEDED:
             app.state.health = Health.READY
+
+            # In kubernetes, mark the pod as ready now setup has completed.
+            probes = ProbeHelper()
+            probes.ready()
         else:
-            app.state.health = Health.SETUP_FAILED
+            _maybe_shutdown(Exception("setup failed"), status=Health.SETUP_FAILED)
 
-        app.state.setup_result = result
-
-        # Reset app.state.setup_task so future calls are a no-op
-        app.state.setup_task = None
+    def _maybe_shutdown(exc: BaseException, *, status: Health = Health.DEFUNCT) -> None:
+        log.error("encountered fatal error", exc_info=exc)
+        app.state.health = status
+        if shutdown_event and not await_explicit_shutdown:
+            log.error("shutting down immediately")
+            shutdown_event.set()
+        else:
+            log.error("awaiting explicit shutdown")
 
     return app
 
@@ -576,6 +600,9 @@ if __name__ == "__main__":
     s.stop()
 
     # return error exit code when setup failed and cog is running in interactive mode (not k8s)
-    if app.state.setup_result and not await_explicit_shutdown:
-        if app.state.setup_result.status == schema.Status.FAILED:
-            sys.exit(-1)
+    if (
+        app.state.setup_result
+        and app.state.setup_result.status == schema.Status.FAILED
+        and not await_explicit_shutdown
+    ):
+        sys.exit(-1)

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -1,24 +1,21 @@
 import io
-import sys
-import threading
 import traceback
-import typing  # TypeAlias, py3.10
-from concurrent.futures import TimeoutError
+from abc import ABC, abstractmethod
+from concurrent.futures import Future
 from datetime import datetime, timezone
-from multiprocessing.pool import AsyncResult, ThreadPool
-from typing import Any, Callable, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, Generic, List, Literal, Optional, TypeVar, Union
 
 import requests
 import structlog
-from attrs import define
+from attrs import define, field
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from .. import schema, types
 from ..files import put_file_to_signed_endpoint
 from ..json import upload_files
+from ..predictor import BaseInput
 from .eventtypes import Done, Log, PredictionOutput, PredictionOutputType
-from .probes import ProbeHelper
 from .telemetry import current_trace_context
 from .useragent import get_user_agent
 from .webhook import SKIP_START_EVENT, webhook_caller_filtered
@@ -42,155 +39,198 @@ class UnknownPredictionError(Exception):
 @define
 class SetupResult:
     started_at: datetime
-    completed_at: datetime
-    logs: str
-    status: schema.Status
+    completed_at: Optional[datetime] = None
+    logs: List[str] = field(factory=list)
+    status: Optional[Literal[schema.Status.FAILED, schema.Status.SUCCEEDED]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "logs": "".join(self.logs),
+            "status": self.status,
+        }
 
 
-PredictionTask: "typing.TypeAlias" = "AsyncResult[schema.PredictionResponse]"
-SetupTask: "typing.TypeAlias" = "AsyncResult[SetupResult]"
-if sys.version_info < (3, 9):
-    PredictionTask = AsyncResult
-    SetupTask = AsyncResult
-RunnerTask: "typing.TypeAlias" = Union[PredictionTask, SetupTask]
+class PredictionRunner:
+    """
+    PredictionRunner manages the state of predictions running through the
+    passed worker.
+    """
 
-
-class PredictionRunner:  # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
         *,
-        predictor_ref: str,
-        shutdown_event: Optional[threading.Event],
-        upload_url: Optional[str] = None,
+        worker: Worker,
     ) -> None:
-        self._thread = None
-        self._threadpool = ThreadPool(processes=1)
+        self._worker = worker
 
-        self._response: Optional[schema.PredictionResponse] = None
-        self._result: Optional[RunnerTask] = None
+        self._setup_task: Optional[SetupTask] = None
+        self._predict_task: Optional[PredictTask] = None
+        self._prediction_id = None
 
-        self._worker = Worker(predictor_ref=predictor_ref)
-        self._should_cancel = threading.Event()
-        self._should_exit = threading.Event()
+    def setup(self) -> "SetupTask":
+        assert self._setup_task is None, "do not call setup twice"
 
-        self._shutdown_event = shutdown_event
-        self._upload_url = upload_url
+        self._setup_task = SetupTask()
 
-    def setup(self) -> SetupTask:
-        if self.is_busy():
-            raise RunnerBusyError()
+        sid = self._worker.subscribe(self._setup_task.handle_event)
+        self._setup_task.track(self._worker.setup())
+        self._setup_task.add_done_callback(lambda _: self._worker.unsubscribe(sid))
 
-        def handle_error(error: BaseException) -> None:
-            # Re-raise the exception in order to more easily capture exc_info,
-            # and then trigger shutdown, as we have no easy way to resume
-            # worker state if an exception was thrown.
-            try:
-                raise error
-            except Exception:  # pylint: disable=broad-exception-caught
-                log.error("caught exception while running setup", exc_info=True)
-                if self._shutdown_event is not None:
-                    self._shutdown_event.set()
+        return self._setup_task
 
-        self._result = self._threadpool.apply_async(
-            func=setup,
-            kwds={"worker": self._worker},
-            error_callback=handle_error,
-        )
-        return self._result
-
-    # TODO: Make the return type AsyncResult[schema.PredictionResponse] when we
-    # no longer have to support Python 3.8
     def predict(
         self,
         prediction: schema.PredictionRequest,
-        upload: bool = True,
-    ) -> Tuple[schema.PredictionResponse, PredictionTask]:
-        # It's the caller's responsibility to not call us if we're busy.
-        if self.is_busy():
-            # If self._result is set, but self._response is not, we're still
-            # doing setup.
-            if self._response is None:
-                raise RunnerBusyError()
-            assert self._result is not None
-            if prediction.id is not None and prediction.id == self._response.id:
-                result = cast(PredictionTask, self._result)
-                return (self._response, result)
-            raise RunnerBusyError()
+        task_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> "PredictTask":
+        self._raise_if_busy()
 
-        # Set up logger context for main thread. The same thing happens inside
-        # the predict thread.
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(prediction_id=prediction.id)
+        task_kwargs = task_kwargs or {}
 
-        self._should_cancel.clear()
-        upload_url = self._upload_url if upload else None
-        event_handler = create_event_handler(
-            prediction,
-            upload_url=upload_url,
-        )
+        self._predict_task = create_predict_task(prediction, **task_kwargs)
+        self._prediction_id = prediction.id
 
-        def cleanup(_: Optional[schema.PredictionResponse] = None) -> None:
-            input = cast(Any, prediction.input)
-            if hasattr(input, "cleanup"):
-                input.cleanup()
+        try:
+            payload = _prepare_predict_payload(prediction.input)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            # Fail the prediction
+            self._predict_task.failed_early(error=str(e))
+        else:
+            sid = self._worker.subscribe(self._predict_task.handle_event)
+            self._predict_task.track(self._worker.predict(payload))
+            self._predict_task.add_done_callback(
+                lambda _: self._worker.unsubscribe(sid)
+            )
 
-        def handle_error(error: BaseException) -> None:
-            # Re-raise the exception in order to more easily capture exc_info,
-            # and then trigger shutdown, as we have no easy way to resume
-            # worker state if an exception was thrown.
-            try:
-                raise error
-            except Exception:  # pylint: disable=broad-exception-caught
-                log.error("caught exception while running prediction", exc_info=True)
-                if self._shutdown_event is not None:
-                    self._shutdown_event.set()
+        return self._predict_task
 
-        self._response = event_handler.response
-        self._result = self._threadpool.apply_async(
-            func=predict,
-            kwds={
-                "worker": self._worker,
-                "request": prediction,
-                "event_handler": event_handler,
-                "should_cancel": self._should_cancel,
-                "should_exit": self._should_exit,
-            },
-            callback=cleanup,
-            error_callback=handle_error,
-        )
-
-        return (self._response, self._result)
+    def get_predict_task(self, id: str) -> Optional["PredictTask"]:
+        if not self._predict_task:
+            return None
+        if self._predict_task.result.id != id:
+            return None
+        return self._predict_task
 
     def is_busy(self) -> bool:
-        if self._result is None:
-            return False
-
-        if not self._result.ready():
+        try:
+            self._raise_if_busy()
+        except RunnerBusyError:
             return True
-
-        self._response = None
-        self._result = None
         return False
 
-    def shutdown(self) -> None:
-        self._should_exit.set()
-        self._worker.terminate()
-        self._threadpool.terminate()
-        self._threadpool.join()
-
-    def cancel(self, prediction_id: Optional[str] = None) -> None:
-        if not self.is_busy():
-            return
-        assert self._response is not None
-        if prediction_id is not None and prediction_id != self._response.id:
+    def cancel(self, prediction_id: str) -> None:
+        if not prediction_id:
+            raise ValueError("prediction_id is required")
+        if self._prediction_id != prediction_id:
             raise UnknownPredictionError()
-        self._should_cancel.set()
+        self._worker.cancel()
+
+    def _raise_if_busy(self) -> None:
+        if self._setup_task is None:
+            # Setup hasn't been called yet.
+            raise RunnerBusyError("setup has not started")
+        if not self._setup_task.done():
+            # Setup is still running.
+            raise RunnerBusyError("setup is not complete")
+        if self._predict_task is not None and not self._predict_task.done():
+            # Prediction is still running.
+            raise RunnerBusyError("prediction running")
 
 
-def create_event_handler(
+T = TypeVar("T")
+
+
+class Task(ABC, Generic[T]):
+    @abstractmethod
+    def track(self, fut: "Future[Done]") -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def add_done_callback(self, fn: Callable[[T], None]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def done(self) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def wait(self, timeout: Optional[float] = None) -> None:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def result(self) -> T:
+        raise NotImplementedError
+
+
+class SetupTask(Task[SetupResult]):
+    def __init__(self, _clock: Optional[Callable[[], datetime]] = None) -> None:
+        self._clock = _clock
+        if self._clock is None:
+            self._clock = lambda: datetime.now(timezone.utc)
+
+        self._result = SetupResult(started_at=self._clock())
+
+    @property
+    def result(self) -> SetupResult:
+        return self._result
+
+    def track(self, fut: "Future[Done]") -> None:
+        self._fut = fut
+        self._fut.add_done_callback(self._handle_done)
+
+    def add_done_callback(self, fn: Callable[[SetupResult], None]) -> None:
+        assert self._fut, "call track before adding callbacks"
+        self._fut.add_done_callback(lambda _: fn(self.result))
+
+    def done(self) -> bool:
+        assert self._fut, "call track before checking done"
+        return self._fut.done()
+
+    def wait(self, timeout: Optional[float] = None) -> None:
+        assert self._fut, "call track before waiting"
+        self._fut.result(timeout=timeout)
+
+    def append_logs(self, message: str) -> None:
+        self._result.logs.append(message)
+
+    def succeeded(self) -> None:
+        assert self._clock
+        self._result.completed_at = self._clock()
+        self._result.status = schema.Status.SUCCEEDED
+
+    def failed(self) -> None:
+        assert self._clock
+        self._result.completed_at = self._clock()
+        self._result.status = schema.Status.FAILED
+
+    def handle_event(self, event: _PublicEventType) -> None:
+        if isinstance(event, Log):
+            self.append_logs(event.message)
+        elif isinstance(event, Done):
+            if event.error:
+                self.failed()
+            else:
+                self.succeeded()
+        else:
+            log.warn("received unexpected event during setup", data=event)
+
+    def _handle_done(self, f: "Future[Done]") -> None:
+        try:
+            # See if the future captured an exception...
+            f.result()
+        except Exception:  # pylint: disable=broad-exception-caught
+            log.error("caught exception while running setup", exc_info=True)
+            self.append_logs(traceback.format_exc())
+            self.failed()
+
+
+def create_predict_task(
     prediction: schema.PredictionRequest,
     upload_url: Optional[str] = None,
-) -> "PredictionEventHandler":
+) -> "PredictTask":
     response = schema.PredictionResponse(**prediction.dict())
 
     webhook = prediction.webhook
@@ -206,7 +246,7 @@ def create_event_handler(
     if upload_url is not None:
         file_uploader = generate_file_uploader(upload_url, prediction_id=prediction.id)
 
-    event_handler = PredictionEventHandler(
+    event_handler = PredictTask(
         response, webhook_sender=webhook_sender, file_uploader=file_uploader
     )
 
@@ -229,20 +269,28 @@ def generate_file_uploader(
     return file_uploader
 
 
-class PredictionEventHandler:
+class PredictTask(Task[schema.PredictionResponse]):
     def __init__(
         self,
         p: schema.PredictionResponse,
         webhook_sender: Optional[Callable[[Any, schema.WebhookEvent], None]] = None,
         file_uploader: Optional[Callable[[Any], Any]] = None,
     ) -> None:
-        log.info("starting prediction")
-        self.p = p
-        self.p.status = schema.Status.PROCESSING
+        super().__init__()
+
+        self._log = log.bind(prediction_id=p.id)
+
+        self._log.info("starting prediction")
+        self._p = p
+        self._p.status = schema.Status.PROCESSING
         self._output_type_multi = None
-        self.p.output = None
-        self.p.logs = ""
-        self.p.started_at = datetime.now(tz=timezone.utc)
+        self._p.output = None
+        self._p.logs = ""
+        self._p.started_at = datetime.now(tz=timezone.utc)
+
+        # Records whether the predict task failed before it even started (e.g.
+        # during validation of inputs).
+        self._early_failure = False
 
         self._webhook_sender = webhook_sender
         self._file_uploader = file_uploader
@@ -254,19 +302,44 @@ class PredictionEventHandler:
             self._send_webhook(schema.WebhookEvent.START)
 
     @property
-    def response(self) -> schema.PredictionResponse:
-        return self.p
+    def result(self) -> schema.PredictionResponse:
+        return self._p
+
+    def track(self, fut: "Future[Done]") -> None:
+        self._fut = fut
+        self._fut.add_done_callback(self._handle_done)
+
+    def add_done_callback(
+        self, fn: Callable[[schema.PredictionResponse], None]
+    ) -> None:
+        if self._early_failure:
+            fn(self.result)
+            return
+        assert self._fut, "call track before adding callbacks"
+        self._fut.add_done_callback(lambda _: fn(self.result))
+
+    def done(self) -> bool:
+        if self._early_failure:
+            return True
+        assert self._fut, "call track before checking done"
+        return self._fut.done()
+
+    def wait(self, timeout: Optional[float] = None) -> None:
+        if self._early_failure:
+            return
+        assert self._fut, "call track before waiting"
+        self._fut.result(timeout=timeout)
 
     def set_output_type(self, *, multi: bool) -> None:
         assert (
             self._output_type_multi is None
         ), "Predictor unexpectedly returned multiple output types"
         assert (
-            self.p.output is None
+            self._p.output is None
         ), "Predictor unexpectedly returned output type after output"
 
         if multi:
-            self.p.output = []
+            self._p.output = []
 
         self._output_type_multi = multi
 
@@ -277,51 +350,72 @@ class PredictionEventHandler:
 
         uploaded_output = self._upload_files(output)
         if self._output_type_multi:
-            self.p.output.append(uploaded_output)
+            self._p.output.append(uploaded_output)
             self._send_webhook(schema.WebhookEvent.OUTPUT)
         else:
-            self.p.output = uploaded_output
+            self._p.output = uploaded_output
             # We don't send a webhook for compatibility with the behaviour of
             # redis_queue. In future we can consider whether it makes sense to send
             # one here.
 
     def append_logs(self, logs: str) -> None:
-        assert self.p.logs is not None
-        self.p.logs += logs
+        assert self._p.logs is not None
+        self._p.logs += logs
         self._send_webhook(schema.WebhookEvent.LOGS)
 
     def succeeded(self) -> None:
-        log.info("prediction succeeded")
-        self.p.status = schema.Status.SUCCEEDED
+        self._log.info("prediction succeeded")
+        self._p.status = schema.Status.SUCCEEDED
         self._set_completed_at()
         # These have been set already: this is to convince the typechecker of
         # that...
-        assert self.p.completed_at is not None
-        assert self.p.started_at is not None
-        self.p.metrics = {
-            "predict_time": (self.p.completed_at - self.p.started_at).total_seconds()
+        assert self._p.completed_at is not None
+        assert self._p.started_at is not None
+        self._p.metrics = {
+            "predict_time": (self._p.completed_at - self._p.started_at).total_seconds()
         }
         self._send_webhook(schema.WebhookEvent.COMPLETED)
 
     def failed(self, error: str) -> None:
-        log.info("prediction failed", error=error)
-        self.p.status = schema.Status.FAILED
-        self.p.error = error
+        self._log.info("prediction failed", error=error)
+        self._p.status = schema.Status.FAILED
+        self._p.error = error
         self._set_completed_at()
         self._send_webhook(schema.WebhookEvent.COMPLETED)
+
+    def failed_early(self, error: str) -> None:
+        self.failed(error)
+        self._early_failure = True
 
     def canceled(self) -> None:
-        log.info("prediction canceled")
-        self.p.status = schema.Status.CANCELED
+        self._log.info("prediction canceled")
+        self._p.status = schema.Status.CANCELED
         self._set_completed_at()
         self._send_webhook(schema.WebhookEvent.COMPLETED)
 
+    def handle_event(self, event: _PublicEventType) -> None:
+        if isinstance(event, Log):
+            self.append_logs(event.message)
+        elif isinstance(event, PredictionOutputType):
+            self.set_output_type(multi=event.multi)
+        elif isinstance(event, PredictionOutput):
+            self.append_output(event.payload)
+        elif isinstance(event, Done):  # pyright: ignore reportUnnecessaryIsinstance
+            if event.canceled:
+                self.canceled()
+            elif event.error:
+                self.failed(error=str(event.error_detail))
+            else:
+                self.succeeded()
+        else:  # shouldn't happen, exhausted the type
+            self._log.warn("received unexpected event during predict", data=event)
+
     def _set_completed_at(self) -> None:
-        self.p.completed_at = datetime.now(tz=timezone.utc)
+        self._p.completed_at = datetime.now(tz=timezone.utc)
 
     def _send_webhook(self, event: schema.WebhookEvent) -> None:
         if self._webhook_sender is not None:
-            self._webhook_sender(self.response, event)
+            self._webhook_sender(self._p, event)
 
     def _upload_files(self, output: Any) -> Any:
         if self._file_uploader is None:
@@ -336,147 +430,34 @@ class PredictionEventHandler:
             # to be failed, with a useful error message.
             raise FileUploadError("Got error trying to upload output files") from error
 
-
-def setup(*, worker: Worker) -> SetupResult:
-    logs = []
-    status = None
-    started_at = datetime.now(tz=timezone.utc)
-
-    def append_logs(event: _PublicEventType) -> None:
-        if isinstance(event, Log):
-            logs.append(event.message)
-
-    subscription_idx = worker.subscribe(append_logs)
-    try:
-        result = worker.setup().result()
-        if result.error:
-            status = schema.Status.FAILED
-        else:
-            status = schema.Status.SUCCEEDED
-    except Exception:  # pylint: disable=broad-exception-caught
-        logs.append(traceback.format_exc())
-        status = schema.Status.FAILED
-    finally:
-        worker.unsubscribe(subscription_idx)
-
-    completed_at = datetime.now(tz=timezone.utc)
-
-    # Only if setup succeeded, mark the container as "ready".
-    if status == schema.Status.SUCCEEDED:
-        probes = ProbeHelper()
-        probes.ready()
-
-    return SetupResult(
-        started_at=started_at,
-        completed_at=completed_at,
-        logs="".join(logs),
-        status=status,
-    )
+    def _handle_done(self, f: "Future[Done]") -> None:
+        try:
+            # See if the future captured an exception...
+            f.result()
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            self._log.error("caught exception while running predict", exc_info=True)
+            self.append_logs(traceback.format_exc())
+            self.failed(error=str(e))
+            self._p._fatal_exception = e
 
 
-def predict(
-    *,
-    worker: Worker,
-    request: schema.PredictionRequest,
-    event_handler: PredictionEventHandler,
-    should_cancel: threading.Event,
-    should_exit: threading.Event,
-) -> schema.PredictionResponse:
-    # Set up logger context within prediction thread.
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(prediction_id=request.id)
-
-    try:
-        return _predict(
-            worker=worker,
-            request=request,
-            event_handler=event_handler,
-            should_cancel=should_cancel,
-            should_exit=should_exit,
-        )
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        tb = traceback.format_exc()
-        event_handler.append_logs(tb)
-        event_handler.failed(error=str(e))
-        raise
-
-
-def _handle_event(
-    event_handler: PredictionEventHandler, event: _PublicEventType
-) -> None:
-    if isinstance(event, Log):
-        event_handler.append_logs(event.message)
-    elif isinstance(event, PredictionOutputType):
-        event_handler.set_output_type(multi=event.multi)
-    elif isinstance(event, PredictionOutput):
-        event_handler.append_output(event.payload)
-    elif isinstance(event, Done):  # pyright: ignore reportUnnecessaryIsinstance
-        pass
-    else:  # shouldn't happen, exhausted the type
-        log.warn("received unexpected event from worker", data=event)
-
-
-def _predict(  # pylint: disable=too-many-branches
-    *,
-    worker: Worker,
-    request: schema.PredictionRequest,
-    event_handler: PredictionEventHandler,
-    should_cancel: threading.Event,
-    should_exit: threading.Event,
-) -> schema.PredictionResponse:
-    initial_prediction = request.dict()
-
-    input_dict = initial_prediction["input"]
+def _prepare_predict_payload(
+    prediction_input: Union[BaseInput, Dict[str, Any]],
+) -> Dict[str, Any]:
+    if isinstance(prediction_input, BaseInput):
+        input_dict = prediction_input.dict()
+    else:
+        input_dict = prediction_input.copy()
 
     for k, v in input_dict.items():
-        try:
-            # Check if v is an instance of URLPath
-            if isinstance(v, types.URLPath):
-                input_dict[k] = v.convert()
-            # Check if v is a list of URLPath instances
-            elif isinstance(v, list) and all(
-                isinstance(item, types.URLPath) for item in v
-            ):
-                input_dict[k] = [item.convert() for item in v]
-        except requests.exceptions.RequestException as e:
-            tb = traceback.format_exc()
-            event_handler.append_logs(tb)
-            event_handler.failed(error=str(e))
-            log.warn("Failed to download url path from input", exc_info=True)
-            return event_handler.response
+        # Check if v is an instance of URLPath
+        if isinstance(v, types.URLPath):
+            input_dict[k] = v.convert()
+        # Check if v is a list of URLPath instances
+        elif isinstance(v, list) and all(isinstance(item, types.URLPath) for item in v):
+            input_dict[k] = [item.convert() for item in v]
 
-    subscription_idx = worker.subscribe(
-        lambda event: _handle_event(event_handler, event)
-    )
-    try:
-        prediction = worker.predict(input_dict)
-
-        while True:
-            try:
-                prediction.result(timeout=0.1)
-            except TimeoutError:
-                pass
-            else:
-                break
-
-            if should_cancel.is_set():
-                worker.cancel()
-                should_cancel.clear()
-
-            if should_exit.is_set():
-                return event_handler.response
-
-        result = prediction.result()
-        if result.canceled:
-            event_handler.canceled()
-        elif result.error:
-            event_handler.failed(error=str(result.error_detail))
-        else:
-            event_handler.succeeded()
-    finally:
-        worker.unsubscribe(subscription_idx)
-
-    return event_handler.response
+    return input_dict
 
 
 def _make_file_upload_http_client() -> requests.Session:

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -521,10 +521,13 @@ def test_asynchronous_prediction_endpoint(client, match):
     )
     assert resp.status_code == 202
 
-    assert resp.json() == match(
-        {"status": "processing", "output": None, "started_at": mock.ANY}
-    )
-    assert resp.json()["started_at"] is not None
+    result = resp.json()
+
+    # The response might be a "processing" response, but the prediction can
+    # also complete before the response is sent.
+    assert result["started_at"] is not None
+    assert result["status"] in {"processing", "succeeded"}
+    assert result["output"] in {None, "hello world"}
 
     n = 0
     while webhook.call_count < 1 and n < 10:
@@ -589,10 +592,13 @@ def test_asynchronous_prediction_endpoint_with_trace_context(client, match):
     )
     assert resp.status_code == 202
 
-    assert resp.json() == match(
-        {"status": "processing", "output": None, "started_at": mock.ANY}
-    )
-    assert resp.json()["started_at"] is not None
+    result = resp.json()
+
+    # The response might be a "processing" response, but the prediction can
+    # also complete before the response is sent.
+    assert result["started_at"] is not None
+    assert result["status"] in {"processing", "succeeded"}
+    assert result["output"] in {None, "https://example.com/upload/file"}
 
     n = 0
     while webhook.call_count < 1 and n < 10:

--- a/python/tests/server/test_http_input.py
+++ b/python/tests/server/test_http_input.py
@@ -261,8 +261,8 @@ def test_untyped_inputs():
     )
     assert app.state.health == Health.SETUP_FAILED
     assert app.state.setup_result.status == schema.Status.FAILED
-    assert (
-        "TypeError: No input type provided for parameter" in app.state.setup_result.logs
+    assert "TypeError: No input type provided for parameter" in "".join(
+        app.state.setup_result.logs
     )
 
 
@@ -275,7 +275,6 @@ def test_input_with_unsupported_type():
     )
     assert app.state.health == Health.SETUP_FAILED
     assert app.state.setup_result.status == schema.Status.FAILED
-    assert (
-        "TypeError: Unsupported input type input_unsupported_type"
-        in app.state.setup_result.logs
+    assert "TypeError: Unsupported input type input_unsupported_type" in "".join(
+        app.state.setup_result.logs
     )

--- a/python/tests/server/test_runner.py
+++ b/python/tests/server/test_runner.py
@@ -1,5 +1,5 @@
 import os
-import threading
+import uuid
 from concurrent.futures import Future
 from datetime import datetime
 from unittest import mock
@@ -7,14 +7,16 @@ from unittest import mock
 import pytest
 
 from cog.schema import PredictionRequest, PredictionResponse, Status, WebhookEvent
-from cog.server.eventtypes import Done, Log, PredictionOutput, PredictionOutputType
+from cog.server.eventtypes import Done, Log
 from cog.server.runner import (
-    PredictionEventHandler,
     PredictionRunner,
+    PredictTask,
     RunnerBusyError,
+    SetupResult,
+    SetupTask,
     UnknownPredictionError,
-    predict,
 )
+from cog.server.worker import Worker
 
 
 def _fixture_path(name):
@@ -22,306 +24,428 @@ def _fixture_path(name):
     return os.path.join(test_dir, f"fixtures/{name}.py") + ":Predictor"
 
 
-@pytest.fixture
-def runner():
-    runner = PredictionRunner(
-        predictor_ref=_fixture_path("sleep"), shutdown_event=threading.Event()
+class FakeClock:
+    def __init__(self, t):
+        self.t = t
+
+    def __call__(self):
+        return self.t
+
+
+tick = mock.sentinel.tick
+
+
+class FakeWorker:
+    def __init__(self):
+        self.subscribers = {}
+        self.last_prediction_payload = None
+
+        self._setup_future = None
+        self._predict_future = None
+
+    def subscribe(self, subscriber):
+        sid = uuid.uuid4()
+        self.subscribers[sid] = subscriber
+        return sid
+
+    def unsubscribe(self, sid):
+        del self.subscribers[sid]
+
+    def setup(self):
+        assert self._setup_future is None
+        self._setup_future = Future()
+        return self._setup_future
+
+    def run_setup(self, events):
+        for event in events:
+            if isinstance(event, Exception):
+                self._setup_future.set_exception(event)
+                return
+            for subscriber in self.subscribers.values():
+                subscriber(event)
+            if isinstance(event, Done):
+                self._setup_future.set_result(event)
+
+    def predict(self, payload):
+        assert self._predict_future is None or self._predict_future.done()
+        self.last_prediction_payload = payload
+        self._predict_future = Future()
+        return self._predict_future
+
+    def run_predict(self, events):
+        for event in events:
+            if isinstance(event, Exception):
+                self._predict_future.set_exception(event)
+                return
+            for subscriber in self.subscribers.values():
+                subscriber(event)
+            if isinstance(event, Done):
+                self._predict_future.set_result(event)
+
+    def cancel(self):
+        done = Done(canceled=True)
+        for subscriber in self.subscribers.values():
+            subscriber(done)
+        self._predict_future.set_result(done)
+
+
+def test_prediction_runner_setup_success():
+    w = FakeWorker()
+    r = PredictionRunner(worker=w)
+
+    task = r.setup()
+    assert not task.done()
+
+    w.run_setup([Log(message="Setting up...", source="stdout")])
+    assert task.result.logs == ["Setting up..."]
+    assert not task.done()
+
+    w.run_setup([Done()])
+    assert task.done()
+    assert task.result.status == Status.SUCCEEDED
+
+
+def test_prediction_runner_setup_failure():
+    w = FakeWorker()
+    r = PredictionRunner(worker=w)
+    task = r.setup()
+
+    w.run_setup([Done(error=True)])
+    assert task.done()
+    assert task.result.status == Status.FAILED
+
+
+def test_prediction_runner_setup_exception():
+    w = FakeWorker()
+    r = PredictionRunner(worker=w)
+
+    task = r.setup()
+
+    w.run_setup([RuntimeError("kaboom!")])
+    assert task.done()
+    assert task.result.status == Status.FAILED
+    assert task.result.logs[0].startswith("Traceback")
+    assert task.result.logs[0].endswith("kaboom!\n")
+
+
+def test_prediction_runner_predict_success():
+    w = FakeWorker()
+    r = PredictionRunner(worker=w)
+
+    r.setup()
+    w.run_setup([Done()])
+
+    task = r.predict(PredictionRequest(input={"text": "giraffes"}))
+    assert w.last_prediction_payload == {"text": "giraffes"}
+    assert task.result.input == {"text": "giraffes"}
+    assert task.result.status == Status.PROCESSING
+
+    w.run_predict([Log(message="Predicting...", source="stdout")])
+    assert task.result.logs == "Predicting..."
+
+    w.run_predict([Done()])
+    assert task.result.status == Status.SUCCEEDED
+
+
+def test_prediction_runner_predict_failure():
+    w = FakeWorker()
+    r = PredictionRunner(worker=w)
+
+    r.setup()
+    w.run_setup([Done()])
+
+    task = r.predict(PredictionRequest(input={"text": "giraffes"}))
+    assert w.last_prediction_payload == {"text": "giraffes"}
+    assert task.result.input == {"text": "giraffes"}
+    assert task.result.status == Status.PROCESSING
+
+    w.run_predict([Done(error=True, error_detail="ErrNeckTooLong")])
+    assert task.result.status == Status.FAILED
+    assert task.result.error == "ErrNeckTooLong"
+
+
+def test_prediction_runner_predict_exception():
+    w = FakeWorker()
+    r = PredictionRunner(worker=w)
+
+    r.setup()
+    w.run_setup([Done()])
+
+    task = r.predict(PredictionRequest(input={"text": "giraffes"}))
+    assert w.last_prediction_payload == {"text": "giraffes"}
+    assert task.result.input == {"text": "giraffes"}
+    assert task.result.status == Status.PROCESSING
+
+    w.run_predict(
+        [
+            Log(message="counting shards\n", source="stdout"),
+            Log(message="reticulating splines\n", source="stdout"),
+            ValueError("splines not reticulable"),
+        ]
     )
-    try:
-        runner.setup().get(5)
-        yield runner
-    finally:
-        runner.shutdown()
+
+    assert task.result.logs.startswith("counting shards\nreticulating splines\n")
+    assert "Traceback" in task.result.logs
+    assert "ValueError: splines not reticulable" in task.result.logs
+    assert task.result.status == Status.FAILED
+    assert task.result.error == "splines not reticulable"
 
 
-def test_prediction_runner_setup():
-    runner = PredictionRunner(
-        predictor_ref=_fixture_path("sleep"), shutdown_event=threading.Event()
-    )
-    try:
-        result = runner.setup().get(5)
+def test_prediction_runner_predict_before_setup():
+    w = FakeWorker()
+    r = PredictionRunner(worker=w)
 
-        assert result.status == Status.SUCCEEDED
-        assert result.logs == ""
-        assert isinstance(result.started_at, datetime)
-        assert isinstance(result.completed_at, datetime)
-    finally:
-        runner.shutdown()
-
-
-def test_prediction_runner(runner):
-    request = PredictionRequest(input={"sleep": 0.1})
-    _, async_result = runner.predict(request)
-    response = async_result.get(timeout=1)
-    assert response.output == "done in 0.1 seconds"
-    assert response.status == "succeeded"
-    assert response.error is None
-    assert response.logs == "starting\n"
-    assert isinstance(response.started_at, datetime)
-    assert isinstance(response.completed_at, datetime)
-
-
-def test_prediction_runner_called_while_busy(runner):
-    request = PredictionRequest(input={"sleep": 0.1})
-    _, async_result = runner.predict(request)
-
-    assert runner.is_busy()
     with pytest.raises(RunnerBusyError):
-        runner.predict(request)
-
-    # Call .get() to ensure that the first prediction is scheduled before we
-    # attempt to shut down the runner.
-    async_result.get()
+        r.predict(PredictionRequest(input={"text": "giraffes"}))
 
 
-def test_prediction_runner_called_while_busy_idempotent(runner):
-    request = PredictionRequest(id="abcd1234", input={"sleep": 0.1})
+def test_prediction_runner_predict_before_setup_completes():
+    w = FakeWorker()
+    r = PredictionRunner(worker=w)
 
-    runner.predict(request)
-    runner.predict(request)
-    _, async_result = runner.predict(request)
+    r.setup()
 
-    response = async_result.get(timeout=1)
-    assert response.id == "abcd1234"
-    assert response.output == "done in 0.1 seconds"
-    assert response.status == "succeeded"
-
-
-def test_prediction_runner_called_while_busy_idempotent_wrong_id(runner):
-    request1 = PredictionRequest(id="abcd1234", input={"sleep": 0.1})
-    request2 = PredictionRequest(id="5678efgh", input={"sleep": 0.1})
-
-    _, async_result = runner.predict(request1)
     with pytest.raises(RunnerBusyError):
-        runner.predict(request2)
-
-    response = async_result.get(timeout=1)
-    assert response.id == "abcd1234"
-    assert response.output == "done in 0.1 seconds"
-    assert response.status == "succeeded"
+        r.predict(PredictionRequest(input={"text": "giraffes"}))
 
 
-def test_prediction_runner_cancel(runner):
-    request = PredictionRequest(input={"sleep": 0.5})
-    _, async_result = runner.predict(request)
+def test_prediction_runner_predict_before_predict_completes():
+    w = FakeWorker()
+    r = PredictionRunner(worker=w)
 
-    runner.cancel()
+    r.setup()
+    w.run_setup([Done()])
 
-    response = async_result.get(timeout=1)
-    assert response.output is None
-    assert response.status == "canceled"
-    assert response.error is None
-    assert response.logs == "starting\n"
-    assert isinstance(response.started_at, datetime)
-    assert isinstance(response.completed_at, datetime)
+    r.predict(PredictionRequest(input={"text": "giraffes"}))
+
+    with pytest.raises(RunnerBusyError):
+        r.predict(PredictionRequest(input={"text": "giraffes"}))
 
 
-def test_prediction_runner_cancel_matching_id(runner):
-    request = PredictionRequest(id="abcd1234", input={"sleep": 0.5})
-    _, async_result = runner.predict(request)
+def test_prediction_runner_predict_after_predict_completes():
+    w = FakeWorker()
+    r = PredictionRunner(worker=w)
 
-    runner.cancel(prediction_id="abcd1234")
+    r.setup()
+    w.run_setup([Done()])
 
-    response = async_result.get(timeout=1)
-    assert response.output is None
-    assert response.status == "canceled"
+    r.predict(PredictionRequest(input={"text": "giraffes"}))
+    w.run_predict([Done()])
+
+    r.predict(PredictionRequest(input={"text": "elephants"}))
+    w.run_predict([Done()])
+
+    assert w.last_prediction_payload == {"text": "elephants"}
 
 
-def test_prediction_runner_cancel_by_mismatched_id(runner):
-    request = PredictionRequest(id="abcd1234", input={"sleep": 0.5})
-    _, async_result = runner.predict(request)
+def test_prediction_runner_is_busy():
+    w = FakeWorker()
+    r = PredictionRunner(worker=w)
 
+    assert r.is_busy()
+
+    r.setup()
+    assert r.is_busy()
+
+    w.run_setup([Done()])
+    assert not r.is_busy()
+
+    r.predict(PredictionRequest(input={"text": "elephants"}))
+    assert r.is_busy()
+
+    w.run_predict([Done()])
+    assert not r.is_busy()
+
+
+def test_prediction_runner_predict_cancelation():
+    w = FakeWorker()
+    r = PredictionRunner(worker=w)
+
+    r.setup()
+    w.run_setup([Done()])
+
+    task = r.predict(PredictionRequest(id="abcd1234", input={"text": "giraffes"}))
+
+    with pytest.raises(ValueError):
+        r.cancel(None)
+    with pytest.raises(ValueError):
+        r.cancel("")
     with pytest.raises(UnknownPredictionError):
-        runner.cancel(prediction_id="5678efgh")
+        r.cancel("wxyz5678")
 
-    response = async_result.get(timeout=1)
-    assert response.output == "done in 0.5 seconds"
-    assert response.status == "succeeded"
+    w.run_predict([Log(message="Predicting...", source="stdout")])
+    assert task.result.status == Status.PROCESSING
 
-
-# list of (events, done, calls)
-PREDICT_TESTS = [
-    (
-        [],
-        Done(),
-        [
-            mock.call.succeeded(),
-        ],
-    ),
-    (
-        [],
-        Done(canceled=True),
-        [
-            mock.call.canceled(),
-        ],
-    ),
-    (
-        [],
-        Done(error=True, error_detail="foo"),
-        [
-            mock.call.failed(error="foo"),
-        ],
-    ),
-    (
-        [
-            Log(source="stdout", message="help"),
-        ],
-        Done(),
-        [
-            mock.call.append_logs("help"),
-            mock.call.succeeded(),
-        ],
-    ),
-    (
-        [
-            PredictionOutputType(multi=False),
-            PredictionOutput(payload="hello world"),
-        ],
-        Done(),
-        [
-            mock.call.set_output_type(multi=False),
-            mock.call.append_output("hello world"),
-            mock.call.succeeded(),
-        ],
-    ),
-    (
-        [
-            PredictionOutputType(multi=True),
-            PredictionOutput(payload="hello"),
-            PredictionOutput(payload="world"),
-        ],
-        Done(),
-        [
-            mock.call.set_output_type(multi=True),
-            mock.call.append_output("hello"),
-            mock.call.append_output("world"),
-            mock.call.succeeded(),
-        ],
-    ),
-    (
-        [
-            PredictionOutputType(multi=False),
-            PredictionOutputType(multi=False),
-            PredictionOutput(payload="hello world"),
-        ],
-        Done(),
-        [
-            mock.call.set_output_type(multi=False),
-            mock.call.set_output_type(multi=False),
-            mock.call.append_output("hello world"),
-            mock.call.succeeded(),
-        ],
-    ),
-    (
-        [
-            PredictionOutput(payload="hello world"),
-        ],
-        Done(),
-        [
-            mock.call.append_output("hello world"),
-            mock.call.succeeded(),
-        ],
-    ),
-]
+    r.cancel("abcd1234")
+    assert task.result.status == Status.CANCELED
 
 
-def fake_worker(events, done):
-    class FakeWorker:
-        def predict(self, _):
-            for event in events:
-                self.subscriber(event)
-            fut = Future()
-            fut.set_result(done)
-            return fut
+def test_prediction_runner_predict_cancelation_multiple_predictions():
+    w = FakeWorker()
+    r = PredictionRunner(worker=w)
 
-        def subscribe(self, subscriber):
-            self.subscriber = subscriber
+    r.setup()
+    w.run_setup([Done()])
 
-        def unsubscribe(self, _):
-            pass
+    task1 = r.predict(PredictionRequest(id="abcd1234", input={"text": "giraffes"}))
+    w.run_predict([Done()])
 
-    return FakeWorker()
+    task2 = r.predict(PredictionRequest(id="defg6789", input={"text": "elephants"}))
+    with pytest.raises(UnknownPredictionError):
+        r.cancel("abcd1234")
 
-
-@pytest.mark.parametrize("events,done,calls", PREDICT_TESTS)
-def test_predict(events, done, calls):
-    worker = fake_worker(events, done)
-    request = PredictionRequest(input={"text": "hello"}, foo="bar")
-    event_handler = mock.Mock()
-    should_cancel = threading.Event()
-    should_exit = threading.Event()
-
-    predict(
-        worker=worker,
-        request=request,
-        event_handler=event_handler,
-        should_cancel=should_cancel,
-        should_exit=should_exit,
-    )
-
-    assert event_handler.method_calls == calls
+    r.cancel("defg6789")
+    assert task1.result.status == Status.SUCCEEDED
+    assert task2.result.status == Status.CANCELED
 
 
-def test_prediction_event_handler():
+def test_prediction_runner_setup_e2e():
+    w = Worker(predictor_ref=_fixture_path("sleep"))
+    r = PredictionRunner(worker=w)
+
+    try:
+        task = r.setup()
+        task.wait(timeout=5)
+    finally:
+        w.shutdown()
+
+    assert task.result.status == Status.SUCCEEDED
+    assert task.result.logs == []
+    assert isinstance(task.result.started_at, datetime)
+    assert isinstance(task.result.completed_at, datetime)
+
+
+def test_prediction_runner_predict_e2e():
+    w = Worker(predictor_ref=_fixture_path("sleep"))
+    r = PredictionRunner(worker=w)
+
+    try:
+        r.setup().wait(timeout=5)
+        task = r.predict(PredictionRequest(input={"sleep": 0.1}))
+        task.wait(timeout=1)
+    finally:
+        w.shutdown()
+
+    assert task.result.output == "done in 0.1 seconds"
+    assert task.result.status == "succeeded"
+    assert task.result.error is None
+    assert task.result.logs == "starting\n"
+    assert isinstance(task.result.started_at, datetime)
+    assert isinstance(task.result.completed_at, datetime)
+
+
+@pytest.mark.parametrize(
+    "log,result",
+    [
+        (
+            [],
+            SetupResult(started_at=1),
+        ),
+        (
+            [tick, Done()],
+            SetupResult(started_at=1, completed_at=2, status=Status.SUCCEEDED),
+        ),
+        (
+            [
+                tick,
+                Log("running 1\n", source="stdout"),
+                Log("running 2\n", source="stdout"),
+                Done(),
+            ],
+            SetupResult(
+                started_at=1,
+                completed_at=2,
+                logs=["running 1\n", "running 2\n"],
+                status=Status.SUCCEEDED,
+            ),
+        ),
+        (
+            [
+                tick,
+                tick,
+                Done(error=True, error_detail="kaboom!"),
+            ],
+            SetupResult(
+                started_at=1,
+                completed_at=3,
+                status=Status.FAILED,
+            ),
+        ),
+    ],
+)
+def test_setup_task(log, result):
+    c = FakeClock(t=1)
+    t = SetupTask(_clock=c)
+
+    for event in log:
+        if event == tick:
+            c.t += 1
+        else:
+            t.handle_event(event)
+
+    assert t.result == result
+
+
+def test_predict_task():
     p = PredictionResponse(input={"hello": "there"})
-    h = PredictionEventHandler(p)
+    t = PredictTask(p)
 
     assert p.status == Status.PROCESSING
     assert p.output is None
     assert p.logs == ""
     assert isinstance(p.started_at, datetime)
 
-    h.set_output_type(multi=False)
-    h.append_output("giraffes")
+    t.set_output_type(multi=False)
+    t.append_output("giraffes")
     assert p.output == "giraffes"
 
 
-def test_prediction_event_handler_multi():
+def test_predict_task_multi():
     p = PredictionResponse(input={"hello": "there"})
-    h = PredictionEventHandler(p)
+    t = PredictTask(p)
 
     assert p.status == Status.PROCESSING
     assert p.output is None
     assert p.logs == ""
     assert isinstance(p.started_at, datetime)
 
-    h.set_output_type(multi=True)
-    h.append_output("elephant")
-    h.append_output("duck")
+    t.set_output_type(multi=True)
+    t.append_output("elephant")
+    t.append_output("duck")
     assert p.output == ["elephant", "duck"]
 
-    h.append_logs("running a prediction\n")
-    h.append_logs("still running\n")
+    t.append_logs("running a prediction\n")
+    t.append_logs("still running\n")
     assert p.logs == "running a prediction\nstill running\n"
 
-    h.succeeded()
+    t.succeeded()
     assert p.status == Status.SUCCEEDED
     assert isinstance(p.completed_at, datetime)
 
-    h.failed("oops")
+    t.failed("oops")
     assert p.status == Status.FAILED
     assert p.error == "oops"
     assert isinstance(p.completed_at, datetime)
 
-    h.canceled()
+    t.canceled()
     assert p.status == Status.CANCELED
     assert isinstance(p.completed_at, datetime)
 
 
-def test_prediction_event_handler_webhook_sender():
+def test_predict_task_webhook_sender():
     s = mock.Mock()
     p = PredictionResponse(input={"hello": "there"})
-    h = PredictionEventHandler(p, webhook_sender=s)
+    t = PredictTask(p, webhook_sender=s)
 
-    h.set_output_type(multi=True)
-    h.append_output("elephant")
-    h.append_output("duck")
+    t.set_output_type(multi=True)
+    t.append_output("elephant")
+    t.append_output("duck")
 
-    h.append_logs("running a prediction\n")
-    h.append_logs("still running\n")
+    t.append_logs("running a prediction\n")
+    t.append_logs("still running\n")
 
     s.reset_mock()
-    h.succeeded()
+    t.succeeded()
 
     s.assert_called_once_with(
         mock.ANY,
@@ -335,33 +459,33 @@ def test_prediction_event_handler_webhook_sender():
     assert "predict_time" in actual.metrics
 
 
-def test_prediction_event_handler_webhook_sender_intermediate():
+def test_predict_task_webhook_sender_intermediate():
     s = mock.Mock()
     p = PredictionResponse(input={"hello": "there"})
-    h = PredictionEventHandler(p, webhook_sender=s)
+    t = PredictTask(p, webhook_sender=s)
 
     s.assert_called_once_with(mock.ANY, WebhookEvent.START)
     actual = s.call_args[0][0]
     assert actual.status == "processing"
 
     s.reset_mock()
-    h.set_output_type(multi=False)
-    h.append_output("giraffes")
+    t.set_output_type(multi=False)
+    t.append_output("giraffes")
     assert s.call_count == 0
 
 
-def test_prediction_event_handler_webhook_sender_intermediate_multi():
+def test_predict_task_webhook_sender_intermediate_multi():
     s = mock.Mock()
     p = PredictionResponse(input={"hello": "there"})
-    h = PredictionEventHandler(p, webhook_sender=s)
+    t = PredictTask(p, webhook_sender=s)
 
     s.assert_called_once_with(mock.ANY, WebhookEvent.START)
     actual = s.call_args[0][0]
     assert actual.status == "processing"
 
     s.reset_mock()
-    h.set_output_type(multi=True)
-    h.append_output("elephant")
+    t.set_output_type(multi=True)
+    t.append_output("elephant")
     print(s.call_args_list)
     assert s.call_count == 1
     actual = s.call_args_list[0][0][0]
@@ -369,35 +493,35 @@ def test_prediction_event_handler_webhook_sender_intermediate_multi():
     assert s.call_args_list[0][0][1] == WebhookEvent.OUTPUT
 
     s.reset_mock()
-    h.append_output("duck")
+    t.append_output("duck")
     assert s.call_count == 1
     actual = s.call_args_list[0][0][0]
     assert actual.output == ["elephant", "duck"]
     assert s.call_args_list[0][0][1] == WebhookEvent.OUTPUT
 
     s.reset_mock()
-    h.append_logs("running a prediction\n")
+    t.append_logs("running a prediction\n")
     assert s.call_count == 1
     actual = s.call_args_list[0][0][0]
     assert actual.logs == "running a prediction\n"
     assert s.call_args_list[0][0][1] == WebhookEvent.LOGS
 
     s.reset_mock()
-    h.append_logs("still running\n")
+    t.append_logs("still running\n")
     assert s.call_count == 1
     actual = s.call_args_list[0][0][0]
     assert actual.logs == "running a prediction\nstill running\n"
     assert s.call_args_list[0][0][1] == WebhookEvent.LOGS
 
     s.reset_mock()
-    h.succeeded()
+    t.succeeded()
     s.assert_called_once()
     actual = s.call_args[0][0]
     assert actual.status == "succeeded"
     assert s.call_args[0][1] == WebhookEvent.COMPLETED
 
     s.reset_mock()
-    h.failed("oops")
+    t.failed("oops")
     s.assert_called_once()
     actual = s.call_args[0][0]
     assert actual.status == "failed"
@@ -405,42 +529,42 @@ def test_prediction_event_handler_webhook_sender_intermediate_multi():
     assert s.call_args[0][1] == WebhookEvent.COMPLETED
 
     s.reset_mock()
-    h.canceled()
+    t.canceled()
     s.assert_called_once()
     actual = s.call_args[0][0]
     assert actual.status == "canceled"
     assert s.call_args[0][1] == WebhookEvent.COMPLETED
 
 
-def test_prediction_event_handler_file_uploads():
+def test_predict_task_file_uploads():
     u = mock.Mock()
     p = PredictionResponse(input={"hello": "there"})
-    h = PredictionEventHandler(p, file_uploader=u)
+    t = PredictTask(p, file_uploader=u)
 
     # in reality this would be a Path object, but in this test we just care it
     # passes the output into the upload files function and uses whatever comes
     # back as final output.
     u.return_value = "http://example.com/output-image.png"
-    h.set_output_type(multi=False)
-    h.append_output("Path(to/my/file)")
+    t.set_output_type(multi=False)
+    t.append_output("Path(to/my/file)")
 
     u.assert_called_once_with("Path(to/my/file)")
     assert p.output == "http://example.com/output-image.png"
 
 
-def test_prediction_event_handler_file_uploads_multi():
+def test_predict_task_file_uploads_multi():
     u = mock.Mock()
     p = PredictionResponse(input={"hello": "there"})
-    h = PredictionEventHandler(p, file_uploader=u)
+    t = PredictTask(p, file_uploader=u)
 
     u.return_value = []
-    h.set_output_type(multi=True)
+    t.set_output_type(multi=True)
 
     u.return_value = "http://example.com/hello.jpg"
-    h.append_output("hello.jpg")
+    t.append_output("hello.jpg")
 
     u.return_value = "http://example.com/world.jpg"
-    h.append_output("world.jpg")
+    t.append_output("world.jpg")
 
     u.assert_has_calls([mock.call("hello.jpg"), mock.call("world.jpg")])
     assert p.output == ["http://example.com/hello.jpg", "http://example.com/world.jpg"]


### PR DESCRIPTION
This simplifies `PredictionRunner`, removing its worker thread and making it a wrapper around the worker which also manages the lifecycle of `PredictTask` and `SetupTask` objects.

`PredictTask` is essentially `PredictionEventHandler` but with the additional responsibilities of a) tracking the future representing the predict task running in the worker, and b) handling the individual event objects returned by worker.

`SetupTask` is the equivalent but for a setup.

We expect that this code will change significantly in the near future to allow the runner to keep track of multiple predictions at once.

This also changes the behaviour of cog in the event of a fatal prediction exception: if `await_explicit_shutdown` is set, then rather than triggering instant shutdown, we will poison the healthcheck with a new DEFUNCT health status.
