### PR TITLE
Migrate to FastAPI Lifespan Events

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -400,8 +400,9 @@ def create_app(
         return JSONResponse({}, status_code=200)
 
     def _handle_predict_done(response: schema.PredictionResponse) -> None:
-        if response._fatal_exception:
-            _maybe_shutdown(response._fatal_exception)
+        exception = response._fatal_exception  # pylint: disable=protected-access
+        if exception:
+            _maybe_shutdown(exception)
 
     def _handle_setup_done(setup_result: SetupResult) -> None:
         app.state.setup_result = setup_result

--- a/python/tests/server/conftest.py
+++ b/python/tests/server/conftest.py
@@ -1,6 +1,7 @@
 import os
 import threading
 import time
+import warnings
 from contextlib import ExitStack
 from typing import Any, Dict, Optional
 from unittest import mock
@@ -69,7 +70,12 @@ def make_client(
         shutdown_event=threading.Event(),
         upload_url=upload_url,
     )
-    return TestClient(app)
+    with warnings.catch_warnings():
+        # DeprecationWarning: The 'app' shortcut is now deprecated. Use the explicit style 'transport=WSGITransport(app=...)' instead.
+        warnings.filterwarnings(
+            "ignore", category=DeprecationWarning, message=".*WSGITransport.*"
+        )
+        return TestClient(app)
 
 
 def wait_for_setup(client: TestClient):


### PR DESCRIPTION
From https://fastapi.tiangolo.com/advanced/events/:

> You can define logic (code) that should be executed before the application starts up. This means that this code will be executed once, before the application starts receiving requests.

> [...]

>Let's start with an example use case and then see how to solve it with this.
>
> Let's imagine that you have some machine learning models that you want to use to handle requests. 🤖
>
> The same models are shared among requests, so, it's not one model per request, or one per user or something similar.
>
> Let's imagine that loading the model can take quite some time, because it has to read a lot of data from disk. So you don't want to do it for every request.

🎯 