### PR TITLE
Move the minimum torch version to 1.13.0

### DIFF
--- a/pkg/dockerfile/base.go
+++ b/pkg/dockerfile/base.go
@@ -12,7 +12,7 @@ import (
 const BaseImageRegistry = "r8.im"
 const MinimumCUDAVersion = "11.6"
 const MinimumPythonVersion = "3.8"
-const MinimumTorchVersion = "1.13.1"
+const MinimumTorchVersion = "1.13.0"
 
 var (
 	baseImageSystemPackages = []string{

--- a/pkg/dockerfile/base_test.go
+++ b/pkg/dockerfile/base_test.go
@@ -28,3 +28,15 @@ func TestBaseImageName(t *testing.T) {
 		require.Equal(t, tt.expected, actual)
 	}
 }
+
+func TestBaseImageConfigurations(t *testing.T) {
+	actual := BaseImageConfigurations()
+	foundTorch1_13 := false
+	for _, config := range actual {
+		if config.TorchVersion == "1.13" {
+			foundTorch1_13 = true
+			break
+		}
+	}
+	require.True(t, foundTorch1_13)
+}


### PR DESCRIPTION
* Allow the generate-matrix command to generate base images supporting torch 1.13.0

The intention here is to generate the necessary base image matrix to support running some torch `1.13.0` configurations. The new base images should be built after this is merged.

Solves the 1st problem here: https://github.com/replicate/cog/issues/1862