### PR TITLE
Download Path inputs in background

### DIFF
--- a/python/tests/server/test_http_input.py
+++ b/python/tests/server/test_http_input.py
@@ -1,8 +1,11 @@
 import base64
 import os
 import threading
+import time
 
 import responses
+from werkzeug.wrappers import Response
+
 
 from cog import schema
 from cog.server.http import Health, create_app
@@ -120,6 +123,29 @@ def test_path_input_data_url(client, match):
     )
     assert resp.json() == match({"output": "txt bar", "status": "succeeded"})
     assert resp.status_code == 200
+
+
+@uses_predictor("input_path")
+def test_path_input_slow_response(client, httpserver, match):
+    def _handle(_):
+        time.sleep(5)
+        return Response("Slow response!")
+
+    httpserver.expect_request("/foo.txt").respond_with_handler(_handle)
+    now = time.monotonic()
+    resp = client.post(
+        "/predictions",
+        json={
+            "input": {
+                "path": httpserver.url_for("/foo.txt"),
+            }
+        },
+        headers={"Prefer": "respond-async"},
+    )
+    # The download of the slow input file should not happen during the request.
+    assert time.monotonic() - now < 0.2
+    assert resp.json() == match({"status": "processing"})
+    assert resp.status_code == 202
 
 
 @uses_predictor("input_path_2")


### PR DESCRIPTION
PR #1865 introduced a regression: URLs for Path inputs were downloaded inside the request handler for `POST/PUT /predictions`.

This creates at least two problems:

1. It blocks the uvicorn thread, stopping us from serving healthchecks.
2. It makes the prediction create request take too long, even when `Prefer: respond-async` is specified.

Both of these issues cause unexpected failures in production.

This commit moves responsibility for fetching these files into Worker, and specifically into its background thread. This is probably not a long-term fix, as we want to make Worker (and ChildWorker) async eventually.

This also adds a test which fails on main and is fixed by this change.