### PR TITLE
Add timeout flag to predict

### DIFF
--- a/pkg/cli/train.go
+++ b/pkg/cli/train.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -121,7 +122,7 @@ func cmdTrain(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	if err := predictor.Start(os.Stderr); err != nil {
+	if err := predictor.Start(os.Stderr, time.Duration(predictTimeout)*time.Second); err != nil {
 		return err
 	}
 

--- a/pkg/global/global.go
+++ b/pkg/global/global.go
@@ -1,16 +1,11 @@
 package global
 
-import (
-	"time"
-)
-
 var (
 	Version               = "dev"
 	Commit                = ""
 	BuildTime             = "none"
 	Debug                 = false
 	ProfilingEnabled      = false
-	StartupTimeout        = 5 * time.Minute
 	ConfigFilename        = "cog.yaml"
 	ReplicateRegistryHost = "r8.im"
 	ReplicateWebsiteHost  = "replicate.com"

--- a/pkg/predict/predictor.go
+++ b/pkg/predict/predictor.go
@@ -58,7 +58,7 @@ func NewPredictor(runOptions docker.RunOptions) Predictor {
 	return Predictor{runOptions: runOptions}
 }
 
-func (p *Predictor) Start(logsWriter io.Writer) error {
+func (p *Predictor) Start(logsWriter io.Writer, timeout time.Duration) error {
 	var err error
 	containerPort := 5000
 
@@ -83,16 +83,16 @@ func (p *Predictor) Start(logsWriter io.Writer) error {
 		}
 	}()
 
-	return p.waitForContainerReady()
+	return p.waitForContainerReady(timeout)
 }
 
-func (p *Predictor) waitForContainerReady() error {
+func (p *Predictor) waitForContainerReady(timeout time.Duration) error {
 	url := fmt.Sprintf("http://localhost:%d/health-check", p.port)
 
 	start := time.Now()
 	for {
 		now := time.Now()
-		if now.Sub(start) > global.StartupTimeout {
+		if now.Sub(start) > timeout {
 			return fmt.Errorf("Timed out")
 		}
 


### PR DESCRIPTION
* Allow the user of cog to specify the timeout when performing predictions.
* This allows some models doing a lot in their setup to not automatically time out and leaves
that parameter up to the user rather than a
hardcoded global.

A solution for: https://github.com/replicate/cog/issues/1857