### PR TITLE
Publish on tag push rather than release

### DIFF
--- a/.github/workflows/pypi-package.yaml
+++ b/.github/workflows/pypi-package.yaml
@@ -4,9 +4,7 @@ name: PyPI package
 on:
   push:
     branches: [main]
-    tags: ["*"]
-  release:
-    types: [published]
+    tags: ["v[0-9]+.[0-9]+.[0-9]+*"]
   workflow_dispatch:
 
 permissions:
@@ -34,7 +32,7 @@ jobs:
 
   release-test-pypi:
     name: Publish dev package to test.pypi.org
-    if: github.repository_owner == 'replicate' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.repository_owner == 'replicate' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build-package
     steps:
@@ -50,7 +48,7 @@ jobs:
 
   release-pypi:
     name: Publish released package to pypi.org
-    if: github.repository_owner == 'replicate' && (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && startsWith(github.ref, 'refs/tags/')
+    if: github.repository_owner == 'replicate' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: build-package
     steps:


### PR DESCRIPTION
Unfortunately the `release` event associated with the release created by `goreleaser` in the CI workflow does not trigger workflow runs. This is because the release is created using the `$GITHUB_TOKEN`, which doesn't trigger workflows to eliminate the possibility of recursive workflow triggers. See:

  https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

This changes the publishing workflow (which is separate so that PyPI trusted publishing can reference specifically this workflow, and not allow publishing from any CI workflow run) to trigger on tag push, just like the main CI workflow.

The drawback here is that this is not conditional on the tests running and passing. For now, this is probably ok, as we should not be pushing tags until we see that the relevant commit has passed CI.