### PR TITLE
Add Python 3.7 back to supported versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ license.file = "LICENSE"
 urls."Source" = "https://github.com/replicate/cog"
 
 classifiers = [
+  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -271,7 +271,11 @@ class BaseInput(BaseModel):
             # A pathlib.Path object shouldn't make its way here,
             # but both have an unlink() method, so we may as well be safe.
             if isinstance(value, (URLPath, Path)):
-                value.unlink(missing_ok=True)
+                # TODO: use unlink(missing_ok=...) when we drop Python 3.7 support.
+                try:
+                    value.unlink()
+                except FileNotFoundError:
+                    pass
 
 
 def validate_input_type(

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -3,12 +3,13 @@ import traceback
 from abc import ABC, abstractmethod
 from concurrent.futures import Future
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, Generic, List, Literal, Optional, TypeVar
+from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar
 
 import requests
 import structlog
 from attrs import define, field
 from requests.adapters import HTTPAdapter
+from typing_extensions import Literal  # Python 3.7
 from urllib3.util.retry import Retry
 
 from .. import schema

--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -156,7 +156,12 @@ class URLPath(pathlib.PosixPath):  # pylint: disable=abstract-method
 
     def unlink(self, missing_ok: bool = False) -> None:
         if self._path:
-            self._path.unlink(missing_ok=missing_ok)
+            # TODO: use unlink(missing_ok=...) when we drop Python 3.7 support.
+            try:
+                self._path.unlink()
+            except FileNotFoundError:
+                if not missing_ok:
+                    raise
 
     def __str__(self) -> str:
         # FastAPI's jsonable_encoder will encode subclasses of pathlib.Path by


### PR DESCRIPTION
We need to support running 3.7 models in Replicate's production environment for now.

This ensures that we run the tests against 3.7.