### PR TITLE
Use tox to run Python tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-data_file = build/.coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch:
 
 env:
+  HYPOTHESIS_PROFILE: ci
   FORCE_COLOR: "1"
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PIP_NO_PYTHON_VERSION_WARNING: "1"
@@ -27,6 +28,29 @@ jobs:
         id: baipp
     outputs:
       python-versions: ${{ steps.baipp.outputs.supported_python_classifiers_json_array }}
+
+  lint:
+    name: Lint
+    needs: build-python
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - name: Download pre-built packages
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+      - name: Set COG_WHEEL
+        run: echo COG_WHEEL=$(ls dist/*.whl) >>"$GITHUB_ENV"
+      - name: Extract source distribution
+        run: tar xf dist/*.tar.gz --strip-components=1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - uses: hynek/setup-cached-uv@v2
+      - name: Prepare tox
+        run: uv pip install --system tox tox-uv
+      - name: Lint
+        run: make lint
 
   test-go:
     name: "Test Go"
@@ -53,8 +77,6 @@ jobs:
           go-version-file: go.mod
       - name: Build
         run: make cog
-      - name: Lint
-        run: make lint-go || true
       - name: Test
         run: make test-go
 
@@ -79,19 +101,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Python dependencies
+      - uses: hynek/setup-cached-uv@v2
+      - name: Prepare tox
         run: |
-          python -m pip install --no-cache uv
-          python -m uv pip install "${COG_WHEEL}[dev]"
-      - name: Lint
-        run: |
-          if [[ $(python -c 'import sys; print(sys.version_info >= (3, 10))') == "True" ]]; then
-            make lint-python || true
-          fi
+          echo TOX_PYTHON=py$(echo "${{ matrix.python-version }}" | tr -d .) >>$GITHUB_ENV
+          uv pip install --system tox
+      - run: uv pip install --system tox-uv
+        if: matrix.python-version != '3.7'
+      - name: Remove src to ensure tests run against wheel
+        run: rm -rf python/cog
       - name: Test
-        run: make test-python
-        env:
-          HYPOTHESIS_PROFILE: ci
+        run: python -Im tox run --installpkg "$COG_WHEEL" -e ${{ env.TOX_PYTHON }}-tests
 
   # cannot run this on mac due to licensing issues: https://github.com/actions/virtual-environments/issues/2150
   test-integration:
@@ -116,10 +136,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.12
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --no-cache uv
-          python -m uv pip install "${COG_WHEEL}[dev]"
+      - uses: hynek/setup-cached-uv@v2
+      - name: Prepare tox
+        run: uv pip install --system tox tox-uv
       - name: Test
         run: make test-integration
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist
 pkg/dockerfile/embed/*.whl
 # Used by a vim plugin (projectionist)
 .projections.json
+.tox/
 .venv/
 .idea/
 .DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,28 +32,30 @@ dependencies = [
   "uvicorn[standard]>=0.12,<1",
 ]
 
-optional-dependencies = { "dev" = [
-  "black",
+dynamic = ["version"]
+
+[project.optional-dependencies]
+dev = [
   "build",
+  "setuptools_scm",
+  "tox",
+  "tox-uv",
+]
+
+tests = [
   "httpx",
   'hypothesis<6.80.0; python_version < "3.8"',
   'hypothesis; python_version >= "3.8"',
   'numpy<1.22.0; python_version < "3.8"',
   'numpy; python_version >= "3.8"',
   "pillow",
-  "pyright==1.1.375",
   "pytest",
   "pytest-httpserver",
-  "pytest-rerunfailures",
   "pytest-timeout",
   "pytest-xdist",
   "pytest-cov",
   "responses",
-  "ruff",
-  "setuptools_scm",
-] }
-
-dynamic = ["version"]
+]
 
 [tool.setuptools_scm]
 write_to = "python/cog/_version.py"
@@ -95,10 +97,8 @@ good-names = ["id", "input"]
 
 ignore-paths = ["python/cog/_version.py", "python/tests"]
 
-[tool.pytest.ini_options]
-addopts = ["--timeout=10"]
-
 [tool.ruff]
+format.exclude = ["python/cog/_version.py"]
 lint.select = [
   "E",   # pycodestyle error
   "F",   # Pyflakes

--- a/python/cog/json.py
+++ b/python/cog/json.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 # numpy is an optional dependency, but the process of importing it is not
 # thread-safe, so we attempt the import once here.
 try:
-    import numpy as np
+    import numpy as np  # type: ignore
 except ImportError:
     np = None
 

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -12,9 +12,9 @@ from typing import Any, Callable, Dict, Optional, TextIO, Union
 
 import structlog
 
-from ..types import URLPath
 from ..json import make_encodeable
 from ..predictor import BasePredictor, get_predict, load_predictor_from_ref, run_setup
+from ..types import URLPath
 from .eventtypes import (
     Done,
     Log,

--- a/python/tests/server/test_http_input.py
+++ b/python/tests/server/test_http_input.py
@@ -6,12 +6,10 @@ import time
 import responses
 from werkzeug.wrappers import Response
 
-
 from cog import schema
 from cog.server.http import Health, create_app
-from tests.server.conftest import _fixture_path
 
-from .conftest import uses_predictor
+from .conftest import _fixture_path, uses_predictor
 
 
 @uses_predictor("input_none")

--- a/test-integration/Makefile
+++ b/test-integration/Makefile
@@ -1,3 +1,0 @@
-.PHONY: test
-test:
-	pytest -n auto -vv --reruns 3

--- a/test-integration/README.md
+++ b/test-integration/README.md
@@ -1,6 +1,0 @@
-# End to end tests
-
-To run:
-
-    $ pip install -r requirements.txt
-    $ make test

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,53 @@
+[tox]
+min_version = 4
+env_list =
+  py3{7,8,9,10,11,12,13}-tests
+  lint
+  typecheck
+  integration
+
+[coverage:paths]
+source =
+  python/cog
+  .tox/*/lib/python*/site-packages/cog
+
+[pytest]
+addopts = --timeout=10
+
+[testenv]
+package = wheel
+# Build the same wheel for all environments
+wheel_build_env = .pkg
+extras =
+  tests: tests
+pass_env =
+  HYPOTHESIS_PROFILE
+  FORCE_COLOR
+set_env =
+  tests: COVERAGE_FILE={env_dir}/.coverage
+commands =
+  tests: pytest python/tests --cov={env_site_packages_dir}/cog {posargs:-n auto -vv --cov-report term-missing}
+
+[testenv:lint]
+base_python = python3.12
+skip_install = true
+deps = ruff
+commands =
+  ruff check python/cog
+  ruff format --check python
+
+[testenv:typecheck]
+base_python = python3.12
+deps = pyright==1.1.375
+commands = pyright {posargs}
+
+[testenv:integration]
+base_python = python3.12
+changedir = test-integration
+skip_install = true
+deps =
+  pytest
+  pytest-rerunfailures
+  pytest-timeout
+  pytest-xdist
+commands = pytest {posargs:-n auto -vv --reruns 3}


### PR DESCRIPTION
Tox makes it much easier for us to ensure that we are testing exactly what we want -- our package, installed from a built wheel, with no hidden dependencies on external packages.

This commit rejigs the Python testing situation so that we run all our tests inside tox environments, including the integration tests.

This in turn allows us to drastically slim down the "dev" dependencies extra, as it only needs to provide the dependencies used to build cog, and tox itself. All the test dependencies move into the "tests" extra.

I've been meaning to do this for a while but it is immediately motivated by #1885, as using tox makes it a lot easier to switch to not using `uv` on Python 3.7.

Small other changes included here:

- consolidate coverage config into tox.ini
- make `python/tests` not a package (this ensures that we are importing `cog` modules from the installed package, not from the working directory)
- remove additional Makefile for integration tests