### PR TITLE
Set useCogBaseImage to false in base-image

### DIFF
--- a/pkg/dockerfile/base.go
+++ b/pkg/dockerfile/base.go
@@ -180,6 +180,8 @@ func (g *BaseImageGenerator) GenerateDockerfile() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	useCogBaseImage := false
+	generator.useCogBaseImage = &useCogBaseImage
 
 	dockerfile, err := generator.generateInitialSteps()
 	if err != nil {

--- a/pkg/dockerfile/base_test.go
+++ b/pkg/dockerfile/base_test.go
@@ -1,6 +1,7 @@
 package dockerfile
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,4 +28,16 @@ func TestBaseImageName(t *testing.T) {
 		actual := BaseImageName(tt.cuda, tt.python, tt.torch)
 		require.Equal(t, tt.expected, actual)
 	}
+}
+
+func TestGenerateDockerfile(t *testing.T) {
+	generator, err := NewBaseImageGenerator(
+		"12.1",
+		"3.8",
+		"2.1.0",
+	)
+	require.NoError(t, err)
+	dockerfile, err := generator.GenerateDockerfile()
+	require.NoError(t, err)
+	require.True(t, strings.Contains(dockerfile, "FROM nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04"))
 }


### PR DESCRIPTION
* We never want to useCogBaseImage when generating base images.

Currently if we execute `./base-images dockerfile --cuda 12.1.1 --torch 2.1.1 --python 3.11` we see the following:

```
#syntax=docker/dockerfile:1.4
FROM r8.im/cog-base:cuda12.1-python3.11-torch2.1
RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq && apt-get install -qqy  && rm -rf /var/lib/apt/lists/*
```

This is due to the generator thinking cog base images is turned on. This is because I changed the configuration to default to true if the user didn't explicitly define whether they wanted to use cog base images. Here we fix it by explicitly saying we don't want to use cog base images, this then forces the generator to produce a full base image rather than a stub.