### PR TITLE
Add new base images for torch 2.4.0

### DIFF
--- a/pkg/config/cuda_base_images.json
+++ b/pkg/config/cuda_base_images.json
@@ -2,14 +2,14 @@
   {
     "Tag": "12.4.1-cudnn-devel-ubuntu22.04",
     "CUDA": "12.4.1",
-    "CuDNN": "",
+    "CuDNN": "9",
     "IsDevel": true,
     "Ubuntu": "22.04"
   },
   {
     "Tag": "12.4.1-cudnn-devel-ubuntu20.04",
     "CUDA": "12.4.1",
-    "CuDNN": "",
+    "CuDNN": "9",
     "IsDevel": true,
     "Ubuntu": "20.04"
   },

--- a/pkg/config/torch_compatibility_matrix.json
+++ b/pkg/config/torch_compatibility_matrix.json
@@ -1,5 +1,65 @@
 [
   {
+    "Torch": "2.4.0",
+    "Torchvision": "0.19.0",
+    "Torchaudio": "2.4.0",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cu124",
+    "CUDA": "12.4",
+    "Pythons": [
+      "3.10",
+      "3.11",
+      "3.12",
+      "3.8",
+      "3.9"
+    ]
+  },
+  {
+    "Torch": "2.4.0",
+    "Torchvision": "0.19.0",
+    "Torchaudio": "2.4.0",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cu121",
+    "CUDA": "12.1",
+    "Pythons": [
+      "3.10",
+      "3.11",
+      "3.12",
+      "3.8",
+      "3.9"
+    ]
+  },
+  {
+    "Torch": "2.4.0",
+    "Torchvision": "0.19.0",
+    "Torchaudio": "2.4.0",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cu118",
+    "CUDA": "11.8",
+    "Pythons": [
+      "3.10",
+      "3.11",
+      "3.12",
+      "3.8",
+      "3.9"
+    ]
+  },
+  {
+    "Torch": "2.4.0",
+    "Torchvision": "0.19.0",
+    "Torchaudio": "2.4.0",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",
+    "CUDA": null,
+    "Pythons": [
+      "3.10",
+      "3.11",
+      "3.12",
+      "3.8",
+      "3.9"
+    ]
+  },
+  {
     "Torch": "2.3.1+cpu",
     "Torchvision": "0.18.1",
     "Torchaudio": "2.3.1",


### PR DESCRIPTION
* Adds torch 2.4.0 compatibility in the matrix
* Add CuDNN to CUDA 12.4.x compatibility

After this new version of torch is added we can build base images with it.