### PR TITLE
Support torch patch base images

### DIFF
--- a/pkg/config/compatibility.go
+++ b/pkg/config/compatibility.go
@@ -61,13 +61,11 @@ type TorchCompatibility struct {
 }
 
 func (c *TorchCompatibility) TorchVersion() string {
-	parts := strings.Split(c.Torch, "+")
-	return parts[0]
+	return version.StripModifier(c.Torch)
 }
 
 func (c *TorchCompatibility) TorchvisionVersion() string {
-	parts := strings.Split(c.Torchvision, "+")
-	return parts[0]
+	return version.StripModifier(c.Torchvision)
 }
 
 type CUDABaseImage struct {
@@ -164,7 +162,7 @@ func cudasFromTorch(ver string) ([]string, error) {
 			if compat.CUDA == nil {
 				continue
 			}
-			if ver == compat.TorchVersion() && *compat.CUDA == cudaVer {
+			if version.Matches(ver, compat.TorchVersion()) && *compat.CUDA == cudaVer {
 				cudas = append(cudas, *compat.CUDA)
 				return cudas, nil
 			}
@@ -172,7 +170,7 @@ func cudasFromTorch(ver string) ([]string, error) {
 	}
 
 	for _, compat := range TorchCompatibilityMatrix {
-		if ver == compat.TorchVersion() && compat.CUDA != nil {
+		if version.Matches(ver, compat.TorchVersion()) && compat.CUDA != nil {
 			cudas = append(cudas, *compat.CUDA)
 		}
 	}

--- a/pkg/config/compatibility_test.go
+++ b/pkg/config/compatibility_test.go
@@ -12,62 +12,9 @@ func TestLatestCuDNNForCUDA(t *testing.T) {
 	require.Equal(t, "8", actual)
 }
 
-func TestGenerateTorchMinorVersionCompatibilityMatrix(t *testing.T) {
-	matrix := []TorchCompatibility{{
-		Torch:   "2.0.0",
-		CUDA:    nil,
-		Pythons: []string{"3.7", "3.8"},
-	}, {
-		Torch:   "2.0.0",
-		CUDA:    stringp("12.0"),
-		Pythons: []string{"3.7", "3.8"},
-	}, {
-		Torch:   "2.0.1",
-		CUDA:    stringp("12.0"),
-		Pythons: []string{"3.7", "3.8", "3.9"},
-	}, {
-		Torch:   "2.0.2",
-		CUDA:    stringp("12.0"),
-		Pythons: []string{"3.8", "3.9"},
-	}, {
-		Torch:   "2.1.0",
-		CUDA:    stringp("12.2"),
-		Pythons: []string{"3.8", "3.9"},
-	}, {
-		Torch:   "2.1.1",
-		CUDA:    stringp("12.3"),
-		Pythons: []string{"3.9", "3.10"},
-	}}
-	actual := generateTorchMinorVersionCompatibilityMatrix(matrix)
-
-	expected := []TorchCompatibility{{
-		Torch:   "2.1",
-		CUDA:    stringp("12.3"),
-		Pythons: []string{"3.9", "3.10"},
-	}, {
-		Torch:   "2.1",
-		CUDA:    stringp("12.2"),
-		Pythons: []string{"3.8", "3.9"},
-	}, {
-		Torch:   "2.0",
-		CUDA:    stringp("12.0"),
-		Pythons: []string{"3.8", "3.9"},
-	}, {
-		Torch:   "2.0",
-		CUDA:    nil,
-		Pythons: []string{"3.7", "3.8"},
-	}}
-
-	require.Equal(t, expected, actual)
-}
-
 func TestCudasFromTorchWithCUVersionModifier(t *testing.T) {
 	cudas, err := cudasFromTorch("2.0.1+cu118")
 	require.GreaterOrEqual(t, len(cudas), 1)
 	require.Equal(t, cudas[0], "11.8")
 	require.Nil(t, err)
-}
-
-func stringp(s string) *string {
-	return &s
 }

--- a/pkg/dockerfile/base.go
+++ b/pkg/dockerfile/base.go
@@ -110,7 +110,7 @@ func BaseImageConfigurations() []BaseImageConfiguration {
 	cudaVersionsSet := make(map[string]bool)
 
 	// Torch configs
-	for _, compat := range config.TorchMinorCompatibilityMatrix {
+	for _, compat := range config.TorchCompatibilityMatrix {
 		for _, python := range compat.Pythons {
 
 			// Only support fast cold boots for Torch with CUDA.

--- a/pkg/dockerfile/base.go
+++ b/pkg/dockerfile/base.go
@@ -228,7 +228,7 @@ func BaseImageName(cudaVersion string, pythonVersion string, torchVersion string
 		components = append(components, "python"+version.StripPatch(pythonVersion))
 	}
 	if torchVersion != "" {
-		components = append(components, "torch"+version.StripPatch(torchVersion))
+		components = append(components, "torch"+version.StripModifier(torchVersion))
 	}
 
 	tag := strings.Join(components, "-")

--- a/pkg/dockerfile/base_test.go
+++ b/pkg/dockerfile/base_test.go
@@ -41,3 +41,8 @@ func TestGenerateDockerfile(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, strings.Contains(dockerfile, "FROM nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04"))
 }
+
+func TestBaseImageNameWithVersionModifier(t *testing.T) {
+	actual := BaseImageName("12.1", "3.8", "2.0.1+cu118")
+	require.Equal(t, "r8.im/cog-base:cuda12.1-python3.8-torch2.0.1", actual)
+}

--- a/pkg/dockerfile/base_test.go
+++ b/pkg/dockerfile/base_test.go
@@ -17,13 +17,13 @@ func TestBaseImageName(t *testing.T) {
 		{"", "3.8", "",
 			"r8.im/cog-base:python3.8"},
 		{"", "3.8", "2.1",
-			"r8.im/cog-base:python3.8-torch2.1"},
+			"r8.im/cog-base:python3.8-torch2.1.2"},
 		{"12.1", "3.8", "",
 			"r8.im/cog-base:cuda12.1-python3.8"},
 		{"12.1", "3.8", "2.1",
-			"r8.im/cog-base:cuda12.1-python3.8-torch2.1"},
+			"r8.im/cog-base:cuda12.1-python3.8-torch2.1.2"},
 		{"12.1", "3.8", "2.1",
-			"r8.im/cog-base:cuda12.1-python3.8-torch2.1"},
+			"r8.im/cog-base:cuda12.1-python3.8-torch2.1.2"},
 	} {
 		actual := BaseImageName(tt.cuda, tt.python, tt.torch)
 		require.Equal(t, tt.expected, actual)
@@ -56,6 +56,12 @@ func TestBaseImageConfigurationExists(t *testing.T) {
 func TestBaseImageConfigurationExistsNoTorch(t *testing.T) {
 	exists, _, _, _ := BaseImageConfigurationExists("", "3.12", "")
 	require.True(t, exists)
+}
+
+func TestBaseImageConfigurationExistsNoCUDA(t *testing.T) {
+	exists, _, _, torchVersion := BaseImageConfigurationExists("", "3.8", "2.1")
+	require.True(t, exists)
+	require.Equal(t, "2.1.2", torchVersion)
 }
 
 func TestIsVersionCompatible(t *testing.T) {

--- a/pkg/dockerfile/base_test.go
+++ b/pkg/dockerfile/base_test.go
@@ -46,3 +46,19 @@ func TestBaseImageNameWithVersionModifier(t *testing.T) {
 	actual := BaseImageName("12.1", "3.8", "2.0.1+cu118")
 	require.Equal(t, "r8.im/cog-base:cuda12.1-python3.8-torch2.0.1", actual)
 }
+
+func TestBaseImageConfigurationExists(t *testing.T) {
+	exists, _, _, torchVersion := BaseImageConfigurationExists("12.1", "3.9", "2.3")
+	require.True(t, exists)
+	require.Equal(t, "2.3.1", torchVersion)
+}
+
+func TestBaseImageConfigurationExistsNoTorch(t *testing.T) {
+	exists, _, _, _ := BaseImageConfigurationExists("", "3.12", "")
+	require.True(t, exists)
+}
+
+func TestIsVersionCompatible(t *testing.T) {
+	compatible := isVersionCompatible("2.3.1+cu121", "2.3")
+	require.True(t, compatible)
+}

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -594,13 +594,6 @@ func (g *Generator) determineBaseImageName() (string, error) {
 	}
 
 	torchVersion, _ := g.Config.TorchVersion()
-	torchVersion, changed, err = stripPatchVersion(torchVersion)
-	if err != nil {
-		return "", err
-	}
-	if changed {
-		console.Warnf("Stripping patch version from Torch version %s to %s", g.Config.Build.PythonVersion, pythonVersion)
-	}
 
 	// validate that the base image configuration exists
 	imageGenerator, err := NewBaseImageGenerator(cudaVersion, pythonVersion, torchVersion)

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -580,9 +580,56 @@ predict: predict.py:Predictor
 		_, actual, _, err := gen.GenerateModelBaseWithSeparateWeights("r8.im/replicate/cog-test")
 		require.NoError(t, err)
 
-		expected := `#syntax=docker/dockerfile:1.4
+		expected := fmt.Sprintf(`#syntax=docker/dockerfile:1.4
 FROM r8.im/replicate/cog-test-weights AS weights
-FROM r8.im/cog-base:cuda11.8-python3.12-torch2.3
+FROM r8.im/cog-base:cuda11.8-python3.12-torch%s
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq && apt-get install -qqy cowsay && rm -rf /var/lib/apt/lists/*
+COPY `+gen.relativeTmpDir+`/requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+RUN cowsay moo
+WORKDIR /src
+EXPOSE 5000
+CMD ["python", "-m", "cog.server.http"]
+COPY . /src`, torchVersion)
+
+		require.Equal(t, expected, actual)
+
+		requirements, err := os.ReadFile(path.Join(gen.tmpDir, "requirements.txt"))
+		require.NoError(t, err)
+		require.Equal(t, "pandas==2.0.3", string(requirements))
+	}
+}
+
+func TestGenerateTorchWithStrippedModifiedVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	yaml := `
+build:
+  gpu: true
+  cuda: "11.8"
+  system_packages:
+    - ffmpeg
+    - cowsay
+  python_packages:
+    - torch==2.3.1+cu118
+    - pandas==2.0.3
+  run:
+    - "cowsay moo"
+predict: predict.py:Predictor
+`
+	conf, err := config.FromYAML([]byte(yaml))
+	require.NoError(t, err)
+	require.NoError(t, conf.ValidateAndComplete(""))
+
+	gen, err := NewGenerator(conf, tmpDir)
+	require.NoError(t, err)
+	gen.SetUseCogBaseImage(true)
+	_, actual, _, err := gen.GenerateModelBaseWithSeparateWeights("r8.im/replicate/cog-test")
+	require.NoError(t, err)
+
+	expected := `#syntax=docker/dockerfile:1.4
+FROM r8.im/replicate/cog-test-weights AS weights
+FROM r8.im/cog-base:cuda11.8-python3.12-torch2.3.1
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq && apt-get install -qqy cowsay && rm -rf /var/lib/apt/lists/*
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt
@@ -592,10 +639,9 @@ EXPOSE 5000
 CMD ["python", "-m", "cog.server.http"]
 COPY . /src`
 
-		require.Equal(t, expected, actual)
+	require.Equal(t, expected, actual)
 
-		requirements, err := os.ReadFile(path.Join(gen.tmpDir, "requirements.txt"))
-		require.NoError(t, err)
-		require.Equal(t, "pandas==2.0.3", string(requirements))
-	}
+	requirements, err := os.ReadFile(path.Join(gen.tmpDir, "requirements.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "pandas==2.0.3", string(requirements))
 }

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -33,11 +33,14 @@ func NewVersion(s string) (version *Version, err error) {
 	}
 	if len(parts) >= 3 {
 		patch, err := strconv.Atoi(parts[2])
-		version.Patch = new(int)
-		*version.Patch = patch
 		if err != nil {
 			return nil, fmt.Errorf("Invalid patch version %s: %w", parts[2], err)
 		}
+		// We assign a pointer here to handle cases where the patch version is not
+		// explicitly assigned and we need to compare versions without patches to
+		// versions with patches.
+		version.Patch = new(int)
+		*version.Patch = patch
 	}
 
 	if len(plusParts) == 2 {

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -115,3 +115,8 @@ func StripPatch(v string) string {
 	ver := MustVersion(v)
 	return fmt.Sprintf("%d.%d", ver.Major, ver.Minor)
 }
+
+func StripModifier(v string) string {
+	modifierSplit := strings.Split(v, "+")
+	return modifierSplit[0]
+}

--- a/pkg/util/version/version_test.go
+++ b/pkg/util/version/version_test.go
@@ -67,3 +67,15 @@ func TestVersionStripModifier(t *testing.T) {
 	versionWithoutModifier := StripModifier(versionWithModifier)
 	require.Equal(t, versionWithoutModifier, version)
 }
+
+func TestVersionMatches(t *testing.T) {
+	version := "2.3"
+	matchVersion := "2.3.2"
+	require.True(t, Matches(version, matchVersion))
+}
+
+func TestVersionMatchesModifier(t *testing.T) {
+	version := "2.3"
+	matchVersion := "2.3.2+cu118"
+	require.True(t, Matches(version, matchVersion))
+}

--- a/pkg/util/version/version_test.go
+++ b/pkg/util/version/version_test.go
@@ -60,3 +60,10 @@ func TestVersionGreater(t *testing.T) {
 		require.Equal(t, tt.greater, Greater(tt.v1, tt.v2), "%s is %sgreater than %s", tt.v1, not, tt.v2)
 	}
 }
+
+func TestVersionStripModifier(t *testing.T) {
+	version := "2.3.1"
+	versionWithModifier := version + "+cu118"
+	versionWithoutModifier := StripModifier(versionWithModifier)
+	require.Equal(t, versionWithoutModifier, version)
+}


### PR DESCRIPTION
* Do not strip patch version from torch
* If the user specifies a torch version without a patch, resolve the highest patch version from our compatibility matrix
* Change the version struct to use a pointer for the patch version in order to handle cases where the pointer has not been supplied (and how that manifests when comparing versions)
* Standardise on StripModifier for the version rendering
* No longer generate a torch minor compatibility matrix, unnecessary now we explicitly define patch version compatibilities