### PR TITLE
fix partial wrappers and deferred annotations

### DIFF
--- a/test-integration/test_integration/fixtures/future-annotations-project/predict.py
+++ b/test-integration/test_integration/fixtures/future-annotations-project/predict.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from cog import BasePredictor, Input
+
+
+class Predictor(BasePredictor):
+    def predict(self, input: str = Input(description="Who to greet")) -> str:
+        return "hello " + input

--- a/test-integration/test_integration/fixtures/partial-predict-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/partial-predict-project/cog.yaml
@@ -1,0 +1,4 @@
+build:
+  python_version: "3.8"
+predict: "predict.py:Predictor"
+train: "predict.py:train"

--- a/test-integration/test_integration/fixtures/partial-predict-project/predict.py
+++ b/test-integration/test_integration/fixtures/partial-predict-project/predict.py
@@ -1,0 +1,38 @@
+from typing import Callable
+import functools
+
+from cog import BasePredictor, Input
+
+
+class Predictor(BasePredictor):
+    def general(
+        self, prompt: str = Input(description="hi"), system_prompt: str = None
+    ) -> int:
+        return 1
+
+    def _remove(f: Callable, defaults: dict[str, Any]) -> Callable:
+        # pylint: disable=no-self-argument
+        def wrapper(self, *args, **kwargs):
+            kwargs.update(defaults)
+            return f(self, *args, **kwargs)
+
+        # Update wrapper attributes for documentation, etc.
+        functools.update_wrapper(wrapper, f)
+
+        # for the purposes of inspect.signature as used by predictor.get_input_type,
+        # remove the argument (system_prompt)
+        sig = inspect.signature(f)
+        params = [p for name, p in sig.parameters.items() if name not in defaults]
+        wrapper.__signature__ = sig.replace(parameters=params)
+
+        # Return partialmethod, wrapper behaves correctly when part of a class
+        return functools.partialmethod(wrapper)
+
+    predict = _remove(general, {"system_prompt": ""})
+
+
+def _train(self, prompt: str = Input(description="hi"), system_prompt: str = None):
+    return 1
+
+
+train = functools.partial(_train, system_prompt="")

--- a/test-integration/test_integration/fixtures/partial-predict-project/predict.py
+++ b/test-integration/test_integration/fixtures/partial-predict-project/predict.py
@@ -1,5 +1,6 @@
-from typing import Callable
 import functools
+import inspect
+from typing import Any, Callable
 
 from cog import BasePredictor, Input
 
@@ -10,7 +11,7 @@ class Predictor(BasePredictor):
     ) -> int:
         return 1
 
-    def _remove(f: Callable, defaults: dict[str, Any]) -> Callable:
+    def _remove(f: Callable, defaults: "dict[str, Any]") -> Callable:
         # pylint: disable=no-self-argument
         def wrapper(self, *args, **kwargs):
             kwargs.update(defaults)
@@ -31,7 +32,7 @@ class Predictor(BasePredictor):
     predict = _remove(general, {"system_prompt": ""})
 
 
-def _train(self, prompt: str = Input(description="hi"), system_prompt: str = None):
+def _train(prompt: str = Input(description="hi"), system_prompt: str = None) -> int:
     return 1
 
 

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -299,6 +299,7 @@ def test_predict_works_with_deferred_annotations():
         timeout=DEFAULT_TIMEOUT,
     )
 
+
 def test_predict_works_with_partial_wrapper():
     project_dir = Path(__file__).parent / "fixtures/partial-predict-project"
 

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -299,6 +299,20 @@ def test_predict_works_with_deferred_annotations():
         timeout=DEFAULT_TIMEOUT,
     )
 
+def test_predict_works_with_partial_wrapper():
+    project_dir = Path(__file__).parent / "fixtures/partial-predict-project"
+
+    subprocess.check_call(
+        ["cog", "predict", "-i", "prompt=world"],
+        cwd=project_dir,
+        timeout=DEFAULT_TIMEOUT,
+    )
+    subprocess.check_call(
+        ["cog", "train", "-i", "prompt=world"],
+        cwd=project_dir,
+        timeout=DEFAULT_TIMEOUT,
+    )
+
 
 def test_predict_int_none_output():
     project_dir = Path(__file__).parent / "fixtures/int-none-output-project"

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -288,3 +288,33 @@ def test_predict_path_list_input(tmpdir_factory):
     )
     assert "test1" in result.stdout
     assert "test2" in result.stdout
+
+
+def test_predict_works_with_deferred_annotations():
+    project_dir = Path(__file__).parent / "fixtures/future-annotations-project"
+
+    subprocess.check_call(
+        ["cog", "predict", "-i", "input=world"],
+        cwd=project_dir,
+        timeout=DEFAULT_TIMEOUT,
+    )
+
+
+def test_predict_int_none_output():
+    project_dir = Path(__file__).parent / "fixtures/int-none-output-project"
+
+    subprocess.check_call(
+        ["cog", "predict"],
+        cwd=project_dir,
+        timeout=DEFAULT_TIMEOUT,
+    )
+
+
+def test_predict_string_none_output():
+    project_dir = Path(__file__).parent / "fixtures/string-none-output-project"
+
+    subprocess.check_call(
+        ["cog", "predict"],
+        cwd=project_dir,
+        timeout=DEFAULT_TIMEOUT,
+    )


### PR DESCRIPTION
https://github.com/replicate/cog/pull/1772 broke partial and partialmethod, as used in https://github.com/replicate/cog-llama-template/blob/main/predict.py#L234-L259. this attempts to fix that while maintaining support for deferred annotations

this PR was ready to be merged except for implementing the test for partialmethod schema generation being an unnecessarily slow integration test instead of a more lightweight test.