### PR TITLE
Support async predictors

### DIFF
--- a/python/cog/server/connection.py
+++ b/python/cog/server/connection.py
@@ -1,0 +1,91 @@
+import asyncio
+import multiprocessing
+from multiprocessing.connection import Connection
+from typing import Any, Optional
+
+from typing_extensions import Buffer
+
+_spawn = multiprocessing.get_context("spawn")
+
+
+class AsyncConnection:
+    def __init__(self, connection: Connection) -> None:
+        self._connection = connection
+        self._event = asyncio.Event()
+        loop = asyncio.get_event_loop()
+        loop.add_reader(self._connection.fileno(), self._event.set)
+
+    def send(self, obj: Any) -> None:
+        """Send a (picklable) object"""
+
+        self._connection.send(obj)
+
+    async def _wait_for_input(self) -> None:
+        """Wait until there is an input available to be read"""
+
+        while not self._connection.poll():
+            await self._event.wait()
+            self._event.clear()
+
+    async def recv(self) -> Any:
+        """Receive a (picklable) object"""
+
+        await self._wait_for_input()
+        return self._connection.recv()
+
+    def fileno(self) -> int:
+        """File descriptor or handle of the connection"""
+        return self._connection.fileno()
+
+    def close(self) -> None:
+        """Close the connection"""
+        self._connection.close()
+
+    async def poll(self, timeout: float = 0.0) -> bool:
+        """Whether there is an input available to be read"""
+
+        if self._connection.poll():
+            return True
+
+        try:
+            await asyncio.wait_for(self._wait_for_input(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return False
+        return self._connection.poll()
+
+    def send_bytes(
+        self, buf: Buffer, offset: int = 0, size: Optional[int] = None
+    ) -> None:
+        """Send the bytes data from a bytes-like object"""
+
+        self._connection.send_bytes(buf, offset, size)
+
+    async def recv_bytes(self, maxlength: Optional[int] = None) -> bytes:
+        """
+        Receive bytes data as a bytes object.
+        """
+
+        await self._wait_for_input()
+        return self._connection.recv_bytes(maxlength)
+
+    async def recv_bytes_into(self, buf: Buffer, offset: int = 0) -> int:
+        """
+        Receive bytes data into a writeable bytes-like object.
+        Return the number of bytes read.
+        """
+
+        await self._wait_for_input()
+        return self._connection.recv_bytes_into(buf, offset)
+
+
+class LockedConnection:
+    def __init__(self, connection: Connection) -> None:
+        self.connection = connection
+        self._lock = _spawn.Lock()
+
+    def send(self, obj: Any) -> None:
+        with self._lock:
+            self.connection.send(obj)
+
+    def recv(self) -> Any:
+        return self.connection.recv()

--- a/python/cog/server/eventtypes.py
+++ b/python/cog/server/eventtypes.py
@@ -6,6 +6,12 @@ from attrs import define, field, validators
 # From worker parent process
 #
 @define
+class Cancel:
+    # TODO: identify which prediction!
+    pass
+
+
+@define
 class PredictionInput:
     payload: Dict[str, Any]
 

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -383,6 +383,8 @@ class _ChildWorker(_spawn.Process):  # type: ignore
                     )
                 else:
                     print(f"Got unexpected event: {ev}", file=sys.stderr)
+            if task:
+                await task
 
     def _predict(
         self,

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -20,6 +20,7 @@ from ..predictor import BasePredictor, get_predict, load_predictor_from_ref, run
 from ..types import URLPath
 from .connection import AsyncConnection, LockedConnection
 from .eventtypes import (
+    Cancel,
     Done,
     Log,
     PredictionInput,
@@ -135,6 +136,7 @@ class Worker:
             and self._child.pid is not None
         ):
             os.kill(self._child.pid, signal.SIGUSR1)
+            self._events.send(Cancel())
             self._allow_cancel = False
 
     def _assert_state(self, state: WorkerState) -> None:
@@ -278,8 +280,8 @@ class _ChildWorker(_spawn.Process):  # type: ignore
         # shutdown is coordinated by the parent process.
         signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-        # We use SIGUSR1 to signal an interrupt for cancelation.
-        signal.signal(signal.SIGUSR1, self._signal_handler)
+        # Initially, we ignore SIGUSR1.
+        signal.signal(signal.SIGUSR1, signal.SIG_IGN)
 
         redirector = StreamRedirector(
             callback=self._stream_write_hook,
@@ -303,6 +305,9 @@ class _ChildWorker(_spawn.Process):  # type: ignore
 
             asyncio.run(self._aloop(predict, redirector))
         else:
+            # We use SIGUSR1 to signal an interrupt for cancelation.
+            signal.signal(signal.SIGUSR1, self._signal_handler)
+
             self._loop(predict, redirector)
 
     def _setup(self, redirector: StreamRedirector) -> None:
@@ -345,9 +350,11 @@ class _ChildWorker(_spawn.Process):  # type: ignore
         with redirector:
             while True:
                 ev = self._events.recv()
-                if isinstance(ev, Shutdown):
+                if isinstance(ev, Cancel):
+                    continue  # Ignored in sync predictors.
+                elif isinstance(ev, Shutdown):
                     break
-                if isinstance(ev, PredictionInput):
+                elif isinstance(ev, PredictionInput):
                     self._predict(ev.payload, predict, redirector)
                 else:
                     print(f"Got unexpected event: {ev}", file=sys.stderr)
@@ -361,14 +368,19 @@ class _ChildWorker(_spawn.Process):  # type: ignore
         assert isinstance(self._events, LockedConnection)
         self._events = AsyncConnection(self._events.connection)
 
+        task = None
+
         with redirector:
             while True:
                 ev = await self._events.recv()
-                if isinstance(ev, Shutdown):
+                if isinstance(ev, Cancel) and task and self._cancelable:
+                    task.cancel()
+                elif isinstance(ev, Shutdown):
                     break
-                if isinstance(ev, PredictionInput):
-                    # TODO: save this so we can cancel it
-                    asyncio.create_task(self._apredict(ev.payload, predict, redirector))
+                elif isinstance(ev, PredictionInput):
+                    task = asyncio.create_task(
+                        self._apredict(ev.payload, predict, redirector)
+                    )
                 else:
                     print(f"Got unexpected event: {ev}", file=sys.stderr)
 
@@ -418,8 +430,17 @@ class _ChildWorker(_spawn.Process):  # type: ignore
         self._cancelable = True
         try:
             yield
+        # regular cancelation
         except CancelationException:
             done.canceled = True
+        # async cancelation
+        except asyncio.CancelledError:
+            done.canceled = True
+            # We've handled the requested cancelation, so we uncancel the task.
+            # This ensures that any cleanup work we do won't be interrupted.
+            task = asyncio.current_task()
+            assert task
+            task.uncancel()
         except Exception as e:  # pylint: disable=broad-exception-caught
             traceback.print_exc()
             done.error = True

--- a/python/tests/server/fixtures/hello_world_async.py
+++ b/python/tests/server/fixtures/hello_world_async.py
@@ -1,0 +1,3 @@
+class Predictor:
+    async def predict(self, name):
+        return f"hello, {name}"

--- a/python/tests/server/fixtures/logging_async.py
+++ b/python/tests/server/fixtures/logging_async.py
@@ -1,0 +1,34 @@
+import ctypes
+import logging
+import sys
+import time
+
+libc = ctypes.CDLL(None)
+
+# test that we can still capture type signature even if we write
+# a bunch of stuff at import time.
+libc.puts(b"writing some stuff from C at import time")
+libc.fflush(None)
+sys.stdout.write("writing to stdout at import time\n")
+sys.stderr.write("writing to stderr at import time\n")
+
+
+class Predictor:
+    def setup(self):
+        print("setting up predictor")
+        self.foo = "foo"
+
+    async def predict(self) -> str:
+        time.sleep(0.1)
+        logging.warn("writing log message")
+        time.sleep(0.1)
+        libc.puts(b"writing from C")  # not expected to be seen
+        libc.fflush(None)
+        time.sleep(0.1)
+        sys.stderr.write("writing to stderr\n")
+        time.sleep(0.1)
+        sys.stderr.flush()
+        time.sleep(0.1)
+        print("writing with print")
+        time.sleep(0.1)
+        return "output"

--- a/python/tests/server/fixtures/sleep_async.py
+++ b/python/tests/server/fixtures/sleep_async.py
@@ -1,0 +1,10 @@
+import asyncio
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    async def predict(self, sleep: float = 0) -> str:
+        print("starting")
+        await asyncio.sleep(sleep)
+        return f"done in {sleep} seconds"

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -56,6 +56,11 @@ OUTPUT_FIXTURES = [
         lambda x: f"hello, {x['name']}",
     ),
     (
+        WorkerConfig("hello_world_async"),
+        {"name": ST_NAMES},
+        lambda x: f"hello, {x['name']}",
+    ),
+    (
         WorkerConfig("count_up"),
         {"upto": st.integers(min_value=0, max_value=100)},
         lambda x: list(range(x["upto"])),

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -267,7 +267,7 @@ def test_predict_logging(worker, expected_stdout, expected_stderr):
     assert result.stderr == expected_stderr
 
 
-@uses_worker("sleep", setup=False)
+@uses_worker(["sleep", "sleep_async"], setup=False)
 def test_cancel_is_safe(worker):
     """
     Calls to cancel at any time should not result in unexpected things
@@ -301,7 +301,7 @@ def test_cancel_is_safe(worker):
     assert result2.output == "done in 0.1 seconds"
 
 
-@uses_worker("sleep", setup=False)
+@uses_worker(["sleep", "sleep_async"], setup=False)
 def test_cancel_idempotency(worker):
     """
     Multiple calls to cancel within the same prediction, while not necessary or
@@ -333,7 +333,7 @@ def test_cancel_idempotency(worker):
     assert result2.output == "done in 0.1 seconds"
 
 
-@uses_worker("sleep")
+@uses_worker(["sleep", "sleep_async"])
 def test_cancel_multiple_predictions(worker):
     """
     Multiple predictions cancelled in a row shouldn't be a problem. This test

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -74,20 +74,36 @@ OUTPUT_FIXTURES = [
 
 SETUP_LOGS_FIXTURES = [
     (
+        WorkerConfig("logging", setup=False),
         (
             "writing some stuff from C at import time\n"
             "writing to stdout at import time\n"
             "setting up predictor\n"
         ),
         "writing to stderr at import time\n",
-    )
+    ),
+    (
+        WorkerConfig("logging_async", setup=False),
+        (
+            "writing some stuff from C at import time\n"
+            "writing to stdout at import time\n"
+            "setting up predictor\n"
+        ),
+        "writing to stderr at import time\n",
+    ),
 ]
 
 PREDICT_LOGS_FIXTURES = [
     (
+        WorkerConfig("logging"),
         ("writing from C\n" "writing with print\n"),
         ("WARNING:root:writing log message\n" "writing to stderr\n"),
-    )
+    ),
+    (
+        WorkerConfig("logging_async"),
+        ("writing with print\n"),
+        ("WARNING:root:writing log message\n" "writing to stderr\n"),
+    ),
 ]
 
 
@@ -218,8 +234,11 @@ def test_output(worker, payloads, output_generator, data):
     assert result.output == expected_output
 
 
-@uses_worker("logging", setup=False)
-@pytest.mark.parametrize("expected_stdout,expected_stderr", SETUP_LOGS_FIXTURES)
+@pytest.mark.parametrize(
+    "worker,expected_stdout,expected_stderr",
+    SETUP_LOGS_FIXTURES,
+    indirect=["worker"],
+)
 def test_setup_logging(worker, expected_stdout, expected_stderr):
     """
     We should get the logs we expect from predictors that generate logs during
@@ -232,8 +251,11 @@ def test_setup_logging(worker, expected_stdout, expected_stderr):
     assert result.stderr == expected_stderr
 
 
-@uses_worker("logging")
-@pytest.mark.parametrize("expected_stdout,expected_stderr", PREDICT_LOGS_FIXTURES)
+@pytest.mark.parametrize(
+    "worker,expected_stdout,expected_stderr",
+    PREDICT_LOGS_FIXTURES,
+    indirect=["worker"],
+)
 def test_predict_logging(worker, expected_stdout, expected_stderr):
     """
     We should get the logs we expect from predictors that generate logs during

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -351,7 +351,7 @@ def test_cancel_multiple_predictions(worker):
     assert not worker.predict({"sleep": 0}).result().canceled
 
 
-@uses_worker("sleep")
+@uses_worker(["sleep", "sleep_async"])
 def test_graceful_shutdown(worker):
     """
     On shutdown, the worker should finish running the current prediction, and


### PR DESCRIPTION
This extracts some of the next steps from @technillogue's `async` branch, with a view to making `async def predict` signatures possible.

Things that don't work yet:

- actually concurrent predictions (I don't want to do this in this PR)
- ~cancelation~
- ~log redirection~

_This is now ready for review. I think this is just about the smallest meaningful change we can make that gets us closer to supporting real concurrent `async def predict` in Cog._