### PR TITLE
Add zstd to base image packages

### DIFF
--- a/pkg/dockerfile/base.go
+++ b/pkg/dockerfile/base.go
@@ -41,6 +41,7 @@ var (
 		"unzip",
 		"wget",
 		"zip",
+		"zstd",
 	}
 )
 


### PR DESCRIPTION
* We require zstd to do some decompression from the tarballs on the image.