### PR TITLE
Add findutils to base image

### DIFF
--- a/pkg/dockerfile/base.go
+++ b/pkg/dockerfile/base.go
@@ -20,6 +20,7 @@ var (
 		"cmake",
 		"curl",
 		"ffmpeg",
+		"findutils",
 		"g++",
 		"gcc",
 		"git",


### PR DESCRIPTION
* Allow base images to use the find unix command
* This is required to use the python compileall command in conjunction with find