### PR TITLE
Install opencv without python in base images

### DIFF
--- a/pkg/dockerfile/base.go
+++ b/pkg/dockerfile/base.go
@@ -31,13 +31,13 @@ var (
 		"libgl1",
 		"libgl1-mesa-glx",
 		"libglib2.0-0",
+		"libopencv-dev",
 		"libsm6",
 		"libsndfile1",
 		"libssl-dev",
 		"libunistring-dev",
 		"libxext6",
 		"libxrender1",
-		"python3-opencv",
 		"sox",
 		"unzip",
 		"wget",
@@ -213,7 +213,10 @@ func (g *BaseImageGenerator) makeConfig() (*config.Config, error) {
 
 func (g *BaseImageGenerator) pythonPackages() []string {
 	if g.torchVersion != "" {
-		pkgs := []string{"torch==" + g.torchVersion}
+		pkgs := []string{
+			"torch==" + g.torchVersion,
+			"opencv-python==4.10.0.84",
+		}
 
 		// Find torchvision compatibility.
 		for _, compat := range config.TorchCompatibilityMatrix {

--- a/pkg/dockerfile/base_test.go
+++ b/pkg/dockerfile/base_test.go
@@ -74,5 +74,10 @@ func TestPythonPackages(t *testing.T) {
 	generator, err := NewBaseImageGenerator("12.1", "3.9", "2.1.0")
 	require.NoError(t, err)
 	pkgs := generator.pythonPackages()
-	require.Truef(t, reflect.DeepEqual(pkgs, []string{"torch==2.1.0", "torchvision==0.16.0", "torchaudio==2.1.0"}), "expected %v", pkgs)
+	require.Truef(t, reflect.DeepEqual(pkgs, []string{
+		"torch==2.1.0",
+		"opencv-python==4.10.0.84",
+		"torchvision==0.16.0",
+		"torchaudio==2.1.0",
+	}), "expected %v", pkgs)
 }


### PR DESCRIPTION
* Currently base images installs python3-opencv
* This installs apt python making us have 2 pythons in the base image
* Instead install opencv-dev libraries and pip install the opencv python package.