### PR TITLE
Revert "Handle predictors with deferred annotations (#1772)"

### DIFF
--- a/test-integration/test_integration/fixtures/future-annotations-project/predict.py
+++ b/test-integration/test_integration/fixtures/future-annotations-project/predict.py
@@ -1,8 +1,0 @@
-from __future__ import annotations
-
-from cog import BasePredictor, Input
-
-
-class Predictor(BasePredictor):
-    def predict(self, input: str = Input(description="Who to greet")) -> str:
-        return "hello " + input

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -288,33 +288,3 @@ def test_predict_path_list_input(tmpdir_factory):
     )
     assert "test1" in result.stdout
     assert "test2" in result.stdout
-
-
-def test_predict_works_with_deferred_annotations():
-    project_dir = Path(__file__).parent / "fixtures/future-annotations-project"
-
-    subprocess.check_call(
-        ["cog", "predict", "-i", "input=world"],
-        cwd=project_dir,
-        timeout=DEFAULT_TIMEOUT,
-    )
-
-
-def test_predict_int_none_output():
-    project_dir = Path(__file__).parent / "fixtures/int-none-output-project"
-
-    subprocess.check_call(
-        ["cog", "predict"],
-        cwd=project_dir,
-        timeout=DEFAULT_TIMEOUT,
-    )
-
-
-def test_predict_string_none_output():
-    project_dir = Path(__file__).parent / "fixtures/string-none-output-project"
-
-    subprocess.check_call(
-        ["cog", "predict"],
-        cwd=project_dir,
-        timeout=DEFAULT_TIMEOUT,
-    )


### PR DESCRIPTION
This reverts commit 05900a7e6d8270df8175b1f7788f0b566486855c.

This is needed to avoid breaking predictors that rely on __signature__ or partial.

I'm suggesting merging this ahead of #1895 to unblock certain language models that have been broken