### PR TITLE
Fix base image build job

### DIFF
--- a/.github/workflows/build-bases.yaml
+++ b/.github/workflows/build-bases.yaml
@@ -57,13 +57,13 @@ jobs:
     needs: generate-matrix
     runs-on: ubuntu-latest-8-cores
     strategy:
-      # TODO: Right Size this, 5 seems like a sane placeholder
-      max-parallel: 5
+      max-parallel: 10
       matrix:
         include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     permissions:
       contents: 'read'
       packages: 'write'
+    continue-on-error: true
 
     outputs:
       image: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.title'] }}:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}

--- a/.github/workflows/build-bases.yaml
+++ b/.github/workflows/build-bases.yaml
@@ -169,5 +169,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha,scope=${{ matrix.image_name }}-${{ matrix.image_tag }}
           cache-to: type=gha,scope=${{ matrix.image_name }}-${{ matrix.image_tag }},mode=max
+          no-cache: true
         env:
           SOURCE_DATE_EPOCH: 0

--- a/pkg/config/torch_compatibility_matrix.json
+++ b/pkg/config/torch_compatibility_matrix.json
@@ -60,7 +60,7 @@
     ]
   },
   {
-    "Torch": "2.3.1+cpu",
+    "Torch": "2.3.1",
     "Torchvision": "0.18.1",
     "Torchaudio": "2.3.1",
     "FindLinks": "",
@@ -75,7 +75,7 @@
     ]
   },
   {
-    "Torch": "2.3.1+cu118",
+    "Torch": "2.3.1",
     "Torchvision": "0.18.1",
     "Torchaudio": "2.3.1",
     "FindLinks": "",
@@ -90,7 +90,7 @@
     ]
   },
   {
-    "Torch": "2.3.1+cu121",
+    "Torch": "2.3.1",
     "Torchvision": "0.18.1",
     "Torchaudio": "2.3.1",
     "FindLinks": "",


### PR DESCRIPTION
* Set no-cache to true to avoid an issue with buildx where it doesn't recognise the cached sha digests
* Set max-parallel to 10 to process these builds faster, this is necessary due to the arm builds taking a very long time to compile python
* Allow continuation on error in case a build later down the pipe causes a small issue
* Remove torch version modifiers in the compatibility matrix, the extra URL does the job of routing them correctly and they make pip fail when using these extra URLs