### PR TITLE
Fix test build integration test

### DIFF
--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -15,7 +15,7 @@ def test_build_without_predictor(docker_image):
     )
     assert build_process.returncode > 0
     assert (
-        "Can't run predictions: 'predict' option not found"
+        "Can\\'t run predictions: \\'predict\\' option not found"
         in build_process.stderr.decode()
     )
 


### PR DESCRIPTION
* This string has escape sequences in it.

On a broader note I'm unsure why this is suddenly the case, it seems to have correlated with the release of new base images, but its unclear to me why it would add escape sequences as part of its stderr output.