### PR TITLE
Allow filtering the generated matrix

### DIFF
--- a/pkg/cli/baseimage.go
+++ b/pkg/cli/baseimage.go
@@ -54,7 +54,6 @@ func newBaseImageGenerateMatrix() *cobra.Command {
 		Use:   "generate-matrix",
 		Short: "Generate a matrix of Cog base image versions (JSON)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			matrix := dockerfile.BaseImageConfigurations()
 			allConfigurations := dockerfile.BaseImageConfigurations()
 			filteredMatrix := make([]dockerfile.BaseImageConfiguration, 0, len(allConfigurations))
 			for _, config := range allConfigurations {

--- a/pkg/cli/baseimage.go
+++ b/pkg/cli/baseimage.go
@@ -55,15 +55,17 @@ func newBaseImageGenerateMatrix() *cobra.Command {
 		Short: "Generate a matrix of Cog base image versions (JSON)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			matrix := dockerfile.BaseImageConfigurations()
-
-			for i := 0; i < len(matrix); i++ {
-				if (baseImageCUDAVersion != "" && matrix[i].CUDAVersion != baseImageCUDAVersion) || (baseImagePythonVersion != "" && matrix[i].PythonVersion != baseImagePythonVersion) || (baseImageTorchVersion != "" && matrix[i].TorchVersion != baseImageTorchVersion) {
-					matrix = append(matrix[:i], matrix[i+1:]...)
-					i--
+			allConfigurations := dockerfile.BaseImageConfigurations()
+			filteredMatrix := make([]dockerfile.BaseImageConfiguration, 0, len(allConfigurations))
+			for _, config := range allConfigurations {
+				if (baseImageCUDAVersion == "" || config.CUDAVersion == baseImageCUDAVersion) &&
+					(baseImagePythonVersion == "" || config.PythonVersion == baseImagePythonVersion) &&
+					(baseImageTorchVersion == "" || config.TorchVersion == baseImageTorchVersion) {
+					filteredMatrix = append(filteredMatrix, config)
 				}
 			}
 
-			output, err := json.Marshal(matrix)
+			output, err := json.Marshal(filteredMatrix)
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/baseimage.go
+++ b/pkg/cli/baseimage.go
@@ -55,6 +55,14 @@ func newBaseImageGenerateMatrix() *cobra.Command {
 		Short: "Generate a matrix of Cog base image versions (JSON)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			matrix := dockerfile.BaseImageConfigurations()
+
+			for i := 0; i < len(matrix); i++ {
+				if (baseImageCUDAVersion != "" && matrix[i].CUDAVersion != baseImageCUDAVersion) || (baseImagePythonVersion != "" && matrix[i].PythonVersion != baseImagePythonVersion) || (baseImageTorchVersion != "" && matrix[i].TorchVersion != baseImageTorchVersion) {
+					matrix = append(matrix[:i], matrix[i+1:]...)
+					i--
+				}
+			}
+
 			output, err := json.Marshal(matrix)
 			if err != nil {
 				return err
@@ -64,6 +72,7 @@ func newBaseImageGenerateMatrix() *cobra.Command {
 		},
 		Args: cobra.MaximumNArgs(0),
 	}
+	addBaseImageFlags(cmd)
 	return cmd
 }
 


### PR DESCRIPTION
* Allow the user to specify specific python, cuda or torch versions in the base image binary.
* This allows an easy way to filter the matrix for CI jobs.