### PR TITLE
Add Precompile Build Flag

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -23,6 +23,7 @@ var buildUseCudaBaseImage string
 var buildDockerfileFile string
 var buildUseCogBaseImage bool
 var buildStrip bool
+var buildPrecompile bool
 
 const useCogBaseImageFlagKey = "use-cog-base-image"
 
@@ -44,6 +45,7 @@ func newBuildCommand() *cobra.Command {
 	addUseCogBaseImageFlag(cmd)
 	addBuildTimestampFlag(cmd)
 	addStripFlag(cmd)
+	addPrecompileFlag(cmd)
 	cmd.Flags().StringVarP(&buildTag, "tag", "t", "", "A name for the built image in the form 'repository:tag'")
 	return cmd
 }
@@ -67,7 +69,7 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := image.Build(cfg, projectDir, imageName, buildSecrets, buildNoCache, buildSeparateWeights, buildUseCudaBaseImage, buildProgressOutput, buildSchemaFile, buildDockerfileFile, DetermineUseCogBaseImage(cmd), buildStrip); err != nil {
+	if err := image.Build(cfg, projectDir, imageName, buildSecrets, buildNoCache, buildSeparateWeights, buildUseCudaBaseImage, buildProgressOutput, buildSchemaFile, buildDockerfileFile, DetermineUseCogBaseImage(cmd), buildStrip, buildPrecompile); err != nil {
 		return err
 	}
 
@@ -126,6 +128,12 @@ func addStripFlag(cmd *cobra.Command) {
 	const stripFlag = "strip"
 	cmd.Flags().BoolVar(&buildStrip, stripFlag, false, "Whether to strip shared libraries for faster inference times")
 	_ = cmd.Flags().MarkHidden(stripFlag)
+}
+
+func addPrecompileFlag(cmd *cobra.Command) {
+	const precompileFlag = "precompile"
+	cmd.Flags().BoolVar(&buildPrecompile, precompileFlag, false, "Whether to precompile python files for faster load times")
+	_ = cmd.Flags().MarkHidden(precompileFlag)
 }
 
 func checkMutuallyExclusiveFlags(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -31,6 +31,7 @@ func newPushCommand() *cobra.Command {
 	addBuildProgressOutputFlag(cmd)
 	addUseCogBaseImageFlag(cmd)
 	addStripFlag(cmd)
+	addPrecompileFlag(cmd)
 
 	return cmd
 }
@@ -57,7 +58,7 @@ func push(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if err := image.Build(cfg, projectDir, imageName, buildSecrets, buildNoCache, buildSeparateWeights, buildUseCudaBaseImage, buildProgressOutput, buildSchemaFile, buildDockerfileFile, DetermineUseCogBaseImage(cmd), buildStrip); err != nil {
+	if err := image.Build(cfg, projectDir, imageName, buildSecrets, buildNoCache, buildSeparateWeights, buildUseCudaBaseImage, buildProgressOutput, buildSchemaFile, buildDockerfileFile, DetermineUseCogBaseImage(cmd), buildStrip, buildPrecompile); err != nil {
 
 		return err
 	}

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -100,6 +100,7 @@ func NewGenerator(config *config.Config, dir string) (*Generator, error) {
 		useCudaBaseImage: true,
 		useCogBaseImage:  nil,
 		strip:            false,
+		precompile:       false,
 	}, nil
 }
 
@@ -153,13 +154,18 @@ func (g *Generator) generateInitialSteps() (string, error) {
 			return "", err
 		}
 
-		return joinStringsWithoutLineSpace([]string{
+		steps := []string{
 			"#syntax=docker/dockerfile:1.4",
 			"FROM " + baseImage,
 			aptInstalls,
 			pipInstalls,
-			runCommands,
-		}), nil
+		}
+		if g.precompile {
+			steps = append(steps, PrecompilePythonCommand)
+		}
+		steps = append(steps, runCommands)
+
+		return joinStringsWithoutLineSpace(steps), nil
 	}
 
 	pipInstallStage, err := g.pipInstallStage()

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -764,6 +764,7 @@ COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
 RUN pip install --no-cache-dir -r /tmp/requirements.txt && find / -type f -name "*python*.so" -not -name "*cpython*.so" -exec strip -S {} \;
 ENV CFLAGS=
+RUN find / -type f -name "*.py[co]" -delete && find / -type f -name "*.py" -exec touch -t 197001010000 {} \; && find / -type f -name "*.py" -printf "%h\n" | sort -u | /usr/bin/python3 -m compileall --invalidation-mode timestamp -o 2 -j 0
 RUN cowsay moo
 WORKDIR /src
 EXPOSE 5000

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -726,3 +726,55 @@ COPY . /src`
 torch==2.3.1
 pandas==2.0.3`, string(requirements))
 }
+
+func TestGenerateWithPrecompile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	yaml := `
+build:
+  gpu: true
+  cuda: "11.8"
+  system_packages:
+    - ffmpeg
+    - cowsay
+  python_packages:
+    - torch==2.3.1
+    - pandas==2.0.3
+  run:
+    - "cowsay moo"
+predict: predict.py:Predictor
+`
+	conf, err := config.FromYAML([]byte(yaml))
+	require.NoError(t, err)
+	require.NoError(t, conf.ValidateAndComplete(""))
+
+	gen, err := NewGenerator(conf, tmpDir)
+	require.NoError(t, err)
+	gen.SetUseCogBaseImage(true)
+	gen.SetStrip(true)
+	gen.SetPrecompile(true)
+	_, actual, _, err := gen.GenerateModelBaseWithSeparateWeights("r8.im/replicate/cog-test")
+	require.NoError(t, err)
+
+	expected := `#syntax=docker/dockerfile:1.4
+FROM r8.im/replicate/cog-test-weights AS weights
+FROM r8.im/cog-base:cuda11.8-python3.12-torch2.3.1
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq && apt-get install -qqy cowsay && rm -rf /var/lib/apt/lists/*
+COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
+ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && find / -type f -name "*python*.so" -not -name "*cpython*.so" -exec strip -S {} \;
+ENV CFLAGS=
+RUN cowsay moo
+WORKDIR /src
+EXPOSE 5000
+CMD ["python", "-m", "cog.server.http"]
+COPY . /src`
+
+	require.Equal(t, expected, actual)
+
+	requirements, err := os.ReadFile(path.Join(gen.tmpDir, "requirements.txt"))
+	require.NoError(t, err)
+	require.Equal(t, `--extra-index-url https://download.pytorch.org/whl/cu118
+torch==2.3.1
+pandas==2.0.3`, string(requirements))
+}

--- a/pkg/dockerfile/generator_test.go
+++ b/pkg/dockerfile/generator_test.go
@@ -764,7 +764,7 @@ predict: predict.py:Predictor
 	require.NotContains(t, actual, "-march=native")
 	require.NotContains(t, actual, "-mtune=native")
 }
-  
+
 func TestGenerateWithPrecompile(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -28,7 +28,7 @@ const bundledSchemaPy = ".cog/schema.py"
 // Build a Cog model from a config
 //
 // This is separated out from docker.Build(), so that can be as close as possible to the behavior of 'docker build'.
-func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache, separateWeights bool, useCudaBaseImage string, progressOutput string, schemaFile string, dockerfileFile string, useCogBaseImage *bool, strip bool) error {
+func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache, separateWeights bool, useCudaBaseImage string, progressOutput string, schemaFile string, dockerfileFile string, useCogBaseImage *bool, strip bool, precompile bool) error {
 	console.Infof("Building Docker image from environment in cog.yaml as %s...", imageName)
 
 	// remove bundled schema files that may be left from previous builds
@@ -56,6 +56,7 @@ func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache,
 			}
 		}()
 		generator.SetStrip(strip)
+		generator.SetPrecompile(precompile)
 		generator.SetUseCudaBaseImage(useCudaBaseImage)
 		if useCogBaseImage != nil {
 			generator.SetUseCogBaseImage(*useCogBaseImage)

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -296,3 +296,22 @@ def test_torch_1_13_0_base_image_fail_explicit(docker_image):
         capture_output=True,
     )
     assert build_process.returncode == 0
+
+
+def test_precompile(docker_image):
+    project_dir = Path(__file__).parent / "fixtures/torch-baseimage-project"
+    build_process = subprocess.run(
+        [
+            "cog",
+            "build",
+            "-t",
+            docker_image,
+            "--openapi-schema",
+            "openapi.json",
+            "--use-cog-base-image=false",
+            "--precompile",
+        ],
+        cwd=project_dir,
+        capture_output=True,
+    )
+    assert build_process.returncode == 0


### PR DESCRIPTION
* Add a —-precompile build flag that allows users to opt in to precompiling their python files so
they load faster.
* This uses the python `compileall` module to compile python files to bytecode
* It uses the invalidation mode of `timestamp` which we have told the python interpreter in its invocation to run