### PR TITLE
fix code block in deploy.md

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -54,6 +54,7 @@ passing input in the format expected by your model:
 curl http://localhost:5001/predictions -X POST \
     --header "Content-Type: application/json" \
     --data '{"input": {"image": "https://.../input.jpg"}}'
+```
 
 For more details about the HTTP API, 
 see the [HTTP API reference documentation](http.md).


### PR DESCRIPTION
Closes the code block so the rest of the docs are rendered properly in markdown.