### PR TITLE
Fix openapi schema

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -196,7 +196,7 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
 
             @app.put(
                 "/trainings/{training_id}",
-                response_model=PredictionResponse,
+                response_model=TrainingResponse,
                 response_model_exclude_unset=True,
             )
             def train_idempotent(


### PR DESCRIPTION
Generating the OpenAPI schema was broken under the circumstances:

- train.py#train had an enum-type input
- cog was running with --x-mode=train

I've verified that this change fixes it.  The current code is obviously wrong in any case.