### PR TITLE
Bump go to 1.23.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.6
+golang 1.23.1

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,7 @@ BINDIR = $(PREFIX)/bin
 INSTALL := install -m 0755
 
 GO ?= go
-# goreleaser v2.3.0 requires go 1.23; PR #1950 is where we're doing that. For
-# now, pin to v2.2.0
-GORELEASER := $(GO) run github.com/goreleaser/goreleaser/v2@v2.2.0
+GORELEASER := $(GO) run github.com/goreleaser/goreleaser/v2@latest
 
 PYTHON ?= python
 TOX := $(PYTHON) -Im tox

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/replicate/cog
 
-go 1.22
+go 1.23.1
 
 require (
 	github.com/anaskhan96/soup v1.2.5


### PR DESCRIPTION
* Fixes tests that require `1.23.1`