### PR TITLE
Add Torch Dependency Resolution

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,7 +118,7 @@ jobs:
     name: "Test integration"
     needs: build-python
     runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pkg/dockerfile/base.go
+++ b/pkg/dockerfile/base.go
@@ -226,7 +226,7 @@ func (g *BaseImageGenerator) pythonPackages() []string {
 				continue
 			}
 
-			pkgs = append(pkgs, "torchvision=="+compat.Torchvision)
+			pkgs = append(pkgs, "torchvision=="+version.StripModifier(compat.Torchvision))
 			break
 		}
 
@@ -239,7 +239,7 @@ func (g *BaseImageGenerator) pythonPackages() []string {
 				continue
 			}
 
-			pkgs = append(pkgs, "torchaudio=="+compat.Torchaudio)
+			pkgs = append(pkgs, "torchaudio=="+version.StripModifier(compat.Torchaudio))
 			break
 		}
 

--- a/test-integration/test_integration/fixtures/torch-torchvision-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/torch-torchvision-project/cog.yaml
@@ -1,0 +1,7 @@
+build:
+  gpu: true
+  python_version: "3.9"
+  python_packages:
+    - "torch"
+    - "torchvision==0.19.0+cu121"
+predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/torch-torchvision-project/predict.py
+++ b/test-integration/test_integration/fixtures/torch-torchvision-project/predict.py
@@ -1,0 +1,6 @@
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def predict(self, s: str) -> str:
+        return "hello " + s

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -296,3 +296,18 @@ def test_torch_1_13_0_base_image_fail_explicit(docker_image):
         capture_output=True,
     )
     assert build_process.returncode == 0
+
+
+def test_torch_version_resolution_with_torchvision(docker_image):
+    project_dir = Path(__file__).parent / "fixtures/torch-torchvision-project"
+    build_process = subprocess.run(
+        [
+            "cog",
+            "build",
+            "-t",
+            docker_image,
+        ],
+        cwd=project_dir,
+        capture_output=True,
+    )
+    assert build_process.returncode == 0


### PR DESCRIPTION
* Use our compatibility matrix to automatically resolve the torch version if the torch version is
blank but adjacent dependencies are defined.
* Make torchaudio capable of determining CUDA version compatibility like torchvision
* Rewrite dependency versions to align with resolved versions
* Remove version modifiers, this is now satisfied by adding in extra index URLs to the requirements

* Fixes: https://github.com/replicate/cog/issues/1951