### PR TITLE
Pin goreleaser to v2.2.0 to avoid pulling in go 1.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ BINDIR = $(PREFIX)/bin
 INSTALL := install -m 0755
 
 GO ?= go
-GORELEASER := $(GO) run github.com/goreleaser/goreleaser/v2@latest
+# goreleaser v2.3.0 requires go 1.23; PR #1950 is where we're doing that. For
+# now, pin to v2.2.0
+GORELEASER := $(GO) run github.com/goreleaser/goreleaser/v2@v2.2.0
 
 PYTHON ?= python
 TOX := $(PYTHON) -Im tox


### PR DESCRIPTION
Our stuff doesn't work with 1.23 yet (#1950 is working on it); for now, pin to goreleaser 2.2.0 so we can still do releases.