### PR TITLE
Install cog when using base images

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -155,10 +155,16 @@ func (g *Generator) generateInitialSteps() (string, error) {
 			return "", err
 		}
 
+		installCog, err := g.installCog()
+		if err != nil {
+			return "", err
+		}
+
 		steps := []string{
 			"#syntax=docker/dockerfile:1.4",
 			"FROM " + baseImage,
 			aptInstalls,
+			installCog,
 			pipInstalls,
 		}
 		if g.precompile {


### PR DESCRIPTION
* This adds the cog install step to images using base images.
* This fulfils the contract of using the current version of cog within the image and not the
version of cog used by the base image.