### PR TITLE
Don't accept Replicate API tokens for CLI login

### DIFF
--- a/pkg/cli/login.go
+++ b/pkg/cli/login.go
@@ -64,6 +64,10 @@ func login(cmd *cobra.Command, args []string) error {
 	}
 	token = strings.TrimSpace(token)
 
+	if err := checkTokenFormat(token); err != nil {
+		return err
+	}
+
 	username, err := verifyToken(registryHost, token)
 	if err != nil {
 		return err
@@ -106,9 +110,9 @@ func readTokenInteractively(registryHost string) (string, error) {
 	maybeOpenBrowser(url)
 
 	console.Info("")
-	console.Info("Once you've signed in, copy the authentication token from that web page, paste it here, then hit enter:")
+	console.Info("Once you've signed in, copy the token from that web page, paste it here, then hit enter:")
 
-	fmt.Print("API Key: ")
+	fmt.Print("CLI auth token: ")
 	// Read the token securely, masking the input
 	tokenBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
@@ -157,6 +161,13 @@ func maybeOpenBrowser(url string) {
 	case "darwin":
 		_ = exec.Command("open", url).Start()
 	}
+}
+
+func checkTokenFormat(token string) error {
+	if strings.HasPrefix(token, "r8_") {
+		return fmt.Errorf("That looks like a Replicate API token, not a CLI auth token. Please fetch a token from https://replicate.com/auth/token to log in!")
+	}
+	return nil
 }
 
 func verifyToken(registryHost string, token string) (username string, err error) {


### PR DESCRIPTION
If the token pasted for CLI login starts with `r8_`, reject it with an error message before we even start.

This also clears up some of the surrounding copy, which is pretty confusing and could easily have led to people thinking an API token was valid here.