### PR TITLE
Prefix server errors with `Cog:`

### DIFF
--- a/python/cog/errors.py
+++ b/python/cog/errors.py
@@ -8,7 +8,3 @@ class ConfigDoesNotExist(CogError):
 
 class PredictorNotSet(CogError):
     """Exception raised when 'predict' is not set in cog.yaml when it needs to be."""
-
-
-"""Prefix for all Cog errors attributable to internals or infrastructure."""
-COG_INTERNAL_ERROR_PREFIX = "cog-internal: "

--- a/python/cog/errors.py
+++ b/python/cog/errors.py
@@ -8,3 +8,7 @@ class ConfigDoesNotExist(CogError):
 
 class PredictorNotSet(CogError):
     """Exception raised when 'predict' is not set in cog.yaml when it needs to be."""
+
+
+"""Prefix for all Cog errors attributable to internals or infrastructure."""
+COG_INTERNAL_ERROR_PREFIX = "cog-internal: "

--- a/python/cog/server/errors.py
+++ b/python/cog/server/errors.py
@@ -1,0 +1,25 @@
+class CogServerError(Exception):
+    """Base class for all Cog server errors."""
+
+    def __str__(self) -> str:
+        return f"Cog: {super().__str__()}"
+
+
+class FileUploadError(CogServerError):
+    pass
+
+
+class RunnerBusyError(CogServerError):
+    pass
+
+
+class UnknownPredictionError(CogServerError):
+    pass
+
+
+class CogRuntimeError(CogServerError, RuntimeError):
+    pass
+
+
+class CogTimeoutError(CogServerError, TimeoutError):
+    pass

--- a/python/cog/server/helpers.py
+++ b/python/cog/server/helpers.py
@@ -12,6 +12,8 @@ from typing import Callable, Sequence, TextIO
 
 from typing_extensions import Self
 
+from ..errors import COG_INTERNAL_ERROR_PREFIX
+
 
 class _StreamWrapper:
     def __init__(self, name: str, stream: TextIO) -> None:
@@ -22,7 +24,7 @@ class _StreamWrapper:
 
     def wrap(self) -> None:
         if self._wrapped_fp or self._original_fp:
-            raise RuntimeError("stream is already wrapped")
+            raise RuntimeError(COG_INTERNAL_ERROR_PREFIX + "stream is already wrapped")
 
         r, w = os.pipe()
 
@@ -48,7 +50,9 @@ class _StreamWrapper:
 
     def unwrap(self) -> None:
         if not self._wrapped_fp or not self._original_fp:
-            raise RuntimeError("stream is not wrapped (call wrap first)")
+            raise RuntimeError(
+                COG_INTERNAL_ERROR_PREFIX + "stream is not wrapped (call wrap first)"
+            )
 
         # Put the original file descriptor back.
         os.dup2(self._original_fp.fileno(), self._stream.fileno())
@@ -70,13 +74,17 @@ class _StreamWrapper:
     @property
     def wrapped(self) -> TextIO:
         if not self._wrapped_fp:
-            raise RuntimeError("stream is not wrapped (call wrap first)")
+            raise RuntimeError(
+                COG_INTERNAL_ERROR_PREFIX + "stream is not wrapped (call wrap first)"
+            )
         return self._wrapped_fp
 
     @property
     def original(self) -> TextIO:
         if not self._original_fp:
-            raise RuntimeError("stream is not wrapped (call wrap first)")
+            raise RuntimeError(
+                COG_INTERNAL_ERROR_PREFIX + "stream is not wrapped (call wrap first)"
+            )
         return self._original_fp
 
 
@@ -151,7 +159,9 @@ class StreamRedirector(_StreamRedirectorBase):
             stream.write(self._drain_token + "\n")
             stream.flush()
         if not self._drain_event.wait(timeout=timeout):
-            raise TimeoutError("output streams failed to drain")
+            raise TimeoutError(
+                COG_INTERNAL_ERROR_PREFIX + "output streams failed to drain"
+            )
 
     def _start(self) -> None:
         selector = selectors.DefaultSelector()

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -16,7 +16,7 @@ from .. import schema
 from ..files import put_file_to_signed_endpoint
 from ..json import upload_files
 from ..predictor import BaseInput
-from .errors import FileUploadError, UnknownPredictionError, RunnerBusyError
+from .errors import FileUploadError, RunnerBusyError, UnknownPredictionError
 from .eventtypes import Done, Log, PredictionOutput, PredictionOutputType
 from .telemetry import current_trace_context
 from .useragent import get_user_agent


### PR DESCRIPTION
to allow for separation of error tracking.

Connected to internal issue PLAT-265