### PR TITLE
Catch cog.whl invalid filenames

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/replicate/cog/pkg/config"
+	"github.com/replicate/cog/pkg/global"
 	"github.com/replicate/cog/pkg/util/console"
 	"github.com/replicate/cog/pkg/util/slices"
 	"github.com/replicate/cog/pkg/util/version"
@@ -421,6 +422,9 @@ func (g *Generator) installCog() (string, error) {
 	data, err := cogEmbed.ReadFile("embed/" + filename)
 	if err != nil {
 		return "", err
+	}
+	if filename == "cog.whl" {
+		filename = "cog-" + global.Version + "-py3-none-any.whl"
 	}
 	lines, containerPath, err := g.writeTemp(filename, data)
 	if err != nil {


### PR DESCRIPTION
* Check if the cog wheel is an invalid filename from the point of view of pip install
* Change the filename to conform to a valid pip filename.

Fixes: https://github.com/replicate/cog/issues/1963

I believe this was some kind of regression in https://github.com/replicate/cog/pull/1873 however I am not entirely sure what. It's important to note that this does not occur on any development branches, I am quite sure this only occurs in release, but the mechanism as to how this occurs I am not entirely sure of. This in turn makes it hard to create a test case against and makes the code here defensive.