### PR TITLE
Improve the build process for Homebrew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __pycache__
 build
 dist
 *.egg-info
-pkg/dockerfile/embed/*.whl
+pkg/dockerfile/embed/*
 # Used by a vim plugin (projectionist)
 .projections.json
 .tox/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,8 +16,14 @@ builds:
       - amd64
       - arm64
     main: ./cmd/cog
+    flags:
+      - -trimpath
     ldflags:
-      - "-s -w -X github.com/replicate/cog/pkg/global.Version={{.Version}} -X github.com/replicate/cog/pkg/global.Commit={{.Commit}} -X github.com/replicate/cog/pkg/global.BuildTime={{.Date}}"
+      - -s
+      - -w
+      - -X github.com/replicate/cog/pkg/global.Version={{ if index .Env "COG_VERSION_OVERRIDE"  }}{{ .Env.COG_VERSION_OVERRIDE }}{{ else }}{{ .Version }}{{ end }}
+      - -X github.com/replicate/cog/pkg/global.Commit={{ if index .Env "COG_COMMIT_OVERRIDE"  }}{{ .Env.COG_COMMIT_OVERRIDE }}{{ else }}{{ .Commit }}{{ end }}
+      - -X github.com/replicate/cog/pkg/global.BuildTime={{ .Date }}
   - binary: base-image
     id: base-image
     goos:
@@ -27,8 +33,14 @@ builds:
       - amd64
       - arm64
     main: ./cmd/base-image
+    flags:
+      - -trimpath
     ldflags:
-      - "-s -w -X github.com/replicate/cog/pkg/global.Version={{.Version}} -X github.com/replicate/cog/pkg/global.Commit={{.Commit}} -X github.com/replicate/cog/pkg/global.BuildTime={{.Date}}"
+      - -s
+      - -w
+      - -X github.com/replicate/cog/pkg/global.Version={{ if index .Env "COG_VERSION_OVERRIDE"  }}{{ .Env.COG_VERSION_OVERRIDE }}{{ else }}{{ .Version }}{{ end }}
+      - -X github.com/replicate/cog/pkg/global.Commit={{ if index .Env "COG_COMMIT_OVERRIDE"  }}{{ .Env.COG_COMMIT_OVERRIDE }}{{ else }}{{ .Commit }}{{ end }}
+      - -X github.com/replicate/cog/pkg/global.BuildTime={{ .Date }}
 archives:
   - format: binary
     builds:


### PR DESCRIPTION
We've recently run into [issues](https://github.com/replicate/cog/issues/1963) where Homebrew's build process for cog doesn't match the build process we use for our own binaries.

This commit makes changes to our build process that will hopefully allow us to update Homebrew to use our Makefile to run its builds.

1. Use `python -m pip wheel` to build the wheel rather than relying on a manual `pip install -e .[dev]` and `python -m build`.

2. Allow COG_VERSION_OVERRIDE and COG_COMMIT_OVERRIDE to specify the version and commit values used by goreleaser.

3. Set the `-trimpath` flag for `go build` so we don't capture directory names from the Homebrew build process or GitHub Actions.