### PR TITLE
add a "quiet" flag to the HTTP API

### DIFF
--- a/python/cog/command/ast_openapi_schema.py
+++ b/python/cog/command/ast_openapi_schema.py
@@ -50,6 +50,11 @@ BASE_SCHEMA = """
             "default": ["start", "output", "logs", "completed"],
             "items": { "$ref": "#/components/schemas/WebhookEvent" },
             "type": "array"
+          },
+          "quiet": {
+            "title": "Quiet",
+            "type": "boolean",
+            "default": false
           }
         },
         "title": "PredictionRequest",

--- a/python/cog/schema.py
+++ b/python/cog/schema.py
@@ -41,8 +41,6 @@ class WebhookEvent(str, Enum):
 
 
 class PredictionBaseModel(pydantic.BaseModel):
-    input: Dict[str, Any]
-
     if PYDANTIC_V2:
         model_config = pydantic.ConfigDict(use_enum_values=True)  # type: ignore
     else:
@@ -66,6 +64,8 @@ else:
 
 
 class PredictionRequest(PredictionBaseModel):
+    input: Dict[str, Any]
+
     id: Optional[str] = None
     created_at: Optional[datetime] = None
 
@@ -76,6 +76,8 @@ class PredictionRequest(PredictionBaseModel):
     webhook_events_filter: Optional[List[WebhookEvent]] = pydantic.Field(
         default=WebhookEvent.default_events(),
     )
+
+    quiet: bool = False
 
     @classmethod
     def with_types(cls, input_type: Type[Any]) -> Any:
@@ -88,6 +90,8 @@ class PredictionRequest(PredictionBaseModel):
 
 
 class PredictionResponse(PredictionBaseModel):
+    input: Optional[Dict[str, Any]] = None
+
     output: Any = None
 
     id: Optional[str] = None

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -259,6 +259,9 @@ class PredictTask(Task[schema.PredictionResponse]):
         else:
             request_dict = prediction_request.dict()
 
+        if prediction_request.quiet:
+            request_dict.pop("input", None)
+            
         self._p = schema.PredictionResponse(**request_dict)
         self._p.status = schema.Status.PROCESSING
         self._output_type_multi = None

--- a/python/tests/server/test_runner.py
+++ b/python/tests/server/test_runner.py
@@ -620,3 +620,43 @@ def test_predict_task_file_uploads_multi():
         "http://example.com/hello.jpg",
         "http://example.com/world.jpg",
     ]
+
+
+def test_predict_quiet():
+    p = PredictionRequest(
+        input={"hello": "there"},
+        id=None,
+        created_at=None,
+        output_file_prefix=None,
+        webhook=None,
+        quiet=False,
+    )
+    t = PredictTask(p)
+
+    assert t.result.status == Status.PROCESSING
+    assert t.result.output is None
+    assert t.result.logs == ""
+    assert isinstance(t.result.started_at, datetime)
+    t.set_output_type(multi=False)
+    t.append_output("giraffes")
+    assert t.result.output == "giraffes"
+    assert t.result.input == {"hello": "there"}
+
+    p = PredictionRequest(
+        input={"hello": "there"},
+        id=None,
+        created_at=None,
+        output_file_prefix=None,
+        webhook=None,
+        quiet=True,
+    )
+    t = PredictTask(p)
+
+    assert t.result.status == Status.PROCESSING
+    assert t.result.output is None
+    assert t.result.logs == ""
+    assert isinstance(t.result.started_at, datetime)
+    t.set_output_type(multi=False)
+    t.append_output("giraffes")
+    assert t.result.output == "giraffes"
+    assert t.result.input == None


### PR DESCRIPTION
For some context, I was working on a use-case where the size of the **inputs** to my predictor were very large, but the size of the **outputs** are relatively small. I noticed that since both `PredictionResponse` and `PredictionRequest` are subclasses of `PredictionBaseModel` (which defines `input`), this meant that the inputs were transmitted in both the response and the request, which used up a lot of network bandwidth.

This PR adds an optional "quiet" flag to the http API, which just makes it so the `PredictionResponse` does not repeat the input.

Let me know if this looks good, or if you would like me to change anything.