### PR TITLE
[async] Support URLFile in the upload_file function

### DIFF
--- a/python/cog/server/clients.py
+++ b/python/cog/server/clients.py
@@ -1,4 +1,3 @@
-from functools import partial
 import base64
 import io
 import mimetypes
@@ -22,7 +21,7 @@ from fastapi.encoders import jsonable_encoder
 
 from .. import types
 from ..schema import PredictionResponse, Status, WebhookEvent
-from ..types import Path, URLFile
+from ..types import Path
 from .eventtypes import PredictionInput
 from .response_throttler import ResponseThrottler
 from .retry_transport import RetryTransport

--- a/python/cog/server/clients.py
+++ b/python/cog/server/clients.py
@@ -293,10 +293,8 @@ class ClientManager:
             with obj.open("rb") as f:
                 return await self.upload_file(f, url=url, prediction_id=prediction_id)
         if isinstance(obj, io.IOBase):
-            try:
+            with obj:
                 return await self.upload_file(obj, url=url, prediction_id=prediction_id)
-            finally:
-                obj.close()
         return obj
 
     # inputs

--- a/python/cog/server/clients.py
+++ b/python/cog/server/clients.py
@@ -131,9 +131,14 @@ class ChunkFileReader:
 
         while True:
             chunk = self.fh.read(1024 * 1024)
+
+            if isinstance(chunk, str):
+                chunk = chunk.encode("utf-8")
+
             if not chunk:
                 log.info("finished reading file")
                 break
+
             yield chunk
 
 

--- a/python/cog/server/clients.py
+++ b/python/cog/server/clients.py
@@ -130,7 +130,11 @@ class ChunkFileReader:
         if self.fh.seekable():
             self.fh.seek(0)
 
-        for chunk in iter(self.fh):
+        while True:
+            chunk = self.fh.read(1024 * 1024)
+            if not chunk:
+                log.info("finished reading file")
+                break
             yield chunk
 
 

--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -237,15 +237,7 @@ class URLFile(io.IOBase):
     # Luckily the only dunder method on HTTPResponse is __iter__
     def __iter__(self) -> Iterator[bytes]:
         response = self.__wrapped__
-
-        # URLFile doesn't support `seek()` so the upload_file function
-        # cannot reset the request should it need to retry. As a hack
-        # we re-create the request each time the iterator is requested.
-        if response.num_bytes_downloaded > 0:
-            response.close()
-            object.__delattr__(self, "__target__")
-
-        yield from self.__wrapped__.iter_raw()
+        return iter(response)
 
     @property
     def __wrapped__(self) -> Any:
@@ -259,9 +251,7 @@ class URLFile(io.IOBase):
             # is that the book keeping for closing the response needs to be
             # handled elsewhere. There's probably a better design for this
             # in the long term.
-            client = httpx.Client()
-            req = client.build_request("GET", url)
-            res = client.send(request=req, stream=True)
+            res = urllib.request.urlopen(url)
             object.__setattr__(self, "__target__", res)
 
             return res

--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -204,7 +204,8 @@ class URLFile(io.IOBase):
     __slots__ = ("__target__", "__url__")
 
     def __init__(self, url: str) -> None:
-        object.__setattr__(self, "name", os.path.basename(url))
+        parsed = urllib.parse.urlparse(url)
+        object.__setattr__(self, "name", os.path.basename(parsed.path))
         object.__setattr__(self, "__url__", url)
 
     # We provide __getstate__ and __setstate__ explicitly to ensure that the

--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -251,7 +251,7 @@ class URLFile(io.IOBase):
             # is that the book keeping for closing the response needs to be
             # handled elsewhere. There's probably a better design for this
             # in the long term.
-            res = urllib.request.urlopen(url)
+            res = urllib.request.urlopen(url)  # noqa: S310
             object.__setattr__(self, "__target__", res)
 
             return res

--- a/python/tests/server/test_clients.py
+++ b/python/tests/server/test_clients.py
@@ -13,6 +13,7 @@ from cog.server.clients import ClientManager
 pytest.mark.asyncio
 
 
+@pytest.mark.asyncio
 async def test_upload_files_without_url():
     client_manager = ClientManager()
     temp_dir = tempfile.mkdtemp()


### PR DESCRIPTION
We would like `predict` functions to be able to return a remote URL rather than a local file on disk and have it behave like a file object. And when it is passed to the file uploader it will stream the file from the remote to the destination provided.

```py
class Predictor(BasePredictor):
    def predict(self, **kwargs) -> File:
        return URLFile("https://replicate.delivery/czjl/9MBNrffKcxoqY0iprW66NF8MZaNeH322a27yE0sjFGtKMXLnA/hello.webp")
```

This PR modifies the URLFile class to use `urllib.request.openurl` instead of `requests` as the HTTP client for reading the file data.

The `urllib.response.addinfourl` interface conforms to the one used by `urllib3.response.HTTPResponse` so I don't think we have any gaps here, longer term we probably want to figure out a more reliable shim. But as this branch is mostly used for language models we're probably okay.

> [!NOTE]
> I've tested this locally by creating a function that returns a `FileURL()` pointing to a remote address and the file is uploaded successfully.