### PR TITLE
fix docs build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
 
       - name: Copy top-level docs like README and CONTRIBUTING
         run: |


### PR DESCRIPTION
The "deploy docs" workflow is broken because it's using the system python.  This is because actions/setup-python hasn't been told which version to install.