### PR TITLE
Increase test timeouts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
     name: "Test integration"
     needs: build-python
     runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ source =
   .tox/*/lib/python*/site-packages/cog
 
 [pytest]
-addopts = --timeout=10
+addopts = --timeout=20
 
 [testenv]
 package = wheel


### PR DESCRIPTION
* Increase test timeouts to 20 minutes to allow for new tests focused around timeliness concepts
such as waiting for events.

This is a subset of https://github.com/replicate/cog/pull/1957/