### PR TITLE
Support custom filename to be provided to URLFile

### DIFF
--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -203,7 +203,7 @@ class URLFile(io.IOBase):
 
     __slots__ = ("__target__", "__url__")
 
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str, filename: Optional[str] = None) -> None:
         parsed = urllib.parse.urlparse(url)
         if parsed.scheme not in {
             "http",
@@ -212,7 +212,10 @@ class URLFile(io.IOBase):
             raise ValueError(
                 "URLFile requires URL to conform to HTTP or HTTPS protocol"
             )
-        object.__setattr__(self, "name", os.path.basename(parsed.path))
+
+        if not filename:
+            filename = os.path.basename(parsed.path)
+        object.__setattr__(self, "name", filename)
         object.__setattr__(self, "__url__", url)
 
     # We provide __getstate__ and __setstate__ explicitly to ensure that the

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -27,6 +27,11 @@ def test_urlfile_protocol_validation():
         URLFile("data:text/plain,hello")
 
 
+def test_urlfile_custom_filename():
+    u = URLFile("https://example.com/some-path", "my_file.txt")
+    assert u.name == "my_file.txt"
+
+
 @mock.patch("urllib.request.urlopen", return_value=file_fixture("hello world"))
 def test_urlfile_acts_like_response(mock_urlopen):
     u = URLFile("https://example.com/some/url")


### PR DESCRIPTION
This works around an issue where the basename of the URL many not actually
contain a file extension and the uploader logic cannot infer the mime
type for the file.