### PR TITLE
Use environment for PyPI releases

### DIFF
--- a/.github/workflows/pypi-package.yaml
+++ b/.github/workflows/pypi-package.yaml
@@ -35,6 +35,7 @@ jobs:
     if: github.repository_owner == 'replicate' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build-package
+    environment: test-pypi
     steps:
       - name: Download packages
         uses: actions/download-artifact@v4
@@ -51,6 +52,7 @@ jobs:
     if: github.repository_owner == 'replicate' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: build-package
+    environment: pypi
     steps:
       - name: Download packages
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This allows us to control which branches are allowed to release to PyPI, and we can configure PyPI trusted publishing to expect releases to come from a specific environment.