### PR TITLE
Add support for image/webp to mimetypes package

### DIFF
--- a/python/cog/__init__.py
+++ b/python/cog/__init__.py
@@ -1,5 +1,8 @@
+import mimetypes
+
 from pydantic import BaseModel
 
+from .mimetypes_ext import install_mime_extensions
 from .predictor import BasePredictor
 from .server.worker import emit_metric
 from .types import (
@@ -10,6 +13,8 @@ from .types import (
     Path,
     Secret,
 )
+
+install_mime_extensions(mimetypes)
 
 try:
     from ._version import __version__

--- a/python/cog/mimetypes_ext.py
+++ b/python/cog/mimetypes_ext.py
@@ -1,0 +1,16 @@
+from typing import Protocol
+
+
+class IMimeTypes(Protocol):
+    def add_type(self, type: str, ext: str, strict: bool = True) -> None: ...
+
+
+def install_mime_extensions(mimetypes: IMimeTypes) -> None:
+    """
+    Older versions of Python are missing the MIME types for more recent file formats
+    this function adds the missing MIME types to the mimetypes module.
+    """
+
+    # This could also be done by loading a mime.types file from disk using
+    # mimetypes.read_mime_types().
+    mimetypes.add_type("image/webp", ".webp")

--- a/python/tests/test_mimetypes_ext.py
+++ b/python/tests/test_mimetypes_ext.py
@@ -1,0 +1,17 @@
+from mimetypes import MimeTypes
+from cog.mimetypes_ext import install_mime_extensions
+
+
+def test_webp_ext_support():
+    # Assert on empty database.
+    mt = MimeTypes(filenames=tuple())
+    assert mt.guess_type("image.webp") == (None, None)
+    install_mime_extensions(mt)
+    assert mt.guess_type("image.webp") == ("image/webp", None)
+
+    # Assert global override
+    import cog
+
+    import mimetypes
+
+    assert mimetypes.guess_type("image.webp") == ("image/webp", None)


### PR DESCRIPTION
Fixes PLAT-341

This has only recently been introduced in Python 3.13.0 and is currently inconsistently implemented across different platforms. Confusingly webp is supported in local development on macOS but not when building the docker image of a cog model. This is either because it's not defined in the system mime.types file of the Linux image or because a dev dependency is manually adding it. I've not done the work to fully understand which.

This commit introduces a function called in the init script for the cog package that patches the global mimetypes registry to understand the .webp extension and image/webp mime type. This will be a no-op on systems that already understand the type.

This fixes a bug whereby files with the .webp extension are uploaded to the --upload-url with the incorrect application/octet-stream header.

> [!NOTE]
> This needs to be ported over to the main 0.11 branch when accepted.
