### PR TITLE
Provide User-Agent and Accept headers in URLFile requests

### DIFF
--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -278,7 +278,13 @@ class URLFile(io.IOBase):
             # is that the book keeping for closing the response needs to be
             # handled elsewhere. There's probably a better design for this
             # in the long term.
-            res = urllib.request.urlopen(url)  # noqa: S310
+            from . import __version__ as cog_version
+
+            req = urllib.request.Request(  # noqa: S310
+                url,
+                headers={"User-agent": f"cog/{cog_version}", "Accept": "*/*"},
+            )
+            res = urllib.request.urlopen(req)  # noqa: S310
             object.__setattr__(self, "__target__", res)
 
             return res

--- a/python/tests/server/test_clients.py
+++ b/python/tests/server/test_clients.py
@@ -138,7 +138,9 @@ async def test_upload_files_with_url_file(urlopen_mock, respx_mock):
 
     assert uploader.call_count == 1
     assert urlopen_mock.call_count == 1
-    assert urlopen_mock.call_args[0][0] == "https://example.com/cdn/my_file.txt"
+    assert (
+        urlopen_mock.call_args[0][0].full_url == "https://example.com/cdn/my_file.txt"
+    )
 
 
 @pytest.mark.asyncio
@@ -164,4 +166,6 @@ async def test_upload_files_with_url_file_with_retry(urlopen_mock, respx_mock):
 
     assert uploader.call_count == 3
     assert urlopen_mock.call_count == 1
-    assert urlopen_mock.call_args[0][0] == "https://example.com/cdn/my_file.txt"
+    assert (
+        urlopen_mock.call_args[0][0].full_url == "https://example.com/cdn/my_file.txt"
+    )


### PR DESCRIPTION
It turns out some providers require these headers to be present
otherwise they'll give an error response. This issue is not present
in the requests version of the codebase because the requests library
provides default headers on our behalf.
