### PR TITLE
Fix no COG_WHEEL in Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ pkg/dockerfile/embed/.wheel: $(COG_PYTHON_SOURCE)
 	@rm -f pkg/dockerfile/embed/*.whl # there can only be one embedded wheel
 	$(PYTHON) -m pip wheel --no-deps --no-binary=:all: --wheel-dir=pkg/dockerfile/embed .
 	@touch $@
+
+define COG_WHEEL
+    $(shell find pkg/dockerfile/embed -type f -name '*.whl')
+endef
+
 endif
 
 $(COG_BINARIES): $(COG_GO_SOURCE) pkg/dockerfile/embed/.wheel
@@ -70,7 +75,7 @@ test-integration: $(COG_BINARIES)
 	PATH="$(PWD):$(PATH)" $(TOX) -e integration
 
 .PHONY: test-python
-test-python: $(COG_WHEEL)
+test-python: pkg/dockerfile/embed/.wheel
 	$(TOX) run --installpkg $(COG_WHEEL) -f tests
 
 .PHONY: test


### PR DESCRIPTION
* make test currently fails if COG_WHEEL is not previously defined. This is the case when performing `make test` on a freshly cloned instance.
* Define COG_WHEEL if it doesn’t exist by finding the wheel file in pkg/dockerfile/embed