### PR TITLE
Bump version constraint for `typing-constraints`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "requests>=2,<3",
   "structlog>=20,<25",
   'typing-compat; python_version < "3.8"',
-  "typing_extensions>=4.4.0",
+  "typing_extensions>=4.6.0",
   "uvicorn[standard]>=0.12,<1",
 ]
 


### PR DESCRIPTION
to require version that provides `Buffer` type.

Connected to PLAT-405