### PR TITLE
add an OutputURL type with a streaming download/upload

### DIFF
--- a/python/cog/server/clients.py
+++ b/python/cog/server/clients.py
@@ -218,7 +218,9 @@ class ClientManager:
 
         # this code path happens when running outside replicate without upload-url
         # in that case we need to return data uris
-        if url is None and not isinstance(fh, OutputURL):
+        if url is None:
+            if isinstance(fh, OutputURL):
+              return fh.url
             return file_to_data_uri(fh, content_type)
         assert url
 

--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -194,6 +194,20 @@ class DataURLTempFilePath(pathlib.PosixPath):
                     raise
 
 
+class OutputURL:
+    def __init__(self, url: str, filename: Optional[str] = None) -> None:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in {"http", "https"}:
+            raise ValueError(
+                "OutputURL requires URL to conform to HTTP or HTTPS protocol"
+            )
+
+        if not filename:
+            filename = os.path.basename(parsed.path)
+        self.name = filename
+        self.url = url
+
+
 class URLFile(io.IOBase):
     """
     URLFile is a proxy object for a :class:`urllib3.response.HTTPResponse`


### PR DESCRIPTION
https://github.com/replicate/cog/pull/1987 and followups aim to improve returning remote URLs. however, they use sync downloads, which can cause coroutines to queue up in the event loop under higher levels of concurrency. it also doesn't use a connection pool and can't overlap download+upload. these problems can be avoided by adding a new output type that's handled differently by ClientManager.upload_file. conveniently, ClientManager already holds a file_client with a connection pool suitable for downloading those images well, and httpx provides good ergonomics for streaming downloads/uploads.