### PR TITLE
Add integration tests around stream redirection

### DIFF
--- a/test-integration/test_integration/fixtures/setup-subprocess-double-fork-http-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/setup-subprocess-double-fork-http-project/cog.yaml
@@ -1,0 +1,5 @@
+build:
+  python_version: "3.8"
+  python_packages:
+  - requests
+predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/setup-subprocess-double-fork-http-project/pong.py
+++ b/test-integration/test_integration/fixtures/setup-subprocess-double-fork-http-project/pong.py
@@ -1,0 +1,35 @@
+import os
+import signal
+import time
+from random import randint
+from wsgiref.simple_server import make_server
+
+
+def main():
+    child_pid = os.fork()
+    is_child = child_pid == 0
+
+    pid = os.getpid()
+
+    if is_child:
+        make_server("127.0.0.1", 7777, app).serve_forever()
+    else:
+        while True:
+            print(f"===> PARENT ({pid})")
+
+            time.sleep(10)
+
+
+def app(environ, start_response):
+    print(f"---> CHILD ({os.getpid()})")
+
+    if environ["PATH_INFO"] == "/ping":
+        start_response("200 OK", [("content-type", "text/plain")])
+        return [b"PONG\n" for n in range(100 + randint(2, 32))]
+
+    start_response("404 Not Found", [("content-type", "text/plain")])
+    return [b"NO\n"]
+
+
+if __name__ == "__main__":
+    main()

--- a/test-integration/test_integration/fixtures/setup-subprocess-double-fork-http-project/predict.py
+++ b/test-integration/test_integration/fixtures/setup-subprocess-double-fork-http-project/predict.py
@@ -1,0 +1,32 @@
+import signal
+import subprocess
+import sys
+
+import requests
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def setup(self) -> None:
+        print("---> starting background process")
+
+        self.bg = subprocess.Popen(["bash", "run-pong.sh"])
+
+        print(f"---> started background process pid={self.bg.pid}")
+
+    def predict(self, s: str) -> str:
+        status = self.bg.poll()
+
+        print(f"---> background job status={status}")
+
+        if status is None:
+            print(f"---> sending request to background job pid={self.bg.pid}")
+
+            print(requests.get("http://127.0.0.1:7777/ping"))
+
+            print(f"---> sent request to background job pid={self.bg.pid}")
+        else:
+            raise SystemExit
+
+        return "hello " + s

--- a/test-integration/test_integration/fixtures/setup-subprocess-double-fork-http-project/run-pong.sh
+++ b/test-integration/test_integration/fixtures/setup-subprocess-double-fork-http-project/run-pong.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+python ./pong.py &
+wait

--- a/test-integration/test_integration/fixtures/setup-subprocess-double-fork-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/setup-subprocess-double-fork-project/cog.yaml
@@ -1,0 +1,3 @@
+build:
+  python_version: "3.8"
+predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/setup-subprocess-double-fork-project/forker.py
+++ b/test-integration/test_integration/fixtures/setup-subprocess-double-fork-project/forker.py
@@ -1,0 +1,39 @@
+import os
+import signal
+import time
+
+
+def main():
+    child_pid = os.fork()
+    is_child = child_pid == 0
+
+    pid = os.getpid()
+    was_pinged = False
+
+    while True:
+        if os.path.exists(".inbox") and is_child:
+            s = ""
+
+            with open(".inbox", "r") as inbox:
+                print(f"---> CHILD ({pid}) reading request")
+
+                s = inbox.read()
+
+            os.unlink(".inbox")
+
+            with open(".outbox", "w") as outbox:
+                print(f"---> CHILD ({pid}) sending response")
+
+                outbox.write("hello " + s)
+
+        if time.time() % 10 == 0:
+            if is_child:
+                print(f"---> CHILD ({pid}) " + ("here " * 20))
+            else:
+                print(f"===> PARENT ({pid})")
+
+        time.sleep(0.01)
+
+
+if __name__ == "__main__":
+    main()

--- a/test-integration/test_integration/fixtures/setup-subprocess-double-fork-project/predict.py
+++ b/test-integration/test_integration/fixtures/setup-subprocess-double-fork-project/predict.py
@@ -1,0 +1,50 @@
+import os.path
+import signal
+import subprocess
+import sys
+import time
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def setup(self) -> None:
+        print("---> starting background process")
+
+        self.bg = subprocess.Popen(["bash", "run-forker.sh"])
+
+        print(f"---> started background process pid={self.bg.pid}")
+
+    def predict(self, s: str) -> str:
+        status = self.bg.poll()
+
+        print(f"---> background job status={status}")
+
+        if status is not None:
+            raise SystemExit
+
+        print(f"---> sending message to background job pid={self.bg.pid}")
+
+        with open(".inbox", "w") as inbox:
+            inbox.write(s)
+
+        print(f"---> sent message to background job pid={self.bg.pid}")
+
+        now = time.time()
+
+        print(f"---> waiting for outbox message from background job pid={self.bg.pid}")
+
+        while not os.path.exists(".outbox"):
+            if time.time() - now > 5:
+                raise TimeoutError
+
+            time.sleep(0.01)
+
+        try:
+            with open(".outbox", "r") as outbox:
+                print(f"---> relaying message from background job pid={self.bg.pid}")
+
+                return outbox.read()
+
+        finally:
+            os.unlink(".outbox")

--- a/test-integration/test_integration/fixtures/setup-subprocess-double-fork-project/run-forker.sh
+++ b/test-integration/test_integration/fixtures/setup-subprocess-double-fork-project/run-forker.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+python ./forker.py &
+wait

--- a/test-integration/test_integration/fixtures/setup-subprocess-simple-project/child.sh
+++ b/test-integration/test_integration/fixtures/setup-subprocess-simple-project/child.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+_pong() {
+  for i in $(seq 100); do
+    echo "${0} (${$}) PONG (${i}/100)"
+  done
+}
+
+trap _pong USR1
+
+for i in $(seq 100); do
+  echo "${0} ($$) SETTING UP (${i}/100)"
+  sleep 0.01
+done
+
+while true; do
+  now="$(date +%s)"
+  now_mod=$((now % 10))
+
+  if [[ "${now_mod}" == 0 ]]; then
+    echo "${0} (${$}) STILL HERE"
+    sleep 1
+  fi
+
+  sleep 0.1
+done

--- a/test-integration/test_integration/fixtures/setup-subprocess-simple-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/setup-subprocess-simple-project/cog.yaml
@@ -1,0 +1,3 @@
+build:
+  python_version: "3.8"
+predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/setup-subprocess-simple-project/predict.py
+++ b/test-integration/test_integration/fixtures/setup-subprocess-simple-project/predict.py
@@ -1,0 +1,30 @@
+import signal
+import subprocess
+import sys
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def setup(self) -> None:
+        print("---> starting background process")
+
+        self.bg = subprocess.Popen(["bash", "child.sh"])
+
+        print(f"---> started background process pid={self.bg.pid}")
+
+    def predict(self, s: str) -> str:
+        status = self.bg.poll()
+
+        if status is None:
+            print(f"---> sending signal to background job pid={self.bg.pid}")
+
+            self.bg.send_signal(signal.SIGUSR1)
+
+            print(f"---> sent signal to background job pid={self.bg.pid}")
+        else:
+            print(f"---> background job died status={status}")
+
+            raise SystemExit
+
+        return "hello " + s

--- a/test-integration/test_integration/util.py
+++ b/test-integration/test_integration/util.py
@@ -1,8 +1,14 @@
+import contextlib
 import random
 import re
+import signal
+import socket
 import string
 import subprocess
+import sys
 import time
+
+import httpx
 
 from packaging.version import VERSION_PATTERN
 
@@ -110,3 +116,73 @@ def remove_docker_image(image_name, max_attempts=5, wait_seconds=1):
             time.sleep(wait_seconds)
     else:
         print(f"Failed to remove image {image_name} after {max_attempts} attempts.")
+
+
+def random_port() -> int:
+    sock = socket.socket()
+    sock.bind(("", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+@contextlib.contextmanager
+def cog_server_http_run(project_dir: str):
+    port = random_port()
+    addr = f"http://127.0.0.1:{port}"
+
+    server: subprocess.Popen | None = None
+
+    try:
+        server = subprocess.Popen(
+            [
+                "cog",
+                "run",
+                "-e",
+                f"PORT={port}",
+                "-p",
+                str(port),
+                "python",
+                "--check-hash-based-pycs",
+                "never",
+                "-m",
+                "cog.server.http",
+                "--await-explicit-shutdown=true",
+            ],
+            cwd=project_dir,
+            # NOTE: inheriting stdout and stderr from the parent process when running
+            # within a pytest context seems to *always fail*, even when using
+            # `capsys.disabled` or `--capture=no` via command line args. Piping the
+            # streams seems to allow behavior that is identical to code run outside of
+            # pytest.
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        i = 0
+
+        while True:
+            try:
+                if httpx.get(f"{addr}/health-check").status_code == 200:
+                    break
+            except httpx.ConnectError:
+                pass
+
+            time.sleep((0.1 + i) * 2)
+            i += 1
+
+        yield addr
+    finally:
+        try:
+            httpx.post(f"{addr}/shutdown")
+        except httpx.HTTPError:
+            pass
+
+        if server is not None:
+            server.send_signal(signal.SIGINT)
+
+            out, err = server.communicate(timeout=5)
+
+            if server.returncode != 0:
+                print(out.decode())
+                print(err.decode(), file=sys.stderr)

--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,7 @@ base_python = python3.12
 changedir = test-integration
 skip_install = true
 deps =
+  httpx
   packaging
   pytest
   pytest-rerunfailures


### PR DESCRIPTION
to ensure we don't have regressions like that seen in `v0.11.4`.

The tests here are somewhat contrived, but based on how some known models work that failed when stream redirection didn't work as expected, and in fact they all fail when run against `v0.11.4`.

Connected to PLAT-410