### PR TITLE
Add version and more URLs to index document

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -38,6 +38,11 @@ from ..predictor import (
 )
 from ..types import PYDANTIC_V2, CogConfig
 
+try:
+    from .._version import __version__
+except ImportError:
+    __version__ = "dev"
+
 if PYDANTIC_V2:
     from .helpers import (
         unwrap_pydantic_serialization_iterators,
@@ -187,6 +192,17 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
 
         return wrapped
 
+    index_document = {
+        "cog_version": __version__,
+        "docs_url": "/docs",
+        "openapi_url": "/openapi.json",
+        "shutdown_url": "/shutdown",
+        "healthcheck_url": "/health-check",
+        "predictions_url": "/predictions",
+        "predictions_idempotent_url": "/predictions/{prediction_id}",
+        "predictions_cancel_url": "/predictions/{prediction_id}/cancel",
+    }
+
     if "train" in config:
         try:
             trainer_ref = get_predictor_ref(config, "train")
@@ -281,6 +297,14 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
             ) -> Any:
                 return cancel(training_id)
 
+            index_document.update(
+                {
+                    "trainings_url": "/trainings",
+                    "trainings_idempotent_url": "/trainings/{training_id}",
+                    "trainings_cancel_url": "/trainings/{training_id}/cancel",
+                }
+            )
+
         except Exception as e:  # pylint: disable=broad-exception-caught
             if isinstance(e, (PredictorNotSet, FileNotFoundError)) and not is_build:
                 pass  # ignore missing train.py for backward compatibility with existing "bad" models in use
@@ -310,11 +334,7 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
 
     @app.get("/")
     async def root() -> Any:
-        return {
-            # "cog_version": "", # TODO
-            "docs_url": "/docs",
-            "openapi_url": "/openapi.json",
-        }
+        return index_document
 
     @app.get("/health-check")
     async def healthcheck() -> Any:
@@ -571,6 +591,9 @@ def _cpu_count() -> int:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Cog HTTP server")
     parser.add_argument(
+        "-v", "--version", action="store_true", help="Show version and exit"
+    )
+    parser.add_argument(
         "--host",
         dest="host",
         type=str,
@@ -607,6 +630,10 @@ if __name__ == "__main__":
         help="Experimental: Run in 'predict' or 'train' mode",
     )
     args = parser.parse_args()
+
+    if args.version:
+        print(f"cog.server.http {__version__}")
+        sys.exit(0)
 
     # log level is configurable so we can make it quiet or verbose for `cog predict`
     # cog predict --debug       # -> debug

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -18,6 +18,24 @@ from .conftest import (
 )
 
 
+def test_index_document():
+    client = make_client(fixture_name="slow_setup")
+    resp = client.get("/")
+    data = resp.json()
+    for field in (
+        "cog_version",
+        "docs_url",
+        "openapi_url",
+        "shutdown_url",
+        "healthcheck_url",
+        "predictions_url",
+        "predictions_idempotent_url",
+        "predictions_cancel_url",
+    ):
+        assert field in data
+        assert data[field] is not None
+
+
 def test_setup_healthcheck():
     client = make_client(fixture_name="slow_setup")
     resp = client.get("/health-check")


### PR DESCRIPTION
primarily for the Cog version so that clients can include it in telemetry.

plus supporting `python -m cog.http.server --version` for improved runtime inspectability.