### PR TITLE
Downgrade `typing-extensions` to fix conflict with `spacy` and `pydantic`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "PyYAML",
   "requests>=2,<3",
   "structlog>=20,<25",
-  "typing_extensions>=4.6.0",
+  "typing_extensions>=4.4.0",
   "uvicorn[standard]>=0.12,<1",
 ]
 

--- a/python/cog/server/connection.py
+++ b/python/cog/server/connection.py
@@ -1,9 +1,23 @@
+import collections.abc
 import asyncio
 import multiprocessing
 from multiprocessing.connection import Connection
 from typing import Any, Optional
 
-from typing_extensions import Buffer
+# Buffer is only available in typing-extensions>=4.6.0 but should be available in stdlib
+# python 3.12+. This compatibility code is nearly identical to the implementation in
+# typing-extensions>=4.6.0
+if hasattr(collections.abc, "Buffer"):
+    Buffer = collections.abc.Buffer
+else:
+    import abc
+
+    class Buffer(abc.ABC):
+        pass
+
+    Buffer.register(memoryview)
+    Buffer.register(bytearray)
+    Buffer.register(bytes)
 
 _spawn = multiprocessing.get_context("spawn")
 

--- a/python/cog/server/connection.py
+++ b/python/cog/server/connection.py
@@ -1,5 +1,6 @@
-import collections.abc
+import abc
 import asyncio
+import collections.abc
 import multiprocessing
 from multiprocessing.connection import Connection
 from typing import Any, Optional
@@ -8,11 +9,10 @@ from typing import Any, Optional
 # python 3.12+. This compatibility code is nearly identical to the implementation in
 # typing-extensions>=4.6.0
 if hasattr(collections.abc, "Buffer"):
-    Buffer = collections.abc.Buffer
+    Buffer = collections.abc.Buffer  # type: ignore
 else:
-    import abc
 
-    class Buffer(abc.ABC):
+    class Buffer(abc.ABC):  # noqa: B024
         pass
 
     Buffer.register(memoryview)
@@ -72,7 +72,7 @@ class AsyncConnection:
     ) -> None:
         """Send the bytes data from a bytes-like object"""
 
-        self._connection.send_bytes(buf, offset, size)
+        self._connection.send_bytes(buf, offset, size)  # type: ignore
 
     async def recv_bytes(self, maxlength: Optional[int] = None) -> bytes:
         """


### PR DESCRIPTION
that results in seemingly unrelated errors like:

```python
  File "/root/.pyenv/versions/3.8.16/lib/python3.8/site-packages/spacy/schemas.py", line 250, in <module>
    class TokenPattern(BaseModel):
  File "pydantic/main.py", line 197, in pydantic.main.ModelMetaclass.__new__
  File "pydantic/fields.py", line 506, in pydantic.fields.ModelField.infer
  File "pydantic/fields.py", line 436, in pydantic.fields.ModelField.__init__
  File "pydantic/fields.py", line 552, in pydantic.fields.ModelField.prepare
  File "pydantic/fields.py", line 661, in pydantic.fields.ModelField._type_analysis
  File "pydantic/fields.py", line 668, in pydantic.fields.ModelField._type_analysis
  File "/root/.pyenv/versions/3.8.16/lib/python3.8/typing.py", line 774, in __subclasscheck__
    return issubclass(cls, self.__origin__)
TypeError: issubclass() arg 1 must be a class
```

Closes PLAT-443