### PR TITLE
Manually patch CuDNN in cuda base images index

### DIFF
--- a/pkg/config/cuda_base_images.json
+++ b/pkg/config/cuda_base_images.json
@@ -2,77 +2,77 @@
   {
     "Tag": "12.6.2-cudnn-devel-ubuntu24.04",
     "CUDA": "12.6.2",
-    "CuDNN": "",
+    "CuDNN": "9",
     "IsDevel": true,
     "Ubuntu": "24.04"
   },
   {
     "Tag": "12.6.2-cudnn-devel-ubuntu22.04",
     "CUDA": "12.6.2",
-    "CuDNN": "",
+    "CuDNN": "9",
     "IsDevel": true,
     "Ubuntu": "22.04"
   },
   {
     "Tag": "12.6.2-cudnn-devel-ubuntu20.04",
     "CUDA": "12.6.2",
-    "CuDNN": "",
+    "CuDNN": "9",
     "IsDevel": true,
     "Ubuntu": "20.04"
   },
   {
     "Tag": "12.6.1-cudnn-devel-ubuntu24.04",
     "CUDA": "12.6.1",
-    "CuDNN": "",
+    "CuDNN": "9",
     "IsDevel": true,
     "Ubuntu": "24.04"
   },
   {
     "Tag": "12.6.1-cudnn-devel-ubuntu22.04",
     "CUDA": "12.6.1",
-    "CuDNN": "",
+    "CuDNN": "9",
     "IsDevel": true,
     "Ubuntu": "22.04"
   },
   {
     "Tag": "12.6.1-cudnn-devel-ubuntu20.04",
     "CUDA": "12.6.1",
-    "CuDNN": "",
+    "CuDNN": "9",
     "IsDevel": true,
     "Ubuntu": "20.04"
   },
   {
     "Tag": "12.6.0-cudnn-devel-ubuntu24.04",
     "CUDA": "12.6.0",
-    "CuDNN": "",
+    "CuDNN": "9",
     "IsDevel": true,
     "Ubuntu": "24.04"
   },
   {
     "Tag": "12.6.0-cudnn-devel-ubuntu22.04",
     "CUDA": "12.6.0",
-    "CuDNN": "",
+    "CuDNN": "9",
     "IsDevel": true,
     "Ubuntu": "22.04"
   },
   {
     "Tag": "12.6.0-cudnn-devel-ubuntu20.04",
     "CUDA": "12.6.0",
-    "CuDNN": "",
+    "CuDNN": "9",
     "IsDevel": true,
     "Ubuntu": "20.04"
   },
   {
     "Tag": "12.5.1-cudnn-devel-ubuntu22.04",
     "CUDA": "12.5.1",
-    "CuDNN": "",
+    "CuDNN": "9",
     "IsDevel": true,
     "Ubuntu": "22.04"
   },
   {
     "Tag": "12.5.1-cudnn-devel-ubuntu20.04",
     "CUDA": "12.5.1",
-    "CuDNN": "",
+    "CuDNN": "9",
     "IsDevel": true,
     "Ubuntu": "20.04"
   },


### PR DESCRIPTION
since the CuDNN version is no longer included in image tags and the `compatgen` tool doesn't know how to look up the CuDNN version from image metadata layers.