### PR TITLE
Add local ignore for integration test fixture outputs

### DIFF
--- a/test-integration/test_integration/fixtures/setup-subprocess-double-fork-project/.gitignore
+++ b/test-integration/test_integration/fixtures/setup-subprocess-double-fork-project/.gitignore
@@ -1,0 +1,2 @@
+.inbox
+.outbox


### PR DESCRIPTION
as they seem to be causing problems with github actions caching.