### PR TITLE
fileToDataURL: use utils.mime wrappers instead of upstream mime pkg

### DIFF
--- a/pkg/predict/input.go
+++ b/pkg/predict/input.go
@@ -2,13 +2,14 @@ package predict
 
 import (
 	"fmt"
-	"mime"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/vincent-petithory/dataurl"
+
+	"github.com/replicate/cog/pkg/util/mime"
 )
 
 type Input struct {


### PR DESCRIPTION
cog/pkg/util/mime had some defaults for mime types, but these weren't used in `cog predict -i`, which was instead using the "mime" pkg

This led to weird failures on systems lacking /etc/mime.types

Fixes #2032 