### PR TITLE
Use correct mime package in input.go

### DIFF
--- a/pkg/predict/input.go
+++ b/pkg/predict/input.go
@@ -2,13 +2,14 @@ package predict
 
 import (
 	"fmt"
-	"mime"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/vincent-petithory/dataurl"
+
+	"github.com/replicate/cog/pkg/util/mime"
 )
 
 type Input struct {


### PR DESCRIPTION
This PR updates the import for the `mime` package to use the local utility which handles the case where `mime.TypeByExtension` returns an empty string. This was likely a regression introduced in 1289b6fe8c2ec01b7d47c6ee970838e5d4be4da7 with auto-imports picking the wrong package to import.

Fixes #2032
