### PR TITLE
Add pip freeze to docker label

### DIFF
--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -167,10 +167,16 @@ func Build(cfg *config.Config, dir, imageName string, secrets []string, noCache,
 		return fmt.Errorf("Failed to convert config to JSON: %w", err)
 	}
 
+	pipFreeze, err := GeneratePipFreeze(imageName)
+	if err != nil {
+		return fmt.Errorf("Failed to generate pip freeze from image: %w", err)
+	}
+
 	labels := map[string]string{
 		global.LabelNamespace + "version":        global.Version,
 		global.LabelNamespace + "config":         string(bytes.TrimSpace(configJSON)),
 		global.LabelNamespace + "openapi_schema": string(schemaJSON),
+		global.LabelNamespace + "pip_freeze":     pipFreeze,
 		// Mark the image as having an appropriate init entrypoint. We can use this
 		// to decide how/if to shim the image.
 		global.LabelNamespace + "has_init": "true",

--- a/pkg/image/pip_freeze.go
+++ b/pkg/image/pip_freeze.go
@@ -1,0 +1,30 @@
+package image
+
+import (
+	"bytes"
+
+	"github.com/replicate/cog/pkg/docker"
+	"github.com/replicate/cog/pkg/util/console"
+)
+
+// GeneratePipFreeze by running a pip freeze on the image.
+// This will be run as part of the build process then added as a label to the image.
+func GeneratePipFreeze(imageName string) (string, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := docker.RunWithIO(docker.RunOptions{
+		Image: imageName,
+		Args: []string{
+			"python", "-m", "pip", "freeze",
+		},
+	}, nil, &stdout, &stderr)
+
+	if err != nil {
+		console.Info(stdout.String())
+		console.Info(stderr.String())
+		return "", err
+	}
+
+	return stdout.String(), nil
+}

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -362,3 +362,25 @@ def test_cog_install_base_image(docker_image):
         semver_version=cog_version,
         pep440_version=cog_installed_version,
     )
+
+
+def test_pip_freeze(docker_image):
+    project_dir = Path(__file__).parent / "fixtures/path-project"
+    subprocess.run(
+        ["cog", "build", "-t", docker_image],
+        cwd=project_dir,
+        check=True,
+    )
+    image = json.loads(
+        subprocess.run(
+            ["docker", "image", "inspect", docker_image],
+            capture_output=True,
+            check=True,
+        ).stdout
+    )
+    labels = image[0]["Config"]["Labels"]
+    pip_freeze = labels["run.cog.pip_freeze"]
+    assert (
+        pip_freeze
+        == "anyio==4.4.0\nattrs==23.2.0\ncertifi==2024.8.30\ncharset-normalizer==3.3.2\nclick==8.1.7\ncog @ file:///tmp/cog-0.13.3.dev1%2Bg746ec535-py3-none-any.whl\nexceptiongroup==1.2.2\nfastapi==0.98.0\nh11==0.14.0\nhttptools==0.6.1\nidna==3.8\npydantic==1.10.18\npython-dotenv==1.0.1\nPyYAML==6.0.2\nrequests==2.32.3\nsniffio==1.3.1\nstarlette==0.27.0\nstructlog==24.4.0\ntyping_extensions==4.12.2\nurllib3==2.2.2\nuvicorn==0.30.6\nuvloop==0.20.0\nwatchfiles==0.24.0\nwebsockets==13.0.1\n"
+    )

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -385,5 +385,5 @@ def test_pip_freeze(docker_image):
     )
     assert (
         pip_freeze
-        == "anyio==4.4.0\nattrs==23.2.0\ncertifi==2024.8.30\ncharset-normalizer==3.3.2\nclick==8.1.7\ncog @ file:///tmp/cog-0.13.3.dev1%2Bg746ec535-py3-none-any.whl\nexceptiongroup==1.2.2\nfastapi==0.98.0\nh11==0.14.0\nhttptools==0.6.1\nidna==3.8\npydantic==1.10.18\npython-dotenv==1.0.1\nPyYAML==6.0.2\nrequests==2.32.3\nsniffio==1.3.1\nstarlette==0.27.0\nstructlog==24.4.0\ntyping_extensions==4.12.2\nurllib3==2.2.2\nuvicorn==0.30.6\nuvloop==0.20.0\nwatchfiles==0.24.0\nwebsockets==13.0.1\n"
+        == "anyio==4.4.0\nattrs==23.2.0\ncertifi==2024.8.30\ncharset-normalizer==3.3.2\nclick==8.1.7\nexceptiongroup==1.2.2\nfastapi==0.98.0\nh11==0.14.0\nhttptools==0.6.1\nidna==3.8\npydantic==1.10.18\npython-dotenv==1.0.1\nPyYAML==6.0.2\nrequests==2.32.3\nsniffio==1.3.1\nstarlette==0.27.0\nstructlog==24.4.0\ntyping_extensions==4.12.2\nurllib3==2.2.2\nuvicorn==0.30.6\nuvloop==0.20.0\nwatchfiles==0.24.0\nwebsockets==13.0.1\n"
     )

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -380,6 +380,9 @@ def test_pip_freeze(docker_image):
     )
     labels = image[0]["Config"]["Labels"]
     pip_freeze = labels["run.cog.pip_freeze"]
+    pip_freeze = "\n".join(
+        [x for x in pip_freeze.split("\n") if not x.startswith("cog @")]
+    )
     assert (
         pip_freeze
         == "anyio==4.4.0\nattrs==23.2.0\ncertifi==2024.8.30\ncharset-normalizer==3.3.2\nclick==8.1.7\ncog @ file:///tmp/cog-0.13.3.dev1%2Bg746ec535-py3-none-any.whl\nexceptiongroup==1.2.2\nfastapi==0.98.0\nh11==0.14.0\nhttptools==0.6.1\nidna==3.8\npydantic==1.10.18\npython-dotenv==1.0.1\nPyYAML==6.0.2\nrequests==2.32.3\nsniffio==1.3.1\nstarlette==0.27.0\nstructlog==24.4.0\ntyping_extensions==4.12.2\nurllib3==2.2.2\nuvicorn==0.30.6\nuvloop==0.20.0\nwatchfiles==0.24.0\nwebsockets==13.0.1\n"


### PR DESCRIPTION
* Record the output of a pip freeze to the docker label so we can determine what packages the image
was frozen with.