### PR TITLE
Bug Fix: Set timeout on requests.get

### DIFF
--- a/python/cog/files.py
+++ b/python/cog/files.py
@@ -15,7 +15,7 @@ def upload_file(fh: io.IOBase, output_file_prefix: Optional[str] = None) -> str:
     if output_file_prefix is not None:
         name = getattr(fh, "name", "output")
         url = output_file_prefix + os.path.basename(name)
-        resp = requests.put(url, files={"file": fh}, timeout=None)
+        resp = requests.put(url, files={"file": fh}, timeout=5)
         resp.raise_for_status()
         return url
 

--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -336,7 +336,7 @@ class URLFile(io.IOBase):
         except AttributeError:
             pass
         url = object.__getattribute__(self, "__url__")
-        resp = requests.get(url, stream=True, timeout=None)
+        resp = requests.get(url, stream=True, timeout=10)
         resp.raise_for_status()
         resp.raw.decode_content = True
         object.__setattr__(self, "__target__", resp.raw)


### PR DESCRIPTION
If requests.get has no timeout it is possible to hang indefinitely on a ill behaved webserver. This timeout is explicitly a connect *and* read timeout, meaning if no bytes received.