### PR TITLE
End-to-end support for concurrent async models

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -64,7 +64,7 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 		imageName = config.DockerImageName(projectDir)
 	}
 
-	err = config.ValidateModelPythonVersion(cfg.Build.PythonVersion)
+	err = config.ValidateModelPythonVersion(cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,9 +30,10 @@ var (
 // TODO(andreas): suggest valid torchvision versions (e.g. if the user wants to use 0.8.0, suggest 0.8.1)
 
 const (
-	MinimumMajorPythonVersion int = 3
-	MinimumMinorPythonVersion int = 8
-	MinimumMajorCudaVersion   int = 11
+	MinimumMajorPythonVersion               int = 3
+	MinimumMinorPythonVersion               int = 8
+	MinimumMinorPythonVersionForConcurrency int = 11
+	MinimumMajorCudaVersion                 int = 11
 )
 
 type RunItem struct {
@@ -58,16 +59,21 @@ type Build struct {
 	pythonRequirementsContent []string
 }
 
+type Concurrency struct {
+	Max int `json:"max,omitempty" yaml:"max"`
+}
+
 type Example struct {
 	Input  map[string]string `json:"input" yaml:"input"`
 	Output string            `json:"output" yaml:"output"`
 }
 
 type Config struct {
-	Build   *Build `json:"build" yaml:"build"`
-	Image   string `json:"image,omitempty" yaml:"image"`
-	Predict string `json:"predict,omitempty" yaml:"predict"`
-	Train   string `json:"train,omitempty" yaml:"train"`
+	Build       *Build       `json:"build" yaml:"build"`
+	Image       string       `json:"image,omitempty" yaml:"image"`
+	Predict     string       `json:"predict,omitempty" yaml:"predict"`
+	Train       string       `json:"train,omitempty" yaml:"train"`
+	Concurrency *Concurrency `json:"concurrency,omitempty" yaml:"concurrency"`
 }
 
 func DefaultConfig() *Config {
@@ -244,7 +250,9 @@ func splitPythonVersion(version string) (major int, minor int, err error) {
 	return major, minor, nil
 }
 
-func ValidateModelPythonVersion(version string) error {
+func ValidateModelPythonVersion(cfg *Config) error {
+	version := cfg.Build.PythonVersion
+
 	// we check for minimum supported here
 	major, minor, err := splitPythonVersion(version)
 	if err != nil {
@@ -254,6 +262,10 @@ func ValidateModelPythonVersion(version string) error {
 		minor < MinimumMinorPythonVersion) {
 		return fmt.Errorf("minimum supported Python version is %d.%d. requested %s",
 			MinimumMajorPythonVersion, MinimumMinorPythonVersion, version)
+	}
+	if cfg.Concurrency.Max > 1 && minor < MinimumMinorPythonVersionForConcurrency {
+		return fmt.Errorf("when concurrency.max is set, minimum supported Python version is %d.%d. requested %s",
+			MinimumMajorPythonVersion, MinimumMinorPythonVersionForConcurrency, version)
 	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -263,7 +263,7 @@ func ValidateModelPythonVersion(cfg *Config) error {
 		return fmt.Errorf("minimum supported Python version is %d.%d. requested %s",
 			MinimumMajorPythonVersion, MinimumMinorPythonVersion, version)
 	}
-	if cfg.Concurrency.Max > 1 && minor < MinimumMinorPythonVersionForConcurrency {
+	if cfg.Concurrency != nil && cfg.Concurrency.Max > 1 && minor < MinimumMinorPythonVersionForConcurrency {
 		return fmt.Errorf("when concurrency.max is set, minimum supported Python version is %d.%d. requested %s",
 			MinimumMajorPythonVersion, MinimumMinorPythonVersionForConcurrency, version)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -13,47 +13,64 @@ import (
 
 func TestValidateModelPythonVersion(t *testing.T) {
 	testCases := []struct {
-		name        string
-		input       string
-		expectedErr bool
+		name           string
+		pythonVersion  string
+		concurrencyMax int
+		expectedErr    string
 	}{
 		{
-			name:        "ValidVersion",
-			input:       "3.12",
-			expectedErr: false,
+			name:          "ValidVersion",
+			pythonVersion: "3.12",
 		},
 		{
-			name:        "MinimumVersion",
-			input:       "3.8",
-			expectedErr: false,
+			name:          "MinimumVersion",
+			pythonVersion: "3.8",
 		},
 		{
-			name:        "FullyQualifiedVersion",
-			input:       "3.12.1",
-			expectedErr: false,
+			name:           "MinimumVersionForConcurrency",
+			pythonVersion:  "3.11",
+			concurrencyMax: 5,
 		},
 		{
-			name:        "InvalidFormat",
-			input:       "3-12",
-			expectedErr: true,
+			name:           "TooOldForConcurrency",
+			pythonVersion:  "3.8",
+			concurrencyMax: 5,
+			expectedErr:    "when concurrency.max is set, minimum supported Python version is 3.11. requested 3.8",
 		},
 		{
-			name:        "InvalidMissingMinor",
-			input:       "3",
-			expectedErr: true,
+			name:          "FullyQualifiedVersion",
+			pythonVersion: "3.12.1",
 		},
 		{
-			name:        "LessThanMinimum",
-			input:       "3.7",
-			expectedErr: true,
+			name:          "InvalidFormat",
+			pythonVersion: "3-12",
+			expectedErr:   "invalid Python version format: missing minor version in 3-12",
+		},
+		{
+			name:          "InvalidMissingMinor",
+			pythonVersion: "3",
+			expectedErr:   "invalid Python version format: missing minor version in 3",
+		},
+		{
+			name:          "LessThanMinimum",
+			pythonVersion: "3.7",
+			expectedErr:   "minimum supported Python version is 3.8. requested 3.7",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateModelPythonVersion(tc.input)
-			if tc.expectedErr {
-				require.Error(t, err)
+			cfg := &Config{
+				Build: &Build{
+					PythonVersion: tc.pythonVersion,
+				},
+				Concurrency: &Concurrency{
+					Max: tc.concurrencyMax,
+				},
+			}
+			err := ValidateModelPythonVersion(cfg)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 			}
@@ -647,17 +664,6 @@ func TestBlankBuild(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, config.Build)
 	require.Equal(t, false, config.Build.GPU)
-}
-
-func TestModelPythonVersionValidation(t *testing.T) {
-	err := ValidateModelPythonVersion("3.8")
-	require.NoError(t, err)
-	err = ValidateModelPythonVersion("3.8.1")
-	require.NoError(t, err)
-	err = ValidateModelPythonVersion("3.7")
-	require.Equal(t, "minimum supported Python version is 3.8. requested 3.7", err.Error())
-	err = ValidateModelPythonVersion("3.7.1")
-	require.Equal(t, "minimum supported Python version is 3.8. requested 3.7.1", err.Error())
 }
 
 func TestSplitPinnedPythonRequirement(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -64,9 +64,13 @@ func TestValidateModelPythonVersion(t *testing.T) {
 				Build: &Build{
 					PythonVersion: tc.pythonVersion,
 				},
-				Concurrency: &Concurrency{
+			}
+			if tc.concurrencyMax != 0 {
+				// the Concurrency key is optional, only populate it if
+				// concurrencyMax is a non-default value
+				cfg.Concurrency = &Concurrency{
 					Max: tc.concurrencyMax,
-				},
+				}
 			}
 			err := ValidateModelPythonVersion(cfg)
 			if tc.expectedErr != "" {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ tests = [
   "numpy",
   "pillow",
   "pytest",
+  "pytest-asyncio",
   "pytest-httpserver",
   "pytest-timeout",
   "pytest-xdist",
@@ -69,6 +70,9 @@ reportUnusedExpression = "warning"
 
 [tool.pyright.defineConstant]
 PYDANTIC_V2 = true
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.setuptools]
 include-package-data = false

--- a/python/cog/__init__.py
+++ b/python/cog/__init__.py
@@ -6,6 +6,7 @@ from .base_predictor import BasePredictor
 from .mimetypes_ext import install_mime_extensions
 from .server.scope import current_scope, emit_metric
 from .types import (
+    AsyncConcatenateIterator,
     ConcatenateIterator,
     ExperimentalFeatureWarning,
     File,
@@ -26,6 +27,7 @@ __all__ = [
     "__version__",
     "current_scope",
     "emit_metric",
+    "AsyncConcatenateIterator",
     "BaseModel",
     "BasePredictor",
     "ConcatenateIterator",

--- a/python/cog/config.py
+++ b/python/cog/config.py
@@ -33,6 +33,7 @@ COG_TRAIN_TYPE_STUB_ENV_VAR = "COG_TRAIN_TYPE_STUB"
 COG_PREDICT_CODE_STRIP_ENV_VAR = "COG_PREDICT_CODE_STRIP"
 COG_TRAIN_CODE_STRIP_ENV_VAR = "COG_TRAIN_CODE_STRIP"
 COG_GPU_ENV_VAR = "COG_GPU"
+COG_MAX_CONCURRENCY_ENV_VAR = "COG_MAX_CONCURRENCY"
 PREDICT_METHOD_NAME = "predict"
 TRAIN_METHOD_NAME = "train"
 
@@ -100,6 +101,12 @@ class Config:
     def requires_gpu(self) -> bool:
         """Whether this cog requires the use of a GPU."""
         return bool(self._cog_config.get("build", {}).get("gpu", False))
+
+    @property
+    @env_property(COG_MAX_CONCURRENCY_ENV_VAR)
+    def max_concurrency(self) -> int:
+        """The maximum concurrency of predictions supported by this model. Defaults to 1."""
+        return int(self._cog_config.get("concurrency", {}).get("max", 1))
 
     def _predictor_code(
         self,

--- a/python/cog/server/helpers.py
+++ b/python/cog/server/helpers.py
@@ -33,7 +33,7 @@ class _SimpleStreamWrapper(io.TextIOWrapper):
         callback: Callable[[str, str], None],
         tee: bool = False,
     ) -> None:
-        super().__init__(buffer, line_buffering=True)
+        super().__init__(buffer)
 
         self._callback = callback
         self._tee = tee
@@ -44,11 +44,10 @@ class _SimpleStreamWrapper(io.TextIOWrapper):
         self._buffer.append(s)
         if self._tee:
             super().write(s)
-        else:
-            # If we're not teeing, we have to handle automatic flush on
-            # newline. When `tee` is true, this is handled by the write method.
-            if "\n" in s or "\r" in s:
-                self.flush()
+
+        if "\n" in s or "\r" in s:
+            self.flush()
+
         return length
 
     def flush(self) -> None:

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -101,11 +101,12 @@ class PredictionRunner:
 
         with self._predict_tasks_lock:
             # first remove finished tasks so we don't grow the dictionary without bound
-            done_ids = [
-                id for id in self._predict_tasks if self._predict_tasks[id].done()
+            # TODO: clean this up by adding a done callback to the task.
+            done_tags = [
+                tag for tag in self._predict_tasks if self._predict_tasks[tag].done()
             ]
-            for id in done_ids:
-                del self._predict_tasks[id]
+            for tag in done_tags:
+                del self._predict_tasks[tag]
 
             self._predict_tasks[tag] = task
 

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -105,8 +105,8 @@ class PredictionRunner:
             done_tags = [
                 tag for tag in self._predict_tasks if self._predict_tasks[tag].done()
             ]
-            for tag in done_tags:
-                del self._predict_tasks[tag]
+            for done_tag in done_tags:
+                del self._predict_tasks[done_tag]
 
             self._predict_tasks[tag] = task
 

--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -1,5 +1,8 @@
+import asyncio
 import io
+import threading
 import traceback
+import uuid
 from abc import ABC, abstractmethod
 from concurrent.futures import Future
 from datetime import datetime, timezone
@@ -60,13 +63,15 @@ class PredictionRunner:
     def __init__(
         self,
         *,
+        max_concurrency: int = 1,
         worker: Worker,
     ) -> None:
         self._worker = worker
+        self._max_concurrency = max_concurrency
 
         self._setup_task: Optional[SetupTask] = None
-        self._predict_task: Optional[PredictTask] = None
-        self._prediction_id = None
+        self._predict_tasks: Dict[str, PredictTask] = {}
+        self._predict_tasks_lock = threading.Lock()
 
     def setup(self) -> "SetupTask":
         assert self._setup_task is None, "do not call setup twice"
@@ -88,8 +93,21 @@ class PredictionRunner:
 
         task_kwargs = task_kwargs or {}
 
-        self._predict_task = PredictTask(prediction, **task_kwargs)
-        self._prediction_id = prediction.id
+        tag = prediction.id
+        if tag is None:
+            tag = uuid.uuid4().hex
+
+        task = PredictTask(prediction, **task_kwargs)
+
+        with self._predict_tasks_lock:
+            # first remove finished tasks so we don't grow the dictionary without bound
+            done_ids = [
+                id for id in self._predict_tasks if self._predict_tasks[id].done()
+            ]
+            for id in done_ids:
+                del self._predict_tasks[id]
+
+            self._predict_tasks[tag] = task
 
         if isinstance(prediction.input, BaseInput):
             if PYDANTIC_V2:
@@ -101,18 +119,15 @@ class PredictionRunner:
         else:
             payload = prediction.input.copy()
 
-        sid = self._worker.subscribe(self._predict_task.handle_event)
-        self._predict_task.track(self._worker.predict(payload))
-        self._predict_task.add_done_callback(lambda _: self._worker.unsubscribe(sid))
+        sid = self._worker.subscribe(task.handle_event, tag=tag)
+        task.track(self._worker.predict(payload, tag=tag))
+        task.add_done_callback(lambda _: self._worker.unsubscribe(sid))
 
-        return self._predict_task
+        return task
 
     def get_predict_task(self, id: str) -> Optional["PredictTask"]:
-        if not self._predict_task:
-            return None
-        if self._predict_task.result.id != id:
-            return None
-        return self._predict_task
+        with self._predict_tasks_lock:
+            return self._predict_tasks.get(id, None)
 
     def is_busy(self) -> bool:
         try:
@@ -124,9 +139,13 @@ class PredictionRunner:
     def cancel(self, prediction_id: str) -> None:
         if not prediction_id:
             raise ValueError("prediction_id is required")
-        if self._prediction_id != prediction_id:
-            raise UnknownPredictionError("id mismatch")
-        self._worker.cancel()
+        with self._predict_tasks_lock:
+            if (
+                prediction_id not in self._predict_tasks
+                or self._predict_tasks[prediction_id].done()
+            ):
+                raise UnknownPredictionError("unknown prediction id")
+        self._worker.cancel(tag=prediction_id)
 
     def _raise_if_busy(self) -> None:
         if self._setup_task is None:
@@ -135,9 +154,17 @@ class PredictionRunner:
         if not self._setup_task.done():
             # Setup is still running.
             raise RunnerBusyError("setup is not complete")
-        if self._predict_task is not None and not self._predict_task.done():
-            # Prediction is still running.
-            raise RunnerBusyError("prediction running")
+
+        with self._predict_tasks_lock:
+            processing_tasks = [
+                id for id in self._predict_tasks if not self._predict_tasks[id].done()
+            ]
+
+        if len(processing_tasks) >= self._max_concurrency:
+            # We're at max concurrency
+            if self._max_concurrency == 1:
+                raise RunnerBusyError("prediction running")
+            raise RunnerBusyError("max predictions running")
 
 
 T = TypeVar("T")
@@ -316,6 +343,11 @@ class PredictTask(Task[schema.PredictionResponse]):
     def done(self) -> bool:
         assert self._fut, "call track before checking done"
         return self._fut.done()
+
+    async def wait_async(self) -> None:
+        assert self._fut, "call track before waiting"
+        await asyncio.wrap_future(self._fut)
+        return None
 
     def wait(self, timeout: Optional[float] = None) -> None:
         assert self._fut, "call track before waiting"

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -472,12 +472,12 @@ class _ChildWorker(_spawn.Process):  # type: ignore
             # We should check for this before getting to this point
             if is_async_predictor and sys.version_info < (3, 11):
                 raise FatalWorkerException(
-                    "Cog requires python >=3.11 for `async def predict(..)` support"
+                    "Cog requires Python >=3.11 for `async def predict()` support"
                 )
 
             if self._max_concurrency > 1 and not is_async_predictor:
                 raise FatalWorkerException(
-                    "max_concurrency>1 requires `async def predict()`"
+                    "max_concurrency > 1 requires an async predict function, e.g. `async def predict()`"
                 )
 
         except Exception as e:  # pylint: disable=broad-exception-caught

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -11,6 +11,7 @@ import threading
 import traceback
 import types
 import uuid
+import warnings
 from concurrent.futures import Future, ThreadPoolExecutor
 from enum import Enum, auto, unique
 from multiprocessing.connection import Connection
@@ -396,6 +397,7 @@ class _ChildWorker(_spawn.Process):  # type: ignore
             # it has sent a error Done event and we're done here.
             if not self._predictor:
                 return
+            self._predictor.log = self._log
 
             predict = get_predict(self._predictor)
             if self._is_async:
@@ -726,6 +728,18 @@ class _ChildWorker(_spawn.Process):  # type: ignore
             self._events.send(
                 Envelope(event=Log(data, source="stderr"), tag=self._current_tag)
             )
+
+    def _log(self, *messages: str, source: str = "stderr") -> None:
+        """
+        DEPRECATED: This function will be removed in a future version of cog.
+        """
+        warnings.warn(
+            "log() is deprecated and will be removed in a future version. Use `print` or `logging` module instead",
+            category=DeprecationWarning,
+            stacklevel=1,
+        )
+        file = sys.stdout if source == "stdout" else sys.stderr
+        print(*messages, file=file)
 
 
 def make_worker(

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -397,7 +397,7 @@ class _ChildWorker(_spawn.Process):  # type: ignore
             # it has sent a error Done event and we're done here.
             if not self._predictor:
                 return
-            self._predictor.log = self._log
+            self._predictor.log = self._log  # type: ignore
 
             predict = get_predict(self._predictor)
             if self._is_async:

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -739,7 +739,7 @@ class _ChildWorker(_spawn.Process):  # type: ignore
             stacklevel=1,
         )
         file = sys.stdout if source == "stdout" else sys.stderr
-        print(*messages, file=file)
+        print(*messages, file=file, end="")
 
 
 def make_worker(

--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -43,6 +43,7 @@ class ExperimentalFeatureWarning(Warning):
 
 class CogConfig(TypedDict):  # pylint: disable=too-many-ancestors
     build: "CogBuildConfig"
+    concurrency: "CogConcurrencyConfig"
     image: NotRequired[str]
     predict: NotRequired[str]
     train: NotRequired[str]
@@ -56,6 +57,10 @@ class CogBuildConfig(TypedDict, total=False):  # pylint: disable=too-many-ancest
     python_requirements: Optional[str]
     python_version: Optional[str]
     run: Optional[Union[List[str], List[Dict[str, Any]]]]
+
+
+class CogConcurrencyConfig(TypedDict, total=False):  # pylint: disable=too-many-ancestors
+    max: Optional[int]
 
 
 def Input(  # pylint: disable=invalid-name, too-many-arguments

--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -60,7 +60,7 @@ class CogBuildConfig(TypedDict, total=False):  # pylint: disable=too-many-ancest
 
 
 class CogConcurrencyConfig(TypedDict, total=False):  # pylint: disable=too-many-ancestors
-    max: Optional[int]
+    max: NotRequired[int]
 
 
 def Input(  # pylint: disable=invalid-name, too-many-arguments

--- a/python/tests/server/conftest.py
+++ b/python/tests/server/conftest.py
@@ -3,7 +3,7 @@ import sys
 import threading
 import time
 from contextlib import ExitStack
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence, Tuple
 from unittest import mock
 
 import pytest

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -333,7 +333,7 @@ def test_async_predictor_on_python_3_10_or_older_raises_error(worker):
     assert result.done.error
     assert (
         result.done.error_detail
-        == "Cog requires python >=3.11 for `async def predict(..)` support"
+        == "Cog requires Python >=3.11 for `async def predict()` support"
     )
 
 
@@ -348,7 +348,8 @@ def test_concurrency_with_sync_predictor_raises_error(worker):
     assert result.done
     assert result.done.error
     assert (
-        result.done.error_detail == "max_concurrency>1 requires `async def predict()`"
+        result.done.error_detail
+        == "max_concurrency > 1 requires an async predict function, e.g. `async def predict()`"
     )
 
 

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -83,6 +83,20 @@ METRICS_FIXTURES = [
             "foo": 123,
         },
     ),
+    (
+        WorkerConfig("emit_metric"),
+        {"name": ST_NAMES},
+        {
+            "foo": 123,
+        },
+    ),
+    (
+        WorkerConfig("emit_metric_async"),
+        {"name": ST_NAMES},
+        {
+            "foo": 123,
+        },
+    ),
 ]
 
 OUTPUT_FIXTURES = [

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -91,7 +91,7 @@ METRICS_FIXTURES = [
         },
     ),
     (
-        WorkerConfig("emit_metric_async"),
+        WorkerConfig("emit_metric_async", min_python=(3, 11)),
         {"name": ST_NAMES},
         {
             "foo": 123,

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -91,7 +91,7 @@ METRICS_FIXTURES = [
         },
     ),
     (
-        WorkerConfig("emit_metric_async", min_python=(3, 11)),
+        WorkerConfig("emit_metric_async", min_python=(3, 11), is_async=True),
         {"name": ST_NAMES},
         {
             "foo": 123,

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import os
+import sys
 import threading
 import time
 import uuid
@@ -76,21 +77,7 @@ METRICS_FIXTURES = [
         },
     ),
     (
-        WorkerConfig("record_metric_async", is_async=True),
-        {"name": ST_NAMES},
-        {
-            "foo": 123,
-        },
-    ),
-    (
-        WorkerConfig("emit_metric"),
-        {"name": ST_NAMES},
-        {
-            "foo": 123,
-        },
-    ),
-    (
-        WorkerConfig("emit_metric_async", is_async=True),
+        WorkerConfig("record_metric_async", min_python=(3, 11), is_async=True),
         {"name": ST_NAMES},
         {
             "foo": 123,
@@ -105,7 +92,7 @@ OUTPUT_FIXTURES = [
         lambda x: f"hello, {x['name']}",
     ),
     (
-        WorkerConfig("hello_world_async", is_async=True),
+        WorkerConfig("hello_world_async", min_python=(3, 11), is_async=True),
         {"name": ST_NAMES},
         lambda x: f"hello, {x['name']}",
     ),
@@ -132,7 +119,7 @@ SETUP_LOGS_FIXTURES = [
         "writing to stderr at import time\n",
     ),
     (
-        WorkerConfig("logging_async", is_async=True, setup=False),
+        WorkerConfig("logging_async", setup=False, min_python=(3, 11), is_async=True),
         ("writing to stdout at import time\n" "setting up predictor\n"),
         "writing to stderr at import time\n",
     ),
@@ -145,10 +132,20 @@ PREDICT_LOGS_FIXTURES = [
         ("WARNING:root:writing log message\n" "writing to stderr\n"),
     ),
     (
-        WorkerConfig("logging_async", is_async=True),
+        WorkerConfig("logging_async", min_python=(3, 11), is_async=True),
         ("writing with print\n"),
         ("WARNING:root:writing log message\n" "writing to stderr\n"),
     ),
+]
+
+SLEEP_FIXTURES = [
+    WorkerConfig("sleep"),
+    WorkerConfig("sleep_async", min_python=(3, 11), is_async=True),
+]
+
+SLEEP_NO_SETUP_FIXTURES = [
+    WorkerConfig("sleep", setup=False),
+    WorkerConfig("sleep_async", min_python=(3, 11), setup=False, is_async=True),
 ]
 
 
@@ -255,9 +252,11 @@ def test_no_exceptions_from_recoverable_failures(worker):
         _process(worker, lambda: worker.predict({}))
 
 
-# TODO test this works with errors and cancelations and the like
 @uses_worker_configs(
-    [WorkerConfig("simple"), WorkerConfig("simple_async", is_async=True)]
+    [
+        WorkerConfig("simple"),
+        WorkerConfig("simple_async", min_python=(3, 11), is_async=True),
+    ]
 )
 def test_can_subscribe_for_a_specific_tag(worker):
     tag = "123"
@@ -280,12 +279,12 @@ def test_can_subscribe_for_a_specific_tag(worker):
         worker.unsubscribe(subid)
 
 
-@uses_worker("sleep_async", is_async=True, max_concurrency=5)
+@uses_worker("sleep_async", max_concurrency=5, min_python=(3, 11), is_async=True)
 def test_can_run_predictions_concurrently_on_async_predictor(worker):
     subids = []
 
     try:
-        start = time.time()
+        start = time.perf_counter()
         futures = []
         results = []
         for i in range(5):
@@ -299,7 +298,7 @@ def test_can_run_predictions_concurrently_on_async_predictor(worker):
         for fut in futures:
             fut.result()
 
-        end = time.time()
+        end = time.perf_counter()
 
         duration = end - start
         # we should take at least 0.5 seconds (the time for 1 prediction) but
@@ -317,6 +316,40 @@ def test_can_run_predictions_concurrently_on_async_predictor(worker):
     finally:
         for subid in subids:
             worker.unsubscribe(subid)
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 11), reason="Testing error message on python versions <3.11"
+)
+@uses_worker("simple_async", setup=False)
+def test_async_predictor_on_python_3_10_or_older_raises_error(worker):
+    fut = worker.setup()
+    result = Result()
+    worker.subscribe(result.handle_event)
+
+    with pytest.raises(FatalWorkerException):
+        fut.result()
+    assert result.done
+    assert result.done.error
+    assert (
+        result.done.error_detail
+        == "Cog requires python >=3.11 for `async def predict(..)` support"
+    )
+
+
+@uses_worker("simple", max_concurrency=5, setup=False)
+def test_concurrency_with_sync_predictor_raises_error(worker):
+    fut = worker.setup()
+    result = Result()
+    worker.subscribe(result.handle_event)
+
+    with pytest.raises(FatalWorkerException):
+        fut.result()
+    assert result.done
+    assert result.done.error
+    assert (
+        result.done.error_detail == "max_concurrency>1 requires `async def predict()`"
+    )
 
 
 @uses_worker("stream_redirector_race_condition")
@@ -403,12 +436,7 @@ def test_predict_logging(worker, expected_stdout, expected_stderr):
     assert result.stderr == expected_stderr
 
 
-@uses_worker_configs(
-    [
-        WorkerConfig("sleep", setup=False),
-        WorkerConfig("sleep_async", is_async=True, setup=False),
-    ]
-)
+@uses_worker_configs(SLEEP_NO_SETUP_FIXTURES)
 def test_cancel_is_safe(worker):
     """
     Calls to cancel at any time should not result in unexpected things
@@ -442,12 +470,7 @@ def test_cancel_is_safe(worker):
     assert result2.output == "done in 0.1 seconds"
 
 
-@uses_worker_configs(
-    [
-        WorkerConfig("sleep", setup=False),
-        WorkerConfig("sleep_async", is_async=True, setup=False),
-    ]
-)
+@uses_worker_configs(SLEEP_NO_SETUP_FIXTURES)
 def test_cancel_idempotency(worker):
     """
     Multiple calls to cancel within the same prediction, while not necessary or
@@ -479,9 +502,7 @@ def test_cancel_idempotency(worker):
     assert result2.output == "done in 0.1 seconds"
 
 
-@uses_worker_configs(
-    [WorkerConfig("sleep"), WorkerConfig("sleep_async", is_async=True)]
-)
+@uses_worker_configs(SLEEP_FIXTURES)
 def test_cancel_multiple_predictions(worker):
     """
     Multiple predictions cancelled in a row shouldn't be a problem. This test
@@ -499,9 +520,7 @@ def test_cancel_multiple_predictions(worker):
     assert not worker.predict({"sleep": 0}).result().canceled
 
 
-@uses_worker_configs(
-    [WorkerConfig("sleep"), WorkerConfig("sleep_async", is_async=True)]
-)
+@uses_worker_configs(SLEEP_FIXTURES)
 def test_graceful_shutdown(worker):
     """
     On shutdown, the worker should finish running the current prediction, and

--- a/test-integration/test_integration/fixtures/async-sleep-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/async-sleep-project/cog.yaml
@@ -1,0 +1,5 @@
+build:
+  python_version: "3.11"
+predict: "predict.py:Predictor"
+concurrency:
+  max: 5

--- a/test-integration/test_integration/fixtures/async-sleep-project/predict.py
+++ b/test-integration/test_integration/fixtures/async-sleep-project/predict.py
@@ -1,0 +1,9 @@
+import asyncio
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    async def predict(self, s: str, sleep: float) -> str:
+        await asyncio.sleep(sleep)
+        return f"wake up {s}"

--- a/test-integration/test_integration/fixtures/async-string-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/async-string-project/cog.yaml
@@ -1,0 +1,3 @@
+build:
+  python_version: "3.11"
+predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/async-string-project/predict.py
+++ b/test-integration/test_integration/fixtures/async-string-project/predict.py
@@ -1,0 +1,6 @@
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    async def predict(self, s: str) -> str:
+        return "hello " + s

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -1,6 +1,8 @@
+import asyncio
 import pathlib
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 import httpx
@@ -25,6 +27,20 @@ def test_predict_takes_string_inputs_and_returns_strings_to_stdout():
     assert result.stdout == "hello world\n"
     assert "cannot use fast loader as current Python <3.9" in result.stderr
     assert "falling back to slow loader" in result.stderr
+
+
+def test_predict_supports_async_predictors():
+    project_dir = Path(__file__).parent / "fixtures/async-string-project"
+    result = subprocess.run(
+        ["cog", "predict", "--debug", "-i", "s=world"],
+        cwd=project_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=DEFAULT_TIMEOUT,
+    )
+    # stdout should be clean without any log messages so it can be piped to other commands
+    assert result.stdout == "hello world\n"
 
 
 def test_predict_takes_int_inputs_and_returns_ints_to_stdout():
@@ -322,3 +338,34 @@ def test_predict_with_subprocess_in_setup(fixture_name):
             assert response.status_code == 200, str(response)
 
         assert busy_count < 10
+
+
+@pytest.mark.asyncio
+async def test_concurrent_predictions():
+    async def make_request(i: int) -> httpx.Response:
+        return await client.post(
+            f"{addr}/predictions",
+            json={
+                "id": f"id-{i}",
+                "input": {"s": f"sleepyhead{i}", "sleep": 1.0},
+            },
+        )
+
+    with cog_server_http_run(
+        Path(__file__).parent / "fixtures" / "async-sleep-project"
+    ) as addr:
+        async with httpx.AsyncClient() as client:
+            tasks = []
+            start = time.perf_counter()
+            async with asyncio.TaskGroup() as tg:
+                for i in range(5):
+                    tasks.append(tg.create_task(make_request(i)))
+                # give time for all of the predictions to be accepted, but not completed
+                await asyncio.sleep(0.2)
+                # we shut the server down, but expect all running predictions to complete
+                await client.post(f"{addr}/shutdown")
+            end = time.perf_counter()
+            assert (end - start) < 3.0  # ensure the predictions ran concurrently
+            for i, task in enumerate(tasks):
+                assert task.result().status_code == 200
+                assert task.result().json()["output"] == f"wake up sleepyhead{i}"


### PR DESCRIPTION
This builds on the work in https://github.com/replicate/cog/pull/2057 and wires it up end-to-end.

We can now support async models with a max concurrency configured, and submit
multiple predictions concurrently to them.

We only support python 3.11 for async models; this is so that we can use
asyncio.TaskGroup to keep track of multiple predictions in flight and ensure
they all complete when shutting down.

The cog http server was already async, but at one point it called wait() on a
concurrent.futures.Future() which blocked the event loop and therefore prevented
concurrent prediction requests (when not using prefer-async, which is how the
tests run).  I have updated this code to wait on asyncio.wrap_future(fut)
instead which does not block the event loop.  As part of this I have updated the
training endpoints to also be asynchronous.

We now have three places in the code which keep track of how many predictions
are in flight: PredictionRunner, Worker and _ChildWorker all do their own
bookkeeping. I'm not sure this is the best design but it works.

The code is now an uneasy mix of threaded and asyncio code.  This is evident in
the usage of threading.Lock, which wouldn't be needed if we were 100% async (and
I'm not sure if it's actually needed currently; I just added it to be safe).