### PR TITLE
Use a single stream redirector for both setup and predict

### DIFF
--- a/python/cog/server/helpers.py
+++ b/python/cog/server/helpers.py
@@ -127,19 +127,19 @@ class _StreamWrapper:
 
 if sys.version_info < (3, 9):
 
-    class _AsyncStreamRedirectorBase(contextlib.AbstractContextManager):
+    class _SimpleStreamRedirectorBase(contextlib.AbstractContextManager):
         pass
 else:
 
-    class _AsyncStreamRedirectorBase(
-        contextlib.AbstractContextManager["AsyncStreamRedirector"]
+    class _SimpleStreamRedirectorBase(
+        contextlib.AbstractContextManager["SimpleStreamRedirector"]
     ):
         pass
 
 
-class AsyncStreamRedirector(_AsyncStreamRedirectorBase):
+class SimpleStreamRedirector(_SimpleStreamRedirectorBase):
     """
-    AsyncStreamRedirector is a context manager that redirects I/O streams to a
+    SimpleStreamRedirector is a context manager that redirects I/O streams to a
     callback function. If `tee` is True, it also writes output to the original
     streams.
 
@@ -179,7 +179,7 @@ class AsyncStreamRedirector(_AsyncStreamRedirectorBase):
         self._stderr_ctx.__exit__(exc_type, exc_value, traceback)
 
     def drain(self, timeout: float = 0.0) -> None:
-        # Draining isn't complicated for AsyncStreamRedirector, since we're not
+        # Draining isn't complicated for SimpleStreamRedirector, since we're not
         # moving data between threads. We just need to flush the streams.
         sys.stdout.flush()
         sys.stderr.flush()

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -156,13 +156,17 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
         return JSONResponse({}, status_code=200)
 
     try:
-        InputType, OutputType, _ = cog_config.get_predictor_types(mode=Mode.PREDICT)
+        InputType, OutputType, is_async = cog_config.get_predictor_types(
+            mode=Mode.PREDICT
+        )
     except Exception:  # pylint: disable=broad-exception-caught
         msg = "Error while loading predictor:\n\n" + traceback.format_exc()
         add_setup_failed_routes(app, started_at, msg)
         return app
 
-    worker = make_worker(predictor_ref=cog_config.get_predictor_ref(mode=mode))
+    worker = make_worker(
+        predictor_ref=cog_config.get_predictor_ref(mode=mode), is_async=is_async
+    )
     runner = PredictionRunner(worker=worker)
 
     class PredictionRequest(schema.PredictionRequest.with_types(input_type=InputType)):

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -156,7 +156,7 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
         return JSONResponse({}, status_code=200)
 
     try:
-        InputType, OutputType = cog_config.get_predictor_types(mode=Mode.PREDICT)
+        InputType, OutputType, _ = cog_config.get_predictor_types(mode=Mode.PREDICT)
     except Exception:  # pylint: disable=broad-exception-caught
         msg = "Error while loading predictor:\n\n" + traceback.format_exc()
         add_setup_failed_routes(app, started_at, msg)
@@ -197,7 +197,7 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
 
     if cog_config.predictor_train_ref:
         try:
-            TrainingInputType, TrainingOutputType = cog_config.get_predictor_types(
+            TrainingInputType, TrainingOutputType, _ = cog_config.get_predictor_types(
                 Mode.TRAIN
             )
 

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -348,6 +348,8 @@ class _ChildWorker(_spawn.Process):  # type: ignore
     def __init__(
         self,
         predictor_ref: str,
+        *,
+        is_async: bool,
         events: Connection,
         tee_output: bool = True,
     ) -> None:
@@ -361,6 +363,7 @@ class _ChildWorker(_spawn.Process):  # type: ignore
 
         # for synchronous predictors only! async predictors use _tag_var instead
         self._sync_tag: Optional[str] = None
+        self._is_async = is_async
 
         super().__init__()
 
@@ -373,32 +376,40 @@ class _ChildWorker(_spawn.Process):  # type: ignore
         # Initially, we ignore SIGUSR1.
         signal.signal(signal.SIGUSR1, signal.SIG_IGN)
 
-        async_redirector = AsyncStreamRedirector(
-            callback=self._stream_write_hook,
-            tee=self._tee_output,
-        )
-
-        with async_redirector:
-            self._setup(async_redirector)
-
-        # If setup didn't set the predictor, we're done here.
-        if not self._predictor:
-            return
-
-        predict = get_predict(self._predictor)
-        if inspect.iscoroutinefunction(predict) or inspect.isasyncgenfunction(predict):
-            asyncio.run(self._aloop(predict, async_redirector))
-        else:
-            # We use SIGUSR1 to signal an interrupt for cancelation.
-            signal.signal(signal.SIGUSR1, self._signal_handler)
-
-            self._loop(
-                predict,
-                StreamRedirector(
-                    callback=self._stream_write_hook,
-                    tee=self._tee_output,
-                ),
+        if self._is_async:
+            redirector = AsyncStreamRedirector(
+                callback=self._stream_write_hook,
+                tee=self._tee_output,
             )
+        else:
+            redirector = StreamRedirector(
+                callback=self._stream_write_hook,
+                tee=self._tee_output,
+            )
+
+        with scope(Scope(record_metric=self.record_metric)), redirector:
+            self._predictor = self._load_predictor()
+
+            # If _load_predictor hasn't returned a predictor instance then
+            # it has sent a error Done event and we're done here.
+            if not self._predictor:
+                return
+
+            predict = get_predict(self._predictor)
+            if self._is_async:
+                assert isinstance(redirector, AsyncStreamRedirector)
+                self._setup(redirector)
+                asyncio.run(self._aloop(predict, redirector))
+            else:
+                # We use SIGUSR1 to signal an interrupt for cancelation.
+                signal.signal(signal.SIGUSR1, self._signal_handler)
+
+                assert isinstance(redirector, StreamRedirector)
+                self._setup(redirector)
+                self._loop(
+                    predict,
+                    redirector,
+                )
 
     def send_cancel(self) -> None:
         if self.is_alive() and self.pid:
@@ -417,11 +428,34 @@ class _ChildWorker(_spawn.Process):  # type: ignore
             return tag
         return self._sync_tag
 
-    def _setup(self, redirector: AsyncStreamRedirector) -> None:
+    def _load_predictor(self) -> Optional[BasePredictor]:
         done = Done()
         wait_for_env()
         try:
-            self._predictor = load_predictor_from_ref(self._predictor_ref)
+            return load_predictor_from_ref(self._predictor_ref)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            traceback.print_exc()
+            done.error = True
+            done.error_detail = str(e)
+            self._events.send(Envelope(event=done))
+        except BaseException as e:
+            # For SystemExit and friends we attempt to add some useful context
+            # to the logs, but reraise to ensure the process dies.
+            traceback.print_exc()
+            done.error = True
+            done.error_detail = str(e)
+            self._events.send(Envelope(event=done))
+            raise
+
+        return None
+
+    def _setup(
+        self, redirector: Union[StreamRedirector, AsyncStreamRedirector]
+    ) -> None:
+        done = Done()
+        try:
+            assert self._predictor
+
             # Could be a function or a class
             if hasattr(self._predictor, "setup"):
                 run_setup(self._predictor)
@@ -456,17 +490,16 @@ class _ChildWorker(_spawn.Process):  # type: ignore
         predict: Callable[..., Any],
         redirector: StreamRedirector,
     ) -> None:
-        with scope(self._loop_scope()), redirector:
-            while True:
-                e = cast(Envelope, self._events.recv())
-                if isinstance(e.event, Cancel):
-                    continue  # Ignored in sync predictors.
-                elif isinstance(e.event, Shutdown):
-                    break
-                elif isinstance(e.event, PredictionInput):
-                    self._predict(e.tag, e.event.payload, predict, redirector)
-                else:
-                    print(f"Got unexpected event: {e.event}", file=sys.stderr)
+        while True:
+            e = cast(Envelope, self._events.recv())
+            if isinstance(e.event, Cancel):
+                continue  # Ignored in sync predictors.
+            elif isinstance(e.event, Shutdown):
+                break
+            elif isinstance(e.event, PredictionInput):
+                self._predict(e.tag, e.event.payload, predict, redirector)
+            else:
+                print(f"Got unexpected event: {e.event}", file=sys.stderr)
 
     async def _aloop(
         self,
@@ -479,24 +512,20 @@ class _ChildWorker(_spawn.Process):  # type: ignore
 
         task = None
 
-        with scope(self._loop_scope()), redirector:
-            while True:
-                e = cast(Envelope, await self._events.recv())
-                if isinstance(e.event, Cancel) and task and self._cancelable:
-                    task.cancel()
-                elif isinstance(e.event, Shutdown):
-                    break
-                elif isinstance(e.event, PredictionInput):
-                    task = asyncio.create_task(
-                        self._apredict(e.tag, e.event.payload, predict, redirector)
-                    )
-                else:
-                    print(f"Got unexpected event: {e.event}", file=sys.stderr)
-            if task:
-                await task
-
-    def _loop_scope(self) -> Scope:
-        return Scope(record_metric=self.record_metric)
+        while True:
+            e = cast(Envelope, await self._events.recv())
+            if isinstance(e.event, Cancel) and task and self._cancelable:
+                task.cancel()
+            elif isinstance(e.event, Shutdown):
+                break
+            elif isinstance(e.event, PredictionInput):
+                task = asyncio.create_task(
+                    self._apredict(e.tag, e.event.payload, predict, redirector)
+                )
+            else:
+                print(f"Got unexpected event: {e.event}", file=sys.stderr)
+        if task:
+            await task
 
     def _predict(
         self,
@@ -680,10 +709,16 @@ class _ChildWorker(_spawn.Process):  # type: ignore
 
 
 def make_worker(
-    predictor_ref: str, tee_output: bool = True, max_concurrency: int = 1
+    predictor_ref: str,
+    *,
+    is_async: bool,
+    tee_output: bool = True,
+    max_concurrency: int = 1,
 ) -> Worker:
     parent_conn, child_conn = _spawn.Pipe()
-    child = _ChildWorker(predictor_ref, events=child_conn, tee_output=tee_output)
+    child = _ChildWorker(
+        predictor_ref, events=child_conn, tee_output=tee_output, is_async=is_async
+    )
     parent = Worker(child=child, events=parent_conn, max_concurrency=max_concurrency)
     return parent
 

--- a/python/tests/server/conftest.py
+++ b/python/tests/server/conftest.py
@@ -24,6 +24,7 @@ class AppConfig:
 @define
 class WorkerConfig:
     fixture_name: str
+    is_async: bool = False
     setup: bool = True
     max_concurrency: int = 1
 
@@ -71,7 +72,7 @@ def uses_predictor_with_client_options(name, **options):
     )
 
 
-def uses_worker(name_or_names, setup=True, max_concurrency=1):
+def uses_worker(name_or_names, setup=True, max_concurrency=1, is_async=False):
     """
     Decorator for tests that require a Worker instance. `name_or_names` can be
     a single fixture name, or a sequence (list, tuple) of fixture names. If
@@ -80,16 +81,25 @@ def uses_worker(name_or_names, setup=True, max_concurrency=1):
     If `setup` is True (the default) setup will be run before the test runs.
     """
     if isinstance(name_or_names, (tuple, list)):
-        values = (
-            WorkerConfig(fixture_name=n, setup=setup, max_concurrency=max_concurrency)
-            for n in name_or_names
-        )
-    else:
-        values = (
+        values = [
             WorkerConfig(
-                fixture_name=name_or_names, setup=setup, max_concurrency=max_concurrency
+                fixture_name=n,
+                setup=setup,
+                max_concurrency=max_concurrency,
+                is_async=is_async,
+            )
+            for n in name_or_names
+        ]
+    else:
+        values = [
+            WorkerConfig(
+                fixture_name=name_or_names,
+                setup=setup,
+                max_concurrency=max_concurrency,
+                is_async=is_async,
             ),
-        )
+        ]
+    return uses_worker_configs(values)
 
 
 def uses_worker_configs(values: Sequence[WorkerConfig]):
@@ -160,6 +170,7 @@ def worker(request):
     ref = _fixture_path(request.param.fixture_name)
     w = make_worker(
         predictor_ref=ref,
+        is_async=request.param.is_async,
         tee_output=False,
         max_concurrency=request.param.max_concurrency,
     )

--- a/python/tests/server/conftest.py
+++ b/python/tests/server/conftest.py
@@ -2,7 +2,7 @@ import os
 import threading
 import time
 from contextlib import ExitStack
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence
 from unittest import mock
 
 import pytest
@@ -90,6 +90,13 @@ def uses_worker(name_or_names, setup=True, max_concurrency=1):
                 fixture_name=name_or_names, setup=setup, max_concurrency=max_concurrency
             ),
         )
+
+
+def uses_worker_configs(values: Sequence[WorkerConfig]):
+    """
+    Decorator for tests that require a Worker instance. `configs` can be
+    a sequence of `WorkerConfig` instances.
+    """
     return pytest.mark.parametrize("worker", values, indirect=True)
 
 

--- a/python/tests/server/test_runner.py
+++ b/python/tests/server/test_runner.py
@@ -300,7 +300,7 @@ def test_prediction_runner_predict_cancelation_multiple_predictions():
 
 
 def test_prediction_runner_setup_e2e():
-    w = make_worker(predictor_ref=_fixture_path("sleep"))
+    w = make_worker(predictor_ref=_fixture_path("sleep"), is_async=False)
     r = PredictionRunner(worker=w)
 
     try:
@@ -316,7 +316,7 @@ def test_prediction_runner_setup_e2e():
 
 
 def test_prediction_runner_predict_e2e():
-    w = make_worker(predictor_ref=_fixture_path("sleep"))
+    w = make_worker(predictor_ref=_fixture_path("sleep"), is_async=False)
     r = PredictionRunner(worker=w)
 
     try:

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -30,7 +30,7 @@ from cog.server.eventtypes import (
 from cog.server.exceptions import FatalWorkerException, InvalidStateException
 from cog.server.worker import Worker, _PublicEventType
 
-from .conftest import WorkerConfig, uses_worker
+from .conftest import WorkerConfig, uses_worker, uses_worker_configs
 
 if TYPE_CHECKING:
     from concurrent.futures import Future
@@ -238,7 +238,7 @@ def test_no_exceptions_from_recoverable_failures(worker):
 
 
 # TODO test this works with errors and cancelations and the like
-@uses_worker(["simple", "simple_async"])
+@uses_worker_configs([WorkerConfig("simple"), WorkerConfig("simple_async")])
 def test_can_subscribe_for_a_specific_tag(worker):
     tag = "123"
 
@@ -383,7 +383,12 @@ def test_predict_logging(worker, expected_stdout, expected_stderr):
     assert result.stderr == expected_stderr
 
 
-@uses_worker(["sleep", "sleep_async"], setup=False)
+@uses_worker_configs(
+    [
+        WorkerConfig("sleep", setup=False),
+        WorkerConfig("sleep_async", setup=False),
+    ]
+)
 def test_cancel_is_safe(worker):
     """
     Calls to cancel at any time should not result in unexpected things
@@ -417,7 +422,12 @@ def test_cancel_is_safe(worker):
     assert result2.output == "done in 0.1 seconds"
 
 
-@uses_worker(["sleep", "sleep_async"], setup=False)
+@uses_worker_configs(
+    [
+        WorkerConfig("sleep", setup=False),
+        WorkerConfig("sleep_async", setup=False),
+    ]
+)
 def test_cancel_idempotency(worker):
     """
     Multiple calls to cancel within the same prediction, while not necessary or
@@ -449,7 +459,7 @@ def test_cancel_idempotency(worker):
     assert result2.output == "done in 0.1 seconds"
 
 
-@uses_worker(["sleep", "sleep_async"])
+@uses_worker_configs([WorkerConfig("sleep"), WorkerConfig("sleep_async")])
 def test_cancel_multiple_predictions(worker):
     """
     Multiple predictions cancelled in a row shouldn't be a problem. This test
@@ -467,7 +477,7 @@ def test_cancel_multiple_predictions(worker):
     assert not worker.predict({"sleep": 0}).result().canceled
 
 
-@uses_worker(["sleep", "sleep_async"])
+@uses_worker_configs([WorkerConfig("sleep"), WorkerConfig("sleep_async")])
 def test_graceful_shutdown(worker):
     """
     On shutdown, the worker should finish running the current prediction, and

--- a/python/tests/server/test_worker.py
+++ b/python/tests/server/test_worker.py
@@ -76,7 +76,7 @@ METRICS_FIXTURES = [
         },
     ),
     (
-        WorkerConfig("record_metric_async"),
+        WorkerConfig("record_metric_async", is_async=True),
         {"name": ST_NAMES},
         {
             "foo": 123,
@@ -91,7 +91,7 @@ OUTPUT_FIXTURES = [
         lambda x: f"hello, {x['name']}",
     ),
     (
-        WorkerConfig("hello_world_async"),
+        WorkerConfig("hello_world_async", is_async=True),
         {"name": ST_NAMES},
         lambda x: f"hello, {x['name']}",
     ),
@@ -110,11 +110,15 @@ OUTPUT_FIXTURES = [
 SETUP_LOGS_FIXTURES = [
     (
         WorkerConfig("logging", setup=False),
-        ("writing to stdout at import time\n" "setting up predictor\n"),
+        (
+            "writing some stuff from C at import time\n"
+            "writing to stdout at import time\n"
+            "setting up predictor\n"
+        ),
         "writing to stderr at import time\n",
     ),
     (
-        WorkerConfig("logging_async", setup=False),
+        WorkerConfig("logging_async", is_async=True, setup=False),
         ("writing to stdout at import time\n" "setting up predictor\n"),
         "writing to stderr at import time\n",
     ),
@@ -127,7 +131,7 @@ PREDICT_LOGS_FIXTURES = [
         ("WARNING:root:writing log message\n" "writing to stderr\n"),
     ),
     (
-        WorkerConfig("logging_async"),
+        WorkerConfig("logging_async", is_async=True),
         ("writing with print\n"),
         ("WARNING:root:writing log message\n" "writing to stderr\n"),
     ),
@@ -238,7 +242,9 @@ def test_no_exceptions_from_recoverable_failures(worker):
 
 
 # TODO test this works with errors and cancelations and the like
-@uses_worker_configs([WorkerConfig("simple"), WorkerConfig("simple_async")])
+@uses_worker_configs(
+    [WorkerConfig("simple"), WorkerConfig("simple_async", is_async=True)]
+)
 def test_can_subscribe_for_a_specific_tag(worker):
     tag = "123"
 
@@ -260,7 +266,7 @@ def test_can_subscribe_for_a_specific_tag(worker):
         worker.unsubscribe(subid)
 
 
-@uses_worker("sleep_async", max_concurrency=5)
+@uses_worker("sleep_async", is_async=True, max_concurrency=5)
 def test_can_run_predictions_concurrently_on_async_predictor(worker):
     subids = []
 
@@ -386,7 +392,7 @@ def test_predict_logging(worker, expected_stdout, expected_stderr):
 @uses_worker_configs(
     [
         WorkerConfig("sleep", setup=False),
-        WorkerConfig("sleep_async", setup=False),
+        WorkerConfig("sleep_async", is_async=True, setup=False),
     ]
 )
 def test_cancel_is_safe(worker):
@@ -425,7 +431,7 @@ def test_cancel_is_safe(worker):
 @uses_worker_configs(
     [
         WorkerConfig("sleep", setup=False),
-        WorkerConfig("sleep_async", setup=False),
+        WorkerConfig("sleep_async", is_async=True, setup=False),
     ]
 )
 def test_cancel_idempotency(worker):
@@ -459,7 +465,9 @@ def test_cancel_idempotency(worker):
     assert result2.output == "done in 0.1 seconds"
 
 
-@uses_worker_configs([WorkerConfig("sleep"), WorkerConfig("sleep_async")])
+@uses_worker_configs(
+    [WorkerConfig("sleep"), WorkerConfig("sleep_async", is_async=True)]
+)
 def test_cancel_multiple_predictions(worker):
     """
     Multiple predictions cancelled in a row shouldn't be a problem. This test
@@ -477,7 +485,9 @@ def test_cancel_multiple_predictions(worker):
     assert not worker.predict({"sleep": 0}).result().canceled
 
 
-@uses_worker_configs([WorkerConfig("sleep"), WorkerConfig("sleep_async")])
+@uses_worker_configs(
+    [WorkerConfig("sleep"), WorkerConfig("sleep_async", is_async=True)]
+)
 def test_graceful_shutdown(worker):
     """
     On shutdown, the worker should finish running the current prediction, and


### PR DESCRIPTION
Currently for models that provide a non-async predict function we have two stream redirectors wrapping stdout/stderr.

We think this entering/exiting the stream redirector context multiple times may have been causing unusual bugs, particularly with models that use libraries like `tqdm` to render progress bars and other manipulation.

This PR changes this behaviour to use either the `StreamRedirector` or (newly renamed) `SimpleStreamRedirector` based on whether the predict is defined with an async function or not. We now use the same redirector for module loading, setup and prediction.

The interrogation of the predict function now happens higher up the stack in http.py when we read the input/output types using `config.get_predictor_types`. This now returns an additional value `is_async` which is `True` when an async function is defined.

This is then passed down the stack into the worker which uses it to select an appropriate stream redirector instance. In future when we come to support async setup functions we may need to revisit whether `is_async` is the correct term for the worker argument, `use_simple_stream` or similar might be more appropriate.

This has been tested with both sync and async models including flux-dev and seems to be working correctly.
