### PR TITLE
Change torch vision to 0.20.0 for torch 2.5.0 cpu

### DIFF
--- a/pkg/config/torch_compatibility_matrix.json
+++ b/pkg/config/torch_compatibility_matrix.json
@@ -57,7 +57,7 @@
   },
   {
     "Torch": "2.5.0+cpu",
-    "Torchvision": "0.20.1",
+    "Torchvision": "0.20.0",
     "Torchaudio": "2.5.0",
     "FindLinks": "",
     "ExtraIndexURL": "https://download.pytorch.org/whl/cpu",


### PR DESCRIPTION
* Torchvision 0.20.1 doesn’t work on 2.5.0 cpu torch