### PR TITLE
pin httpx to <0.28.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "attrs>=20.1,<24",
   "fastapi>=0.75.2,<0.99.0",
   # we may not need http2
-  "httpx[http2]>=0.21.0,<1",
+  "httpx[http2]>=0.21.0,<0.28.0",
   "pydantic>=1.9,<2",
   "PyYAML",
   "requests>=2,<3",


### PR DESCRIPTION
httpx 0.28.0 has changed a few things that break things for us.  Pin to <0.28.0 so things keep working.