### PR TITLE
Async setup

### DIFF
--- a/python/cog/base_predictor.py
+++ b/python/cog/base_predictor.py
@@ -1,18 +1,13 @@
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
-from .types import (
-    File as CogFile,
-)
-from .types import (
-    Path as CogPath,
-)
+from .types import Weights
 
 
 class BasePredictor(ABC):
     def setup(
         self,
-        weights: Optional[Union[CogFile, CogPath, str]] = None,  # pylint: disable=unused-argument
+        weights: Optional[Weights] = None,  # pylint: disable=unused-argument
     ) -> None:
         """
         An optional method to prepare the model so multiple predictions run efficiently.

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -2,13 +2,11 @@ import builtins
 import enum
 import importlib.util
 import inspect
-import io
 import os.path
 import sys
 import types
 import uuid
 from collections.abc import Iterable, Iterator
-from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -38,11 +36,13 @@ from .code_xforms import load_module_from_string, strip_model_source_code
 from .types import (
     PYDANTIC_V2,
     Input,
+    Weights,
 )
 from .types import (
     File as CogFile,
+)
+from .types import (
     Path as CogPath,
-    Weights,
 )
 from .types import Secret as CogSecret
 

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -41,9 +41,8 @@ from .types import (
 )
 from .types import (
     File as CogFile,
-)
-from .types import (
     Path as CogPath,
+    Weights,
 )
 from .types import Secret as CogSecret
 
@@ -60,15 +59,16 @@ ALLOWED_INPUT_TYPES: List[Type[Any]] = [
 ]
 
 
-def run_setup(predictor: BasePredictor) -> None:
+def has_setup_weights(predictor: BasePredictor) -> bool:
     weights_type = get_weights_type(predictor.setup)
+    return weights_type is not None
 
-    # No weights need to be passed, so just run setup() without any arguments.
-    if weights_type is None:
-        predictor.setup()
-        return
 
-    weights: Union[io.IOBase, Path, str, None]
+def extract_setup_weights(predictor: BasePredictor) -> Optional[Weights]:
+    weights_type = get_weights_type(predictor.setup)
+    assert weights_type
+
+    weights: Optional[Weights]
 
     weights_url = os.environ.get("COG_WEIGHTS")
     weights_path = "weights"
@@ -119,7 +119,7 @@ def run_setup(predictor: BasePredictor) -> None:
     else:
         weights = None
 
-    predictor.setup(weights=weights)  # type: ignore
+    return weights
 
 
 def get_weights_type(setup_function: Callable[[Any], None]) -> Optional[Any]:

--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -479,9 +479,6 @@ class _ChildWorker(_spawn.Process):  # type: ignore
         with self._handle_setup_error(redirector):
             assert self._predictor
 
-            predict = get_predict(self._predictor)
-
-
             # Async models require python >= 3.11 so we can use asyncio.TaskGroup
             # We should check for this before getting to this point
             if self._has_async_predictor and sys.version_info < (3, 11):

--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -521,6 +521,9 @@ class AsyncConcatenateIterator(AsyncIterator[Item]):
             yield cls.validate
 
 
+Weights = Union[File, Path, str]
+
+
 def get_filename_from_urlopen(resp: urllib.response.addinfourl) -> str:
     mime_type = resp.headers.get_content_type()
     extension = mimetypes.guess_extension(mime_type)

--- a/python/tests/server/fixtures/async_setup_uses_same_loop_as_predict.py
+++ b/python/tests/server/fixtures/async_setup_uses_same_loop_as_predict.py
@@ -1,6 +1,5 @@
 import asyncio
 
-
 class Predictor:
     async def setup(self) -> None:
         self.loop = asyncio.get_running_loop()

--- a/python/tests/server/fixtures/setup_async.py
+++ b/python/tests/server/fixtures/setup_async.py
@@ -1,0 +1,12 @@
+class Predictor:
+    async def download(self) -> None:
+        print("download complete!")
+
+    async def setup(self) -> None:
+        print("setup starting...")
+        await self.download()
+        print("setup complete!")
+
+    async def predict(self) -> str:
+        print("running prediction")
+        return "output"

--- a/python/tests/server/fixtures/setup_async_with_sync_predict.py
+++ b/python/tests/server/fixtures/setup_async_with_sync_predict.py
@@ -1,0 +1,9 @@
+class Predictor:
+    async def download(self) -> None:
+        print("setup used asyncio.run! it's not very effective...")
+
+    async def setup(self) -> None:
+        await self.download()
+
+    def predict(self) -> str:
+        return "output"


### PR DESCRIPTION
This commit introduces the ability to define an async `setup` function on your predictor. For simplicity an async `setup()` function is only supported alongside an async `predict()` function. An error will be raised during setup if this is not the case.

Various pieces of the code have been extracted into smaller methods in order to achieve this. A new `_handle_setup_error` context manager has been created to handle setup errors and send appropriate `Done` event over the worker channel.

The `_setup()` method has been split into two phases, first we perform validation on the requirements for async/concurrency support. Then we attempt to run the `setup()` method either as a direct call for the non-async path or as part of the event loop in the async path.

### TODO

 - [x] Add tests for async setup
 - [ ] Perform async validation at build time, we should be able to perform the concurrency checks as part of the app start-up which would mean errors are caught during build/publish.

