### PR TITLE
Check version formats in fast_generator

### DIFF
--- a/pkg/dockerfile/fast_generator.go
+++ b/pkg/dockerfile/fast_generator.go
@@ -1,9 +1,14 @@
 package dockerfile
 
 import (
+	"cmp"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/replicate/cog/pkg/config"
@@ -23,13 +28,64 @@ type FastGenerator struct {
 	Config  *config.Config
 	Dir     string
 	command docker.Command
+	matrix  MonobaseMatrix
+}
+
+type MonobaseMatrix struct {
+	Id             int            `json:"id"`
+	CudaVersions   []string       `json:"cuda_versions"`
+	CudnnVersions  []string       `json:"cudnn_versions"`
+	PythonVersions []string       `json:"python_versions"`
+	TorchVersions  []string       `json:"torch_versions"`
+	Venvs          []MonobaseVenv `json:"venvs"`
+}
+
+type MonobaseVenv struct {
+	Python string `json:"python"`
+	Torch  string `json:"torch"`
+	Cuda   string `json:"cuda"`
+}
+
+func (m MonobaseMatrix) DefaultCudnnVersion() string {
+	slices.SortFunc(m.CudnnVersions, func(s1, s2 string) int {
+		i1, e1 := strconv.Atoi(s1)
+		i2, e2 := strconv.Atoi(s2)
+		if e1 != nil || e2 != nil {
+			return strings.Compare(s1, s2)
+		}
+		return cmp.Compare(i1, i2)
+	})
+	return m.CudnnVersions[len(m.CudnnVersions)-1]
+}
+
+func (m MonobaseMatrix) IsSupported(python string, torch string, cuda string) bool {
+	if torch == "" {
+		return slices.Contains(m.PythonVersions, python)
+	}
+	if cuda == "" {
+		cuda = "cpu"
+	}
+	return slices.Contains(m.Venvs, MonobaseVenv{Python: python, Torch: torch, Cuda: cuda})
 }
 
 func NewFastGenerator(config *config.Config, dir string, command docker.Command) (*FastGenerator, error) {
+	resp, err := http.DefaultClient.Get("https://raw.githubusercontent.com/replicate/monobase/refs/heads/main/matrix.json")
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("Failed to fetch Monobase support matrix")
+	}
+	var matrix MonobaseMatrix
+	if err := json.NewDecoder(resp.Body).Decode(&matrix); err != nil {
+		return nil, err
+	}
+
 	return &FastGenerator{
 		Config:  config,
 		Dir:     dir,
 		command: command,
+		matrix:  matrix,
 	}, nil
 }
 
@@ -138,6 +194,16 @@ func (g *FastGenerator) generateMonobase(lines []string, tmpDir string) ([]strin
 	if g.Config.Build.GPU {
 		cudaVersion := g.Config.Build.CUDA
 		cudnnVersion := g.Config.Build.CuDNN
+		if cudnnVersion == "" {
+			cudnnVersion = g.matrix.DefaultCudnnVersion()
+		}
+		if !CheckMajorMinorOnly(cudaVersion) {
+			return nil, fmt.Errorf("CUDA version must be <major>.<minor>, supported versions: %s", strings.Join(g.matrix.CudaVersions, ", "))
+		}
+		if !CheckMajorOnly(cudnnVersion) {
+			return nil, fmt.Errorf("CUDNN version must be <major> only, supported versions: %s", strings.Join(g.matrix.CudnnVersions, ", "))
+		}
+
 		lines = append(lines, []string{
 			"ENV R8_CUDA_VERSION=" + cudaVersion,
 			"ENV R8_CUDNN_VERSION=" + cudnnVersion,
@@ -146,15 +212,28 @@ func (g *FastGenerator) generateMonobase(lines []string, tmpDir string) ([]strin
 		}...)
 	}
 
+	if !CheckMajorMinorOnly(g.Config.Build.PythonVersion) {
+		return nil, fmt.Errorf(
+			"Python version must be <major>.<minor>, supported versions: %s", strings.Join(g.matrix.PythonVersions, ", "))
+	}
 	lines = append(lines, []string{
 		"ENV R8_PYTHON_VERSION=" + g.Config.Build.PythonVersion,
 	}...)
 
 	torchVersion, ok := g.Config.TorchVersion()
 	if ok {
+		if !CheckMajorMinorPatch(torchVersion) {
+			return nil, fmt.Errorf("Torch version must be <major>.<minor>.<patch>: %s", strings.Join(g.matrix.TorchVersions, ", "))
+		}
 		lines = append(lines, []string{
 			"ENV R8_TORCH_VERSION=" + torchVersion,
 		}...)
+	}
+
+	if !g.matrix.IsSupported(g.Config.Build.PythonVersion, torchVersion, g.Config.Build.CUDA) {
+		return nil, fmt.Errorf(
+			"Unsupported version combination: Python=%s, Torch=%s, CUDA=%s",
+			g.Config.Build.PythonVersion, torchVersion, g.Config.Build.CUDA)
 	}
 
 	buildTmpMount, err := g.buildTmpMount(tmpDir)

--- a/pkg/dockerfile/fast_generator_test.go
+++ b/pkg/dockerfile/fast_generator_test.go
@@ -13,6 +13,7 @@ import (
 func TestGenerate(t *testing.T) {
 	dir := t.TempDir()
 	build := config.Build{
+		PythonVersion:  "3.8",
 		PythonPackages: []string{"torch==2.5.1"},
 	}
 	config := config.Config{
@@ -30,6 +31,7 @@ func TestGenerate(t *testing.T) {
 func TestGenerateUVCacheMount(t *testing.T) {
 	dir := t.TempDir()
 	build := config.Build{
+		PythonVersion: "3.8",
 		PythonPackages: []string{
 			"torch==2.5.1",
 			"catboost==1.2.7",
@@ -50,8 +52,9 @@ func TestGenerateUVCacheMount(t *testing.T) {
 func TestGenerateCUDA(t *testing.T) {
 	dir := t.TempDir()
 	build := config.Build{
-		GPU:  true,
-		CUDA: "12.4",
+		GPU:           true,
+		CUDA:          "12.4",
+		PythonVersion: "3.8",
 	}
 	config := config.Config{
 		Build: &build,
@@ -68,6 +71,7 @@ func TestGenerateCUDA(t *testing.T) {
 func TestGeneratePythonPackages(t *testing.T) {
 	dir := t.TempDir()
 	build := config.Build{
+		PythonVersion: "3.8",
 		PythonPackages: []string{
 			"catboost==1.2.7",
 		},
@@ -87,6 +91,7 @@ func TestGeneratePythonPackages(t *testing.T) {
 func TestGenerateVerboseEnv(t *testing.T) {
 	dir := t.TempDir()
 	build := config.Build{
+		PythonVersion:  "3.8",
 		PythonPackages: []string{"torch==2.5.1"},
 	}
 	config := config.Config{
@@ -104,6 +109,7 @@ func TestGenerateVerboseEnv(t *testing.T) {
 func TestAptInstall(t *testing.T) {
 	dir := t.TempDir()
 	build := config.Build{
+		PythonVersion:  "3.8",
 		SystemPackages: []string{"git"},
 	}
 	config := config.Config{

--- a/pkg/dockerfile/version_check.go
+++ b/pkg/dockerfile/version_check.go
@@ -1,0 +1,36 @@
+package dockerfile
+
+import (
+	"regexp"
+)
+
+// Version string in the form x.y.z for Monobase R8_*_VERSION
+// We do not support suffixes like -alpha1 or +cu124
+var versionRegex = regexp.MustCompile(`^(?P<major>\d+)(\.(?P<minor>\d+)(\.(?P<patch>\d+))?)?$`)
+
+func parse(s string) (string, string, string) {
+	m := versionRegex.FindStringSubmatch(s)
+	if m == nil {
+		return "", "", ""
+	}
+	major := m[versionRegex.SubexpIndex("major")]
+	minor := m[versionRegex.SubexpIndex("minor")]
+	patch := m[versionRegex.SubexpIndex("patch")]
+	return major, minor, patch
+
+}
+
+func CheckMajorOnly(s string) bool {
+	major, minor, patch := parse(s)
+	return major != "" && minor == "" && patch == ""
+}
+
+func CheckMajorMinorOnly(s string) bool {
+	major, minor, patch := parse(s)
+	return major != "" && minor != "" && patch == ""
+}
+
+func CheckMajorMinorPatch(s string) bool {
+	major, minor, patch := parse(s)
+	return major != "" && minor != "" && patch != ""
+}


### PR DESCRIPTION
Incorrect formats will likely fail `monobase.build` but it's nice to fail fast here.

We now:
* Pull the support matrix from monobase: https://github.com/replicate/monobase/blob/main/matrix.json
* Compute latest CuDNN version as default if not set
* Check Python+Torch+CUDA venv is in the matrix
* Include supported versions in error message