### PR TITLE
Capture standard output when loading the predictor

### DIFF
--- a/python/tests/server/fixtures/import_err.py
+++ b/python/tests/server/fixtures/import_err.py
@@ -1,0 +1,14 @@
+import sys
+
+sys.stdout.write("writing to stdout at import time\n")
+sys.stderr.write("writing to stderr at import time\n")
+
+import missing_module
+
+
+class Predictor:
+    def setup(self):
+        pass
+
+    def predict(self):
+        print("did predict")


### PR DESCRIPTION
This commit fixes a bug where we failed to flush the StreamRedirector when catching an exception during the loading of the predictor module.

We now use the existing `_handle_setup_error` function to ensure that the streams are flushed. I've kept the naming of the context manager the same because this all happens as part of the model setup.

Two regression tests have been added to reproduce and verify that the issue has been fixed, both in normal and concurrent/async mode.
