### PR TITLE
Enforce usage of r8.im image name

### DIFF
--- a/pkg/docker/fast_push_test.go
+++ b/pkg/docker/fast_push_test.go
@@ -22,7 +22,7 @@ import (
 func TestFastPush(t *testing.T) {
 	// Setup mock http server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "//test/versions" {
+		if r.URL.Path == "/username/modelname/versions" {
 			w.WriteHeader(http.StatusCreated)
 		} else {
 			w.WriteHeader(http.StatusConflict)
@@ -60,14 +60,14 @@ func TestFastPush(t *testing.T) {
 	monobeamClient := monobeam.NewClient(client)
 
 	// Run fast push
-	err = FastPush(context.Background(), "test", dir, command, webClient, monobeamClient)
+	err = FastPush(context.Background(), "r8.im/username/modelname", dir, command, webClient, monobeamClient)
 	require.NoError(t, err)
 }
 
 func TestFastPushWithWeight(t *testing.T) {
 	// Setup mock http server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "//test/versions" {
+		if r.URL.Path == "/username/modelname/versions" {
 			w.WriteHeader(http.StatusCreated)
 		} else {
 			w.WriteHeader(http.StatusConflict)
@@ -118,6 +118,6 @@ func TestFastPushWithWeight(t *testing.T) {
 	monobeamClient := monobeam.NewClient(client)
 
 	// Run fast push
-	err = FastPush(context.Background(), "test", dir, command, webClient, monobeamClient)
+	err = FastPush(context.Background(), "r8.im/username/modelname", dir, command, webClient, monobeamClient)
 	require.NoError(t, err)
 }

--- a/pkg/docker/push_test.go
+++ b/pkg/docker/push_test.go
@@ -20,7 +20,7 @@ import (
 func TestPush(t *testing.T) {
 	// Setup mock http server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "//test/versions" {
+		if r.URL.Path == "/username/modelname/versions" {
 			w.WriteHeader(http.StatusCreated)
 		} else {
 			w.WriteHeader(http.StatusConflict)
@@ -54,14 +54,14 @@ func TestPush(t *testing.T) {
 	command := dockertest.NewMockCommand()
 
 	// Run fast push
-	err = Push("test", true, dir, command)
+	err = Push("r8.im/username/modelname", true, dir, command)
 	require.NoError(t, err)
 }
 
 func TestPushWithWeight(t *testing.T) {
 	// Setup mock http server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "//test/versions" {
+		if r.URL.Path == "/username/modelname/versions" {
 			w.WriteHeader(http.StatusCreated)
 		} else {
 			w.WriteHeader(http.StatusConflict)
@@ -108,6 +108,6 @@ func TestPushWithWeight(t *testing.T) {
 	command := dockertest.NewMockCommand()
 
 	// Run fast push
-	err = Push("test", true, dir, command)
+	err = Push("r8.im/username/modelname", true, dir, command)
 	require.NoError(t, err)
 }

--- a/pkg/web/client.go
+++ b/pkg/web/client.go
@@ -194,8 +194,11 @@ func (c *Client) versionFromManifest(image string, weights []File, files []File)
 func newVersionURL(image string) (url.URL, error) {
 	imageComponents := strings.Split(image, "/")
 	newVersionUrl := webBaseURL()
+	if len(imageComponents) != 3 {
+		return newVersionUrl, errors.New("The image URL must have 3 components in the format of " + global.ReplicateRegistryHost + "/username/modelname")
+	}
 	if imageComponents[0] != global.ReplicateRegistryHost {
-		return newVersionUrl, errors.New("The image name must have the r8.im prefix in fast push.")
+		return newVersionUrl, errors.New("The image name must have the " + global.ReplicateRegistryHost + " prefix in fast push.")
 	}
 	newVersionUrl.Path = strings.Join([]string{"", imageComponents[1], imageComponents[2], "versions"}, "/")
 	return newVersionUrl, nil

--- a/pkg/web/client.go
+++ b/pkg/web/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/docker/command"
 	"github.com/replicate/cog/pkg/env"
+	"github.com/replicate/cog/pkg/global"
 )
 
 type Client struct {
@@ -193,7 +194,7 @@ func (c *Client) versionFromManifest(image string, weights []File, files []File)
 func newVersionURL(image string) (url.URL, error) {
 	imageComponents := strings.Split(image, "/")
 	newVersionUrl := webBaseURL()
-	if imageComponents[0] != "r8.im" {
+	if imageComponents[0] != global.ReplicateRegistryHost {
 		return newVersionUrl, errors.New("The image name must have the r8.im prefix in fast push.")
 	}
 	newVersionUrl.Path = strings.Join([]string{"", imageComponents[1], imageComponents[2], "versions"}, "/")

--- a/pkg/web/client.go
+++ b/pkg/web/client.go
@@ -195,7 +195,7 @@ func newVersionURL(image string) (url.URL, error) {
 	imageComponents := strings.Split(image, "/")
 	newVersionUrl := webBaseURL()
 	if len(imageComponents) != 3 {
-		return newVersionUrl, errors.New("The image URL must have 3 components in the format of " + global.ReplicateRegistryHost + "/username/modelname")
+		return newVersionUrl, errors.New("The image URL must have 3 components in the format of " + global.ReplicateRegistryHost + "/your-username/your-model")
 	}
 	if imageComponents[0] != global.ReplicateRegistryHost {
 		return newVersionUrl, errors.New("The image name must have the " + global.ReplicateRegistryHost + " prefix when using --x-fast.")

--- a/pkg/web/client.go
+++ b/pkg/web/client.go
@@ -198,7 +198,7 @@ func newVersionURL(image string) (url.URL, error) {
 		return newVersionUrl, errors.New("The image URL must have 3 components in the format of " + global.ReplicateRegistryHost + "/username/modelname")
 	}
 	if imageComponents[0] != global.ReplicateRegistryHost {
-		return newVersionUrl, errors.New("The image name must have the " + global.ReplicateRegistryHost + " prefix in fast push.")
+		return newVersionUrl, errors.New("The image name must have the " + global.ReplicateRegistryHost + " prefix when using --x-fast.")
 	}
 	newVersionUrl.Path = strings.Join([]string{"", imageComponents[1], imageComponents[2], "versions"}, "/")
 	return newVersionUrl, nil

--- a/pkg/web/client_test.go
+++ b/pkg/web/client_test.go
@@ -79,3 +79,8 @@ func TestVersionURLErrorWithoutR8IMPrefix(t *testing.T) {
 	_, err := newVersionURL("docker.com/thing/thing")
 	require.Error(t, err)
 }
+
+func TestVersionURLErrorWithout3Components(t *testing.T) {
+	_, err := newVersionURL("r8.im/username")
+	require.Error(t, err)
+}

--- a/pkg/web/client_test.go
+++ b/pkg/web/client_test.go
@@ -42,7 +42,7 @@ func TestPostNewVersion(t *testing.T) {
 
 	client := NewClient(command, http.DefaultClient)
 	ctx := context.Background()
-	err = client.PostNewVersion(ctx, "test", []File{}, []File{})
+	err = client.PostNewVersion(ctx, "r8.im/user/test", []File{}, []File{})
 	require.NoError(t, err)
 }
 
@@ -60,7 +60,7 @@ func TestVersionFromManifest(t *testing.T) {
 	dockertest.MockOpenAPISchema = "{\"test\": true}"
 
 	client := NewClient(command, http.DefaultClient)
-	version, err := client.versionFromManifest("test", []File{}, []File{})
+	version, err := client.versionFromManifest("r8.im/user/test", []File{}, []File{})
 	require.NoError(t, err)
 
 	var openAPISchema map[string]any
@@ -73,4 +73,9 @@ func TestVersionFromManifest(t *testing.T) {
 
 	require.Equal(t, openAPISchema, version.OpenAPISchema)
 	require.Equal(t, cogConfig, version.CogConfig)
+}
+
+func TestVersionURLErrorWithoutR8IMPrefix(t *testing.T) {
+	_, err := newVersionURL("docker.com/thing/thing")
+	require.Error(t, err)
 }

--- a/pkg/web/client_test.go
+++ b/pkg/web/client_test.go
@@ -81,6 +81,6 @@ func TestVersionURLErrorWithoutR8IMPrefix(t *testing.T) {
 }
 
 func TestVersionURLErrorWithout3Components(t *testing.T) {
-	_, err := newVersionURL("r8.im/username")
+	_, err := newVersionURL("username/test")
 	require.Error(t, err)
 }


### PR DESCRIPTION
* Do not use the username from the authentication credentials, the user could always push to an org
that they have access to.
* Make sure the URL is a r8.im URL before breaking it up.