### PR TITLE
Include `sha256:` prefix in generated runtime config files

### DIFF
--- a/pkg/web/client.go
+++ b/pkg/web/client.go
@@ -174,9 +174,29 @@ func (c *Client) versionFromManifest(image string, weights []File, files []File)
 		R8TorchVersion:      torchVersion,
 	}
 
+	prefixedFiles := make([]File, len(files))
+
+	for i, file := range files {
+		prefixedFiles[i] = File{
+			Path:   file.Path,
+			Digest: "sha256:" + file.Digest,
+			Size:   file.Size,
+		}
+	}
+
+	prefixedWeights := make([]File, len(weights))
+
+	for i, file := range weights {
+		prefixedWeights[i] = File{
+			Path:   file.Path,
+			Digest: "sha256:" + file.Digest,
+			Size:   file.Size,
+		}
+	}
+
 	runtimeConfig := RuntimeConfig{
-		Weights: weights,
-		Files:   files,
+		Weights: prefixedWeights,
+		Files:   prefixedFiles,
 		Env:     env,
 	}
 


### PR DESCRIPTION
Since all previous runtime configs include the `sha256:` prefix expected by other components in the whole thing.

Connected to PLAT-848