### PR TITLE
Support Python requirements package[extra,...]==version

### DIFF
--- a/pkg/config/requirements.go
+++ b/pkg/config/requirements.go
@@ -6,9 +6,9 @@ import (
 )
 
 // SplitPinnedPythonRequirement returns the name, version, findLinks, and extraIndexURLs from a requirements.txt line
-// in the form name==version [--find-links=<findLink>] [-f <findLink>] [--extra-index-url=<extraIndexURL>]
+// in the form name[extras]==version [--find-links=<findLink>] [-f <findLink>] [--extra-index-url=<extraIndexURL>]
 func SplitPinnedPythonRequirement(requirement string) (name string, version string, findLinks []string, extraIndexURLs []string, err error) {
-	pinnedPackageRe := regexp.MustCompile(`(?:([a-zA-Z0-9\-_]+)==([^ ]+)|--find-links=([^\s]+)|-f\s+([^\s]+)|--extra-index-url=([^\s]+))`)
+	pinnedPackageRe := regexp.MustCompile(`(?:([a-zA-Z0-9\-_]+)(\[[a-zA-Z0-9\-_,]+])?==([^ ]+)|--find-links=([^\s]+)|-f\s+([^\s]+)|--extra-index-url=([^\s]+))`)
 
 	matches := pinnedPackageRe.FindAllStringSubmatch(requirement, -1)
 	if matches == nil {
@@ -24,13 +24,9 @@ func SplitPinnedPythonRequirement(requirement string) (name string, version stri
 			nameFound = true
 		}
 
-		if match[2] != "" {
-			version = match[2]
-			versionFound = true
-		}
-
 		if match[3] != "" {
-			findLinks = append(findLinks, match[3])
+			version = match[3]
+			versionFound = true
 		}
 
 		if match[4] != "" {
@@ -38,7 +34,11 @@ func SplitPinnedPythonRequirement(requirement string) (name string, version stri
 		}
 
 		if match[5] != "" {
-			extraIndexURLs = append(extraIndexURLs, match[5])
+			findLinks = append(findLinks, match[5])
+		}
+
+		if match[6] != "" {
+			extraIndexURLs = append(extraIndexURLs, match[6])
 		}
 	}
 

--- a/pkg/config/requirements_test.go
+++ b/pkg/config/requirements_test.go
@@ -16,6 +16,7 @@ func TestSplitPinnedPythonRequirement(t *testing.T) {
 		expectedError          bool
 	}{
 		{"package1==1.0.0", "package1", "1.0.0", nil, nil, false},
+		{"package1[extra1,extra2]==1.0.0", "package1", "1.0.0", nil, nil, false},
 		{"package1==1.0.0+alpha", "package1", "1.0.0+alpha", nil, nil, false},
 		{"--find-links=link1 --find-links=link2 package3==3.0.0", "package3", "3.0.0", []string{"link1", "link2"}, nil, false},
 		{"package4==4.0.0 --extra-index-url=url1 --extra-index-url=url2", "package4", "4.0.0", nil, []string{"url1", "url2"}, false},


### PR DESCRIPTION
Apparently this works:
`uv pip install 'imageio[ffmpeg]==2.37.0'`

And pulls in `imageio-ffmpeg==0.6.0`