### PR TITLE
Fail python_packages on --x-fast

### DIFF
--- a/pkg/dockerfile/fast_generator_test.go
+++ b/pkg/dockerfile/fast_generator_test.go
@@ -1,6 +1,8 @@
 package dockerfile
 
 import (
+	"os"
+	"path"
 	"strings"
 	"testing"
 
@@ -10,11 +12,19 @@ import (
 	"github.com/replicate/cog/pkg/docker/dockertest"
 )
 
+func writeRequirements(t *testing.T, req string) string {
+	srcDir := t.TempDir()
+	reqFile := path.Join(srcDir, "requirements.txt")
+	err := os.WriteFile(reqFile, []byte(req), 0o644)
+	require.NoError(t, err)
+	return reqFile
+}
+
 func TestGenerate(t *testing.T) {
 	dir := t.TempDir()
 	build := config.Build{
-		PythonVersion:  "3.8",
-		PythonPackages: []string{"torch==2.5.1"},
+		PythonVersion:      "3.8",
+		PythonRequirements: writeRequirements(t, "torch==2.5.1"),
 	}
 	config := config.Config{
 		Build: &build,
@@ -55,11 +65,8 @@ func TestGenerate(t *testing.T) {
 func TestGenerateUVCacheMount(t *testing.T) {
 	dir := t.TempDir()
 	build := config.Build{
-		PythonVersion: "3.8",
-		PythonPackages: []string{
-			"torch==2.5.1",
-			"catboost==1.2.7",
-		},
+		PythonVersion:      "3.8",
+		PythonRequirements: writeRequirements(t, "torch==2.5.1\ncatboost==1.2.7"),
 	}
 	config := config.Config{
 		Build: &build,
@@ -142,10 +149,8 @@ func TestGenerateCUDA(t *testing.T) {
 func TestGeneratePythonPackages(t *testing.T) {
 	dir := t.TempDir()
 	build := config.Build{
-		PythonVersion: "3.8",
-		PythonPackages: []string{
-			"catboost==1.2.7",
-		},
+		PythonVersion:      "3.8",
+		PythonRequirements: writeRequirements(t, "catboost==1.2.7"),
 	}
 	config := config.Config{
 		Build: &build,
@@ -186,8 +191,8 @@ func TestGeneratePythonPackages(t *testing.T) {
 func TestGenerateVerboseEnv(t *testing.T) {
 	dir := t.TempDir()
 	build := config.Build{
-		PythonVersion:  "3.8",
-		PythonPackages: []string{"torch==2.5.1"},
+		PythonVersion:      "3.8",
+		PythonRequirements: writeRequirements(t, "torch==2.5.1"),
 	}
 	config := config.Config{
 		Build: &build,

--- a/pkg/requirements/requirements_test.go
+++ b/pkg/requirements/requirements_test.go
@@ -1,6 +1,8 @@
 package requirements
 
 import (
+	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -9,7 +11,7 @@ import (
 	"github.com/replicate/cog/pkg/config"
 )
 
-func TestGenerateRequirements(t *testing.T) {
+func TestPythonPackages(t *testing.T) {
 	tmpDir := t.TempDir()
 	build := config.Build{
 		PythonPackages: []string{"torch==2.5.1"},
@@ -17,6 +19,23 @@ func TestGenerateRequirements(t *testing.T) {
 	config := config.Config{
 		Build: &build,
 	}
+	_, err := GenerateRequirements(tmpDir, &config)
+	require.ErrorContains(t, err, "python_packages is no longer supported, use python_requirements instead")
+}
+
+func TestPythonRequirements(t *testing.T) {
+	srcDir := t.TempDir()
+	reqFile := path.Join(srcDir, "requirements.txt")
+	err := os.WriteFile(reqFile, []byte("torch==2.5.1"), 0o644)
+	require.NoError(t, err)
+
+	build := config.Build{
+		PythonRequirements: reqFile,
+	}
+	config := config.Config{
+		Build: &build,
+	}
+	tmpDir := t.TempDir()
 	requirementsFile, err := GenerateRequirements(tmpDir, &config)
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(tmpDir, "requirements.txt"), requirementsFile)

--- a/test-integration/test_integration/fixtures/fast-build/cog.yaml
+++ b/test-integration/test_integration/fixtures/fast-build/cog.yaml
@@ -1,8 +1,6 @@
 build:
   python_version: "3.12"
-  python_packages:
-    - "torch==2.5.0"
-    - "beautifulsoup4==4.12.3"
+  python_requirements: requirements.txt
   system_packages:
     - "git"
 predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/fast-build/requirements.txt
+++ b/test-integration/test_integration/fixtures/fast-build/requirements.txt
@@ -1,0 +1,2 @@
+torch==2.5.0
+beautifulsoup4==4.12.3


### PR DESCRIPTION
So that we don't attempt to parse requirements specs and instead pass
them as is to monobase, i.e. `uv pip compile` for validation
