### PR TITLE
Update ruff config so lint works again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-dev = ["build", "setuptools_scm==8.1.0", "tox", "tox-uv"]
+dev = ["build", "setuptools_scm", "tox", "tox-uv"]
 
 tests = [
   "httpx",
@@ -98,7 +98,7 @@ good-names = ["id", "input"]
 ignore-paths = ["python/cog/_version.py", "python/tests"]
 
 [tool.ruff]
-format.exclude = ["python/cog/_version.py"]
+exclude = ["python/cog/_version.py"]
 lint.select = [
   "E",   # pycodestyle error
   "F",   # Pyflakes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-dev = ["build", "setuptools_scm", "tox", "tox-uv"]
+dev = ["build", "setuptools_scm==8.1.0", "tox", "tox-uv"]
 
 tests = [
   "httpx",

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ base_python = python3.12
 skip_install = true
 deps = ruff==0.9.1
 commands =
+  ruff --version
   ruff check python/cog
   ruff format --check python
 

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ commands =
 base_python = python3.12
 skip_install = true
 deps = ruff==0.9.1
+allowlist_externals = ["cat"]
 commands =
   cat python/cog/_version.py
   ruff check python/cog

--- a/tox.ini
+++ b/tox.ini
@@ -34,10 +34,10 @@ commands =
 [testenv:lint]
 base_python = python3.12
 skip_install = true
-deps = ruff==0.9.1
-allowlist_externals = cat
+deps =
+  ruff==0.9.1
+  setuptools-scm==8.1.0
 commands =
-  cat python/cog/_version.py
   ruff check python/cog
   ruff format --check python
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,9 +34,7 @@ commands =
 [testenv:lint]
 base_python = python3.12
 skip_install = true
-deps =
-  ruff==0.9.1
-  setuptools-scm==8.1.0
+deps = ruff==0.9.1
 commands =
   ruff check python/cog
   ruff format --check python

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 base_python = python3.12
 skip_install = true
 deps = ruff==0.9.1
-allowlist_externals = ["cat"]
+allowlist_externals = cat
 commands =
   cat python/cog/_version.py
   ruff check python/cog

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ base_python = python3.12
 skip_install = true
 deps = ruff==0.9.1
 commands =
-  ruff --version
+  cat python/cog/_version.py
   ruff check python/cog
   ruff format --check python
 


### PR DESCRIPTION
### Summary

Linting got broken because of an autogenerated file by `setuptools-scm` now failing lint after a `setuptools-scm` update. But the question is, should we be linting this file in the first place?

### Test Plan

Linting on any PR newer than 2025/02/21 is failing. Linting on this PR should not be failing.