### PR TITLE
Add integration test for URLs in web hooks on async

### DIFF
--- a/test-integration/test_integration/util.py
+++ b/test-integration/test_integration/util.py
@@ -125,6 +125,14 @@ def random_port() -> int:
     return port
 
 
+def local_network_ip() -> str:
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 80))
+    ip_address = s.getsockname()[0]
+    s.close()
+    return ip_address
+
+
 @contextlib.contextmanager
 def cog_server_http_run(project_dir: str):
     port = random_port()

--- a/tox.ini
+++ b/tox.ini
@@ -71,4 +71,5 @@ deps =
   pytest-rerunfailures
   pytest-timeout
   pytest-xdist
+  requests
 commands = pytest {posargs:-n auto -vv --reruns 3}


### PR DESCRIPTION
* Boot up cog serve on the path output project
* Boot up custom python HTTP server in separate thread
* Post a new prediction request to the cog serve using the custom python HTTP server as a webhook
* Wait for the webhook to be posted then compare the results.
