### PR TITLE
Handle weights moved to subdir

### DIFF
--- a/pkg/docker/fast_push.go
+++ b/pkg/docker/fast_push.go
@@ -30,7 +30,7 @@ func FastPush(ctx context.Context, image string, projectDir string, command comm
 		mpb.WithRefreshRate(180 * time.Millisecond),
 	)
 
-	tmpDir := filepath.Join(projectDir, ".cog", "tmp")
+	tmpDir := filepath.Join(projectDir, ".cog", "tmp", "weights")
 	weights, err := weights.ReadFastWeights(tmpDir)
 	if err != nil {
 		return fmt.Errorf("read weights error: %w", err)

--- a/pkg/docker/fast_push_test.go
+++ b/pkg/docker/fast_push_test.go
@@ -53,8 +53,8 @@ func TestFastPush(t *testing.T) {
 	cogDir := filepath.Join(dir, ".cog")
 	err = os.Mkdir(cogDir, 0o755)
 	require.NoError(t, err)
-	tmpDir := filepath.Join(cogDir, "tmp")
-	err = os.Mkdir(tmpDir, 0o755)
+	tmpDir := filepath.Join(cogDir, "tmp", "weights")
+	err = os.MkdirAll(tmpDir, 0o755)
 	require.NoError(t, err)
 
 	// Create mock predict
@@ -109,8 +109,8 @@ func TestFastPushWithWeight(t *testing.T) {
 	cogDir := filepath.Join(dir, ".cog")
 	err = os.Mkdir(cogDir, 0o755)
 	require.NoError(t, err)
-	tmpDir := filepath.Join(cogDir, "tmp")
-	err = os.Mkdir(tmpDir, 0o755)
+	tmpDir := filepath.Join(cogDir, "tmp", "weights")
+	err = os.MkdirAll(tmpDir, 0o755)
 	require.NoError(t, err)
 
 	// Create mock predict

--- a/pkg/docker/push_test.go
+++ b/pkg/docker/push_test.go
@@ -51,8 +51,8 @@ func TestPush(t *testing.T) {
 	cogDir := filepath.Join(dir, ".cog")
 	err = os.Mkdir(cogDir, 0o755)
 	require.NoError(t, err)
-	tmpDir := filepath.Join(cogDir, "tmp")
-	err = os.Mkdir(tmpDir, 0o755)
+	tmpDir := filepath.Join(cogDir, "tmp", "weights")
+	err = os.MkdirAll(tmpDir, 0o755)
 	require.NoError(t, err)
 
 	// Create mock predict
@@ -103,8 +103,8 @@ func TestPushWithWeight(t *testing.T) {
 	cogDir := filepath.Join(dir, ".cog")
 	err = os.Mkdir(cogDir, 0o755)
 	require.NoError(t, err)
-	tmpDir := filepath.Join(cogDir, "tmp")
-	err = os.Mkdir(tmpDir, 0o755)
+	tmpDir := filepath.Join(cogDir, "tmp", "weights")
+	err = os.MkdirAll(tmpDir, 0o755)
 	require.NoError(t, err)
 
 	// Create mock predict


### PR DESCRIPTION
### Summary

In [this](https://github.com/replicate/cog/pull/2182) PR we moved the weights from `tmp/weights.json` to `tmp/weights/weights.json` but forgot to update one location to keep track of that change.