### PR TITLE
update token config in `cog init` actions workflow template

### DIFF
--- a/pkg/cli/init-templates/.github/workflows/push.yaml
+++ b/pkg/cli/init-templates/.github/workflows/push.yaml
@@ -37,10 +37,13 @@ jobs:
       - name: Setup Cog
         uses: replicate/setup-cog@v2
         with:
-          # If you set REPLICATE_API_TOKEN in your GitHub repository secrets,
+          # If you add a CI auth token to your GitHub repository secrets, 
           # the action will authenticate with Replicate automatically so you
-          # can push your model
-          token: ${{ secrets.REPLICATE_API_TOKEN }}
+          # can push your model without needing to pass in a token.
+          # 
+          # To genereate a CLI auth token, run `cog login` or visit this page
+          # in your browser: https://replicate.com/account/api-token
+          token: ${{ secrets.REPLICATE_CLI_AUTH_TOKEN }}
 
       # If you trigger the workflow manually, you can specify the model name.
       # If you leave it blank (or if the workflow is triggered by a push), the 


### PR DESCRIPTION
You used to be able to use a Replicate API token as a CLI auth token, but that's no longer supported.

This PR updates the `push.yaml` GitHub Actions workflow that's generated by `cog init`, so users know to use a "CLI auth token" instead of an API token.

See:

- https://github.com/replicate/setup-cog/pull/45
- https://github.com/replicate/frontend/pull/677