### PR TITLE
Fix fast tarball tmp dir

### DIFF
--- a/pkg/docker/fast_push_test.go
+++ b/pkg/docker/fast_push_test.go
@@ -53,9 +53,11 @@ func TestFastPush(t *testing.T) {
 	cogDir := filepath.Join(dir, ".cog")
 	err = os.Mkdir(cogDir, 0o755)
 	require.NoError(t, err)
-	tmpDir := filepath.Join(cogDir, "tmp", "weights")
-	err = os.MkdirAll(tmpDir, 0o755)
-	require.NoError(t, err)
+	for _, d := range []string{"apt", "tarballs", "weights"} {
+		tmpDir := filepath.Join(cogDir, "tmp", d)
+		err = os.MkdirAll(tmpDir, 0o755)
+		require.NoError(t, err)
+	}
 
 	// Create mock predict
 	predictPyPath := filepath.Join(dir, "predict.py")
@@ -109,9 +111,11 @@ func TestFastPushWithWeight(t *testing.T) {
 	cogDir := filepath.Join(dir, ".cog")
 	err = os.Mkdir(cogDir, 0o755)
 	require.NoError(t, err)
-	tmpDir := filepath.Join(cogDir, "tmp", "weights")
-	err = os.MkdirAll(tmpDir, 0o755)
-	require.NoError(t, err)
+	for _, d := range []string{"apt", "tarballs", "weights"} {
+		tmpDir := filepath.Join(cogDir, "tmp", d)
+		err = os.MkdirAll(tmpDir, 0o755)
+		require.NoError(t, err)
+	}
 
 	// Create mock predict
 	predictPyPath := filepath.Join(dir, "predict.py")

--- a/pkg/docker/push_test.go
+++ b/pkg/docker/push_test.go
@@ -51,9 +51,11 @@ func TestPush(t *testing.T) {
 	cogDir := filepath.Join(dir, ".cog")
 	err = os.Mkdir(cogDir, 0o755)
 	require.NoError(t, err)
-	tmpDir := filepath.Join(cogDir, "tmp", "weights")
-	err = os.MkdirAll(tmpDir, 0o755)
-	require.NoError(t, err)
+	for _, d := range []string{"apt", "tarballs", "weights"} {
+		tmpDir := filepath.Join(cogDir, "tmp", d)
+		err = os.MkdirAll(tmpDir, 0o755)
+		require.NoError(t, err)
+	}
 
 	// Create mock predict
 	predictPyPath := filepath.Join(dir, "predict.py")
@@ -103,9 +105,11 @@ func TestPushWithWeight(t *testing.T) {
 	cogDir := filepath.Join(dir, ".cog")
 	err = os.Mkdir(cogDir, 0o755)
 	require.NoError(t, err)
-	tmpDir := filepath.Join(cogDir, "tmp", "weights")
-	err = os.MkdirAll(tmpDir, 0o755)
-	require.NoError(t, err)
+	for _, d := range []string{"apt", "tarballs", "weights"} {
+		tmpDir := filepath.Join(cogDir, "tmp", d)
+		err = os.MkdirAll(tmpDir, 0o755)
+		require.NoError(t, err)
+	}
 
 	// Create mock predict
 	predictPyPath := filepath.Join(dir, "predict.py")

--- a/pkg/dockerfile/fast_generator.go
+++ b/pkg/dockerfile/fast_generator.go
@@ -147,7 +147,7 @@ func (g *FastGenerator) generate() (string, error) {
 
 	// User layer
 	// Includes requirements.txt, triggered by python_requirements changes
-	tmpUserDir, err := BuildCogTempDir(g.Dir, "user")
+	tmpRequirementsDir, err := BuildCogTempDir(g.Dir, "requirements")
 	if err != nil {
 		return "", err
 	}
@@ -162,7 +162,7 @@ func (g *FastGenerator) generate() (string, error) {
 		return "", err
 	}
 
-	lines, err = g.installPython(lines, tmpUserDir)
+	lines, err = g.installPython(lines, tmpRequirementsDir)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/dockerfile/fast_generator_test.go
+++ b/pkg/dockerfile/fast_generator_test.go
@@ -157,7 +157,7 @@ func TestGeneratePythonPackages(t *testing.T) {
 	dockerfile, err := generator.GenerateDockerfileWithoutSeparateWeights()
 	require.NoError(t, err)
 	dockerfileLines := strings.Split(dockerfile, "\n")
-	require.Equal(t, "RUN --mount=type=bind,ro,source=\".cog/tmp/user\",target=\"/buildtmp\" --mount=type=cache,target=/srv/r8/monobase/uv/cache,id=uv-cache --mount=type=bind,ro,source=.,target=/src cd /src && UV_CACHE_DIR=\"/srv/r8/monobase/uv/cache\" UV_LINK_MODE=copy UV_COMPILE_BYTECODE=0 /opt/r8/monobase/run.sh monobase.user --requirements=/buildtmp/requirements.txt", dockerfileLines[5])
+	require.Equal(t, "RUN --mount=type=bind,ro,source=\".cog/tmp/requirements\",target=\"/buildtmp\" --mount=type=cache,target=/srv/r8/monobase/uv/cache,id=uv-cache --mount=type=bind,ro,source=.,target=/src cd /src && UV_CACHE_DIR=\"/srv/r8/monobase/uv/cache\" UV_LINK_MODE=copy UV_COMPILE_BYTECODE=0 /opt/r8/monobase/run.sh monobase.user --requirements=/buildtmp/requirements.txt", dockerfileLines[5])
 }
 
 func TestGenerateVerboseEnv(t *testing.T) {

--- a/pkg/weights/fast_weights.go
+++ b/pkg/weights/fast_weights.go
@@ -63,6 +63,11 @@ func findFullWeights(folder string, weights []Weight, weightFile string) ([]Weig
 			return err
 		}
 
+		// Skip the .cog directory when looking for weights - this is where we store cog generated files
+		if info.IsDir() && info.Name() == ".cog" {
+			return filepath.SkipDir
+		}
+
 		relPath, err := filepath.Rel(folder, path)
 		if err != nil {
 			return err


### PR DESCRIPTION
Follow up to #2191
Make sure that separate temp dirs in `fast_push.go` are consistent with `fast_generator.go`.
Add a new tmp dir for tarballs extracted from images, so that they don't cause cache invalidation.