### PR TITLE
Make progress bar more pretty

### DIFF
--- a/pkg/monobeam/client.go
+++ b/pkg/monobeam/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -96,7 +97,10 @@ func (c *Client) UploadFile(ctx context.Context, objectType string, digest strin
 		return err
 	}
 
-	console.Info("Waiting to verify the image was received by the server...")
+	_, err = p.Write([]byte(fmt.Sprintf("Waiting to verify %s was received by the server...\n", desc)))
+	if err != nil {
+		console.Debugf("failed to write to progress bar: %v", err)
+	}
 
 	// Begin verification
 	verificationUrl := verificationURL(objectType, digest, data.Uuid)

--- a/tools/uploader/s3.go
+++ b/tools/uploader/s3.go
@@ -106,6 +106,7 @@ func (s *s3Uploader) UploadObject(ctx context.Context, objectPath, bucket, key s
 			decor.Name(" ] "),
 			decor.EwmaSpeed(decor.SizeB1024(0), "% .2f", 30),
 		),
+		mpb.BarRemoveOnComplete(),
 	)
 	defer bar.Abort(false)
 


### PR DESCRIPTION
### Summary

The progress bar for fast push has a lot of issues where it eats logs and looks weird. Change a log to a prepended write and remove the bar after it completes so it is more pretty.

### Test Plan

Push a model with fast push - the progress bar shouldn't look as ugly.