### PR TITLE
Mark current_scope() as no longer experimental

### DIFF
--- a/python/cog/server/scope.py
+++ b/python/cog/server/scope.py
@@ -1,11 +1,8 @@
-import warnings
 from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, Callable, Generator, Optional, Union
 
 from attrs import evolve, frozen
-
-from ..types import ExperimentalFeatureWarning
 
 
 @frozen
@@ -18,11 +15,6 @@ _current_scope: ContextVar[Optional[Scope]] = ContextVar("scope", default=None)
 
 
 def current_scope() -> Scope:
-    warnings.warn(
-        "current_scope is an experimental internal function. It may change or be removed without warning.",
-        category=ExperimentalFeatureWarning,
-        stacklevel=1,
-    )
     return _get_current_scope()
 
 


### PR DESCRIPTION
This was marked as experimental in the 0.14.0-alpha1 release, but now concurrency support is in a production release this isn't experimental any more and we shouldn't mark it as such.