### PR TITLE
Add documentation for concurrency support

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -144,6 +144,16 @@ build:
     - "libavcodec-dev"
 ```
 
+## `concurrency`
+
+> Added in cog 0.14.0.
+
+This stanza describes the concurrency capabilities of the model. It has one option:
+
+### `max`
+
+The maximum number of concurrent predictions the model can process.  If this is set, the model must specify an [async `predict()` method](python.md#async-predictors-and-concurrency).
+
 ## `image`
 
 The name given to built Docker images. If you want to push to a registry, this should also include the registry name.


### PR DESCRIPTION
This adds documentation for the new concurrency support in cog 0.14.0.

I moved the "streaming output" section to be under the "output" heading; it fits better here, and it means I can introduce async predictors before talking about AsyncIterator and AsyncConcatenateIterator.  As a result this is probably better viewed as a split diff instead of a unified diff.