### PR TITLE
Hit pre-upload route as part of monobeam uploads

### DIFF
--- a/pkg/docker/push.go
+++ b/pkg/docker/push.go
@@ -30,6 +30,10 @@ func Push(image string, fast bool, projectDir string, command command.Command, b
 
 	if fast {
 		monobeamClient := monobeam.NewClient(client)
+		if err := monobeamClient.PostPreUpload(ctx); err != nil {
+			// The pre upload is not required, just helpful. If it fails, log and continue
+			console.Debugf("Failed to POST pre_upload: %v", err)
+		}
 		return FastPush(ctx, image, projectDir, command, webClient, monobeamClient)
 	}
 	return StandardPush(image, command)

--- a/pkg/monobeam/client.go
+++ b/pkg/monobeam/client.go
@@ -17,8 +17,13 @@ import (
 	"github.com/vbauerster/mpb/v8"
 
 	"github.com/replicate/cog/pkg/env"
+	"github.com/replicate/cog/pkg/util"
 	"github.com/replicate/cog/pkg/util/console"
 	"github.com/replicate/cog/tools/uploader"
+)
+
+const (
+	preUploadPath = "/pre_upload"
 )
 
 type Client struct {
@@ -45,6 +50,19 @@ func NewClient(client *http.Client) *Client {
 	return &Client{
 		client: client,
 	}
+}
+
+func (c *Client) PostPreUpload(ctx context.Context) error {
+	preUploadUrl := baseURL()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, preUploadUrl.String(), nil)
+	if err != nil {
+		return util.WrapError(err, "create request")
+	}
+	_, err = c.client.Do(req)
+	if err != nil {
+		return util.WrapError(err, "do request")
+	}
+	return nil
 }
 
 func (c *Client) UploadFile(ctx context.Context, objectType string, digest string, path string, p *mpb.Progress, desc string) error {

--- a/pkg/monobeam/client.go
+++ b/pkg/monobeam/client.go
@@ -54,6 +54,7 @@ func NewClient(client *http.Client) *Client {
 
 func (c *Client) PostPreUpload(ctx context.Context) error {
 	preUploadUrl := baseURL()
+	preUploadUrl.Path = preUploadPath
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, preUploadUrl.String(), nil)
 	if err != nil {
 		return util.WrapError(err, "create request")


### PR DESCRIPTION
### Summary

On the server side, it is useful to know someone wants to upload stuff before they actually start uploading stuff. This PR lets the server know that the user wants to upload stuff.