### PR TITLE
Fix conditional on util package

### DIFF
--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -12,7 +12,7 @@ func GetEnvOrDefault[T any](key string, defaultVal T, conversionFunc func(string
 	val, exists := os.LookupEnv(key)
 	if exists {
 		v, err := conversionFunc(val)
-		if err != nil {
+		if err == nil {
 			return v
 		} else {
 			console.Warnf("Failed to convert env var %s to expected type. Continuing with default. Error: %v", key, err)


### PR DESCRIPTION
### Summary

This is rarely used without the default right now so it's not urgent, but this conditional is wrong. If the error _is_ nil, return the parsed value, otherwise log the error and continue with the default.