### PR TITLE
Skip weights that are ignored in dockerignore

### DIFF
--- a/pkg/dockerignore/dockerignore.go
+++ b/pkg/dockerignore/dockerignore.go
@@ -2,7 +2,6 @@ package dockerignore
 
 import (
 	"bufio"
-	"errors"
 	"os"
 	"path/filepath"
 
@@ -42,26 +41,4 @@ func readDockerIgnore(dockerIgnorePath string) ([]string, error) {
 		patterns = append(patterns, line)
 	}
 	return patterns, scanner.Err()
-}
-
-func checkCompatibleDockerIgnore(dir string) error {
-	dockerIgnorePath := filepath.Join(dir, ".dockerignore")
-	dockerIgnoreExists, err := files.Exists(dockerIgnorePath)
-	if err != nil {
-		return err
-	}
-	if !dockerIgnoreExists {
-		return nil
-	}
-
-	patterns, err := readDockerIgnore(dockerIgnorePath)
-	if err != nil {
-		return err
-	}
-
-	matcher := ignore.CompileIgnoreLines(patterns...)
-	if matcher.MatchesPath(".cog") {
-		return errors.New("The .cog tmp path cannot be ignored by docker in .dockerignore.")
-	}
-	return nil
 }

--- a/pkg/dockerignore/dockerignore.go
+++ b/pkg/dockerignore/dockerignore.go
@@ -1,0 +1,67 @@
+package dockerignore
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"path/filepath"
+
+	ignore "github.com/sabhiram/go-gitignore"
+
+	"github.com/replicate/cog/pkg/util/files"
+)
+
+func CreateMatcher(dir string) (*ignore.GitIgnore, error) {
+	dockerIgnorePath := filepath.Join(dir, ".dockerignore")
+	dockerIgnoreExists, err := files.Exists(dockerIgnorePath)
+	if err != nil {
+		return nil, err
+	}
+	if !dockerIgnoreExists {
+		return nil, nil
+	}
+
+	patterns, err := readDockerIgnore(dockerIgnorePath)
+	if err != nil {
+		return nil, err
+	}
+	return ignore.CompileIgnoreLines(patterns...), nil
+}
+
+func readDockerIgnore(dockerIgnorePath string) ([]string, error) {
+	var patterns []string
+	file, err := os.Open(dockerIgnorePath)
+	if err != nil {
+		return patterns, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		patterns = append(patterns, line)
+	}
+	return patterns, scanner.Err()
+}
+
+func checkCompatibleDockerIgnore(dir string) error {
+	dockerIgnorePath := filepath.Join(dir, ".dockerignore")
+	dockerIgnoreExists, err := files.Exists(dockerIgnorePath)
+	if err != nil {
+		return err
+	}
+	if !dockerIgnoreExists {
+		return nil
+	}
+
+	patterns, err := readDockerIgnore(dockerIgnorePath)
+	if err != nil {
+		return err
+	}
+
+	matcher := ignore.CompileIgnoreLines(patterns...)
+	if matcher.MatchesPath(".cog") {
+		return errors.New("The .cog tmp path cannot be ignored by docker in .dockerignore.")
+	}
+	return nil
+}

--- a/pkg/weights/fast_weights_test.go
+++ b/pkg/weights/fast_weights_test.go
@@ -45,3 +45,22 @@ func TestReadFastWeightsNoFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, weights)
 }
+
+func TestFindFastWeightsWithDockerIgnore(t *testing.T) {
+	folder := t.TempDir()
+
+	weightFileName := "test_weight"
+	weightFilePath := filepath.Join(folder, weightFileName)
+	weightData := make([]byte, WEIGHT_FILE_SIZE_INCLUSION)
+	err := os.WriteFile(weightFilePath, weightData, 0644)
+	require.NoError(t, err)
+
+	dockerIgnoreFilePath := filepath.Join(folder, ".dockerignore")
+	err = os.WriteFile(dockerIgnoreFilePath, []byte(weightFileName+"\n"), 0644)
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	weights, err := FindFastWeights(folder, tmpDir)
+	require.NoError(t, err)
+	require.Empty(t, weights)
+}

--- a/pkg/weights/fast_weights_test.go
+++ b/pkg/weights/fast_weights_test.go
@@ -52,11 +52,11 @@ func TestFindFastWeightsWithDockerIgnore(t *testing.T) {
 	weightFileName := "test_weight"
 	weightFilePath := filepath.Join(folder, weightFileName)
 	weightData := make([]byte, WEIGHT_FILE_SIZE_INCLUSION)
-	err := os.WriteFile(weightFilePath, weightData, 0644)
+	err := os.WriteFile(weightFilePath, weightData, 0o644)
 	require.NoError(t, err)
 
 	dockerIgnoreFilePath := filepath.Join(folder, ".dockerignore")
-	err = os.WriteFile(dockerIgnoreFilePath, []byte(weightFileName+"\n"), 0644)
+	err = os.WriteFile(dockerIgnoreFilePath, []byte(weightFileName+"\n"), 0o644)
 	require.NoError(t, err)
 
 	tmpDir := t.TempDir()


### PR DESCRIPTION
* Respect .dockerignore exclusions and only process weights that appear visible to docker
* Otherwise the `COPY —link` command can’t see the files.
* Centralise the dockerignore functions since they are now used by 2 different packages.