### PR TITLE
Add a config option to enable fast builds

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -57,6 +57,9 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if cfg.Build.Fast {
+		buildFast = cfg.Build.Fast
+	}
 
 	imageName := cfg.Image
 	if buildTag != "" {

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -76,6 +76,9 @@ func cmdPredict(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+		if cfg.Build.Fast {
+			buildFast = cfg.Build.Fast
+		}
 
 		if imageName, err = image.BuildBase(cfg, projectDir, buildUseCudaBaseImage, DetermineUseCogBaseImage(cmd), buildProgressOutput); err != nil {
 			return err
@@ -116,6 +119,9 @@ func cmdPredict(cmd *cobra.Command, args []string) error {
 		}
 		if gpus == "" && conf.Build.GPU {
 			gpus = "all"
+		}
+		if conf.Build.Fast {
+			buildFast = conf.Build.Fast
 		}
 	}
 

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -45,6 +45,9 @@ func push(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if cfg.Build.Fast {
+		buildFast = cfg.Build.Fast
+	}
 
 	imageName := cfg.Image
 	if len(args) > 0 {

--- a/pkg/cli/train.go
+++ b/pkg/cli/train.go
@@ -63,6 +63,9 @@ func cmdTrain(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+		if cfg.Build.Fast {
+			buildFast = cfg.Build.Fast
+		}
 
 		if imageName, err = image.BuildBase(cfg, projectDir, buildUseCudaBaseImage, DetermineUseCogBaseImage(cmd), buildProgressOutput); err != nil {
 			return err
@@ -97,6 +100,9 @@ func cmdTrain(cmd *cobra.Command, args []string) error {
 		}
 		if gpus == "" && conf.Build.GPU {
 			gpus = "all"
+		}
+		if conf.Build.Fast {
+			buildFast = conf.Build.Fast
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,6 +55,7 @@ type Build struct {
 	PreInstall         []string  `json:"pre_install,omitempty" yaml:"pre_install"` // Deprecated, but included for backwards compatibility
 	CUDA               string    `json:"cuda,omitempty" yaml:"cuda"`
 	CuDNN              string    `json:"cudnn,omitempty" yaml:"cudnn"`
+	Fast               bool      `json:"fast,omitempty" yaml:"fast"`
 
 	pythonRequirementsContent []string
 }


### PR DESCRIPTION
* This enables fast builds throughout the build without specifying —x-fast in every command