### PR TITLE
add Nonetype

### DIFF
--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -59,6 +59,7 @@ ALLOWED_INPUT_TYPES: List[Type[Any]] = [
     CogFile,
     CogPath,
     CogSecret,
+    NoneType,
 ]
 
 


### PR DESCRIPTION
See this issue: https://github.com/replicate/cog/issues/2206#issuecomment-2749298089 
Optional inputs give an error because Nonetype is not in the allowed types list.