### PR TITLE
Remove checks for static schema

### DIFF
--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -59,12 +59,11 @@ def test_predict_works_with_functions(client, match):
 
 
 @uses_predictor("openapi_complex_input")
-def test_openapi_specification(client, static_schema):
+def test_openapi_specification(client):
     resp = client.get("/openapi.json")
     assert resp.status_code == 200
 
     schema = resp.json()
-    assert schema == static_schema
     assert schema["openapi"] == "3.0.2"
     assert schema["info"] == {"title": "Cog", "version": "0.1.0"}
     assert schema["paths"]["/"] == {
@@ -226,13 +225,12 @@ def test_openapi_specification(client, static_schema):
 
 @uses_predictor("openapi_custom_output_type")
 def test_openapi_specification_with_custom_user_defined_output_type(
-    client, static_schema
+    client,
 ):
     resp = client.get("/openapi.json")
     assert resp.status_code == 200
 
     schema = resp.json()
-    assert schema == static_schema
     assert schema["components"]["schemas"]["Output"] == {
         "$ref": "#/components/schemas/MyOutput",
         "title": "Output",
@@ -257,12 +255,11 @@ def test_openapi_specification_with_custom_user_defined_output_type(
 
 @uses_predictor("openapi_output_type")
 def test_openapi_specification_with_custom_user_defined_output_type_called_output(
-    client, static_schema
+    client,
 ):
     resp = client.get("/openapi.json")
     assert resp.status_code == 200
     schema = resp.json()
-    assert schema == static_schema
     assert resp.json()["components"]["schemas"]["Output"] == {
         "properties": {
             "foo_number": {"default": "42", "title": "Foo Number", "type": "integer"},
@@ -278,11 +275,10 @@ def test_openapi_specification_with_custom_user_defined_output_type_called_outpu
 
 
 @uses_predictor("openapi_output_yield")
-def test_openapi_specification_with_yield(client, static_schema):
+def test_openapi_specification_with_yield(client):
     resp = client.get("/openapi.json")
     assert resp.status_code == 200
     schema = resp.json()
-    assert schema == static_schema
     assert schema["components"]["schemas"]["Output"] == {
         "title": "Output",
         "type": "array",
@@ -294,14 +290,11 @@ def test_openapi_specification_with_yield(client, static_schema):
 
 
 @uses_predictor("yield_concatenate_iterator")
-def test_openapi_specification_with_yield_with_concatenate_iterator(
-    client, static_schema
-):
+def test_openapi_specification_with_yield_with_concatenate_iterator(client):
     resp = client.get("/openapi.json")
     assert resp.status_code == 200
 
     schema = resp.json()
-    assert schema == static_schema
     assert schema["components"]["schemas"]["Output"] == {
         "title": "Output",
         "type": "array",
@@ -314,12 +307,11 @@ def test_openapi_specification_with_yield_with_concatenate_iterator(
 
 
 @uses_predictor("openapi_output_list")
-def test_openapi_specification_with_list(client, static_schema):
+def test_openapi_specification_with_list(client):
     resp = client.get("/openapi.json")
     assert resp.status_code == 200
 
     schema = resp.json()
-    assert schema == static_schema
     assert schema["components"]["schemas"]["Output"] == {
         "title": "Output",
         "type": "array",
@@ -330,12 +322,11 @@ def test_openapi_specification_with_list(client, static_schema):
 
 
 @uses_predictor("openapi_input_int_choices")
-def test_openapi_specification_with_int_choices(client, static_schema):
+def test_openapi_specification_with_int_choices(client):
     resp = client.get("/openapi.json")
     assert resp.status_code == 200
 
     schema = resp.json()
-    assert schema == static_schema
     schemas = schema["components"]["schemas"]
 
     assert schemas["Input"]["properties"]["pick_a_number_any_number"] == {


### PR DESCRIPTION
* Static schema checks are now made redundant by Pydantic 2.11 adding in additional metadata
* Use the tests to check for targeted dictionary equality instead.