### PR TITLE
Allow `pathlib.Path` and descendants as uploadables

### DIFF
--- a/python/cog/json.py
+++ b/python/cog/json.py
@@ -1,4 +1,5 @@
 import io
+import pathlib
 from datetime import datetime
 from enum import Enum
 from types import GeneratorType
@@ -61,9 +62,9 @@ def upload_files(obj: Any, upload_file: Callable[[io.IOBase], str]) -> Any:
         return {key: upload_files(value, upload_file) for key, value in obj.items()}
     if isinstance(obj, list):
         return [upload_files(value, upload_file) for value in obj]
-    if isinstance(obj, io.IOBase):
-        return upload_file(obj)
-    if callable(getattr(obj, "open", None)):
+    if isinstance(obj, pathlib.Path):
         with obj.open("rb") as f:
             return upload_file(f)
+    if isinstance(obj, io.IOBase):
+        return upload_file(obj)
     return obj

--- a/python/cog/json.py
+++ b/python/cog/json.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     np = None
 
-from .types import PYDANTIC_V2, Path
+from .types import PYDANTIC_V2
 
 
 def make_encodeable(obj: Any) -> Any:  # pylint: disable=too-many-return-statements

--- a/python/cog/json.py
+++ b/python/cog/json.py
@@ -61,9 +61,9 @@ def upload_files(obj: Any, upload_file: Callable[[io.IOBase], str]) -> Any:
         return {key: upload_files(value, upload_file) for key, value in obj.items()}
     if isinstance(obj, list):
         return [upload_files(value, upload_file) for value in obj]
-    if isinstance(obj, Path):
-        with obj.open("rb") as f:
-            return upload_file(f)
     if isinstance(obj, io.IOBase):
         return upload_file(obj)
+    if callable(getattr(obj, "open", None)):
+        with obj.open("rb") as f:
+            return upload_file(f)
     return obj


### PR DESCRIPTION
so that more types than `cog.types.Path` will be treated as path-like uploadables.

Connected to PLAT-1107