### PR TITLE
Update `cog init` command to use `python_requirements` and `requirements.txt`

### DIFF
--- a/pkg/cli/init-templates/cog.yaml
+++ b/pkg/cli/init-templates/cog.yaml
@@ -13,11 +13,8 @@ build:
   # python version in the form '3.11' or '3.11.4'
   python_version: "3.11"
 
-  # a list of packages in the format <package-name>==<version>
-  # python_packages:
-  #   - "numpy==1.19.4"
-  #   - "torch==1.8.0"
-  #   - "torchvision==0.9.0"
+  # path to a Python requirements.txt file
+  python_requirements: requirements.txt
 
   # commands run after the environment is setup
   # run:

--- a/pkg/cli/init-templates/requirements.txt
+++ b/pkg/cli/init-templates/requirements.txt
@@ -1,0 +1,23 @@
+# This is a normal Python requirements.txt file.
+
+# You can add dependencies directly from PyPI:
+# 
+# numpy==1.26.4
+# torch==2.2.1
+# torchvision==0.17.1
+
+
+# You can also add Git repos as dependencies, but you'll need to add git to the system_packages list in cog.yaml:
+# 
+# build:
+#   system_packages:
+#     - "git"
+# 
+# Then you can use a URL like this:
+# 
+# git+https://github.com/huggingface/transformers
+
+
+# You can also pin Git repos to a specific commit:
+# 
+# git+https://github.com/huggingface/transformers@2d1602a

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -25,6 +25,9 @@ var predictPyContent []byte
 //go:embed init-templates/.github/workflows/push.yaml
 var actionsWorkflowContent []byte
 
+//go:embed init-templates/requirements.txt
+var requirementsTxtContent []byte
+
 func newInitCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:        "init",
@@ -52,6 +55,7 @@ func initCommand(args []string) error {
 		"predict.py":                  predictPyContent,
 		".dockerignore":               dockerignoreContent,
 		".github/workflows/push.yaml": actionsWorkflowContent,
+		"requirements.txt":            requirementsTxtContent,
 	}
 
 	for filename, content := range fileContentMap {


### PR DESCRIPTION
The `python_packages` key in cog.yaml is [deprecated](https://github.com/replicate/cog/blob/4ce6fb90b3812d46b753413e5dc4b3b689ba5785/docs/yaml.md#python_packages) and may eventually stop working entirely.

This PR updates the `cog init` command to use `python_requirements` instead, and adds a starter `requirements.txt` file to the mix with some helpful comments.
