### PR TITLE
Allow fast as a build property in cog.yaml

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -698,3 +698,13 @@ build:
 	_, err := FromYAML([]byte(yamlString))
 	require.NoError(t, err)
 }
+
+func TestFastPushConfig(t *testing.T) {
+	yamlString := `
+build:
+  python_version: "3.12"
+  fast: true
+`
+	_, err := FromYAML([]byte(yamlString))
+	require.NoError(t, err)
+}

--- a/pkg/config/data/config_schema_v1.0.json
+++ b/pkg/config/data/config_schema_v1.0.json
@@ -145,6 +145,11 @@
               }
             ]
           }
+        },
+        "fast": {
+          "$id": "#/properties/build/properties/fast",
+          "type": "boolean",
+          "description": "A flag to enable the experimental fast-push feature from a config level."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
* Allows fast to be defined as a build property in cog.yaml to prevent the constant use of —x-fast flags on the CLI.