### PR TITLE
Add empty namespace package for `cog.ext`

### DIFF
--- a/python/cog/ext/__init__.py
+++ b/python/cog/ext/__init__.py
@@ -1,0 +1,3 @@
+# This `cog/ext` directory is a [namespace
+# directory](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/)
+# that intentionally does not contain any production code.


### PR DESCRIPTION
~to see if it's an off by one issue that's preventing extension packages from directly depending on `cog`.~

It _is_ an off-by-one level issue! By adding an "empty" `cog.ext` module, we can now add `cog` as a proper dependency of separately distributed packages that want to use `cog.ext` as a namespace package.