### PR TITLE
Prevent Optional Input Types from being required

### DIFF
--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -50,7 +50,7 @@ from .types import (
 from .types import Secret as CogSecret
 
 if PYDANTIC_V2:
-    from pydantic.fields import PydanticUndefined
+    from pydantic.fields import PydanticUndefined  # type: ignore
 else:
     from pydantic.fields import Undefined as PydanticUndefined
 

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -242,19 +242,22 @@ def get_input_create_model_kwargs(signature: inspect.Signature) -> Dict[str, Any
 
         # if no default is specified, create an empty, required input
         if parameter.default is inspect.Signature.empty:
-            # But only if it is not an optional, which explicitly isn't required.
-            if is_optional(InputType):
-                default = Input(default=None)
-            else:
-                default = Input()
+            default = Input()
         else:
             if not isinstance(parameter.default, FieldInfo):
                 default = Input(default=parameter.default)
             else:
                 if is_optional(InputType):
                     # If we are an optional, make sure the default is None
-                    if parameter.default.default is PydanticUndefined:
-                        parameter.default.default = None
+                    if (
+                        parameter.default.default is PydanticUndefined
+                        or parameter.default.default is ...
+                    ):
+                        if PYDANTIC_V2:
+                            parameter.default.default = None
+                        else:
+                            parameter.default.default_factory = None
+                            parameter.default.default = None
                 default = parameter.default
 
         if PYDANTIC_V2:

--- a/python/tests/test_predictor.py
+++ b/python/tests/test_predictor.py
@@ -1,13 +1,30 @@
+import inspect
 import os
 import sys
 from typing import Optional
 from unittest.mock import patch
 
-from cog import File, Path
+from pydantic.fields import FieldInfo
+
+from cog import File, Input, Path
 from cog.predictor import (
+    get_input_create_model_kwargs,
+    get_predict,
     get_weights_type,
     load_predictor_from_ref,
 )
+from cog.types import PYDANTIC_V2
+
+if PYDANTIC_V2:
+    from pydantic.fields import PydanticUndefined
+else:
+    from pydantic.fields import Undefined as PydanticUndefined
+
+
+def is_field_required(field: FieldInfo):
+    if hasattr(field, "is_required"):
+        return field.is_required()
+    return field.default is PydanticUndefined and field.default_factory is None
 
 
 def test_get_weights_type() -> None:
@@ -40,6 +57,16 @@ def test_load_predictor_from_ref_overrides_argv():
         assert predictor.predict() == ["foo.py"]
         # check we reset the args correctly
         assert sys.argv == ["foo.py", "exec", "--giraffes=2", "--eat-cookies"]
+
+
+def test_get_input_create_model_kwargs():
+    def predict(thing: Optional[str] = Input(description="Hello String.")) -> str:
+        return thing if thing is not None else "Nothing"
+
+    predict_type = get_predict(predict)
+    signature = inspect.signature(predict_type)
+    output = get_input_create_model_kwargs(signature)
+    assert not is_field_required(output["thing"][1])
 
 
 def _fixture_path(name):

--- a/python/tests/test_predictor.py
+++ b/python/tests/test_predictor.py
@@ -24,6 +24,8 @@ else:
 def is_field_required(field: FieldInfo):
     if hasattr(field, "is_required"):
         return field.is_required()
+    if hasattr(field, "required"):
+        return field.required
     return field.default is PydanticUndefined and field.default_factory is None
 
 

--- a/test-integration/test_integration/fixtures/optional-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/optional-project/cog.yaml
@@ -1,0 +1,3 @@
+build:
+  python_version: "3.8"
+predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/optional-project/predict.py
+++ b/test-integration/test_integration/fixtures/optional-project/predict.py
@@ -1,0 +1,7 @@
+from cog import BasePredictor, Input
+from typing import Optional
+
+
+class Predictor(BasePredictor):
+    def predict(self, s: Optional[str] = Input(description="Hello String.")) -> str:
+        return "hello " + (s if s is not None else "No One")

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -417,3 +417,18 @@ def test_predict_with_fast_build_with_local_image(docker_image):
     os.remove(weights_file)
     assert build_process.returncode == 0
     assert result.returncode == 0
+
+
+def test_predict_optional_project(tmpdir_factory):
+    project_dir = Path(__file__).parent / "fixtures/optional-project"
+    result = subprocess.run(
+        ["cog", "predict", "--debug"],
+        cwd=project_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=DEFAULT_TIMEOUT,
+    )
+    # stdout should be clean without any log messages so it can be piped to other commands
+    assert result.returncode == 0
+    assert result.stdout == "hello No One\n"


### PR DESCRIPTION
* Check if the type is optional, if it is and the default is undefined set the default to `None`
* This allows OpenAPI to understand that the field is not required