### PR TITLE
Disable provenance attestations

### DIFF
--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -14,9 +14,11 @@ import (
 )
 
 func Build(dir, dockerfileContents, imageName string, secrets []string, noCache bool, progressOutput string, epoch int64, contextDir string, buildContexts map[string]string) error {
-	var args []string
-
-	args = append(args, "buildx", "build")
+	args := []string{
+		"buildx", "build",
+		// disable provenance attestations since we don't want them cluttering the registry
+		"--provenance", "false",
+	}
 
 	if util.IsAppleSiliconMac(runtime.GOOS, runtime.GOARCH) {
 		// Fixes "WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested"
@@ -74,11 +76,11 @@ func Build(dir, dockerfileContents, imageName string, secrets []string, noCache 
 }
 
 func BuildAddLabelsAndSchemaToImage(image string, labels map[string]string, bundledSchemaFile string, bundledSchemaPy string) error {
-	var args []string
-
-	args = append(args,
+	args := []string{
 		"buildx", "build",
-	)
+		// disable provenance attestations since we don't want them cluttering the registry
+		"--provenance", "false",
+	}
 
 	if util.IsAppleSiliconMac(runtime.GOOS, runtime.GOARCH) {
 		// Fixes "WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested"


### PR DESCRIPTION
Docker desktop w/ containerd enabled is creating [provenance attestations](https://docs.docker.com/build/metadata/attestations/slsa-provenance/) with each build. When this happens, each image is pushed with 2 additional manifests, one is the provenance manifest containing build facts, and the other an index pointing to the actual image and the provenance manifest. While useful in some contexts, cog is not one of them atm. The registry is ignoring them, but this PR disables creation entirely.