### PR TITLE
Handle cog predict lists

### DIFF
--- a/pkg/predict/input.go
+++ b/pkg/predict/input.go
@@ -54,6 +54,10 @@ func NewInputs(keyVals map[string][]string, schema *openapi3.T) (Inputs, error) 
 							encodedVal := json.RawMessage(val)
 							input[key] = Input{Json: &encodedVal}
 							continue
+						} else if propertySchema.Type.Is("array") {
+							var arr = []any{val}
+							input[key] = Input{Array: &arr}
+							continue
 						}
 					}
 				}

--- a/test-integration/test_integration/fixtures/string-list-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/string-list-project/cog.yaml
@@ -1,0 +1,3 @@
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/string-list-project/predict.py
+++ b/test-integration/test_integration/fixtures/string-list-project/predict.py
@@ -1,0 +1,6 @@
+from cog import BasePredictor, Input
+
+
+class Predictor(BasePredictor):
+    def predict(self, s: list[str] = Input(description="A list of strings to print.")) -> str:
+        return "hello " + "|".join(s)

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -520,4 +520,4 @@ def test_predict_string_list(docker_image):
         timeout=DEFAULT_TIMEOUT,
     )
     assert result.returncode == 0
-    assert result.stdout == "hello world"
+    assert result.stdout == "hello world\n"

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -501,3 +501,23 @@ def test_predict_zsh_package(docker_image):
     assert result.returncode == 0
     assert ",sh," in result.stdout
     assert ",zsh," in result.stdout
+
+
+def test_predict_string_list(docker_image):
+    project_dir = Path(__file__).parent / "fixtures/string-list-project"
+    build_process = subprocess.run(
+        ["cog", "build", "-t", docker_image],
+        cwd=project_dir,
+        capture_output=True,
+    )
+    assert build_process.returncode == 0
+    result = subprocess.run(
+        ["cog", "predict", "--debug", docker_image, "-i", "s=world"],
+        cwd=project_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=DEFAULT_TIMEOUT,
+    )
+    assert result.returncode == 0
+    assert result.stdout == "hello world"


### PR DESCRIPTION
* When the user has an input of `s: list[str]` we want the following to be handled:
```
cog predict -i s=world
```