### PR TITLE
Add .python-version to .dockerignore

### DIFF
--- a/pkg/cli/init-templates/.dockerignore
+++ b/pkg/cli/init-templates/.dockerignore
@@ -7,6 +7,9 @@
 **/.github
 **/.gitignore
 
+# Exclude Python tooling
+.python-version
+
 # Exclude Python cache files
 __pycache__
 .mypy_cache


### PR DESCRIPTION
Fixes #2275

There is a bug where an existing .python-version file will be copied
from an existing project into the Docker container and conflict with the
Python version set in the cog.yaml.

We now include the .python-version in the .dockerignore file so that
it will not be copied into the container at build time.
