### PR TITLE
fix: Support platform requirements in generated requirements files

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -409,6 +409,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "danfairs",
+      "name": "Dan Fairs",
+      "avatar_url": "https://avatars.githubusercontent.com/u/24726?v=4",
+      "profile": "https://github.com/danfairs",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -409,15 +409,6 @@
       "contributions": [
         "doc"
       ]
-    },
-    {
-      "login": "danfairs",
-      "name": "Dan Fairs",
-      "avatar_url": "https://avatars.githubusercontent.com/u/24726?v=4",
-      "profile": "https://github.com/danfairs",
-      "contributions": [
-        "code"
-      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/vincent-petithory/dataurl v1.0.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/xeonx/timeago v1.0.0-rc5
-	golang.org/x/crypto v0.37.0
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0
 	golang.org/x/sync v0.13.0
 	golang.org/x/sys v0.32.0
@@ -271,6 +270,7 @@ require (
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
+	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20250210185358-939b2ce775ac // indirect
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/net v0.39.0 // indirect

--- a/pkg/config/compatibility.go
+++ b/pkg/config/compatibility.go
@@ -276,7 +276,11 @@ func CUDABaseImageFor(cuda string, cuDNN string) (string, error) {
 func tfGPUPackage(ver string, cuda string) (PythonRequirement, error) {
 	for _, compat := range TFCompatibilityMatrix {
 		if compat.TF == ver && version.Equal(compat.CUDA, cuda) {
-			return SplitPinnedPythonRequirement(compat.TFGPUPackage)
+			if req := SplitPinnedPythonRequirement(compat.TFGPUPackage); !req.ParsedFieldsValid {
+				return PythonRequirement{}, fmt.Errorf("Invalid Python requirement for %s version %s", ver, cuda)
+			} else {
+				return req, nil
+			}
 		}
 	}
 	// We've already warned user if they're doing something stupid in validateAndCompleteCUDA(), so fail silently
@@ -293,6 +297,7 @@ func torchCPUPackage(ver, goos, goarch string) (req PythonRequirement, err error
 			req.Version = torchStripCPUSuffixForM1(compat.Torch, goos, goarch)
 			req.FindLinks = []string{compat.FindLinks}
 			req.ExtraIndexURLs = []string{compat.ExtraIndexURL}
+			req.ParsedFieldsValid = true
 		}
 	}
 	return
@@ -334,6 +339,7 @@ func torchGPUPackage(ver string, cuda string) (req PythonRequirement, err error)
 		req.Version = version.StripModifier(latest.Torch)
 		req.FindLinks = []string{latest.FindLinks}
 		req.ExtraIndexURLs = []string{latest.ExtraIndexURL}
+		req.ParsedFieldsValid = true
 	}
 
 	return
@@ -349,6 +355,7 @@ func torchvisionCPUPackage(ver, goos, goarch string) (req PythonRequirement, err
 			req.Version = torchStripCPUSuffixForM1(compat.Torchvision, goos, goarch)
 			req.FindLinks = []string{compat.FindLinks}
 			req.ExtraIndexURLs = []string{compat.ExtraIndexURL}
+			req.ParsedFieldsValid = true
 		}
 	}
 	return
@@ -393,6 +400,7 @@ func torchvisionGPUPackage(ver, cuda string) (req PythonRequirement, err error) 
 		req.Version = version.StripModifier(latest.Torchvision)
 		req.FindLinks = []string{latest.FindLinks}
 		req.ExtraIndexURLs = []string{latest.ExtraIndexURL}
+		req.ParsedFieldsValid = true
 	}
 
 	return

--- a/pkg/config/compatibility.go
+++ b/pkg/config/compatibility.go
@@ -290,6 +290,7 @@ func tfGPUPackage(ver string, cuda string) (PythonRequirement, error) {
 func torchCPUPackage(ver, goos, goarch string) (req PythonRequirement, err error) {
 	req.Name = "torch"
 	req.Version = ver
+	req.ParsedFieldsValid = true
 
 	// The default is to just install the default version. For older pytorch versions, they don't have any CPU versions.
 	for _, compat := range TorchCompatibilityMatrix {
@@ -297,7 +298,6 @@ func torchCPUPackage(ver, goos, goarch string) (req PythonRequirement, err error
 			req.Version = torchStripCPUSuffixForM1(compat.Torch, goos, goarch)
 			req.FindLinks = []string{compat.FindLinks}
 			req.ExtraIndexURLs = []string{compat.ExtraIndexURL}
-			req.ParsedFieldsValid = true
 		}
 	}
 	return

--- a/pkg/config/compatibility.go
+++ b/pkg/config/compatibility.go
@@ -334,12 +334,12 @@ func torchGPUPackage(ver string, cuda string) (req PythonRequirement, err error)
 	}
 
 	req.Name = "torch"
+	req.ParsedFieldsValid = true
 	// We've already warned user if they're doing something stupid in validateAndCompleteCUDA()
 	if latest != nil {
 		req.Version = version.StripModifier(latest.Torch)
 		req.FindLinks = []string{latest.FindLinks}
 		req.ExtraIndexURLs = []string{latest.ExtraIndexURL}
-		req.ParsedFieldsValid = true
 	}
 
 	return
@@ -347,6 +347,7 @@ func torchGPUPackage(ver string, cuda string) (req PythonRequirement, err error)
 
 func torchvisionCPUPackage(ver, goos, goarch string) (req PythonRequirement, err error) {
 	req.Name = "torchvision"
+	req.ParsedFieldsValid = true
 
 	// Fall back to just installing default version. For older torchvision versions, they don't have any CPU versions.
 	req.Version = ver
@@ -355,7 +356,6 @@ func torchvisionCPUPackage(ver, goos, goarch string) (req PythonRequirement, err
 			req.Version = torchStripCPUSuffixForM1(compat.Torchvision, goos, goarch)
 			req.FindLinks = []string{compat.FindLinks}
 			req.ExtraIndexURLs = []string{compat.ExtraIndexURL}
-			req.ParsedFieldsValid = true
 		}
 	}
 	return
@@ -392,6 +392,7 @@ func torchvisionGPUPackage(ver, cuda string) (req PythonRequirement, err error) 
 	}
 
 	req.Name = "torchvision"
+	req.ParsedFieldsValid = true
 	if latest == nil {
 		// TODO: can we suggest a CUDA version known to be compatible?
 		console.Warnf("Cog doesn't know if CUDA %s is compatible with torchvision %s. This might cause CUDA problems.", cuda, ver)
@@ -400,7 +401,6 @@ func torchvisionGPUPackage(ver, cuda string) (req PythonRequirement, err error) 
 		req.Version = version.StripModifier(latest.Torchvision)
 		req.FindLinks = []string{latest.FindLinks}
 		req.ExtraIndexURLs = []string{latest.ExtraIndexURL}
-		req.ParsedFieldsValid = true
 	}
 
 	return

--- a/pkg/config/compatibility.go
+++ b/pkg/config/compatibility.go
@@ -273,29 +273,32 @@ func CUDABaseImageFor(cuda string, cuDNN string) (string, error) {
 	return images[0].ImageTag(), nil
 }
 
-func tfGPUPackage(ver string, cuda string) (name string, cpuVersion string, err error) {
+func tfGPUPackage(ver string, cuda string) (PythonRequirement, error) {
 	for _, compat := range TFCompatibilityMatrix {
 		if compat.TF == ver && version.Equal(compat.CUDA, cuda) {
-			name, cpuVersion, _, _, err = SplitPinnedPythonRequirement(compat.TFGPUPackage)
-			return name, cpuVersion, err
+			return SplitPinnedPythonRequirement(compat.TFGPUPackage)
 		}
 	}
 	// We've already warned user if they're doing something stupid in validateAndCompleteCUDA(), so fail silently
-	return "", "", nil
+	return PythonRequirement{}, nil
 }
 
-func torchCPUPackage(ver, goos, goarch string) (name, cpuVersion, findLinks, extraIndexURL string, err error) {
+func torchCPUPackage(ver, goos, goarch string) (req PythonRequirement, err error) {
+	req.Name = "torch"
+	req.Version = ver
+
+	// The default is to just install the default version. For older pytorch versions, they don't have any CPU versions.
 	for _, compat := range TorchCompatibilityMatrix {
 		if compat.TorchVersion() == ver && compat.CUDA == nil {
-			return "torch", torchStripCPUSuffixForM1(compat.Torch, goos, goarch), compat.FindLinks, compat.ExtraIndexURL, nil
+			req.Version = torchStripCPUSuffixForM1(compat.Torch, goos, goarch)
+			req.FindLinks = []string{compat.FindLinks}
+			req.ExtraIndexURLs = []string{compat.ExtraIndexURL}
 		}
 	}
-
-	// Fall back to just installing default version. For older pytorch versions, they don't have any CPU versions.
-	return "torch", ver, "", "", nil
+	return
 }
 
-func torchGPUPackage(ver string, cuda string) (name, cpuVersion, findLinks, extraIndexURL string, err error) {
+func torchGPUPackage(ver string, cuda string) (req PythonRequirement, err error) {
 	// find the torch package that has the requested torch version and the latest cuda version
 	// that is at most as high as the requested cuda version
 	var latest *TorchCompatibility
@@ -324,25 +327,34 @@ func torchGPUPackage(ver string, cuda string) (name, cpuVersion, findLinks, extr
 			}
 		}
 	}
-	if latest == nil {
-		// We've already warned user if they're doing something stupid in validateAndCompleteCUDA()
-		return "torch", ver, "", "", nil
+
+	req.Name = "torch"
+	// We've already warned user if they're doing something stupid in validateAndCompleteCUDA()
+	if latest != nil {
+		req.Version = version.StripModifier(latest.Torch)
+		req.FindLinks = []string{latest.FindLinks}
+		req.ExtraIndexURLs = []string{latest.ExtraIndexURL}
 	}
 
-	return "torch", version.StripModifier(latest.Torch), latest.FindLinks, latest.ExtraIndexURL, nil
+	return
 }
 
-func torchvisionCPUPackage(ver, goos, goarch string) (name, cpuVersion, findLinks, extraIndexURL string, err error) {
+func torchvisionCPUPackage(ver, goos, goarch string) (req PythonRequirement, err error) {
+	req.Name = "torchvision"
+
+	// Fall back to just installing default version. For older torchvision versions, they don't have any CPU versions.
+	req.Version = ver
 	for _, compat := range TorchCompatibilityMatrix {
 		if compat.TorchvisionVersion() == ver && compat.CUDA == nil {
-			return "torchvision", torchStripCPUSuffixForM1(compat.Torchvision, goos, goarch), compat.FindLinks, compat.ExtraIndexURL, nil
+			req.Version = torchStripCPUSuffixForM1(compat.Torchvision, goos, goarch)
+			req.FindLinks = []string{compat.FindLinks}
+			req.ExtraIndexURLs = []string{compat.ExtraIndexURL}
 		}
 	}
-	// Fall back to just installing default version. For older torchvision versions, they don't have any CPU versions.
-	return "torchvision", ver, "", "", nil
+	return
 }
 
-func torchvisionGPUPackage(ver, cuda string) (name, cpuVersion, findLinks, extraIndexURL string, err error) {
+func torchvisionGPUPackage(ver, cuda string) (req PythonRequirement, err error) {
 	// find the torchvision package that has the requested
 	// torchvision version and the latest cuda version that is at
 	// most as high as the requested cuda version
@@ -371,13 +383,19 @@ func torchvisionGPUPackage(ver, cuda string) (name, cpuVersion, findLinks, extra
 			}
 		}
 	}
+
+	req.Name = "torchvision"
 	if latest == nil {
 		// TODO: can we suggest a CUDA version known to be compatible?
 		console.Warnf("Cog doesn't know if CUDA %s is compatible with torchvision %s. This might cause CUDA problems.", cuda, ver)
-		return "torchvision", ver, "", "", nil
+		req.Version = ver
+	} else {
+		req.Version = version.StripModifier(latest.Torchvision)
+		req.FindLinks = []string{latest.FindLinks}
+		req.ExtraIndexURLs = []string{latest.ExtraIndexURL}
 	}
 
-	return "torchvision", version.StripModifier(latest.Torchvision), latest.FindLinks, latest.ExtraIndexURL, nil
+	return
 }
 
 // aarch64 packages don't have +cpu suffix: https://download.pytorch.org/whl/torch_stable.html

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -326,7 +326,7 @@ func (c *Config) ValidateAndComplete(projectDir string) error {
 // PythonRequirementsForArch returns a requirements.txt file with all the GPU packages resolved for given OS and architecture.
 // The packages listed in c.Build.pythonRequirementsContent are user-supplied requirements. Packages listed in the
 // `includePackages` parameter are defaults. The two sets are union'd together, with the user's own requirements
-// taking precendence (version, find-links, etc) if there is a duplicate.
+// taking precedence (version, find-links, etc) if there is a duplicate.
 //
 // The method will return the string content of the requirements file, or an error.
 func (c *Config) PythonRequirementsForArch(goos string, goarch string, includePackages []string) (string, error) {
@@ -356,7 +356,7 @@ func (c *Config) PythonRequirementsForArch(goos string, goarch string, includePa
 	// add them back in later.
 	unparsed := make([]PythonRequirement, 0)
 
-	// Next, build a map of requirements keyed on the requirement name. We'll initialise this with the requirements
+	// Next, build a map of requirements keyed on the requirement name. We'll init this with the requirements
 	// from `includePackages`, and update it with the user's requirements (which may therefore overwrite the defaults).
 	finalRequirementsMap := make(map[string]PythonRequirement)
 	for _, req := range includeRequirements {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -422,8 +422,8 @@ func (c *Config) pythonPackageForArch(req PythonRequirement, goos, goarch string
 	if req.Version != "" && out.Version == "" {
 		out.Version = req.Version
 	}
-	if req.EnvironmentAndHash != "" {
-		out.EnvironmentAndHash = req.EnvironmentAndHash
+	if req.EnvironmentMarkers != "" {
+		out.EnvironmentMarkers = req.EnvironmentMarkers
 	}
 	if len(req.FindLinks) > 0 {
 		out.FindLinks = req.FindLinks

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -666,7 +666,7 @@ func TestBlankBuild(t *testing.T) {
 }
 
 // TestPythonRequirementsForArchWithPlatform checks that generated requirements don't lose any metadata that
-// was supplied in the original requirements.txt, such as platform restrictions and hashes.
+// was supplied in the original requirements.txt, such as platform restrictions. We do expect hashes to be dropped.
 func TestPythonRequirementsForArchWithPlatform(t *testing.T) {
 	tmpDir := t.TempDir()
 	err := os.WriteFile(path.Join(tmpDir, "requirements.txt"), []byte(`pywin32==310 ; sys_platform == 'win32' \

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -681,7 +681,7 @@ func TestPythonRequirementsForArchWithPlatform(t *testing.T) {
 	require.NoError(t, config.ValidateAndComplete(tmpDir))
 	requirements, err := config.PythonRequirementsForArch("", "", []string{})
 	require.NoError(t, err)
-	expected := "pywin32==310 ; sys_platform == 'win32' --hash=sha256:126298077a9d7c95c53823934f000599f66ec9296b09167810eb24875f32689c"
+	expected := "pywin32==310 ; sys_platform == 'win32'"
 	require.Equal(t, expected, requirements)
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -665,6 +665,26 @@ func TestBlankBuild(t *testing.T) {
 	require.Equal(t, false, config.Build.GPU)
 }
 
+// TestPythonRequirementsForArchWithPlatform checks that generated requirements don't lose any metadata that
+// was supplied in the original requirements.txt, such as platform restrictions and hashes.
+func TestPythonRequirementsForArchWithPlatform(t *testing.T) {
+	tmpDir := t.TempDir()
+	err := os.WriteFile(path.Join(tmpDir, "requirements.txt"), []byte(`pywin32==310 ; sys_platform == 'win32' \
+--hash=sha256:126298077a9d7c95c53823934f000599f66ec9296b09167810eb24875f32689c`), 0o644)
+	require.NoError(t, err)
+	config := &Config{
+		Build: &Build{
+			PythonVersion:      "3.8",
+			PythonRequirements: "requirements.txt",
+		},
+	}
+	require.NoError(t, config.ValidateAndComplete(tmpDir))
+	requirements, err := config.PythonRequirementsForArch("", "", []string{})
+	require.NoError(t, err)
+	expected := "pywin32==310 ; sys_platform == 'win32' --hash=sha256:126298077a9d7c95c53823934f000599f66ec9296b09167810eb24875f32689c"
+	require.Equal(t, expected, requirements)
+}
+
 func TestPythonRequirementsForArchWithAddedPackage(t *testing.T) {
 	config := &Config{
 		Build: &Build{

--- a/pkg/config/requirements.go
+++ b/pkg/config/requirements.go
@@ -16,9 +16,9 @@ type PythonRequirement struct {
 	ExtraIndexURLs []string
 }
 
-// String returns a string representation of the Python requirement. Note that find links
+// NameAndVersion returns a string representation of the Python requirement. Note that find links
 // and extra index URLs are not included in the string representation.
-func (p PythonRequirement) String() string {
+func (p PythonRequirement) NameAndVersion() string {
 	if p.Name == "" {
 		return ""
 	}
@@ -61,7 +61,7 @@ func (p PythonRequirements) RequirementsFileContent() string {
 	}
 
 	for _, req := range p {
-		lines = append(lines, req.String())
+		lines = append(lines, req.NameAndVersion())
 	}
 	return strings.Join(lines, "\n")
 }
@@ -119,12 +119,4 @@ func SplitPinnedPythonRequirement(requirement string) (req PythonRequirement, er
 		return PythonRequirement{}, fmt.Errorf("Package name or version is missing in %s", requirement)
 	}
 	return
-}
-
-func PackageName(pipRequirement string) (string, error) {
-	if req, err := SplitPinnedPythonRequirement(pipRequirement); err != nil {
-		return "", err
-	} else {
-		return req.Name, nil
-	}
 }

--- a/pkg/config/requirements.go
+++ b/pkg/config/requirements.go
@@ -2,17 +2,90 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"regexp"
+	"slices"
+	"strings"
 )
+
+// PythonRequirement represents a single line of a Python requirements.txt-style file.
+type PythonRequirement struct {
+	Name           string
+	Version        string
+	FindLinks      []string
+	ExtraIndexURLs []string
+}
+
+// String returns a string representation of the Python requirement. Note that find links
+// and extra index URLs are not included in the string representation.
+func (p PythonRequirement) String() string {
+	if p.Name == "" {
+		return ""
+	}
+
+	fields := []string{p.Name}
+	if p.Version != "" {
+		fields = append(fields, "==", p.Version)
+	}
+	return strings.Join(fields, "")
+}
+
+type PythonRequirements []PythonRequirement
+
+// RequirementsFileContent returns a string representation of all the Python requirements. --find-links and --extra-index-url entries
+// will be prepended to the requirements.
+func (p PythonRequirements) RequirementsFileContent() string {
+	findLinks := make(map[string]struct{})
+	extraIndexURLs := make(map[string]struct{})
+
+	lines := make([]string, 0)
+	for _, req := range p {
+		for _, findLink := range req.FindLinks {
+			findLinks[findLink] = struct{}{}
+		}
+		for _, extraIndexURL := range req.ExtraIndexURLs {
+			extraIndexURLs[extraIndexURL] = struct{}{}
+		}
+	}
+
+	// First, emit the --find-links lines. Sort for stability.
+	sortedFindLinks := slices.Sorted(maps.Keys(findLinks))
+	for _, findLink := range sortedFindLinks {
+		lines = append(lines, "--find-links "+findLink)
+	}
+
+	// Now, emit the --extra-index-url lines
+	sortedExtraIndexURLs := slices.Sorted(maps.Keys(extraIndexURLs))
+	for _, extraIndexURL := range sortedExtraIndexURLs {
+		lines = append(lines, "--extra-index-url "+extraIndexURL)
+	}
+
+	for _, req := range p {
+		lines = append(lines, req.String())
+	}
+	return strings.Join(lines, "\n")
+}
+
+func ParseRequirements(packages []string) (PythonRequirements, error) {
+	reqs := make(PythonRequirements, 0, len(packages))
+	for _, pkg := range packages {
+		if req, err := SplitPinnedPythonRequirement(pkg); err != nil {
+			return nil, fmt.Errorf("failed to parse requirements for %s: %w", pkg, err)
+		} else {
+			reqs = append(reqs, req)
+		}
+	}
+	return reqs, nil
+}
 
 // SplitPinnedPythonRequirement returns the name, version, findLinks, and extraIndexURLs from a requirements.txt line
 // in the form name==version [--find-links=<findLink>] [-f <findLink>] [--extra-index-url=<extraIndexURL>]
-func SplitPinnedPythonRequirement(requirement string) (name string, version string, findLinks []string, extraIndexURLs []string, err error) {
+func SplitPinnedPythonRequirement(requirement string) (req PythonRequirement, err error) {
 	pinnedPackageRe := regexp.MustCompile(`(?:([a-zA-Z0-9\-_]+)==([^ ]+)|--find-links=([^\s]+)|-f\s+([^\s]+)|--extra-index-url=([^\s]+))`)
 
 	matches := pinnedPackageRe.FindAllStringSubmatch(requirement, -1)
 	if matches == nil {
-		return "", "", nil, nil, fmt.Errorf("Package %s is not in the expected format", requirement)
+		return req, fmt.Errorf("Package %s is not in the expected format", requirement)
 	}
 
 	nameFound := false
@@ -20,36 +93,38 @@ func SplitPinnedPythonRequirement(requirement string) (name string, version stri
 
 	for _, match := range matches {
 		if match[1] != "" {
-			name = match[1]
+			req.Name = match[1]
 			nameFound = true
 		}
 
 		if match[2] != "" {
-			version = match[2]
+			req.Version = match[2]
 			versionFound = true
 		}
 
 		if match[3] != "" {
-			findLinks = append(findLinks, match[3])
+			req.FindLinks = append(req.FindLinks, match[3])
 		}
 
 		if match[4] != "" {
-			findLinks = append(findLinks, match[4])
+			req.FindLinks = append(req.FindLinks, match[4])
 		}
 
 		if match[5] != "" {
-			extraIndexURLs = append(extraIndexURLs, match[5])
+			req.ExtraIndexURLs = append(req.ExtraIndexURLs, match[5])
 		}
 	}
 
 	if !nameFound || !versionFound {
-		return "", "", nil, nil, fmt.Errorf("Package name or version is missing in %s", requirement)
+		return PythonRequirement{}, fmt.Errorf("Package name or version is missing in %s", requirement)
 	}
-
-	return name, version, findLinks, extraIndexURLs, nil
+	return
 }
 
 func PackageName(pipRequirement string) (string, error) {
-	name, _, _, _, err := SplitPinnedPythonRequirement(pipRequirement)
-	return name, err
+	if req, err := SplitPinnedPythonRequirement(pipRequirement); err != nil {
+		return "", err
+	} else {
+		return req.Name, nil
+	}
 }

--- a/pkg/config/requirements_test.go
+++ b/pkg/config/requirements_test.go
@@ -62,32 +62,36 @@ func TestPythonRequirementNameAndVersion(t *testing.T) {
 		{
 			name: "basic package with version",
 			req: PythonRequirement{
-				Name:    "package1",
-				Version: "1.0.0",
+				Name:              "package1",
+				Version:           "1.0.0",
+				ParsedFieldsValid: true,
 			},
 			expected: "package1==1.0.0",
 		},
 		{
 			name: "package with no version",
 			req: PythonRequirement{
-				Name: "package2",
+				Name:              "package2",
+				ParsedFieldsValid: true,
 			},
 			expected: "package2",
 		},
 		{
 			name: "empty requirement",
 			req: PythonRequirement{
-				Name: "",
+				Name:              "",
+				ParsedFieldsValid: true,
 			},
 			expected: "",
 		},
 		{
 			name: "package with find links and extra index URLs",
 			req: PythonRequirement{
-				Name:           "package3",
-				Version:        "3.0.0",
-				FindLinks:      []string{"link1", "link2"},
-				ExtraIndexURLs: []string{"url1", "url2"},
+				Name:              "package3",
+				Version:           "3.0.0",
+				FindLinks:         []string{"link1", "link2"},
+				ExtraIndexURLs:    []string{"url1", "url2"},
+				ParsedFieldsValid: true,
 			},
 			expected: "package3==3.0.0",
 		},
@@ -97,6 +101,7 @@ func TestPythonRequirementNameAndVersion(t *testing.T) {
 				Name:               "package4",
 				Version:            "4.0.0",
 				EnvironmentAndHash: "python_version >= '3.8'",
+				ParsedFieldsValid:  true,
 			},
 			expected: "package4==4.0.0 ; python_version >= '3.8'",
 		},
@@ -105,8 +110,19 @@ func TestPythonRequirementNameAndVersion(t *testing.T) {
 			req: PythonRequirement{
 				Name:               "package5",
 				EnvironmentAndHash: "sys_platform == 'win32'",
+				ParsedFieldsValid:  true,
 			},
 			expected: "package5 ; sys_platform == 'win32'",
+		},
+		{
+			name: "parsed field not valid",
+			req: PythonRequirement{
+				Name:               "package6",
+				EnvironmentAndHash: "python_version >= '3.8'",
+				ParsedFieldsValid:  false,
+				Literal:            "some-text",
+			},
+			expected: "some-text",
 		},
 	}
 
@@ -133,8 +149,9 @@ func TestPythonRequirementsRequirementsFileContent(t *testing.T) {
 			name: "single package without find links or extra index urls",
 			reqs: PythonRequirements{
 				{
-					Name:    "package1",
-					Version: "1.0.0",
+					Name:              "package1",
+					Version:           "1.0.0",
+					ParsedFieldsValid: true,
 				},
 			},
 			expected: "package1==1.0.0",
@@ -143,14 +160,16 @@ func TestPythonRequirementsRequirementsFileContent(t *testing.T) {
 			name: "multiple packages with find links",
 			reqs: PythonRequirements{
 				{
-					Name:      "package1",
-					Version:   "1.0.0",
-					FindLinks: []string{"link1"},
+					Name:              "package1",
+					Version:           "1.0.0",
+					FindLinks:         []string{"link1"},
+					ParsedFieldsValid: true,
 				},
 				{
-					Name:      "package2",
-					Version:   "2.0.0",
-					FindLinks: []string{"link2"},
+					Name:              "package2",
+					Version:           "2.0.0",
+					FindLinks:         []string{"link2"},
+					ParsedFieldsValid: true,
 				},
 			},
 			expected: `--find-links link1
@@ -162,14 +181,16 @@ package2==2.0.0`,
 			name: "multiple packages with extra index urls",
 			reqs: PythonRequirements{
 				{
-					Name:           "package1",
-					Version:        "1.0.0",
-					ExtraIndexURLs: []string{"url1"},
+					Name:              "package1",
+					Version:           "1.0.0",
+					ExtraIndexURLs:    []string{"url1"},
+					ParsedFieldsValid: true,
 				},
 				{
-					Name:           "package2",
-					Version:        "2.0.0",
-					ExtraIndexURLs: []string{"url2"},
+					Name:              "package2",
+					Version:           "2.0.0",
+					ExtraIndexURLs:    []string{"url2"},
+					ParsedFieldsValid: true,
 				},
 			},
 			expected: `--extra-index-url url1
@@ -181,16 +202,18 @@ package2==2.0.0`,
 			name: "multiple packages with both find links and extra index urls",
 			reqs: PythonRequirements{
 				{
-					Name:           "package1",
-					Version:        "1.0.0",
-					FindLinks:      []string{"link1"},
-					ExtraIndexURLs: []string{"url1"},
+					Name:              "package1",
+					Version:           "1.0.0",
+					FindLinks:         []string{"link1"},
+					ExtraIndexURLs:    []string{"url1"},
+					ParsedFieldsValid: true,
 				},
 				{
-					Name:           "package2",
-					Version:        "2.0.0",
-					FindLinks:      []string{"link2"},
-					ExtraIndexURLs: []string{"url2"},
+					Name:              "package2",
+					Version:           "2.0.0",
+					FindLinks:         []string{"link2"},
+					ExtraIndexURLs:    []string{"url2"},
+					ParsedFieldsValid: true,
 				},
 			},
 			expected: `--find-links link1
@@ -204,16 +227,18 @@ package2==2.0.0`,
 			name: "duplicate find links and extra index urls",
 			reqs: PythonRequirements{
 				{
-					Name:           "package1",
-					Version:        "1.0.0",
-					FindLinks:      []string{"link1", "link1"},
-					ExtraIndexURLs: []string{"url1", "url1"},
+					Name:              "package1",
+					Version:           "1.0.0",
+					FindLinks:         []string{"link1", "link1"},
+					ExtraIndexURLs:    []string{"url1", "url1"},
+					ParsedFieldsValid: true,
 				},
 				{
-					Name:           "package2",
-					Version:        "2.0.0",
-					FindLinks:      []string{"link1"},
-					ExtraIndexURLs: []string{"url1"},
+					Name:              "package2",
+					Version:           "2.0.0",
+					FindLinks:         []string{"link1"},
+					ExtraIndexURLs:    []string{"url1"},
+					ParsedFieldsValid: true,
 				},
 			},
 			expected: `--find-links link1
@@ -225,10 +250,12 @@ package2==2.0.0`,
 			name: "packages without versions",
 			reqs: PythonRequirements{
 				{
-					Name: "package1",
+					Name:              "package1",
+					ParsedFieldsValid: true,
 				},
 				{
-					Name: "package2",
+					Name:              "package2",
+					ParsedFieldsValid: true,
 				},
 			},
 			expected: `package1
@@ -241,15 +268,32 @@ package2`,
 					Name:               "package1",
 					Version:            "1.0.0",
 					EnvironmentAndHash: "python_version >= '3.8'",
+					ParsedFieldsValid:  true,
 				},
 				{
 					Name:               "package2",
 					Version:            "2.0.0",
 					EnvironmentAndHash: "sys_platform == 'win32'",
+					ParsedFieldsValid:  true,
 				},
 			},
 			expected: `package1==1.0.0 ; python_version >= '3.8'
 package2==2.0.0 ; sys_platform == 'win32'`,
+		},
+		{
+			name: "packages that did not parse but have literals",
+			reqs: PythonRequirements{
+				{
+					Literal:           "hello-world",
+					ParsedFieldsValid: false,
+				},
+				{
+					Name:              "package1",
+					ParsedFieldsValid: true,
+				},
+			},
+			expected: `hello-world
+package1`,
 		},
 	}
 

--- a/pkg/config/requirements_test.go
+++ b/pkg/config/requirements_test.go
@@ -13,26 +13,31 @@ func TestSplitPinnedPythonRequirement(t *testing.T) {
 		expectedVersion        string
 		expectedFindLinks      []string
 		expectedExtraIndexURLs []string
+		expectedEnvAndHash     string
 		expectedError          bool
 	}{
-		{"package1==1.0.0", "package1", "1.0.0", nil, nil, false},
-		{"package1==1.0.0+alpha", "package1", "1.0.0+alpha", nil, nil, false},
-		{"--find-links=link1 --find-links=link2 package3==3.0.0", "package3", "3.0.0", []string{"link1", "link2"}, nil, false},
-		{"package4==4.0.0 --extra-index-url=url1 --extra-index-url=url2", "package4", "4.0.0", nil, []string{"url1", "url2"}, false},
-		{"-f link1 --find-links=link2 package5==5.0.0 --extra-index-url=url1 --extra-index-url=url2", "package5", "5.0.0", []string{"link1", "link2"}, []string{"url1", "url2"}, false},
-		{"package6 --find-links=link1 --find-links=link2 --extra-index-url=url1 --extra-index-url=url2", "", "", nil, nil, true},
-		{"invalid package", "", "", nil, nil, true},
-		{"package8==", "", "", nil, nil, true},
-		{"==8.0.0", "", "", nil, nil, true},
+		{"package1==1.0.0", "package1", "1.0.0", nil, nil, "", false},
+		{"package1==1.0.0+alpha", "package1", "1.0.0+alpha", nil, nil, "", false},
+		{"--find-links=link1 --find-links=link2 package3==3.0.0", "package3", "3.0.0", []string{"link1", "link2"}, nil, "", false},
+		{"package4==4.0.0 --extra-index-url=url1 --extra-index-url=url2", "package4", "4.0.0", nil, []string{"url1", "url2"}, "", false},
+		{"-f link1 --find-links=link2 package5==5.0.0 --extra-index-url=url1 --extra-index-url=url2", "package5", "5.0.0", []string{"link1", "link2"}, []string{"url1", "url2"}, "", false},
+		{"package6 --find-links=link1 --find-links=link2 --extra-index-url=url1 --extra-index-url=url2", "", "", nil, nil, "", true},
+		{"invalid package", "", "", nil, nil, "", true},
+		{"package8==", "", "", nil, nil, "", true},
+		{"==8.0.0", "", "", nil, nil, "", true},
+		{"package9==1.0.0 ; python_version >= '3.8'", "package9", "1.0.0", nil, nil, "python_version >= '3.8'", false},
+		{"package10==2.0.0 ; sys_platform == 'win32' and python_version < '3.9'", "package10", "2.0.0", nil, nil, "sys_platform == 'win32' and python_version < '3.9'", false},
+		{"package11==3.0.0 --find-links=link1 ; extra == 'gpu'", "package11", "3.0.0", []string{"link1"}, nil, "extra == 'gpu'", false},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
 			expectedReq := PythonRequirement{
-				Name:           tc.expectedName,
-				Version:        tc.expectedVersion,
-				FindLinks:      tc.expectedFindLinks,
-				ExtraIndexURLs: tc.expectedExtraIndexURLs,
+				Name:               tc.expectedName,
+				Version:            tc.expectedVersion,
+				FindLinks:          tc.expectedFindLinks,
+				ExtraIndexURLs:     tc.expectedExtraIndexURLs,
+				EnvironmentAndHash: tc.expectedEnvAndHash,
 			}
 			req, err := SplitPinnedPythonRequirement(tc.input)
 
@@ -83,6 +88,23 @@ func TestPythonRequirementNameAndVersion(t *testing.T) {
 				ExtraIndexURLs: []string{"url1", "url2"},
 			},
 			expected: "package3==3.0.0",
+		},
+		{
+			name: "package with environment marker",
+			req: PythonRequirement{
+				Name:               "package4",
+				Version:            "4.0.0",
+				EnvironmentAndHash: "python_version >= '3.8'",
+			},
+			expected: "package4==4.0.0 ; python_version >= '3.8'",
+		},
+		{
+			name: "package with environment marker and no version",
+			req: PythonRequirement{
+				Name:               "package5",
+				EnvironmentAndHash: "sys_platform == 'win32'",
+			},
+			expected: "package5 ; sys_platform == 'win32'",
 		},
 	}
 
@@ -209,6 +231,23 @@ package2==2.0.0`,
 			},
 			expected: `package1
 package2`,
+		},
+		{
+			name: "packages with environment markers",
+			reqs: PythonRequirements{
+				{
+					Name:               "package1",
+					Version:            "1.0.0",
+					EnvironmentAndHash: "python_version >= '3.8'",
+				},
+				{
+					Name:               "package2",
+					Version:            "2.0.0",
+					EnvironmentAndHash: "sys_platform == 'win32'",
+				},
+			},
+			expected: `package1==1.0.0 ; python_version >= '3.8'
+package2==2.0.0 ; sys_platform == 'win32'`,
 		},
 	}
 

--- a/pkg/config/requirements_test.go
+++ b/pkg/config/requirements_test.go
@@ -38,13 +38,15 @@ func TestSplitPinnedPythonRequirement(t *testing.T) {
 				FindLinks:          tc.expectedFindLinks,
 				ExtraIndexURLs:     tc.expectedExtraIndexURLs,
 				EnvironmentAndHash: tc.expectedEnvAndHash,
+				Literal:            tc.input,
+				ParsedFieldsValid:  !tc.expectedError,
 			}
-			req, err := SplitPinnedPythonRequirement(tc.input)
+			req := SplitPinnedPythonRequirement(tc.input)
 
 			if tc.expectedError {
-				require.Error(t, err)
+				require.False(t, req.ParsedFieldsValid)
 			} else {
-				require.NoError(t, err)
+				require.True(t, req.ParsedFieldsValid)
 				require.Equal(t, expectedReq, req)
 			}
 		})

--- a/pkg/config/requirements_test.go
+++ b/pkg/config/requirements_test.go
@@ -27,16 +27,69 @@ func TestSplitPinnedPythonRequirement(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		name, version, findLinks, extraIndexURLs, err := SplitPinnedPythonRequirement(tc.input)
+		t.Run(tc.input, func(t *testing.T) {
+			expectedReq := PythonRequirement{
+				Name:           tc.expectedName,
+				Version:        tc.expectedVersion,
+				FindLinks:      tc.expectedFindLinks,
+				ExtraIndexURLs: tc.expectedExtraIndexURLs,
+			}
+			req, err := SplitPinnedPythonRequirement(tc.input)
 
-		if tc.expectedError {
-			require.Error(t, err)
-		} else {
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedName, name, "input: "+tc.input)
-			require.Equal(t, tc.expectedVersion, version, "input: "+tc.input)
-			require.Equal(t, tc.expectedFindLinks, findLinks, "input: "+tc.input)
-			require.Equal(t, tc.expectedExtraIndexURLs, extraIndexURLs, "input: "+tc.input)
-		}
+			if tc.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, expectedReq, req)
+			}
+		})
+	}
+}
+
+func TestPythonRequirementString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		req      PythonRequirement
+		expected string
+	}{
+		{
+			name: "basic package with version",
+			req: PythonRequirement{
+				Name:    "package1",
+				Version: "1.0.0",
+			},
+			expected: "package1==1.0.0",
+		},
+		{
+			name: "package with no version",
+			req: PythonRequirement{
+				Name: "package2",
+			},
+			expected: "package2",
+		},
+		{
+			name: "empty requirement",
+			req: PythonRequirement{
+				Name: "",
+			},
+			expected: "",
+		},
+		{
+			name: "package with find links and extra index URLs",
+			req: PythonRequirement{
+				Name:           "package3",
+				Version:        "3.0.0",
+				FindLinks:      []string{"link1", "link2"},
+				ExtraIndexURLs: []string{"url1", "url2"},
+			},
+			expected: "package3==3.0.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.req.String()
+			require.Equal(t, tc.expected, result)
+		})
 	}
 }

--- a/pkg/config/requirements_test.go
+++ b/pkg/config/requirements_test.go
@@ -110,7 +110,7 @@ func TestPythonRequirementNameAndVersion(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := tc.req.NameAndVersion()
+			result := tc.req.RequirementLine()
 			require.Equal(t, tc.expected, result)
 		})
 	}

--- a/pkg/config/requirements_test.go
+++ b/pkg/config/requirements_test.go
@@ -28,6 +28,9 @@ func TestSplitPinnedPythonRequirement(t *testing.T) {
 		{"package9==1.0.0 ; python_version >= '3.8'", "package9", "1.0.0", nil, nil, "python_version >= '3.8'", false},
 		{"package10==2.0.0 ; sys_platform == 'win32' and python_version < '3.9'", "package10", "2.0.0", nil, nil, "sys_platform == 'win32' and python_version < '3.9'", false},
 		{"package11==3.0.0 --find-links=link1 ; extra == 'gpu'", "package11", "3.0.0", []string{"link1"}, nil, "extra == 'gpu'", false},
+		{"package12==4.0.0 ; platform_machine == 'x86_64' --hash=some-hash --hash=some-other-hash", "package12", "4.0.0", nil, nil, "platform_machine == 'x86_64'", false},
+		{"package13==5.0.0 ; --hash=some-hash --hash=some-other-hash", "package13", "5.0.0", nil, nil, "", false},
+		{"package14==6.0.0 ; --hash=some-hash --hash=some-other-hash platform_machine == 'x86_64'", "package14", "6.0.0", nil, nil, "platform_machine == 'x86_64'", false},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/config/requirements_test.go
+++ b/pkg/config/requirements_test.go
@@ -40,7 +40,7 @@ func TestSplitPinnedPythonRequirement(t *testing.T) {
 				Version:            tc.expectedVersion,
 				FindLinks:          tc.expectedFindLinks,
 				ExtraIndexURLs:     tc.expectedExtraIndexURLs,
-				EnvironmentAndHash: tc.expectedEnvAndHash,
+				EnvironmentMarkers: tc.expectedEnvAndHash,
 				Literal:            tc.input,
 				ParsedFieldsValid:  !tc.expectedError,
 			}
@@ -103,7 +103,7 @@ func TestPythonRequirementNameAndVersion(t *testing.T) {
 			req: PythonRequirement{
 				Name:               "package4",
 				Version:            "4.0.0",
-				EnvironmentAndHash: "python_version >= '3.8'",
+				EnvironmentMarkers: "python_version >= '3.8'",
 				ParsedFieldsValid:  true,
 			},
 			expected: "package4==4.0.0 ; python_version >= '3.8'",
@@ -112,7 +112,7 @@ func TestPythonRequirementNameAndVersion(t *testing.T) {
 			name: "package with environment marker and no version",
 			req: PythonRequirement{
 				Name:               "package5",
-				EnvironmentAndHash: "sys_platform == 'win32'",
+				EnvironmentMarkers: "sys_platform == 'win32'",
 				ParsedFieldsValid:  true,
 			},
 			expected: "package5 ; sys_platform == 'win32'",
@@ -121,7 +121,7 @@ func TestPythonRequirementNameAndVersion(t *testing.T) {
 			name: "parsed field not valid",
 			req: PythonRequirement{
 				Name:               "package6",
-				EnvironmentAndHash: "python_version >= '3.8'",
+				EnvironmentMarkers: "python_version >= '3.8'",
 				ParsedFieldsValid:  false,
 				Literal:            "some-text",
 			},
@@ -270,13 +270,13 @@ package2`,
 				{
 					Name:               "package1",
 					Version:            "1.0.0",
-					EnvironmentAndHash: "python_version >= '3.8'",
+					EnvironmentMarkers: "python_version >= '3.8'",
 					ParsedFieldsValid:  true,
 				},
 				{
 					Name:               "package2",
 					Version:            "2.0.0",
-					EnvironmentAndHash: "sys_platform == 'win32'",
+					EnvironmentMarkers: "sys_platform == 'win32'",
 					ParsedFieldsValid:  true,
 				},
 			},


### PR DESCRIPTION
This PR allows environment markers from user requirements files to be propagated into the generated output requirements file. 

It also lays the foundation for future support of `--hash`. These are currently removed, since their presence triggers the `--require-hashes` mode, and that would break existing builds.

This looks a fairly chunky PR, because we refactor the requirements processor to use a new `PythonRequirement` struct to capture everything we need to know about a requirement, rather than manipulating strings directly. This has allowed the generation of the requirements file itself to be separated from the version handling logic. I have also added a lot more tests.

I have taken care to maintain the ordering of requirements in the output, so that they continue to reflect the user's own requirements file (not to mention the test cases!). This bookkeeping adds a small amount of extra complexity.

While this change passes all tests, and my own image now builds, it would benefit from testing on others' images.

For example, I have a requirements.txt file - an extract of which looks like this:

```
python-dateutil==2.9.0.post0 \
    --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
    --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
pywin32==310 ; sys_platform == 'windows'
setuptools==79.0.1 ; python_full_version >= '3.12' \
    --hash=sha256:128ce7b8f33c3079fd1b067ecbb4051a66e8526e7b65f6cec075dfc650ddfa88 \
    --hash=sha256:e147c0549f27767ba362f9da434eab9c5dc0045d5304feb602a0af001089fc51
```

Here's the build output with `--debug` set. Note that both the platform requirements are preserved for the `pywin32` package (and others), and the hashes are omitted:

```
Setting CUDA to version 12.4 from Torch version
Setting CuDNN to version 12.4
Building Docker image from environment in cog.yaml...
Generated requirements.txt:
--extra-index-url https://download.pytorch.org/whl/cu124
contourpy==1.3.2
cycler==0.12.1
filelock==3.18.0
fonttools==4.57.0
fsspec==2025.3.2
jinja2==3.1.6
kiwisolver==1.4.8
markupsafe==3.0.2
matplotlib==3.10.1
mpmath==1.3.0
networkx==3.4.2
numpy==2.2.5
nvidia-cublas-cu12==12.4.5.8 ; platform_machine == 'x86_64' and sys_platform == 'linux'
nvidia-cuda-cupti-cu12==12.4.127 ; platform_machine == 'x86_64' and sys_platform == 'linux'
nvidia-cuda-nvrtc-cu12==12.4.127 ; platform_machine == 'x86_64' and sys_platform == 'linux'
nvidia-cuda-runtime-cu12==12.4.127 ; platform_machine == 'x86_64' and sys_platform == 'linux'
nvidia-cudnn-cu12==9.1.0.70 ; platform_machine == 'x86_64' and sys_platform == 'linux'
nvidia-cufft-cu12==11.2.1.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
nvidia-curand-cu12==10.3.5.147 ; platform_machine == 'x86_64' and sys_platform == 'linux'
nvidia-cusolver-cu12==11.6.1.9 ; platform_machine == 'x86_64' and sys_platform == 'linux'
nvidia-cusparse-cu12==12.3.1.170 ; platform_machine == 'x86_64' and sys_platform == 'linux'
nvidia-nccl-cu12==2.21.5 ; platform_machine == 'x86_64' and sys_platform == 'linux'
nvidia-nvjitlink-cu12==12.4.127 ; platform_machine == 'x86_64' and sys_platform == 'linux'
nvidia-nvtx-cu12==12.4.127 ; platform_machine == 'x86_64' and sys_platform == 'linux'
opencv-python==4.11.0.86
packaging==25.0
pillow==11.2.1
pyparsing==3.2.3
python-dateutil==2.9.0.post0
pywin32==310 ; sys_platform == 'windows'
setuptools==79.0.1 ; python_full_version >= '3.12'
six==1.17.0
sympy==1.13.1
torch==2.5.1
triton==3.1.0 ; python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'
typing-extensions==4.13.2
$ docker buildx build --provenance false --platform linux/amd64 --load --cache-to type=inline --file - --tag cog-condense-sam2-base --progress auto .
[+] Building 26.6s (16/16) FINISHED                                                                                                                                                                                     docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                                                    0.0s
 => => transferring dockerfile: 1.07kB                                                                                                                                                                                                  0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1.4
... etc ...
```

This fixes #2078.

If there are any standards/expectations around individual commits, let me know. I'm used to squash-and-merge, and this PR might be a bit messy if you just use merge commits.