### PR TITLE
Update all integration tests to use the `cog_binary` fixture

### DIFF
--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -8,10 +8,10 @@ import pytest
 from .util import assert_versions_match
 
 
-def test_build_without_predictor(docker_image):
+def test_build_without_predictor(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/no-predictor-project"
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )
@@ -22,7 +22,7 @@ def test_build_without_predictor(docker_image):
     )
 
 
-def test_build_names_uses_image_option_in_cog_yaml(tmpdir, docker_image):
+def test_build_names_uses_image_option_in_cog_yaml(tmpdir, docker_image, cog_binary):
     with open(tmpdir / "cog.yaml", "w") as f:
         cog_yaml = f"""
 image: {docker_image}
@@ -44,7 +44,7 @@ class Predictor(BasePredictor):
         f.write(code)
 
     subprocess.run(
-        ["cog", "build"],
+        [cog_binary, "build"],
         cwd=tmpdir,
         check=True,
     )
@@ -53,10 +53,10 @@ class Predictor(BasePredictor):
     )
 
 
-def test_build_with_model(docker_image):
+def test_build_with_model(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/path-project"
     subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         check=True,
     )
@@ -86,10 +86,10 @@ def test_build_with_model(docker_image):
     }
 
 
-def test_build_invalid_schema(docker_image):
+def test_build_invalid_schema(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/invalid-int-project"
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )
@@ -98,7 +98,7 @@ def test_build_invalid_schema(docker_image):
 
 
 @pytest.mark.skipif(os.environ.get("CI") != "true", reason="only runs in CI")
-def test_build_gpu_model_on_cpu(tmpdir, docker_image):
+def test_build_gpu_model_on_cpu(tmpdir, docker_image, cog_binary):
     with open(tmpdir / "cog.yaml", "w") as f:
         cog_yaml = """
 build:
@@ -148,7 +148,7 @@ class Predictor(BasePredictor):
     )
 
     subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=tmpdir,
         check=True,
     )
@@ -180,16 +180,16 @@ class Predictor(BasePredictor):
     assert len(labels["org.opencontainers.image.revision"]) > 0
 
 
-def test_build_with_cog_init_templates(tmpdir, docker_image):
+def test_build_with_cog_init_templates(tmpdir, docker_image, cog_binary):
     subprocess.run(
-        ["cog", "init"],
+        [cog_binary, "init"],
         cwd=tmpdir,
         capture_output=True,
         check=True,
     )
 
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=tmpdir,
         capture_output=True,
         check=True,
@@ -199,10 +199,10 @@ def test_build_with_cog_init_templates(tmpdir, docker_image):
     assert "Image built as cog-" in build_process.stderr.decode()
 
 
-def test_build_with_complex_output(tmpdir, docker_image):
+def test_build_with_complex_output(tmpdir, docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/complex_output_project"
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )
@@ -210,10 +210,10 @@ def test_build_with_complex_output(tmpdir, docker_image):
     assert "Image built as cog-" in build_process.stderr.decode()
 
 
-def test_python_37_deprecated(docker_image):
+def test_python_37_deprecated(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/python_37"
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )
@@ -224,10 +224,10 @@ def test_python_37_deprecated(docker_image):
     )
 
 
-def test_build_base_image_sha(docker_image):
+def test_build_base_image_sha(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/path-project"
     subprocess.run(
-        ["cog", "build", "-t", docker_image, "--use-cog-base-image"],
+        [cog_binary, "build", "-t", docker_image, "--use-cog-base-image"],
         cwd=project_dir,
         check=True,
     )
@@ -244,31 +244,31 @@ def test_build_base_image_sha(docker_image):
     assert base_layer_hash in layers
 
 
-def test_torch_2_0_3_cu118_base_image(docker_image):
+def test_torch_2_0_3_cu118_base_image(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/torch-cuda-baseimage-project"
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image, "--use-cog-base-image"],
+        [cog_binary, "build", "-t", docker_image, "--use-cog-base-image"],
         cwd=project_dir,
         capture_output=True,
     )
     assert build_process.returncode == 0
 
 
-def test_torch_1_13_0_base_image_fallback(docker_image):
+def test_torch_1_13_0_base_image_fallback(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/torch-baseimage-project"
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image, "--openapi-schema", "openapi.json"],
+        [cog_binary, "build", "-t", docker_image, "--openapi-schema", "openapi.json"],
         cwd=project_dir,
         capture_output=True,
     )
     assert build_process.returncode == 0
 
 
-def test_torch_1_13_0_base_image_fail(docker_image):
+def test_torch_1_13_0_base_image_fail(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/torch-baseimage-project"
     build_process = subprocess.run(
         [
-            "cog",
+            cog_binary,
             "build",
             "-t",
             docker_image,
@@ -282,11 +282,11 @@ def test_torch_1_13_0_base_image_fail(docker_image):
     assert build_process.returncode == 1
 
 
-def test_torch_1_13_0_base_image_fail_explicit(docker_image):
+def test_torch_1_13_0_base_image_fail_explicit(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/torch-baseimage-project"
     build_process = subprocess.run(
         [
-            "cog",
+            cog_binary,
             "build",
             "-t",
             docker_image,
@@ -300,11 +300,11 @@ def test_torch_1_13_0_base_image_fail_explicit(docker_image):
     assert build_process.returncode == 0
 
 
-def test_precompile(docker_image):
+def test_precompile(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/torch-baseimage-project"
     build_process = subprocess.run(
         [
-            "cog",
+            cog_binary,
             "build",
             "-t",
             docker_image,
@@ -319,11 +319,11 @@ def test_precompile(docker_image):
     assert build_process.returncode == 0
 
 
-def test_cog_install_base_image(docker_image):
+def test_cog_install_base_image(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/string-project"
     build_process = subprocess.run(
         [
-            "cog",
+            cog_binary,
             "build",
             "-t",
             docker_image,
@@ -350,7 +350,7 @@ def test_cog_install_base_image(docker_image):
     cog_installed_version = cog_installed_version_process.stdout.decode().strip()
     cog_version_process = subprocess.run(
         [
-            "cog",
+            cog_binary,
             "--version",
         ],
         cwd=project_dir,
@@ -364,10 +364,10 @@ def test_cog_install_base_image(docker_image):
     )
 
 
-def test_pip_freeze(docker_image):
+def test_pip_freeze(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/path-project"
     subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         check=True,
     )
@@ -395,11 +395,11 @@ def test_pip_freeze(docker_image):
     )
 
 
-def test_cog_installs_apt_packages(docker_image):
+def test_cog_installs_apt_packages(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/apt-packages"
     build_process = subprocess.run(
         [
-            "cog",
+            cog_binary,
             "build",
             "-t",
             docker_image,
@@ -412,7 +412,7 @@ def test_cog_installs_apt_packages(docker_image):
     assert build_process.returncode == 0
 
 
-def test_fast_build(docker_image):
+def test_fast_build(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/fast-build"
     weights_file = os.path.join(project_dir, "weights.h5")
     with open(weights_file, "w", encoding="utf8") as handle:
@@ -420,7 +420,7 @@ def test_fast_build(docker_image):
         handle.write("\0")
 
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image, "--x-fast"],
+        [cog_binary, "build", "-t", docker_image, "--x-fast"],
         cwd=project_dir,
         capture_output=True,
     )
@@ -430,11 +430,11 @@ def test_fast_build(docker_image):
     assert build_process.returncode == 0
 
 
-def test_pydantic2(docker_image):
+def test_pydantic2(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/pydantic2"
 
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )
@@ -442,11 +442,11 @@ def test_pydantic2(docker_image):
     assert build_process.returncode == 0
 
 
-def test_ffmpeg_base_image(docker_image):
+def test_ffmpeg_base_image(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/ffmpeg-package"
 
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )
@@ -454,11 +454,11 @@ def test_ffmpeg_base_image(docker_image):
     assert build_process.returncode == 0
 
 
-def test_bad_dockerignore(docker_image):
+def test_bad_dockerignore(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/bad-dockerignore"
 
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )
@@ -470,11 +470,11 @@ def test_bad_dockerignore(docker_image):
     )
 
 
-def test_pydantic1_none(docker_image):
+def test_pydantic1_none(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/pydantic1-none"
 
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )
@@ -482,7 +482,7 @@ def test_pydantic1_none(docker_image):
     assert build_process.returncode == 0
 
 
-def test_fast_build_with_local_image(docker_image):
+def test_fast_build_with_local_image(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/fast-build"
     weights_file = os.path.join(project_dir, "weights.h5")
     with open(weights_file, "w", encoding="utf8") as handle:
@@ -490,7 +490,7 @@ def test_fast_build_with_local_image(docker_image):
         handle.write("\0")
 
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image, "--x-fast", "--x-localimage"],
+        [cog_binary, "build", "-t", docker_image, "--x-fast", "--x-localimage"],
         cwd=project_dir,
         capture_output=True,
     )
@@ -500,11 +500,11 @@ def test_fast_build_with_local_image(docker_image):
     assert build_process.returncode == 0
 
 
-def test_local_whl_install(docker_image):
+def test_local_whl_install(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/local-whl-install"
 
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )
@@ -512,11 +512,11 @@ def test_local_whl_install(docker_image):
     assert build_process.returncode == 0
 
 
-def test_overrides(docker_image):
+def test_overrides(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/overrides-project"
 
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )
@@ -524,11 +524,11 @@ def test_overrides(docker_image):
     assert build_process.returncode == 0
 
 
-def test_install_requires_packaging(docker_image):
+def test_install_requires_packaging(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/install-requires-packaging"
 
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )

--- a/test-integration/test_integration/test_config.py
+++ b/test-integration/test_integration/test_config.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 
 
-def test_config(tmpdir_factory):
+def test_config(tmpdir_factory, cog_binary):
     tmpdir = tmpdir_factory.mktemp("project")
     with open(tmpdir / "cog.yaml", "w") as f:
         cog_yaml = """
@@ -15,7 +15,7 @@ build:
     os.makedirs(subdir)
 
     result = subprocess.run(
-        ["cog", "run", "echo", "hello world"],
+        [cog_binary, "run", "echo", "hello world"],
         cwd=subdir,
         check=True,
         capture_output=True,

--- a/test-integration/test_integration/test_migrate.py
+++ b/test-integration/test_integration/test_migrate.py
@@ -7,13 +7,13 @@ from pathlib import Path
 DEFAULT_TIMEOUT = 60
 
 
-def test_migrate(tmpdir_factory):
+def test_migrate(tmpdir_factory, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/migration-project"
     out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
     shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
     result = subprocess.run(
         [
-            "cog",
+            cog_binary,
             "migrate",
             "--y",
         ],
@@ -44,13 +44,13 @@ class Predictor(BasePredictor):
         assert handle.read(), "pillow"
 
 
-def test_migrate_gpu(tmpdir_factory):
+def test_migrate_gpu(tmpdir_factory, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/migration-gpu-project"
     out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
     shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
     result = subprocess.run(
         [
-            "cog",
+            cog_binary,
             "migrate",
             "--y",
         ],

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -14,10 +14,10 @@ from .util import cog_server_http_run
 DEFAULT_TIMEOUT = 60
 
 
-def test_predict_takes_string_inputs_and_returns_strings_to_stdout():
+def test_predict_takes_string_inputs_and_returns_strings_to_stdout(cog_binary):
     project_dir = Path(__file__).parent / "fixtures/string-project"
     result = subprocess.run(
-        ["cog", "predict", "--debug", "-i", "s=world"],
+        [cog_binary, "predict", "--debug", "-i", "s=world"],
         cwd=project_dir,
         check=True,
         capture_output=True,
@@ -30,10 +30,10 @@ def test_predict_takes_string_inputs_and_returns_strings_to_stdout():
     assert "falling back to slow loader" in result.stderr
 
 
-def test_predict_supports_async_predictors():
+def test_predict_supports_async_predictors(cog_binary):
     project_dir = Path(__file__).parent / "fixtures/async-string-project"
     result = subprocess.run(
-        ["cog", "predict", "--debug", "-i", "s=world"],
+        [cog_binary, "predict", "--debug", "-i", "s=world"],
         cwd=project_dir,
         check=True,
         capture_output=True,
@@ -44,10 +44,10 @@ def test_predict_supports_async_predictors():
     assert result.stdout == "hello world\n"
 
 
-def test_predict_takes_int_inputs_and_returns_ints_to_stdout():
+def test_predict_takes_int_inputs_and_returns_ints_to_stdout(cog_binary):
     project_dir = Path(__file__).parent / "fixtures/int-project"
     result = subprocess.run(
-        ["cog", "predict", "--debug", "-i", "num=2"],
+        [cog_binary, "predict", "--debug", "-i", "num=2"],
         cwd=project_dir,
         check=True,
         capture_output=True,
@@ -59,14 +59,14 @@ def test_predict_takes_int_inputs_and_returns_ints_to_stdout():
     assert "falling back to slow loader" not in result.stderr
 
 
-def test_predict_takes_file_inputs(tmpdir_factory):
+def test_predict_takes_file_inputs(tmpdir_factory, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/path-input-project"
     out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
     shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
     with open(out_dir / "input.txt", "w", encoding="utf-8") as fh:
         fh.write("what up")
     result = subprocess.run(
-        ["cog", "predict", "--debug", "-i", "path=@" + str(out_dir / "input.txt")],
+        [cog_binary, "predict", "--debug", "-i", "path=@" + str(out_dir / "input.txt")],
         cwd=out_dir,
         check=True,
         capture_output=True,
@@ -77,12 +77,12 @@ def test_predict_takes_file_inputs(tmpdir_factory):
     assert "falling back to slow loader" not in result.stderr
 
 
-def test_predict_writes_files_to_files(tmpdir_factory):
+def test_predict_writes_files_to_files(tmpdir_factory, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/path-output-project"
     out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
     shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
     result = subprocess.run(
-        ["cog", "predict", "--debug"],
+        [cog_binary, "predict", "--debug"],
         cwd=out_dir,
         check=True,
         capture_output=True,
@@ -95,12 +95,12 @@ def test_predict_writes_files_to_files(tmpdir_factory):
     assert "falling back to slow loader" not in result.stderr
 
 
-def test_predict_writes_files_to_files_with_custom_name(tmpdir_factory):
+def test_predict_writes_files_to_files_with_custom_name(tmpdir_factory, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/path-output-project"
     out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
     shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
     result = subprocess.run(
-        ["cog", "predict", "--debug", "-o", out_dir / "myoutput.bmp"],
+        [cog_binary, "predict", "--debug", "-o", out_dir / "myoutput.bmp"],
         cwd=out_dir,
         check=True,
         capture_output=True,
@@ -113,14 +113,14 @@ def test_predict_writes_files_to_files_with_custom_name(tmpdir_factory):
     assert "falling back to slow loader" not in result.stderr
 
 
-def test_predict_writes_multiple_files_to_files(tmpdir_factory):
+def test_predict_writes_multiple_files_to_files(tmpdir_factory, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/path-list-output-project"
 
     out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
     shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
 
     result = subprocess.run(
-        ["cog", "predict"],
+        [cog_binary, "predict"],
         cwd=out_dir,
         check=True,
         capture_output=True,
@@ -138,11 +138,11 @@ def test_predict_writes_multiple_files_to_files(tmpdir_factory):
     assert "falling back to slow loader" not in result.stderr
 
 
-def test_predict_writes_strings_to_files(tmpdir_factory):
+def test_predict_writes_strings_to_files(tmpdir_factory, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/string-project"
     out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
     result = subprocess.run(
-        ["cog", "predict", "--debug", "-i", "s=world", "-o", out_dir / "out.txt"],
+        [cog_binary, "predict", "--debug", "-i", "s=world", "-o", out_dir / "out.txt"],
         cwd=project_dir,
         check=True,
         capture_output=True,
@@ -156,11 +156,11 @@ def test_predict_writes_strings_to_files(tmpdir_factory):
     assert "falling back to slow loader" in result.stderr
 
 
-def test_predict_runs_an_existing_image(docker_image, tmpdir_factory):
+def test_predict_runs_an_existing_image(docker_image, tmpdir_factory, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/string-project"
 
     subprocess.run(
-        ["cog", "build", "--debug", "-t", docker_image],
+        [cog_binary, "build", "--debug", "-t", docker_image],
         cwd=project_dir,
         check=True,
     )
@@ -168,7 +168,7 @@ def test_predict_runs_an_existing_image(docker_image, tmpdir_factory):
     # Run in another directory to ensure it doesn't use cog.yaml
     another_directory = tmpdir_factory.mktemp("project")
     result = subprocess.run(
-        ["cog", "predict", "--debug", docker_image, "-i", "s=world"],
+        [cog_binary, "predict", "--debug", docker_image, "-i", "s=world"],
         cwd=another_directory,
         capture_output=True,
         text=True,
@@ -183,14 +183,14 @@ def test_predict_runs_an_existing_image(docker_image, tmpdir_factory):
 # https://github.com/replicate/cog/commit/28202b12ea40f71d791e840b97a51164e7be3b3c
 # we need to find a better way to test this
 @pytest.mark.skip("incredibly slow")
-def test_predict_with_remote_image(tmpdir_factory):
+def test_predict_with_remote_image(tmpdir_factory, cog_binary):
     image_name = "r8.im/replicate/hello-world@sha256:5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa"
     subprocess.run(["docker", "rmi", "-f", image_name], check=True)
 
     # Run in another directory to ensure it doesn't use cog.yaml
     another_directory = tmpdir_factory.mktemp("project")
     result = subprocess.run(
-        ["cog", "predict", image_name, "-i", "text=world"],
+        [cog_binary, "predict", image_name, "-i", "text=world"],
         cwd=another_directory,
         check=True,
         capture_output=True,
@@ -203,10 +203,10 @@ def test_predict_with_remote_image(tmpdir_factory):
     assert result.stdout.strip().endswith("hello world")
 
 
-def test_predict_in_subdirectory_with_imports(tmpdir_factory):
+def test_predict_in_subdirectory_with_imports(tmpdir_factory, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/subdirectory-project"
     result = subprocess.run(
-        ["cog", "predict", "--debug", "-i", "s=world"],
+        [cog_binary, "predict", "--debug", "-i", "s=world"],
         cwd=project_dir,
         check=True,
         capture_output=True,
@@ -218,7 +218,7 @@ def test_predict_in_subdirectory_with_imports(tmpdir_factory):
     assert "falling back to slow loader" not in result.stderr
 
 
-def test_predict_many_inputs(tmpdir_factory):
+def test_predict_many_inputs(tmpdir_factory, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/many-inputs-project"
     out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
     shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
@@ -233,7 +233,7 @@ def test_predict_many_inputs(tmpdir_factory):
         fh.write("world")
     with open(out_dir / "image.jpg", "w", encoding="utf-8") as fh:
         fh.write("")
-    cmd = ["cog", "--debug", "predict"]
+    cmd = [cog_binary, "--debug", "predict"]
 
     for k, v in inputs.items():
         cmd += ["-i", f"{k}={v}"]
@@ -250,11 +250,13 @@ def test_predict_many_inputs(tmpdir_factory):
     assert "falling back to slow loader" not in result.stderr
 
 
-def test_predict_many_inputs_with_existing_image(docker_image, tmpdir_factory):
+def test_predict_many_inputs_with_existing_image(
+    docker_image, tmpdir_factory, cog_binary
+):
     project_dir = Path(__file__).parent / "fixtures/many-inputs-project"
 
     subprocess.run(
-        ["cog", "build", "--debug", "-t", docker_image],
+        [cog_binary, "build", "--debug", "-t", docker_image],
         cwd=project_dir,
         check=True,
     )
@@ -272,7 +274,7 @@ def test_predict_many_inputs_with_existing_image(docker_image, tmpdir_factory):
         fh.write("world")
     with open(out_dir / "image.jpg", "w", encoding="utf-8") as fh:
         fh.write("")
-    cmd = ["cog", "--debug", "predict", docker_image]
+    cmd = [cog_binary, "--debug", "predict", docker_image]
 
     for k, v in inputs.items():
         cmd += ["-i", f"{k}={v}"]
@@ -288,7 +290,7 @@ def test_predict_many_inputs_with_existing_image(docker_image, tmpdir_factory):
     assert "falling back to slow loader" not in str(result.stderr)
 
 
-def test_predict_path_list_input(tmpdir_factory):
+def test_predict_path_list_input(tmpdir_factory, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/path-list-input-project"
     out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
     shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
@@ -296,7 +298,7 @@ def test_predict_path_list_input(tmpdir_factory):
         fh.write("test1")
     with open(out_dir / "2.txt", "w", encoding="utf-8") as fh:
         fh.write("test2")
-    cmd = ["cog", "predict", "-i", "paths=@1.txt", "-i", "paths=@2.txt"]
+    cmd = [cog_binary, "predict", "-i", "paths=@1.txt", "-i", "paths=@2.txt"]
 
     result = subprocess.run(
         cmd,
@@ -319,12 +321,12 @@ def test_predict_path_list_input(tmpdir_factory):
         ("multiprocessing",),
     ],
 )
-def test_predict_with_subprocess_in_setup(fixture_name):
+def test_predict_with_subprocess_in_setup(fixture_name, cog_binary):
     project_dir = (
         Path(__file__).parent / "fixtures" / f"setup-subprocess-{fixture_name}-project"
     )
 
-    with cog_server_http_run(project_dir) as addr:
+    with cog_server_http_run(project_dir, cog_binary) as addr:
         busy_count = 0
 
         for i in range(100):
@@ -342,7 +344,7 @@ def test_predict_with_subprocess_in_setup(fixture_name):
 
 
 @pytest.mark.asyncio
-async def test_concurrent_predictions():
+async def test_concurrent_predictions(cog_binary):
     async def make_request(i: int) -> httpx.Response:
         return await client.post(
             f"{addr}/predictions",
@@ -353,7 +355,7 @@ async def test_concurrent_predictions():
         )
 
     with cog_server_http_run(
-        Path(__file__).parent / "fixtures" / "async-sleep-project"
+        Path(__file__).parent / "fixtures" / "async-sleep-project", cog_binary
     ) as addr:
         async with httpx.AsyncClient() as client:
             tasks = []
@@ -372,10 +374,10 @@ async def test_concurrent_predictions():
                 assert task.result().json()["output"] == f"wake up sleepyhead{i}"
 
 
-def test_predict_new_union_project(tmpdir_factory):
+def test_predict_new_union_project(tmpdir_factory, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/new-union-project"
     result = subprocess.run(
-        ["cog", "predict", "--debug", "-i", "text=world"],
+        [cog_binary, "predict", "--debug", "-i", "text=world"],
         cwd=project_dir,
         check=True,
         capture_output=True,
@@ -387,7 +389,7 @@ def test_predict_new_union_project(tmpdir_factory):
     assert result.stdout == "hello world\n"
 
 
-def test_predict_with_fast_build_with_local_image(docker_image):
+def test_predict_with_fast_build_with_local_image(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/fast-build"
     weights_file = os.path.join(project_dir, "weights.h5")
     with open(weights_file, "w", encoding="utf8") as handle:
@@ -395,14 +397,14 @@ def test_predict_with_fast_build_with_local_image(docker_image):
         handle.write("\0")
 
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image, "--x-fast", "--x-localimage"],
+        [cog_binary, "build", "-t", docker_image, "--x-fast", "--x-localimage"],
         cwd=project_dir,
         capture_output=True,
     )
 
     result = subprocess.run(
         [
-            "cog",
+            cog_binary,
             "predict",
             docker_image,
             "--x-fast",
@@ -419,10 +421,10 @@ def test_predict_with_fast_build_with_local_image(docker_image):
     assert result.returncode == 0
 
 
-def test_predict_optional_project(tmpdir_factory):
+def test_predict_optional_project(tmpdir_factory, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/optional-project"
     result = subprocess.run(
-        ["cog", "predict", "--debug"],
+        [cog_binary, "predict", "--debug"],
         cwd=project_dir,
         check=True,
         capture_output=True,
@@ -434,18 +436,18 @@ def test_predict_optional_project(tmpdir_factory):
     assert result.stdout == "hello No One\n"
 
 
-def test_predict_complex_types(docker_image):
+def test_predict_complex_types(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/complex-types"
 
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image, "--x-fast", "--x-localimage"],
+        [cog_binary, "build", "-t", docker_image, "--x-fast", "--x-localimage"],
         cwd=project_dir,
         capture_output=True,
     )
     assert build_process.returncode == 0
     result = subprocess.run(
         [
-            "cog",
+            cog_binary,
             "predict",
             "--debug",
             docker_image,
@@ -462,16 +464,16 @@ def test_predict_complex_types(docker_image):
     assert result.stdout == "Content: Hi There\n"
 
 
-def test_predict_overrides_project(docker_image):
+def test_predict_overrides_project(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/overrides-project"
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )
     assert build_process.returncode == 0
     result = subprocess.run(
-        ["cog", "predict", "--debug", docker_image],
+        [cog_binary, "predict", "--debug", docker_image],
         cwd=project_dir,
         check=True,
         capture_output=True,
@@ -482,16 +484,16 @@ def test_predict_overrides_project(docker_image):
     assert result.stdout == "hello 1.26.4\n"
 
 
-def test_predict_zsh_package(docker_image):
+def test_predict_zsh_package(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/zsh-package"
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )
     assert build_process.returncode == 0
     result = subprocess.run(
-        ["cog", "predict", "--debug", docker_image],
+        [cog_binary, "predict", "--debug", docker_image],
         cwd=project_dir,
         check=True,
         capture_output=True,
@@ -503,16 +505,16 @@ def test_predict_zsh_package(docker_image):
     assert ",zsh," in result.stdout
 
 
-def test_predict_string_list(docker_image):
+def test_predict_string_list(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/string-list-project"
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )
     assert build_process.returncode == 0
     result = subprocess.run(
-        ["cog", "predict", "--debug", docker_image, "-i", "s=world"],
+        [cog_binary, "predict", "--debug", docker_image, "-i", "s=world"],
         cwd=project_dir,
         check=True,
         capture_output=True,
@@ -523,17 +525,17 @@ def test_predict_string_list(docker_image):
     assert result.stdout == "hello world\n"
 
 
-def test_predict_granite_project(docker_image):
+def test_predict_granite_project(docker_image, cog_binary):
     # We are checking that we are not clobbering pydantic to a <2 version.
     project_dir = Path(__file__).parent / "fixtures/granite-project"
     build_process = subprocess.run(
-        ["cog", "build", "-t", docker_image],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )
     assert build_process.returncode == 0
     result = subprocess.run(
-        ["cog", "predict", "--debug", docker_image],
+        [cog_binary, "predict", "--debug", docker_image],
         cwd=project_dir,
         check=True,
         capture_output=True,
@@ -544,11 +546,11 @@ def test_predict_granite_project(docker_image):
     assert result.stdout == "2.11.3\n"
 
 
-def test_predict_fast_build(docker_image):
+def test_predict_fast_build(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/fast-build"
 
     result = subprocess.run(
-        ["cog", "predict", "--x-fast", "-i", "s=world"],
+        [cog_binary, "predict", "--x-fast", "-i", "s=world"],
         cwd=project_dir,
         capture_output=True,
         text=True,
@@ -575,4 +577,3 @@ def test_predict_env_vars(docker_image, cog_binary):
     )
     assert result.returncode == 0
     assert result.stdout == "ENV[TEST_VAR]=test_value\n"
-

--- a/test-integration/test_integration/test_run.py
+++ b/test-integration/test_integration/test_run.py
@@ -1,7 +1,7 @@
 import subprocess
 
 
-def test_run(tmpdir_factory):
+def test_run(tmpdir_factory, cog_binary):
     tmpdir = tmpdir_factory.mktemp("project")
     with open(tmpdir / "cog.yaml", "w") as f:
         cog_yaml = """
@@ -11,7 +11,7 @@ build:
         f.write(cog_yaml)
 
     result = subprocess.run(
-        ["cog", "run", "echo", "hello world"],
+        [cog_binary, "run", "echo", "hello world"],
         cwd=tmpdir,
         check=True,
         capture_output=True,
@@ -19,7 +19,7 @@ build:
     assert b"hello world" in result.stdout
 
 
-def test_run_with_secret(tmpdir_factory):
+def test_run_with_secret(tmpdir_factory, cog_binary):
     tmpdir = tmpdir_factory.mktemp("project")
     with open(tmpdir / "cog.yaml", "w") as f:
         cog_yaml = """
@@ -39,7 +39,7 @@ build:
         f.write("🤫")
 
     result = subprocess.run(
-        ["cog", "debug"],
+        [cog_binary, "debug"],
         cwd=tmpdir,
         check=True,
         capture_output=True,

--- a/test-integration/test_integration/test_train.py
+++ b/test-integration/test_integration/test_train.py
@@ -4,12 +4,12 @@ import subprocess
 from pathlib import Path
 
 
-def test_train_takes_input_and_produces_weights(tmpdir_factory):
+def test_train_takes_input_and_produces_weights(tmpdir_factory, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/train-project"
     out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
     shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
     result = subprocess.run(
-        ["cog", "train", "--debug", "-i", "n=42"],
+        [cog_binary, "train", "--debug", "-i", "n=42"],
         cwd=out_dir,
         check=False,
         capture_output=True,
@@ -21,12 +21,12 @@ def test_train_takes_input_and_produces_weights(tmpdir_factory):
     assert "falling back to slow loader" not in str(result.stderr)
 
 
-def test_train_pydantic2(tmpdir_factory):
+def test_train_pydantic2(tmpdir_factory, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/pydantic2-output"
     out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
     shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
     result = subprocess.run(
-        ["cog", "train", "--debug", "-i", 'some_input="hello"'],
+        [cog_binary, "train", "--debug", "-i", 'some_input="hello"'],
         cwd=out_dir,
         check=False,
         capture_output=True,

--- a/test-integration/test_integration/util.py
+++ b/test-integration/test_integration/util.py
@@ -126,7 +126,7 @@ def random_port() -> int:
 
 
 @contextlib.contextmanager
-def cog_server_http_run(project_dir: str):
+def cog_server_http_run(project_dir: str, cog_binary: str):
     port = random_port()
     addr = f"http://127.0.0.1:{port}"
 
@@ -135,7 +135,7 @@ def cog_server_http_run(project_dir: str):
     try:
         server = subprocess.Popen(
             [
-                "cog",
+                cog_binary,
                 "serve",
                 "-p",
                 str(port),


### PR DESCRIPTION
This PR updates all the integration tests to use [the `cog_binary` fixture](https://github.com/replicate/cog/pull/2274/commits/ae288968b3bed5102996913592b24086d61dcdd2). This allows the test runner to specify a cog binary to test. When not provided it'll fallback to the existing behavior, which is a PATH lookup for `"cog"`.