### PR TITLE
enable `build.fast` in `cog init` template

### DIFF
--- a/pkg/cli/init-templates/cog.yaml
+++ b/pkg/cli/init-templates/cog.yaml
@@ -16,6 +16,9 @@ build:
   # path to a Python requirements.txt file
   python_requirements: requirements.txt
 
+  # enable fast boots
+  fast: true
+
   # commands run after the environment is setup
   # run:
   #   - "echo env is ready!"


### PR DESCRIPTION
Resolves https://linear.app/replicate/issue/RUNT-76/update-new-model-template-to-set-fast-true