### PR TITLE
feat: Export the cog wheel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	golang.org/x/sys v0.32.0
 	golang.org/x/term v0.31.0
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -279,7 +280,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250218202821-56aae31c358a // indirect
 	google.golang.org/grpc v1.71.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/gotestsum v1.12.2 // indirect
 	honnef.co/go/tools v0.6.1 // indirect
 	mvdan.cc/gofumpt v0.7.0 // indirect

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -46,6 +46,7 @@ https://github.com/replicate/cog`,
 		newServeCommand(),
 		newTrainCommand(),
 		newMigrateCommand(),
+		newWheelCommand(),
 	)
 
 	return &rootCmd, nil

--- a/pkg/cli/wheel.go
+++ b/pkg/cli/wheel.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"os"
+	"path/filepath"
+
+	"github.com/replicate/cog/pkg/dockerfile"
+)
+
+var (
+	wheelOutPath string
+)
+
+func newWheelCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "wheel",
+		Short: "Export the cog wheel",
+		Long: `Export the cog wheel embedded in the cog binary.
+
+If a path is provided, the wheel will be written to that path.
+Otherwise, the wheel will be written to the current directory with a default name.
+
+This is useful for testing Cog models locally, outside of a Docker container.`,
+		RunE:   cmdWheel,
+		Hidden: true,
+		Args:   cobra.MaximumNArgs(0),
+	}
+
+	cmd.Flags().StringVarP(&wheelOutPath, "output", "o", "", "Path to write the wheel to")
+	return cmd
+}
+
+func cmdWheel(*cobra.Command, []string) error {
+	filename, err := dockerfile.WheelFilename()
+	if err != nil {
+		return err
+	}
+	fullPath := filepath.Join(wheelOutPath, filename)
+	data, _, err := dockerfile.ReadWheelFile()
+	if err != nil {
+		return err
+	}
+
+	if err = os.WriteFile(fullPath, data, 0644); err != nil {
+		return err
+	} else {
+		fmt.Print(fullPath)
+	}
+	return nil
+}


### PR DESCRIPTION
This change adds a (hidden) subcommand that will write the embedded Cog wheel to a local file. This is useful when testing Python predictor/wrapper code outside of the Docker environment. You can now run a command like this:

```
cog wheel -o .dev-deps | xargs uv add --dev
```

... and the wheel will be available to your Python code run through `uv`.

If you're not using `uv` then you can eg. `pip install --dev cog-XXX.whl` to achieve a similar effect.

This makes it much easier to test your `predict.py`.
