### PR TITLE
Add default CUDA versions to torch in fast boots

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -305,7 +305,11 @@ func (c *Config) ValidateAndComplete(projectDir string) error {
 
 	// Load python_requirements into memory to simplify reading it multiple times
 	if c.Build.PythonRequirements != "" {
-		c.Build.pythonRequirementsContent, err = requirements.ReadRequirements(path.Join(projectDir, c.Build.PythonRequirements))
+		requirementsFilePath := c.Build.PythonRequirements
+		if !strings.HasPrefix(requirementsFilePath, "/") {
+			requirementsFilePath = path.Join(projectDir, c.Build.PythonRequirements)
+		}
+		c.Build.pythonRequirementsContent, err = requirements.ReadRequirements(requirementsFilePath)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("Failed to open python_requirements file: %w", err))
 		}

--- a/pkg/dockerfile/env.go
+++ b/pkg/dockerfile/env.go
@@ -9,6 +9,8 @@ import (
 )
 
 const CogletVersionEnvVarName = "R8_COGLET_VERSION"
+const MonobaseMatrixHostVarName = "R8_MONOBASE_MATRIX_HOST"
+const MonobaseMatrixSchemeVarName = "R8_MONOBASE_MATRIX_SCHEME"
 
 func envLineFromConfig(c *config.Config) (string, error) {
 	vars := c.ParsedEnvironment()
@@ -31,4 +33,20 @@ func CogletVersionFromEnvironment() string {
 		host = "coglet"
 	}
 	return host
+}
+
+func MonobaseMatrixHostFromEnvironment() string {
+	host := os.Getenv(MonobaseMatrixHostVarName)
+	if host == "" {
+		host = "raw.githubusercontent.com"
+	}
+	return host
+}
+
+func MonobaseMatrixSchemeFromEnvironment() string {
+	scheme := os.Getenv(MonobaseMatrixSchemeVarName)
+	if scheme == "" {
+		scheme = "https"
+	}
+	return scheme
 }

--- a/pkg/dockerfile/env_test.go
+++ b/pkg/dockerfile/env_test.go
@@ -11,3 +11,15 @@ func TestCogletVersionFromEnvironment(t *testing.T) {
 	t.Setenv(CogletVersionEnvVarName, cogletVersion)
 	require.Equal(t, CogletVersionFromEnvironment(), cogletVersion)
 }
+
+func TestMonobaseMatrixHostFromEnvironment(t *testing.T) {
+	const monobaseMatrixHost = "localhost"
+	t.Setenv(MonobaseMatrixHostVarName, monobaseMatrixHost)
+	require.Equal(t, MonobaseMatrixHostFromEnvironment(), monobaseMatrixHost)
+}
+
+func TestMonobaseMatrixSchemeFromEnvironment(t *testing.T) {
+	const monobaseMatrixScheme = "http"
+	t.Setenv(MonobaseMatrixSchemeVarName, monobaseMatrixScheme)
+	require.Equal(t, MonobaseMatrixSchemeFromEnvironment(), monobaseMatrixScheme)
+}

--- a/pkg/dockerfile/monobase_matrix.go
+++ b/pkg/dockerfile/monobase_matrix.go
@@ -11,16 +11,17 @@ import (
 )
 
 type MonobaseMatrix struct {
-	Id             int            `json:"id"`
-	CudaVersions   []string       `json:"cuda_versions"`
-	CudnnVersions  []string       `json:"cudnn_versions"`
-	PythonVersions []string       `json:"python_versions"`
-	TorchVersions  []string       `json:"torch_versions"`
-	Venvs          []MonobaseVenv `json:"venvs"`
+	Id             int                 `json:"id"`
+	CudaVersions   []string            `json:"cuda_versions"`
+	CudnnVersions  []string            `json:"cudnn_versions"`
+	PythonVersions []string            `json:"python_versions"`
+	TorchVersions  []string            `json:"torch_versions"`
+	Venvs          []MonobaseVenv      `json:"venvs"`
+	TorchCUDAs     map[string][]string `json:"torch_cudas"`
 }
 
 func NewMonobaseMatrix(client *http.Client) (*MonobaseMatrix, error) {
-	resp, err := client.Get("https://raw.githubusercontent.com/replicate/monobase/refs/heads/main/matrix.json")
+	resp, err := client.Get(MonobaseMatrixSchemeFromEnvironment() + "://" + MonobaseMatrixHostFromEnvironment() + "/replicate/monobase/refs/heads/main/matrix.json")
 	if err != nil {
 		return nil, err
 	}
@@ -59,4 +60,9 @@ func (m MonobaseMatrix) IsSupported(python string, torch string, cuda string) bo
 		cuda = "cpu"
 	}
 	return slices.Contains(m.Venvs, MonobaseVenv{Python: python, Torch: torch, Cuda: cuda})
+}
+
+func (m MonobaseMatrix) DefaultCUDAVersion(torch string) string {
+	cudas := m.TorchCUDAs[torch]
+	return cudas[len(cudas)-1]
 }

--- a/pkg/dockerfile/monobase_matrix_test.go
+++ b/pkg/dockerfile/monobase_matrix_test.go
@@ -1,0 +1,1313 @@
+package dockerfile
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/replicate/cog/pkg/docker/dockertest"
+	r8HTTP "github.com/replicate/cog/pkg/http"
+)
+
+func TestMonobaseMatrixDefaultCUDA(t *testing.T) {
+	// Setup mock http server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+  "id": 18,
+  "cuda_versions": [
+    "11.7",
+    "11.8",
+    "12.1",
+    "12.4",
+    "12.6",
+    "12.8"
+  ],
+  "cudnn_versions": [
+    "8",
+    "9"
+  ],
+  "python_versions": [
+    "3.8",
+    "3.9",
+    "3.10",
+    "3.11",
+    "3.12",
+    "3.13"
+  ],
+  "torch_versions": [
+    "2.0.0",
+    "2.0.1",
+    "2.1.0",
+    "2.1.1",
+    "2.1.2",
+    "2.2.0",
+    "2.2.1",
+    "2.2.2",
+    "2.3.0",
+    "2.3.1",
+    "2.4.0",
+    "2.4.1",
+    "2.5.0",
+    "2.5.1",
+    "2.6.0",
+    "2.7.0"
+  ],
+  "torch_cudas": {
+    "2.0.0": [
+      "11.7",
+      "11.8"
+    ],
+    "2.0.1": [
+      "11.7",
+      "11.8"
+    ],
+    "2.1.0": [
+      "11.8",
+      "12.1"
+    ],
+    "2.1.1": [
+      "11.8",
+      "12.1"
+    ],
+    "2.1.2": [
+      "11.8",
+      "12.1"
+    ],
+    "2.2.0": [
+      "11.8",
+      "12.1"
+    ],
+    "2.2.1": [
+      "11.8",
+      "12.1"
+    ],
+    "2.2.2": [
+      "11.8",
+      "12.1"
+    ],
+    "2.3.0": [
+      "11.8",
+      "12.1"
+    ],
+    "2.3.1": [
+      "11.8",
+      "12.1"
+    ],
+    "2.4.0": [
+      "11.8",
+      "12.1",
+      "12.4"
+    ],
+    "2.4.1": [
+      "11.8",
+      "12.1",
+      "12.4"
+    ],
+    "2.5.0": [
+      "11.8",
+      "12.1",
+      "12.4"
+    ],
+    "2.5.1": [
+      "11.8",
+      "12.1",
+      "12.4"
+    ],
+    "2.6.0": [
+      "11.8",
+      "12.4",
+      "12.6"
+    ],
+    "2.7.0": [
+      "11.8",
+      "12.6",
+      "12.8"
+    ]
+  },
+  "venvs": [
+    {
+      "python": "3.13",
+      "torch": "2.7.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.13",
+      "torch": "2.7.0",
+      "cuda": "12.8"
+    },
+    {
+      "python": "3.13",
+      "torch": "2.7.0",
+      "cuda": "12.6"
+    },
+    {
+      "python": "3.13",
+      "torch": "2.7.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.13",
+      "torch": "2.6.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.13",
+      "torch": "2.6.0",
+      "cuda": "12.6"
+    },
+    {
+      "python": "3.13",
+      "torch": "2.6.0",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.13",
+      "torch": "2.6.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.7.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.7.0",
+      "cuda": "12.8"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.7.0",
+      "cuda": "12.6"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.7.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.6.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.6.0",
+      "cuda": "12.6"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.6.0",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.6.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.5.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.5.1",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.5.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.5.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.5.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.5.0",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.5.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.5.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.4.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.4.1",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.4.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.4.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.4.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.4.0",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.4.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.12",
+      "torch": "2.4.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.7.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.7.0",
+      "cuda": "12.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.7.0",
+      "cuda": "12.6"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.7.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.6.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.6.0",
+      "cuda": "12.6"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.6.0",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.6.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.5.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.5.1",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.5.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.5.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.5.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.5.0",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.5.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.5.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.4.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.4.1",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.4.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.4.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.4.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.4.0",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.4.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.4.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.3.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.3.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.3.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.3.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.3.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.3.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.2.2",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.2.2",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.2.2",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.2.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.2.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.2.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.2.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.2.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.2.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.1.2",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.1.2",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.1.2",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.1.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.1.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.1.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.1.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.1.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.1.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.0.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.0.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.0.1",
+      "cuda": "11.7"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.0.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.0.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.11",
+      "torch": "2.0.0",
+      "cuda": "11.7"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.7.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.7.0",
+      "cuda": "12.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.7.0",
+      "cuda": "12.6"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.7.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.6.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.6.0",
+      "cuda": "12.6"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.6.0",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.6.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.5.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.5.1",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.5.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.5.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.5.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.5.0",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.5.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.5.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.4.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.4.1",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.4.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.4.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.4.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.4.0",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.4.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.4.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.3.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.3.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.3.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.3.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.3.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.3.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.2.2",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.2.2",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.2.2",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.2.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.2.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.2.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.2.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.2.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.2.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.1.2",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.1.2",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.1.2",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.1.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.1.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.1.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.1.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.1.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.1.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.0.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.0.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.0.1",
+      "cuda": "11.7"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.0.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.0.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.10",
+      "torch": "2.0.0",
+      "cuda": "11.7"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.7.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.7.0",
+      "cuda": "12.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.7.0",
+      "cuda": "12.6"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.7.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.6.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.6.0",
+      "cuda": "12.6"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.6.0",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.6.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.5.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.5.1",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.5.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.5.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.5.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.5.0",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.5.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.5.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.4.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.4.1",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.4.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.4.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.4.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.4.0",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.4.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.4.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.3.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.3.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.3.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.3.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.3.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.3.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.2.2",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.2.2",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.2.2",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.2.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.2.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.2.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.2.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.2.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.2.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.1.2",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.1.2",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.1.2",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.1.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.1.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.1.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.1.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.1.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.1.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.0.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.0.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.0.1",
+      "cuda": "11.7"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.0.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.0.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.9",
+      "torch": "2.0.0",
+      "cuda": "11.7"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.4.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.4.1",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.4.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.4.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.4.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.4.0",
+      "cuda": "12.4"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.4.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.4.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.3.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.3.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.3.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.3.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.3.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.3.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.2.2",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.2.2",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.2.2",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.2.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.2.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.2.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.2.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.2.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.2.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.1.2",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.1.2",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.1.2",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.1.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.1.1",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.1.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.1.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.1.0",
+      "cuda": "12.1"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.1.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.0.1",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.0.1",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.0.1",
+      "cuda": "11.7"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.0.0",
+      "cuda": "cpu"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.0.0",
+      "cuda": "11.8"
+    },
+    {
+      "python": "3.8",
+      "torch": "2.0.0",
+      "cuda": "11.7"
+    }
+  ]
+}`))
+	}))
+	defer server.Close()
+	url, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	t.Setenv(MonobaseMatrixHostVarName, url.Host)
+	t.Setenv(MonobaseMatrixSchemeVarName, url.Scheme)
+
+	// Setup mock command
+	command := dockertest.NewMockCommand()
+
+	// Setup http client
+	httpClient, err := r8HTTP.ProvideHTTPClient(t.Context(), command)
+	require.NoError(t, err)
+
+	monobaseMatrix, err := NewMonobaseMatrix(httpClient)
+	require.NoError(t, err)
+
+	defaultCuda := monobaseMatrix.DefaultCUDAVersion("2.7.0")
+	require.Equal(t, defaultCuda, "12.8")
+}

--- a/pkg/requirements/requirements.go
+++ b/pkg/requirements/requirements.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/replicate/cog/pkg/util/console"
 	"github.com/replicate/cog/pkg/util/files"
 )
 
@@ -41,6 +42,7 @@ func CurrentRequirements(tmpDir string) (string, error) {
 }
 
 func ReadRequirements(path string) ([]string, error) {
+	console.Infof("path %s", path)
 	fh, err := os.Open(path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* If the user doesn’t select a CUDA version, select the latest one from the compatibility
matrix