### PR TITLE
Toggle docker client using an env var

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -62,8 +62,12 @@ func newBuildCommand() *cobra.Command {
 func buildCommand(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
-	command := docker.NewDockerCommand()
-	client, err := http.ProvideHTTPClient(ctx, command)
+	dockerClient, err := docker.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	client, err := http.ProvideHTTPClient(ctx, dockerClient)
 	if err != nil {
 		return err
 	}
@@ -93,7 +97,7 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := image.Build(ctx, cfg, projectDir, imageName, buildSecrets, buildNoCache, buildSeparateWeights, buildUseCudaBaseImage, buildProgressOutput, buildSchemaFile, buildDockerfileFile, DetermineUseCogBaseImage(cmd), buildStrip, buildPrecompile, buildFast, nil, buildLocalImage, command); err != nil {
+	if err := image.Build(ctx, cfg, projectDir, imageName, buildSecrets, buildNoCache, buildSeparateWeights, buildUseCudaBaseImage, buildProgressOutput, buildSchemaFile, buildDockerfileFile, DetermineUseCogBaseImage(cmd), buildStrip, buildPrecompile, buildFast, nil, buildLocalImage, dockerClient); err != nil {
 		logClient.EndBuild(ctx, err, logCtx)
 		return err
 	}

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -42,8 +42,12 @@ func cmdDockerfile(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	command := docker.NewDockerCommand()
-	generator, err := dockerfile.NewGenerator(cfg, projectDir, buildFast, command, buildLocalImage)
+	dockerClient, err := docker.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	generator, err := dockerfile.NewGenerator(cfg, projectDir, buildFast, dockerClient, buildLocalImage)
 	if err != nil {
 		return fmt.Errorf("Error creating Dockerfile generator: %w", err)
 	}

--- a/pkg/cli/migrate.go
+++ b/pkg/cli/migrate.go
@@ -32,8 +32,12 @@ This will attempt to migrate your cog project to be compatible with fast boots.`
 func cmdMigrate(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
-	command := docker.NewDockerCommand()
-	client, err := http.ProvideHTTPClient(ctx, command)
+	dockerClient, err := docker.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	client, err := http.ProvideHTTPClient(ctx, dockerClient)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -49,8 +49,12 @@ func newPushCommand() *cobra.Command {
 func push(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
-	command := docker.NewDockerCommand()
-	client, err := http.ProvideHTTPClient(ctx, command)
+	dockerClient, err := docker.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	client, err := http.ProvideHTTPClient(ctx, dockerClient)
 	if err != nil {
 		return err
 	}
@@ -106,7 +110,7 @@ func push(cmd *cobra.Command, args []string) error {
 
 	startBuildTime := time.Now()
 
-	if err := image.Build(ctx, cfg, projectDir, imageName, buildSecrets, buildNoCache, buildSeparateWeights, buildUseCudaBaseImage, buildProgressOutput, buildSchemaFile, buildDockerfileFile, DetermineUseCogBaseImage(cmd), buildStrip, buildPrecompile, buildFast, annotations, buildLocalImage, command); err != nil {
+	if err := image.Build(ctx, cfg, projectDir, imageName, buildSecrets, buildNoCache, buildSeparateWeights, buildUseCudaBaseImage, buildProgressOutput, buildSchemaFile, buildDockerfileFile, DetermineUseCogBaseImage(cmd), buildStrip, buildPrecompile, buildFast, annotations, buildLocalImage, dockerClient); err != nil {
 		return err
 	}
 
@@ -117,7 +121,7 @@ func push(cmd *cobra.Command, args []string) error {
 		console.Info("Fast push enabled.")
 	}
 
-	err = docker.Push(ctx, imageName, buildFast, projectDir, command, docker.BuildInfo{
+	err = docker.Push(ctx, imageName, buildFast, projectDir, dockerClient, docker.BuildInfo{
 		BuildTime: buildDuration,
 		BuildID:   buildID.String(),
 	}, client)

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -1,0 +1,21 @@
+package docker
+
+import (
+	"context"
+	"os"
+	"strconv"
+
+	"github.com/replicate/cog/pkg/docker/command"
+	"github.com/replicate/cog/pkg/util/console"
+)
+
+func NewClient(ctx context.Context, opts ...Option) (command.Command, error) {
+	enabled, _ := strconv.ParseBool(os.Getenv("COG_DOCKER_SDK_CLIENT"))
+	if enabled {
+		console.Debugf("Docker client: sdk")
+		return NewAPIClient(ctx, opts...)
+	}
+
+	console.Debugf("Docker client: cli")
+	return NewDockerCommand(), nil
+}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -13,7 +13,8 @@ func NewClient(ctx context.Context, opts ...Option) (command.Command, error) {
 	enabled, _ := strconv.ParseBool(os.Getenv("COG_DOCKER_SDK_CLIENT"))
 	if enabled {
 		console.Debugf("Docker client: sdk")
-		return NewAPIClient(ctx, opts...)
+		panic("not implemented yet")
+		// return NewAPIClient(ctx, opts...)
 	}
 
 	console.Debugf("Docker client: cli")

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -13,8 +13,7 @@ func NewClient(ctx context.Context, opts ...Option) (command.Command, error) {
 	enabled, _ := strconv.ParseBool(os.Getenv("COG_DOCKER_SDK_CLIENT"))
 	if enabled {
 		console.Debugf("Docker client: sdk")
-		panic("not implemented yet")
-		// return NewAPIClient(ctx, opts...)
+		panic("not implemented in this branch :sad-panda:")
 	}
 
 	console.Debugf("Docker client: cli")

--- a/pkg/docker/options.go
+++ b/pkg/docker/options.go
@@ -1,0 +1,15 @@
+package docker
+
+import "github.com/docker/docker/api/types/registry"
+
+type clientOptions struct {
+	authConfigs map[string]registry.AuthConfig
+}
+
+type Option func(*clientOptions)
+
+func WithAuthConfig(authConfig registry.AuthConfig) Option {
+	return func(o *clientOptions) {
+		o.authConfigs[authConfig.ServerAddress] = authConfig
+	}
+}


### PR DESCRIPTION
Extracted from #2327 to keep the diff small. Once the new client is merged in, setting a truthy value to `COG_DOCKER_SDK_CLIENT` will use it. Needed to run integration tests for both clients in parallel.