### PR TITLE
Stop printing the container ID at the end of `cog predict`

### DIFF
--- a/pkg/docker/docker_command.go
+++ b/pkg/docker/docker_command.go
@@ -248,7 +248,7 @@ func (c *DockerCommand) ContainerStop(ctx context.Context, containerID string) e
 		containerID,
 	}
 
-	if err := c.exec(ctx, nil, nil, nil, "", args); err != nil {
+	if err := c.exec(ctx, nil, io.Discard, nil, "", args); err != nil {
 		if strings.Contains(err.Error(), "No such container") {
 			err = &command.NotFoundError{Object: "container", Ref: containerID}
 		}


### PR DESCRIPTION
`docker container stop` prints the container id to stdout -- ignore it 

cc @fofr 