### PR TITLE
Support kwargs predictors

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 golang 1.24.2
+python 3.13.2

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -246,7 +246,7 @@ def get_input_create_model_kwargs(signature: inspect.Signature) -> Dict[str, Any
 
         if parameter.kind == inspect.Parameter.VAR_KEYWORD:
             if order != 0:
-                raise TypeError(f"Unsupported keyword parameter **{name}")
+                raise TypeError(f"Unsupported variadic keyword parameter **{name}")
 
             class ExtraKeywordInput(BaseInput):
                 if PYDANTIC_V2:

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -242,7 +242,7 @@ def get_input_create_model_kwargs(signature: inspect.Signature) -> Dict[str, Any
         InputType = parameter.annotation
 
         if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
-            raise TypeError(f"Unsupported positional parameter *{name}.")
+            raise TypeError(f"Unsupported variadic positional parameter *{name}.")
 
         if parameter.kind == inspect.Parameter.VAR_KEYWORD:
             if order != 0:

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -231,7 +231,7 @@ def validate_input_type(
 
 
 def get_input_create_model_kwargs(signature: inspect.Signature) -> Dict[str, Any]:
-    create_model_kwargs: Dict[str, Any] = {"__config__": None}
+    create_model_kwargs: Dict[str, Any] = {}
 
     order = 0
 
@@ -244,6 +244,7 @@ def get_input_create_model_kwargs(signature: inspect.Signature) -> Dict[str, Any
             raise TypeError(f"Unsupported varargs parameter *{name}.")
         if parameter.kind == inspect.Parameter.VAR_KEYWORD:
             create_model_kwargs["__config__"] = {"extra": "allow"}
+            create_model_kwargs["__base__"] = None
             name = "__pydantic_extra__"
             InputType = Dict[str, InputType]
 
@@ -333,6 +334,7 @@ def get_input_type(predictor: BasePredictor) -> Type[BaseInput]:
     return create_model(
         "Input",
         __base__=BaseInput,
+        __config__=None,
         __module__=__name__,
         __validators__=None,
         **get_input_create_model_kwargs(signature),

--- a/python/cog/predictor.py
+++ b/python/cog/predictor.py
@@ -240,19 +240,12 @@ def get_input_create_model_kwargs(signature: inspect.Signature) -> Dict[str, Any
 
         validate_input_type(InputType, name)
 
-        match parameter.kind:
-            case (
-                inspect.Parameter.POSITIONAL_ONLY
-                | inspect.Parameter.POSITIONAL_OR_KEYWORD
-                | inspect.Parameter.KEYWORD_ONLY
-            ):
-                pass
-            case inspect.Parameter.VAR_POSITIONAL:
-                raise TypeError(f"Unsupported varargs parameter *{name}.")
-            case inspect.Parameter.VAR_KEYWORD:
-                create_model_kwargs["__config__"] = {"extra": "allow"}
-                name = "__pydantic_extra__"
-                InputType = Dict[str, InputType]
+        if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
+            raise TypeError(f"Unsupported varargs parameter *{name}.")
+        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            create_model_kwargs["__config__"] = {"extra": "allow"}
+            name = "__pydantic_extra__"
+            InputType = Dict[str, InputType]
 
         # if no default is specified, create an empty, required input
         if parameter.default is inspect.Signature.empty:

--- a/python/tests/server/fixtures/input_kwargs.py
+++ b/python/tests/server/fixtures/input_kwargs.py
@@ -1,8 +1,8 @@
-import json
+from typing import Union, Dict
 
 from cog import BasePredictor
 
 
 class Predictor(BasePredictor):
-    def predict(self, **kwargs: str | int) -> str:
-        return json.dumps(kwargs)
+    def predict(self, **kwargs: Union[str, int]) -> Dict:
+        return kwargs

--- a/python/tests/server/fixtures/input_kwargs.py
+++ b/python/tests/server/fixtures/input_kwargs.py
@@ -1,0 +1,8 @@
+import json
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def predict(self, **kwargs: str | int) -> str:
+        return json.dumps(kwargs)

--- a/python/tests/server/fixtures/input_kwargs.py
+++ b/python/tests/server/fixtures/input_kwargs.py
@@ -1,8 +1,8 @@
-from typing import Union, Dict
+from typing import Dict
 
 from cog import BasePredictor
 
 
 class Predictor(BasePredictor):
-    def predict(self, **kwargs: Union[str, int]) -> Dict:
+    def predict(self, **kwargs) -> Dict:
         return kwargs

--- a/python/tests/server/test_http_input.py
+++ b/python/tests/server/test_http_input.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import os
 import sys
 import threading
@@ -37,6 +38,18 @@ def test_empty_input(client, match):
     resp = client.post("/predictions", json={"input": {}})
     assert resp.status_code == 200
     assert resp.json() == match({"status": "succeeded", "output": "foobar"})
+
+
+@uses_predictor("input_kwargs")
+def test_kwargs_input(client, match):
+    """Check we support kwargs input fields"""
+    input = {"animal": "giraffe", "no": 5}
+    resp = client.post("/predictions", json={"input": input})
+    assert resp.json() == match({"status": "succeeded"})
+    assert resp.status_code == 200
+
+    result = json.loads(resp.json()["output"])
+    assert result == input
 
 
 @uses_predictor("input_integer")

--- a/python/tests/server/test_http_input.py
+++ b/python/tests/server/test_http_input.py
@@ -1,5 +1,4 @@
 import base64
-import json
 import os
 import sys
 import threading
@@ -48,7 +47,7 @@ def test_kwargs_input(client, match):
     assert resp.json() == match({"status": "succeeded"})
     assert resp.status_code == 200
 
-    result = json.loads(resp.json()["output"])
+    result = resp.json()["output"]
     assert result == input
 
 


### PR DESCRIPTION
This change allows a predictor input to be defined exclusively as `**kwargs`. This is an experimental change that allows a model to be used as a proxy where any inputs will be passed through directly without modification.


```py
import json

def predict(**kwargs) -> str:
  return json.dumps(kwargs)
```

This change restricts the use of `**kwargs` to functions/methods that accept only that as an argument to avoid the complexity of having to support both dynamic and fixed inputs.

The OpenAPI schema for such a model will be:

```json
{
   "properties": {},
   "additionalProperties": true,
   "type": "object",
   "title": "Input"
}
```
