### PR TITLE
Set python version in .tools-version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 golang 1.24.2
+python 3.13.2


### PR DESCRIPTION
This ensures that tools that support it will select the same Python
version as defined in the .python-version file.
