### PR TITLE
Fix for branch protection rules + dynamic matrix jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,17 @@ jobs:
       - name: Lint
         run: make lint
 
+  test:
+    name: "Test Results"
+    needs:
+      - test-go
+      - test-python
+      - test-integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test status
+        run: echo "All tests passed successfully!"
+
   test-go:
     name: "Test Go"
     needs: build-python


### PR DESCRIPTION
I ran into an issue over in #2327 where branch protection rules will never pass when referring to matrix jobs.

The rule requires a check named `"Test Integration"` to be successful, but after making that GHA job a matrix, names are now `"Test Integration (matrix-param)"`, which obviously won't match.

This PR adds a new meta job named "Test Results" which depends on the integration matrix job, as well as the other tests that were probably not required because of the same issue.

@tempusfrangit once this is merged can you change the required check name to "Test Results"?

