### PR TITLE
Make all instances of --x-fast use fast:true instead

### DIFF
--- a/pkg/dockerfile/fast_generator.go
+++ b/pkg/dockerfile/fast_generator.go
@@ -453,7 +453,7 @@ func (g *FastGenerator) generateAptTarball(ctx context.Context, tmpDir string) (
 
 func (g *FastGenerator) validateConfig() error {
 	if len(g.Config.Build.Run) > 0 {
-		return errors.New("cog builds with --x-fast do not support build run commands.")
+		return errors.New("cog builds with fast: true in the cog.yaml do not support build run commands.")
 	}
 	return nil
 }

--- a/pkg/web/client.go
+++ b/pkg/web/client.go
@@ -37,7 +37,7 @@ var (
 	ErrorBadResponsePushStartEndpoint         = errors.New("Bad response from push start endpoint")
 	ErrorBadResponseInitiateChallengeEndpoint = errors.New("Bad response from start file challenge endpoint")
 	ErrorBadRegistryURL                       = errors.New("The image URL must have 3 components in the format of " + global.ReplicateRegistryHost + "/your-username/your-model")
-	ErrorBadRegistryHost                      = errors.New("The image name must have the " + global.ReplicateRegistryHost + " prefix when using --x-fast.")
+	ErrorBadRegistryHost                      = errors.New("The image name must have the " + global.ReplicateRegistryHost + " prefix when using fast: true in cog.yaml.")
 	ErrorNoSuchDigest                         = errors.New("No digest submitted matches the digest requested")
 )
 

--- a/test-integration/test_integration/fixtures/fast-build/cog.yaml
+++ b/test-integration/test_integration/fixtures/fast-build/cog.yaml
@@ -3,4 +3,5 @@ build:
   python_requirements: requirements.txt
   system_packages:
     - "git"
+  fast: true
 predict: "predict.py:Predictor"

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -420,7 +420,7 @@ def test_fast_build(docker_image, cog_binary):
         handle.write("\0")
 
     build_process = subprocess.run(
-        [cog_binary, "build", "-t", docker_image, "--x-fast"],
+        [cog_binary, "build", "-t", docker_image],
         cwd=project_dir,
         capture_output=True,
     )
@@ -490,7 +490,7 @@ def test_fast_build_with_local_image(docker_image, cog_binary):
         handle.write("\0")
 
     build_process = subprocess.run(
-        [cog_binary, "build", "-t", docker_image, "--x-fast", "--x-localimage"],
+        [cog_binary, "build", "-t", docker_image, "--x-localimage"],
         cwd=project_dir,
         capture_output=True,
     )

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -439,7 +439,7 @@ def test_predict_complex_types(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/complex-types"
 
     build_process = subprocess.run(
-        [cog_binary, "build", "-t", docker_image, "--x-localimage"],
+        [cog_binary, "build", "-t", docker_image, "--x-fast", "--x-localimage"],
         cwd=project_dir,
         capture_output=True,
     )

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -397,7 +397,7 @@ def test_predict_with_fast_build_with_local_image(docker_image, cog_binary):
         handle.write("\0")
 
     build_process = subprocess.run(
-        [cog_binary, "build", "-t", docker_image, "--x-fast", "--x-localimage"],
+        [cog_binary, "build", "-t", docker_image, "--x-localimage"],
         cwd=project_dir,
         capture_output=True,
     )
@@ -407,7 +407,6 @@ def test_predict_with_fast_build_with_local_image(docker_image, cog_binary):
             cog_binary,
             "predict",
             docker_image,
-            "--x-fast",
             "--x-localimage",
             "--debug",
             "-i",
@@ -440,7 +439,7 @@ def test_predict_complex_types(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/complex-types"
 
     build_process = subprocess.run(
-        [cog_binary, "build", "-t", docker_image, "--x-fast", "--x-localimage"],
+        [cog_binary, "build", "-t", docker_image, "--x-localimage"],
         cwd=project_dir,
         capture_output=True,
     )
@@ -550,7 +549,7 @@ def test_predict_fast_build(docker_image, cog_binary):
     project_dir = Path(__file__).parent / "fixtures/fast-build"
 
     result = subprocess.run(
-        [cog_binary, "predict", "--x-fast", "-i", "s=world"],
+        [cog_binary, "predict", "-i", "s=world"],
         cwd=project_dir,
         capture_output=True,
         text=True,


### PR DESCRIPTION
### Summary

We've transitioned usage of `--x-fast` to `fast: true` in the `cog.yaml`. We should change all references within our code to reflect this.