### PR TITLE
Add deprecated field to Input

### DIFF
--- a/python/cog/types.py
+++ b/python/cog/types.py
@@ -73,6 +73,7 @@ def Input(  # pylint: disable=invalid-name, too-many-arguments
     max_length: Optional[int] = None,
     regex: Optional[str] = None,
     choices: Optional[List[Union[str, int]]] = None,
+    deprecated: Optional[bool] = None,
 ) -> Any:
     """Input is similar to pydantic.Field, but doesn't require a default value to be the first argument."""
     field_kwargs = {
@@ -94,6 +95,10 @@ def Input(  # pylint: disable=invalid-name, too-many-arguments
     else:
         field_kwargs["regex"] = regex
         field_kwargs["enum"] = choices
+
+    if deprecated is not None:
+        field_kwargs["deprecated"] = deprecated
+
     return pydantic.Field(**field_kwargs)
 
 

--- a/python/tests/server/fixtures/input_deprecated.py
+++ b/python/tests/server/fixtures/input_deprecated.py
@@ -1,0 +1,7 @@
+from cog import BasePredictor, Input
+
+
+class Predictor(BasePredictor):
+    def predict(self, text: str = Input(description="Some deprecated text", deprecated=True)) -> str:
+        assert type(text) == str
+        return text

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -1,4 +1,5 @@
 import base64
+import http
 import io
 import time
 import unittest.mock as mock
@@ -729,3 +730,20 @@ def test_weights_are_read_from_environment_variables(client, match):
     resp = client.post("/predictions")
     assert resp.status_code == 200
     assert resp.json() == match({"status": "succeeded", "output": "hello"})
+
+
+@uses_predictor("input_deprecated")
+def test_openapi_specification_with_deprecated(client, static_schema):
+    resp = client.get("/openapi.json")
+    assert resp.status_code == http.HTTPStatus.OK
+
+    schema = resp.json()
+    schemas = schema["components"]["schemas"]
+
+    assert schemas["Input"]["properties"]["text"] == {
+        "x-order": 0,
+        "deprecated": True,
+        "type": "string",
+        "title": "Text",
+        "description": "Some deprecated text",
+    }


### PR DESCRIPTION
* Allow inputs to be marked as deprecated
* If they are, declare them deprecated in the openapi schema