### PR TITLE
Only overwrite header if it doesn’t exist

### DIFF
--- a/pkg/http/transport.go
+++ b/pkg/http/transport.go
@@ -9,7 +9,9 @@ type Transport struct {
 
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	for k, v := range t.headers {
-		req.Header.Set(k, v)
+		if req.Header.Get(k) == "" {
+			req.Header.Set(k, v)
+		}
 	}
 	base := t.base
 	if base == nil {

--- a/pkg/http/transport_test.go
+++ b/pkg/http/transport_test.go
@@ -28,3 +28,26 @@ func TestTransportAddsHeaders(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.Request.Header.Get(testHeader), testValue)
 }
+
+func TestTransportOnlyAddsHeaderIfMissing(t *testing.T) {
+	// Setup mock http server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	const testHeader = "X-Test-Header"
+	const testValue = "TestValue"
+	transport := Transport{
+		headers: map[string]string{
+			testHeader: testValue,
+		},
+	}
+	const expectedValue = "ExpectedValue"
+	req, err := http.NewRequest("GET", server.URL, nil)
+	req.Header.Set(testHeader, expectedValue)
+	require.NoError(t, err)
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, resp.Request.Header.Get(testHeader), expectedValue)
+}


### PR DESCRIPTION
* Do not overwrite the content-type header if it is explicitly set by the user