### PR TITLE
Allow comma separated versions in generate-matrix

### DIFF
--- a/pkg/cli/baseimage.go
+++ b/pkg/cli/baseimage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -57,14 +58,57 @@ func newBaseImageGenerateMatrix() *cobra.Command {
 		Use:   "generate-matrix",
 		Short: "Generate a matrix of Cog base image versions (JSON)",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			validCudaVersions := strings.FieldsFunc(baseImageCUDAVersion, func(c rune) bool {
+				return c == ','
+			})
+			validPythonVersions := strings.FieldsFunc(baseImagePythonVersion, func(c rune) bool {
+				return c == ','
+			})
+			validTorchVersions := strings.FieldsFunc(baseImageTorchVersion, func(c rune) bool {
+				return c == ','
+			})
+
 			allConfigurations := dockerfile.BaseImageConfigurations()
 			filteredMatrix := make([]dockerfile.BaseImageConfiguration, 0, len(allConfigurations))
 			for _, config := range allConfigurations {
-				if (baseImageCUDAVersion == "" || config.CUDAVersion == baseImageCUDAVersion) &&
-					(baseImagePythonVersion == "" || config.PythonVersion == baseImagePythonVersion) &&
-					(baseImageTorchVersion == "" || config.TorchVersion == baseImageTorchVersion) {
-					filteredMatrix = append(filteredMatrix, config)
+				var found bool
+				if len(validCudaVersions) > 0 {
+					found = false
+					for _, validCudaVersion := range validCudaVersions {
+						if config.CUDAVersion == validCudaVersion {
+							found = true
+						}
+					}
+					if !found {
+						continue
+					}
 				}
+
+				if len(validPythonVersions) > 0 {
+					found = false
+					for _, validPythonVersion := range validPythonVersions {
+						if config.PythonVersion == validPythonVersion {
+							found = true
+						}
+					}
+					if !found {
+						continue
+					}
+				}
+
+				if len(validTorchVersions) > 0 {
+					found = false
+					for _, validTorchVersion := range validPythonVersions {
+						if config.TorchVersion == validTorchVersion {
+							found = true
+						}
+					}
+					if !found {
+						continue
+					}
+				}
+
+				filteredMatrix = append(filteredMatrix, config)
 			}
 
 			output, err := json.Marshal(filteredMatrix)


### PR DESCRIPTION
* Allow generate-matrix to generate a matrix of builds with multiple parameters for
cuda/python/torch