### PR TITLE
Fix flaky registry test

### DIFF
--- a/pkg/docker/docker_client_test.go
+++ b/pkg/docker/docker_client_test.go
@@ -347,7 +347,7 @@ func runDockerClientTests(t *testing.T, dockerClient command.Command) {
 			assert.Condition(t, func() bool {
 				msg := err.Error()
 				return strings.Contains(msg, "connection refused") || strings.Contains(msg, "EOF")
-			}, "Error should indicate registry is unreachable")
+			}, "Error should indicate registry is unreachable, got: %q", err.Error())
 		})
 
 		t.Run("missing image", func(t *testing.T) {

--- a/pkg/docker/docker_client_test.go
+++ b/pkg/docker/docker_client_test.go
@@ -343,11 +343,7 @@ func runDockerClientTests(t *testing.T, dockerClient command.Command) {
 			err = dockerClient.Push(t.Context(), ref.String())
 			require.Error(t, err, "Push should fail with unreachable registry")
 
-			// error message varies between dev and CI host environments, cover them all...
-			assert.Condition(t, func() bool {
-				msg := err.Error()
-				return strings.Contains(msg, "connection refused") || strings.Contains(msg, "EOF")
-			}, "Error should indicate registry is unreachable, got: %q", err.Error())
+			assert.True(t, isNetworkError(err), "Error should be a network error, got: %q", err.Error())
 		})
 
 		t.Run("missing image", func(t *testing.T) {


### PR DESCRIPTION
We have a test that makes sure the docker client correctly handles network errors on push. The test checks for one of several known errors, but every so often the suite lands on a GHA runner that correctly fails, but with a different error message. 

This adds a helper to match common errors and calls that from the test.