### PR TITLE
Use Python 3.13 in generated cog.yaml

### DIFF
--- a/pkg/cli/init-templates/cog.yaml
+++ b/pkg/cli/init-templates/cog.yaml
@@ -11,13 +11,10 @@ build:
   #   - "libglib2.0-0"
 
   # python version in the form '3.11' or '3.11.4'
-  python_version: "3.11"
+  python_version: "3.13"
 
   # path to a Python requirements.txt file
   python_requirements: requirements.txt
-
-  # enable fast boots
-  fast: true
 
   # commands run after the environment is setup
   # run:


### PR DESCRIPTION
Python 3.11 is now two versions old and 3.13 has been out for over a
year at this point.

This commit also removes the `fast: true` flag which is unlikely
to be supported going forward.
