### PR TITLE
Refactor PostNewPipeline to use Replicate public API

### DIFF
--- a/pkg/docker/dockertest/mock_command.go
+++ b/pkg/docker/dockertest/mock_command.go
@@ -33,8 +33,8 @@ func (c *MockCommand) Push(ctx context.Context, image string) error {
 
 func (c *MockCommand) LoadUserInformation(ctx context.Context, registryHost string) (*command.UserInfo, error) {
 	userInfo := command.UserInfo{
-		Token:    "",
-		Username: "",
+		Token:    "test-token",
+		Username: "test-user",
 	}
 	return &userInfo, nil
 }

--- a/pkg/docker/push_test.go
+++ b/pkg/docker/push_test.go
@@ -155,37 +155,3 @@ func TestPushWithWeight(t *testing.T) {
 	err = Push(t.Context(), "r8.im/username/modelname", true, dir, command, BuildInfo{}, client, cfg)
 	require.NoError(t, err)
 }
-
-func TestPushPipeline(t *testing.T) {
-	// Setup mock http server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		output := "{\"version\":\"user/test:53c740f17ce88a61c3da5b0c20e48fd48e2da537c3a1276dec63ab11fbad6bcb\"}"
-		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte(output))
-	}))
-	defer server.Close()
-	url, err := url.Parse(server.URL)
-	require.NoError(t, err)
-	t.Setenv(env.SchemeEnvVarName, url.Scheme)
-	t.Setenv(env.WebHostEnvVarName, url.Host)
-
-	dir := t.TempDir()
-
-	// Create mock predict
-	predictPyPath := filepath.Join(dir, "predict.py")
-	handle, err := os.Create(predictPyPath)
-	require.NoError(t, err)
-	handle.WriteString("import cog")
-	dockertest.MockCogConfig = "{\"build\":{\"python_version\":\"3.12\",\"python_packages\":[\"torch==2.5.0\",\"beautifulsoup4==4.12.3\"],\"system_packages\":[\"git\"]},\"image\":\"test\",\"predict\":\"" + predictPyPath + ":Predictor\"}"
-
-	// Setup mock command
-	command := dockertest.NewMockCommand()
-	client, err := cogHttp.ProvideHTTPClient(t.Context(), command)
-	require.NoError(t, err)
-
-	cfg := config.DefaultConfig()
-	err = Push(t.Context(), "r8.im/username/modelname", false, dir, command, BuildInfo{
-		Pipeline: true,
-	}, client, cfg)
-	require.NoError(t, err)
-}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -5,6 +5,7 @@ import "os"
 const SchemeEnvVarName = "R8_SCHEME"
 const MonobeamHostEnvVarName = "R8_MONOBEAM_HOST"
 const WebHostEnvVarName = "R8_WEB_HOST"
+const APIHostEnvVarName = "R8_API_HOST"
 const PipelinesRuntimeHostEnvVarName = "R8_PIPELINES_RUNTIME_HOST"
 
 func SchemeFromEnvironment() string {
@@ -27,6 +28,14 @@ func WebHostFromEnvironment() string {
 	host := os.Getenv(WebHostEnvVarName)
 	if host == "" {
 		host = "cog.replicate.com"
+	}
+	return host
+}
+
+func APIHostFromEnvironment() string {
+	host := os.Getenv(APIHostEnvVarName)
+	if host == "" {
+		host = "api.replicate.com"
 	}
 	return host
 }

--- a/pkg/web/client.go
+++ b/pkg/web/client.go
@@ -168,7 +168,7 @@ func (c *Client) PostNewVersion(ctx context.Context, image string, weights []Fil
 		return util.WrapError(err, "failed to marshal JSON for new version")
 	}
 
-	versionUrl, err := newVersionURL(image, false)
+	versionUrl, err := newVersionURL(image)
 	if err != nil {
 		return err
 	}
@@ -214,6 +214,47 @@ func (c *Client) PostNewPipeline(ctx context.Context, image string, tarball *byt
 		return util.WrapError(err, "failed to inspect docker image")
 	}
 
+	// Create version URL
+	imageComponents := strings.Split(image, "/")
+	if len(imageComponents) != 3 {
+		return ErrorBadRegistryURL
+	}
+	if imageComponents[0] != global.ReplicateRegistryHost {
+		return ErrorBadRegistryHost
+	}
+
+	tokenURL := fmt.Sprintf("https://cog.replicate.com/api/token/%s", imageComponents[1])
+
+	// Authorization header is provided by the transport.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, nil)
+	if err != nil {
+		return err
+	}
+
+	// Make the request
+	tokenResp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer tokenResp.Body.Close()
+
+	if tokenResp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Bad response: %s attempting to exchange tokens", strconv.Itoa(tokenResp.StatusCode))
+	}
+
+	var tokenData struct {
+		Keys struct {
+			Cog struct {
+				Key       string `json:"key"`
+				ExpiresAt string `json:"expires_at"`
+			} `json:"cog"`
+		} `json:"keys"`
+	}
+	if err := json.NewDecoder(tokenResp.Body).Decode(&tokenData); err != nil {
+		return fmt.Errorf("Unable to decode response body: %w", err)
+	}
+	token := tokenData.Keys.Cog.Key
+
 	// Create form data body
 	body := new(bytes.Buffer)
 	mp := multipart.NewWriter(body)
@@ -222,32 +263,33 @@ func (c *Client) PostNewPipeline(ctx context.Context, image string, tarball *byt
 	if err != nil {
 		return err
 	}
-	err = mp.WriteField("dependencies", manifest.Config.Labels[command.CogModelDependenciesLabelKey])
+
+	dependencies := manifest.Config.Labels[command.CogModelDependenciesLabelKey]
+	if dependencies != "" && dependencies != `[""]` {
+		err = mp.WriteField("dependencies", dependencies)
+		if err != nil {
+			return err
+		}
+	}
+
+	part, err := mp.CreateFormFile("source_archive", "source_archive.tar")
 	if err != nil {
 		return err
 	}
-	part, err := mp.CreateFormFile("source_archive", "source.tar")
-	if err != nil {
-		return err
-	}
+
 	_, err = io.Copy(part, bytes.NewReader(tarball.Bytes()))
 	if err != nil {
 		return err
 	}
+	mp.Close()
 
-	// Create version URL
-	versionUrl, err := newVersionURL(image, true)
-	if err != nil {
-		return err
-	}
-
-	// Create a new request
-	versionURLString := versionUrl.String()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, versionURLString, bytes.NewReader(body.Bytes()))
+	versionURL := fmt.Sprintf("https://api.replicate.com/v1/models/%s/%s/versions", imageComponents[1], imageComponents[2])
+	req, err = http.NewRequestWithContext(ctx, http.MethodPost, versionURL, bytes.NewReader(body.Bytes()))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", mp.FormDataContentType())
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
 	// Make the request
 	resp, err := c.client.Do(req)
@@ -258,6 +300,44 @@ func (c *Client) PostNewPipeline(ctx context.Context, image string, tarball *byt
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return util.WrapError(ErrorBadResponseNewVersionEndpoint, strconv.Itoa(resp.StatusCode))
+	}
+
+	var v struct {
+		Id string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		return fmt.Errorf("Unable to decode response body: %w", err)
+	}
+
+	releaseURL := fmt.Sprintf("https://api.replicate.com/v1/models/%s/%s/releases", imageComponents[1], imageComponents[2])
+	buf := new(bytes.Buffer)
+	if err := json.NewEncoder(buf).Encode(struct {
+		Version string `json:"version"`
+	}{Version: v.Id}); err != nil {
+		return fmt.Errorf("Unable to encode JSON request body: %w", err)
+	}
+
+	req, err = http.NewRequestWithContext(ctx, http.MethodPost, releaseURL, buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	// Make the request
+	releaseResp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer releaseResp.Body.Close()
+
+	if releaseResp.StatusCode != http.StatusNoContent {
+		body, err := io.ReadAll(releaseResp.Body)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(body))
+		return fmt.Errorf("Bad response: %s attempting to create a release", strconv.Itoa(releaseResp.StatusCode))
 	}
 
 	return nil
@@ -462,7 +542,7 @@ func (c *Client) doSingleFileChallenge(ctx context.Context, file File, fileType 
 	}, nil
 }
 
-func newVersionURL(image string, isProcedure bool) (url.URL, error) {
+func newVersionURL(image string) (url.URL, error) {
 	imageComponents := strings.Split(image, "/")
 	newVersionUrl := webBaseURL()
 	if len(imageComponents) != 3 {
@@ -472,11 +552,6 @@ func newVersionURL(image string, isProcedure bool) (url.URL, error) {
 		return newVersionUrl, ErrorBadRegistryHost
 	}
 	newVersionUrl.Path = strings.Join([]string{"", "api", "models", imageComponents[1], imageComponents[2], "versions"}, "/")
-	if isProcedure {
-		query := newVersionUrl.Query()
-		query.Add("type", "procedure")
-		newVersionUrl.RawQuery = query.Encode()
-	}
 	return newVersionUrl, nil
 }
 

--- a/pkg/web/client_test.go
+++ b/pkg/web/client_test.go
@@ -78,12 +78,12 @@ func TestVersionFromManifest(t *testing.T) {
 }
 
 func TestVersionURLErrorWithoutR8IMPrefix(t *testing.T) {
-	_, err := newVersionURL("docker.com/thing/thing", false)
+	_, err := newVersionURL("docker.com/thing/thing")
 	require.Error(t, err)
 }
 
 func TestVersionURLErrorWithout3Components(t *testing.T) {
-	_, err := newVersionURL("username/test", false)
+	_, err := newVersionURL("username/test")
 	require.Error(t, err)
 }
 

--- a/pkg/web/client_test.go
+++ b/pkg/web/client_test.go
@@ -170,17 +170,53 @@ func TestDoFileChallenge(t *testing.T) {
 }
 
 func TestPostPipeline(t *testing.T) {
-	// Setup mock http server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		output := "{\"version\":\"user/test:53c740f17ce88a61c3da5b0c20e48fd48e2da537c3a1276dec63ab11fbad6bcb\"}"
-		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte(output))
+	// Setup mock web server for cog.replicate.com (token exchange)
+	webServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/token/user":
+			// Mock token exchange response
+			//nolint:gosec
+			tokenResponse := `{
+				"keys": {
+					"cog": {
+						"key": "test-api-token",
+						"expires_at": "2024-12-31T23:59:59Z"
+					}
+				}
+			}`
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(tokenResponse))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
 	}))
-	defer server.Close()
-	url, err := url.Parse(server.URL)
+	defer webServer.Close()
+
+	// Setup mock API server for api.replicate.com (version and release endpoints)
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models/user/test/versions":
+			// Mock version creation response
+			versionResponse := `{"id": "test-version-id"}`
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(versionResponse))
+		case "/v1/models/user/test/releases":
+			// Mock release creation response - empty body with 204 status
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer apiServer.Close()
+
+	webURL, err := url.Parse(webServer.URL)
 	require.NoError(t, err)
-	t.Setenv(env.SchemeEnvVarName, url.Scheme)
-	t.Setenv(env.WebHostEnvVarName, url.Host)
+	apiURL, err := url.Parse(apiServer.URL)
+	require.NoError(t, err)
+
+	t.Setenv(env.SchemeEnvVarName, webURL.Scheme)
+	t.Setenv(env.WebHostEnvVarName, webURL.Host)
+	t.Setenv(env.APIHostEnvVarName, apiURL.Host)
 
 	dir := t.TempDir()
 


### PR DESCRIPTION
This follows the procedure for shipping an experimental "pipeline" model via the API used by other areas of the Replicate product.

We use the new cog.replicate.com/api/token/{account} endpoint to exchange the cog token for a short lived Replicate API token that is restricted only to read/write actions on model resources.

Usage:

    cog push --x-pipeline r8.im/username/my-model
