### PR TITLE
Support `os.PathLike` output from models

### DIFF
--- a/python/cog/json.py
+++ b/python/cog/json.py
@@ -1,4 +1,5 @@
 import io
+import os
 import pathlib
 from datetime import datetime
 from enum import Enum
@@ -39,6 +40,8 @@ def make_encodeable(obj: Any) -> Any:  # pylint: disable=too-many-return-stateme
         return obj.value
     if isinstance(obj, datetime):
         return obj.isoformat()
+    if isinstance(obj, os.PathLike):
+        return pathlib.Path(obj)
     if np:
         if isinstance(obj, np.integer):
             return int(obj)
@@ -62,8 +65,8 @@ def upload_files(obj: Any, upload_file: Callable[[io.IOBase], str]) -> Any:
         return {key: upload_files(value, upload_file) for key, value in obj.items()}
     if isinstance(obj, list):
         return [upload_files(value, upload_file) for value in obj]
-    if isinstance(obj, pathlib.Path):
-        with obj.open("rb") as f:
+    if isinstance(obj, os.PathLike):
+        with open(obj, "rb") as f:
             return upload_file(f)
     if isinstance(obj, io.IOBase):
         return upload_file(obj)


### PR DESCRIPTION
This commit updates two pieces of our file handling code to work with `os.PathLike` objects.

 1. When transforming the output into a data-structure suitable for encoding in `make_encodable` we convert the `PathLike` into a `pathlib.Path` instance.
 2. When reading the file data from disk in `upload_files` we use `open()` instead of `Path.open()`.

This provides broader support for path-like objects, particularly the new replicate-python client which will return path-like objects from the new `use()` helper.
