### PR TITLE
Correctly set tag in scope

### DIFF
--- a/python/cog/server/worker.py
+++ b/python/cog/server/worker.py
@@ -640,7 +640,7 @@ class _ChildWorker(_spawn.Process):  # type: ignore
         predict: Callable[..., Any],
         redirector: StreamRedirector,
     ) -> None:
-        with evolve_scope(context=context), self._handle_predict_error(
+        with evolve_scope(context=context, _tag=tag), self._handle_predict_error(
             redirector, tag=tag
         ):
             result = predict(**payload)
@@ -695,7 +695,7 @@ class _ChildWorker(_spawn.Process):  # type: ignore
         predict: Callable[..., Any],
         redirector: SimpleStreamRedirector,
     ) -> None:
-        with evolve_scope(context=context, tag=tag), self._handle_predict_error(
+        with evolve_scope(context=context, _tag=tag), self._handle_predict_error(
             redirector, tag=tag
         ):
             future_result = predict(**payload)


### PR DESCRIPTION
The tag field of the scope is named `_tag`, so we must use this kwarg name in the evolve_scope method call.