### PR TITLE
Check if token is empty

### DIFF
--- a/pkg/cli/login.go
+++ b/pkg/cli/login.go
@@ -173,6 +173,10 @@ func checkTokenFormat(token string) error {
 }
 
 func verifyToken(registryHost string, token string) (username string, err error) {
+	if token == "" {
+		return "", fmt.Errorf("Token is empty")
+	}
+
 	resp, err := http.PostForm(addressWithScheme(registryHost)+"/cog/v1/verify-token", url.Values{
 		"token": []string{token},
 	})


### PR DESCRIPTION
* If token is empty, explicitly warn against it