### PR TITLE
Fix FastAPI deprecation warnings by migrating to lifespan handlers

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -12,7 +12,16 @@ import traceback
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from enum import Enum, auto, unique
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Dict, Optional, Type
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncGenerator,
+    Awaitable,
+    Callable,
+    Dict,
+    Optional,
+    Type,
+)
 
 import structlog
 import uvicorn
@@ -146,7 +155,7 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
     app = MyFastAPI(  # pylint: disable=redefined-outer-name
         title="Cog",  # TODO: mention model name?
         # version=None # TODO
-        lifespan=lifespan
+        lifespan=lifespan,
     )
 
     def custom_openapi() -> Dict[str, Any]:

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -12,7 +12,7 @@ import traceback
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from enum import Enum, auto, unique
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Optional, Type
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Dict, Optional, Type
 
 import structlog
 import uvicorn
@@ -124,7 +124,7 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
     started_at = datetime.now(tz=timezone.utc)
 
     @asynccontextmanager
-    async def lifespan(app: MyFastAPI):
+    async def lifespan(app: MyFastAPI) -> AsyncGenerator[None, None]:
         # Startup code (was previously in @app.on_event("startup"))
         # check for early setup failures
         if (

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -121,17 +121,11 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
     is_build: bool = False,
     await_explicit_shutdown: bool = False,  # pylint: disable=redefined-outer-name
 ) -> MyFastAPI:
-    
-    # Store references for lifespan event handler
-    worker_ref = None
-    runner_ref = None
-    
+    started_at = datetime.now(tz=timezone.utc)
+
     @asynccontextmanager
-    async def lifespan(app: FastAPI):
-        """Lifespan event handler for startup and shutdown events"""
-        nonlocal worker_ref, runner_ref
-        
-        # Startup logic (previously in @app.on_event("startup"))
+    async def lifespan(app: MyFastAPI):
+        # Startup code (was previously in @app.on_event("startup"))
         # check for early setup failures
         if (
             app.state.setup_result
@@ -141,20 +135,18 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
             if shutdown_event and not await_explicit_shutdown:
                 shutdown_event.set()
         else:
-            if runner_ref:
-                setup_task = runner_ref.setup()
-                setup_task.add_done_callback(_handle_setup_done)
-        
-        yield  # Application runs here
-        
-        # Shutdown logic (previously in @app.on_event("shutdown"))
-        if worker_ref:
-            worker_ref.terminate()
+            setup_task = runner.setup()
+            setup_task.add_done_callback(_handle_setup_done)
+
+        yield
+
+        # Shutdown code (was previously in @app.on_event("shutdown"))
+        worker.terminate()
 
     app = MyFastAPI(  # pylint: disable=redefined-outer-name
         title="Cog",  # TODO: mention model name?
-        lifespan=lifespan,
         # version=None # TODO
+        lifespan=lifespan
     )
 
     def custom_openapi() -> Dict[str, Any]:
@@ -181,7 +173,6 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
 
     app.state.health = Health.STARTING
     app.state.setup_result = None
-    started_at = datetime.now(tz=timezone.utc)
 
     # shutdown is needed no matter what happens
     @app.post("/shutdown")
@@ -207,10 +198,6 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
         max_concurrency=cog_config.max_concurrency,
     )
     runner = PredictionRunner(worker=worker, max_concurrency=cog_config.max_concurrency)
-    
-    # Store references for lifespan handler
-    worker_ref = worker
-    runner_ref = runner
 
     class PredictionRequest(schema.PredictionRequest.with_types(input_type=InputType)):
         pass

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -9,6 +9,7 @@ import sys
 import textwrap
 import threading
 import traceback
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from enum import Enum, auto, unique
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Optional, Type
@@ -120,8 +121,39 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
     is_build: bool = False,
     await_explicit_shutdown: bool = False,  # pylint: disable=redefined-outer-name
 ) -> MyFastAPI:
+    
+    # Store references for lifespan event handler
+    worker_ref = None
+    runner_ref = None
+    
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        """Lifespan event handler for startup and shutdown events"""
+        nonlocal worker_ref, runner_ref
+        
+        # Startup logic (previously in @app.on_event("startup"))
+        # check for early setup failures
+        if (
+            app.state.setup_result
+            and app.state.setup_result.status == schema.Status.FAILED
+        ):
+            # signal shutdown if interactive run
+            if shutdown_event and not await_explicit_shutdown:
+                shutdown_event.set()
+        else:
+            if runner_ref:
+                setup_task = runner_ref.setup()
+                setup_task.add_done_callback(_handle_setup_done)
+        
+        yield  # Application runs here
+        
+        # Shutdown logic (previously in @app.on_event("shutdown"))
+        if worker_ref:
+            worker_ref.terminate()
+
     app = MyFastAPI(  # pylint: disable=redefined-outer-name
         title="Cog",  # TODO: mention model name?
+        lifespan=lifespan,
         # version=None # TODO
     )
 
@@ -175,6 +207,10 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
         max_concurrency=cog_config.max_concurrency,
     )
     runner = PredictionRunner(worker=worker, max_concurrency=cog_config.max_concurrency)
+    
+    # Store references for lifespan handler
+    worker_ref = worker
+    runner_ref = runner
 
     class PredictionRequest(schema.PredictionRequest.with_types(input_type=InputType)):
         pass
@@ -317,24 +353,6 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
                 msg = "Error while loading trainer:\n\n" + traceback.format_exc()
                 add_setup_failed_routes(app, started_at, msg)
                 return app
-
-    @app.on_event("startup")
-    def startup() -> None:
-        # check for early setup failures
-        if (
-            app.state.setup_result
-            and app.state.setup_result.status == schema.Status.FAILED
-        ):
-            # signal shutdown if interactive run
-            if shutdown_event and not await_explicit_shutdown:
-                shutdown_event.set()
-        else:
-            setup_task = runner.setup()
-            setup_task.add_done_callback(_handle_setup_done)
-
-    @app.on_event("shutdown")
-    def shutdown() -> None:
-        worker.terminate()
 
     @app.get("/")
     async def root() -> Any:


### PR DESCRIPTION
## Fix FastAPI deprecation warnings

### Problem
Cog currently uses deprecated `@app.on_event()` handlers which cause deprecation warnings in FastAPI.

### Solution
- Migrated from `@app.on_event("startup")` and `@app.on_event("shutdown")` to FastAPI's lifespan handlers
- Updated imports to include `asynccontextmanager`
- No functional changes, just API modernization

### Testing
- [x] Tested locally with `cog predict`
- [x] No deprecation warnings appear
- [x] Server startup/shutdown works correctly