### PR TITLE
Refactor `cog predict` to support `--json` flag

### DIFF
--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -364,6 +364,7 @@ func runPrediction(predictor predict.Predictor, inputs predict.Inputs, outputPat
 		return fmt.Errorf("Failed to predict: %w", err)
 	}
 
+	// FIXME: Return JSON if needsJSON is true.
 	if prediction.Output == nil {
 		console.Warn("No output generated")
 		return nil
@@ -388,7 +389,7 @@ func runPrediction(predictor predict.Predictor, inputs predict.Inputs, outputPat
 			fileOutputPath = trimExt(fileOutputPath)
 		}
 
-		path, err := writeDataURLOutput(outputStr, fileOutputPath)
+		path, err := writeDataURLToFile(outputStr, fileOutputPath)
 		if err != nil {
 			return fmt.Errorf("Failed to write output: %w", err)
 		}
@@ -403,7 +404,7 @@ func runPrediction(predictor predict.Predictor, inputs predict.Inputs, outputPat
 				return fmt.Errorf("Failed to encode prediction output as JSON: %w", err)
 			}
 			if writeOutputToDisk {
-				path, err := writeOutput(rawJSON, outputPath)
+				path, err := writeFile(rawJSON, outputPath)
 				if err != nil {
 					return fmt.Errorf("Failed to write output: %w", err)
 				}
@@ -433,7 +434,7 @@ func runPrediction(predictor predict.Predictor, inputs predict.Inputs, outputPat
 				return fmt.Errorf("Failed to convert prediction output to string")
 			}
 
-			path, err := writeDataURLOutput(outputStr, fileOutputPath)
+			path, err := writeDataURLToFile(outputStr, fileOutputPath)
 			if err != nil {
 				return fmt.Errorf("Failed to write output %d: %w", i, err)
 			}
@@ -451,7 +452,7 @@ func runPrediction(predictor predict.Predictor, inputs predict.Inputs, outputPat
 				return fmt.Errorf("Failed to encode prediction output as JSON: %w", err)
 			}
 			if writeOutputToDisk {
-				path, err := writeOutput(rawJSON, outputPath)
+				path, err := writeFile(rawJSON, outputPath)
 				if err != nil {
 					return fmt.Errorf("Failed to write output: %w", err)
 				}
@@ -479,7 +480,7 @@ func runPrediction(predictor predict.Predictor, inputs predict.Inputs, outputPat
 			}
 
 			if writeOutputToDisk {
-				path, err := writeOutput(rawJSON, outputPath)
+				path, err := writeFile(rawJSON, outputPath)
 				if err != nil {
 					return fmt.Errorf("Failed to write output: %w", err)
 				}
@@ -491,7 +492,7 @@ func runPrediction(predictor predict.Predictor, inputs predict.Inputs, outputPat
 		}
 
 		if writeOutputToDisk {
-			path, err := writeOutput([]byte(s), outputPath)
+			path, err := writeFile([]byte(s), outputPath)
 			if err != nil {
 				return fmt.Errorf("Failed to write output: %w", err)
 			}
@@ -514,7 +515,7 @@ func runPrediction(predictor predict.Predictor, inputs predict.Inputs, outputPat
 
 		// No special handling for needsJSON here.
 		if writeOutputToDisk {
-			path, err := writeOutput(indentedJSON.Bytes(), outputPath)
+			path, err := writeFile(indentedJSON.Bytes(), outputPath)
 			if err != nil {
 				return fmt.Errorf("Failed to write output: %w", err)
 			}
@@ -602,7 +603,7 @@ func ensureOutputWriteable(outputPath string, fallbackPath string) (string, erro
 	return outputPath, nil
 }
 
-func writeOutput(output []byte, outputPath string) (string, error) {
+func writeFile(output []byte, outputPath string) (string, error) {
 	outputPath, err := homedir.Expand(outputPath)
 	if err != nil {
 		return "", err
@@ -625,7 +626,7 @@ func writeOutput(output []byte, outputPath string) (string, error) {
 
 // Writes a data URL to the destination. If no file extension is provided then it
 // will be inferred from the data URL mime type and appended.
-func writeDataURLOutput(url string, destination string) (string, error) {
+func writeDataURLToFile(url string, destination string) (string, error) {
 	dataurlObj, err := dataurl.DecodeString(url)
 	if err != nil {
 		return "", fmt.Errorf("Failed to decode data URL: %w", err)
@@ -641,7 +642,7 @@ func writeDataURLOutput(url string, destination string) (string, error) {
 		ext = mime.ExtensionByType(dataurlObj.ContentType())
 	}
 
-	path, err := writeOutput(output, path.Join(dir, name+ext))
+	path, err := writeFile(output, path.Join(dir, name+ext))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -616,8 +617,13 @@ func writeDataURLToFile(url string, destination string) (string, error) {
 
 	ext := path.Ext(destination)
 	dir := path.Dir(destination)
-	base := path.Base(destination)
-	name := trimExt(base)
+	name := trimExt(path.Base(destination))
+
+	// Check if ext is an integer, in which case ignore it...
+	if _, err := strconv.Atoi(ext); err != nil {
+		ext = ""
+		name = path.Base(destination)
+	}
 
 	if ext == "" {
 		ext = mime.ExtensionByType(dataurlObj.ContentType())

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -406,11 +406,14 @@ func runPrediction(predictor predict.Predictor, inputs predict.Inputs, outputPat
 		// Strip the suffix when in JSON mode.
 		fileOutputPath = trimExt(fileOutputPath)
 	}
-	transformed, err := processFileOutputs(*prediction.Output, outputSchema, fileOutputPath)
-	if err != nil {
-		return err
+
+	if prediction.Status == "succeeded" && prediction.Output != nil {
+		transformed, err := processFileOutputs(*prediction.Output, outputSchema, fileOutputPath)
+		if err != nil {
+			return err
+		}
+		prediction.Output = &transformed
 	}
-	prediction.Output = &transformed
 
 	if needsJSON {
 		rawJSON, err := json.Marshal(prediction)

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -12,7 +12,6 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -635,8 +634,7 @@ func writeDataURLToFile(url string, destination string) (string, error) {
 	name := r8_path.TrimExt(path.Base(destination))
 
 	// Check if ext is an integer, in which case ignore it...
-	_, err = strconv.Atoi(ext)
-	if err == nil {
+	if r8_path.IsExtInteger(ext) {
 		ext = ""
 		name = path.Base(destination)
 	}

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -549,7 +549,7 @@ func ensureOutputWriteable(outputPath string, fallbackPath string) (string, erro
 	if stat.IsDir() {
 		// If the fallback path already exists as a directory error.
 		if usingFallback {
-			return "", fmt.Errorf("Default output name \"%s\" conflicts with directory, provide --output", outputPath)
+			return "", fmt.Errorf("Default output name %q conflicts with directory, provide --output", outputPath)
 		}
 		err := unix.Access(outputPath, unix.W_OK)
 		if err != nil {

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -27,6 +27,7 @@ import (
 	"github.com/replicate/cog/pkg/docker"
 	"github.com/replicate/cog/pkg/docker/command"
 	"github.com/replicate/cog/pkg/image"
+	r8_path "github.com/replicate/cog/pkg/path"
 	"github.com/replicate/cog/pkg/predict"
 	"github.com/replicate/cog/pkg/registry"
 	"github.com/replicate/cog/pkg/util/console"
@@ -404,7 +405,7 @@ func runPrediction(predictor predict.Predictor, inputs predict.Inputs, outputPat
 	fileOutputPath := outputPath
 	if needsJSON {
 		// Strip the suffix when in JSON mode.
-		fileOutputPath = trimExt(fileOutputPath)
+		fileOutputPath = r8_path.TrimExt(fileOutputPath)
 	}
 
 	if prediction.Status == "succeeded" && prediction.Output != nil {
@@ -584,7 +585,7 @@ func processFileOutputs(output any, schema *openapi3.Schema, destination string)
 
 		clone := []any{}
 		for i, output := range outputs {
-			itemDestination := fmt.Sprintf("%s.%d%s", trimExt(destination), i, path.Ext(destination))
+			itemDestination := fmt.Sprintf("%s.%d%s", r8_path.TrimExt(destination), i, path.Ext(destination))
 			item, err := processFileOutputs(output, schema.Items.Value, itemDestination)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to write output %d: %w", i, err)
@@ -631,10 +632,11 @@ func writeDataURLToFile(url string, destination string) (string, error) {
 
 	ext := path.Ext(destination)
 	dir := path.Dir(destination)
-	name := trimExt(path.Base(destination))
+	name := r8_path.TrimExt(path.Base(destination))
 
 	// Check if ext is an integer, in which case ignore it...
-	if _, err := strconv.Atoi(ext); err != nil {
+	_, err = strconv.Atoi(ext)
+	if err == nil {
 		ext = ""
 		name = path.Base(destination)
 	}
@@ -649,10 +651,6 @@ func writeDataURLToFile(url string, destination string) (string, error) {
 	}
 
 	return path, nil
-}
-
-func trimExt(s string) string {
-	return strings.TrimSuffix(s, path.Ext(s))
 }
 
 func parseInputFlags(inputs []string, schema *openapi3.T) (predict.Inputs, error) {

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -461,8 +461,7 @@ func runPrediction(predictor predict.Predictor, inputs predict.Inputs, outputPat
 	}
 
 	if prediction.Status != "succeeded" {
-		console.Errorf("Prediction failed with status \"%s\": %s", prediction.Status, prediction.Error)
-		os.Exit(1)
+		return fmt.Errorf("Prediction failed with status %q: %s", prediction.Status, prediction.Error)
 	}
 
 	if prediction.Output == nil {

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -434,7 +434,18 @@ func runPrediction(predictor predict.Predictor, inputs predict.Inputs, outputPat
 		} else {
 			console.Output(indentedJSON.String())
 		}
+
+		// Exit with non-zero code if the prediction has failed.
+		if prediction.Status != "succeeded" {
+			os.Exit(1)
+		}
+
 		return nil
+	}
+
+	if prediction.Status != "succeeded" {
+		console.Errorf("Prediction failed with status \"%s\": %s", prediction.Status, prediction.Error)
+		os.Exit(1)
 	}
 
 	if prediction.Output == nil {

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -2,9 +2,18 @@ package path
 
 import (
 	go_path "path"
+	"strconv"
 	"strings"
 )
 
 func TrimExt(s string) string {
 	return strings.TrimSuffix(s, go_path.Ext(s))
+}
+
+func IsExtInteger(ext string) bool {
+	if strings.HasPrefix(ext, ".") {
+		ext = ext[1:]
+	}
+	_, err := strconv.Atoi(ext)
+	return err == nil
 }

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -1,0 +1,10 @@
+package path
+
+import (
+	go_path "path"
+	"strings"
+)
+
+func TrimExt(s string) string {
+	return strings.TrimSuffix(s, go_path.Ext(s))
+}

--- a/pkg/path/path_test.go
+++ b/pkg/path/path_test.go
@@ -10,3 +10,7 @@ func TestTrimExt(t *testing.T) {
 	path := TrimExt("/mydir/myoutput.bmp")
 	require.Equal(t, path, "/mydir/myoutput")
 }
+
+func TestIsExtInteger(t *testing.T) {
+	require.True(t, IsExtInteger(".0"))
+}

--- a/pkg/path/path_test.go
+++ b/pkg/path/path_test.go
@@ -1,0 +1,12 @@
+package path
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrimExt(t *testing.T) {
+	path := TrimExt("/mydir/myoutput.bmp")
+	require.Equal(t, path, "/mydir/myoutput")
+}

--- a/pkg/web/client.go
+++ b/pkg/web/client.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/docker/docker/api/types/image"
@@ -366,6 +367,7 @@ func (c *Client) versionFromManifest(ctx context.Context, image string, weights 
 
 func (c *Client) InitiateAndDoFileChallenge(ctx context.Context, weights []File, files []File) ([]FileChallengeAnswer, error) {
 	var challengeAnswers []FileChallengeAnswer
+	var mu sync.Mutex
 
 	var wg errgroup.Group
 	for _, item := range files {
@@ -374,7 +376,9 @@ func (c *Client) InitiateAndDoFileChallenge(ctx context.Context, weights []File,
 			if err != nil {
 				return util.WrapError(err, fmt.Sprintf("do file challenge for digest %s", item.Digest))
 			}
+			mu.Lock()
 			challengeAnswers = append(challengeAnswers, answer)
+			mu.Unlock()
 			return nil
 		})
 	}
@@ -384,7 +388,9 @@ func (c *Client) InitiateAndDoFileChallenge(ctx context.Context, weights []File,
 			if err != nil {
 				return util.WrapError(err, fmt.Sprintf("do file challenge for digest %s", item.Digest))
 			}
+			mu.Lock()
 			challengeAnswers = append(challengeAnswers, answer)
+			mu.Unlock()
 			return nil
 		})
 	}

--- a/test-integration/test_integration/fixtures/string-project/input.json
+++ b/test-integration/test_integration/fixtures/string-project/input.json
@@ -1,0 +1,3 @@
+{
+    "s": "sackfield"
+}

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -618,3 +618,24 @@ def test_predict_tensorflow_project(docker_image, cog_binary):
     )
     assert result.returncode == 0
     assert result.stdout == "2.10.0\n"
+
+
+def test_predict_json_input(docker_image, cog_binary):
+    project_dir = Path(__file__).parent / "fixtures/string-project"
+
+    result = subprocess.run(
+        [
+            cog_binary,
+            "predict",
+            "--debug",
+            "--json",
+            '{"s": "sackfield"}',
+        ],
+        cwd=project_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120.0,
+    )
+    assert result.returncode == 0
+    assert result.stdout == "2.10.0\n"

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -107,8 +107,6 @@ def test_predict_writes_files_to_files_with_custom_name(tmpdir_factory, cog_bina
         text=True,
         timeout=DEFAULT_TIMEOUT,
     )
-    # DEBUG: Print the last 30 lines of stderr to try and help debugging.
-    print(result.stderr.splitlines()[-30:])
 
     assert result.returncode == 0
     assert result.stdout == ""

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -739,7 +739,6 @@ def test_predict_json_output(tmpdir_factory, cog_binary):
   "error": ""
 }"""
         )
-    assert result.stdout == "Output written to: output.json\n"
 
 
 def test_predict_json_input_stdin_dash(cog_binary):

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -107,9 +107,8 @@ def test_predict_writes_files_to_files_with_custom_name(tmpdir_factory, cog_bina
         text=True,
         timeout=DEFAULT_TIMEOUT,
     )
-    if result.returncode > 0:
-        # DEBUG: Print the last 30 lines of stderr to try and help debugging.
-        print(result.stderr.splitlines()[-30:])
+    # DEBUG: Print the last 30 lines of stderr to try and help debugging.
+    print(result.stderr.splitlines()[-30:])
 
     assert result.returncode == 0
     assert result.stdout == ""

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -107,6 +107,11 @@ def test_predict_writes_files_to_files_with_custom_name(tmpdir_factory, cog_bina
         text=True,
         timeout=DEFAULT_TIMEOUT,
     )
+    if result.returncode > 0:
+        # DEBUG: Print the last 30 lines of stderr to try and help debugging.
+        print(result.stderr.splitlines()[-30:])
+
+    assert result.returncode == 0
     assert result.stdout == ""
     with open(out_dir / "myoutput.bmp", "rb") as f:
         assert len(f.read()) == 195894

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -737,8 +737,7 @@ def test_predict_json_output(tmpdir_factory, cog_binary):
   "status": "succeeded",
   "output": "hello sackfield",
   "error": ""
-}
-"""
+}"""
         )
     assert result.stdout == "Output written to: output.json\n"
 

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -644,7 +644,8 @@ def test_predict_json_input(cog_binary):
   "status": "succeeded",
   "output": "hello sackfield",
   "error": ""
-}"""
+}
+"""
     )
 
 
@@ -672,7 +673,8 @@ def test_predict_json_input_filename(cog_binary):
   "status": "succeeded",
   "output": "hello sackfield",
   "error": ""
-}"""
+}
+"""
     )
 
 
@@ -701,7 +703,8 @@ def test_predict_json_input_stdin(cog_binary):
   "status": "succeeded",
   "output": "hello sackfield",
   "error": ""
-}"""
+}
+"""
     )
 
 
@@ -734,6 +737,37 @@ def test_predict_json_output(tmpdir_factory, cog_binary):
   "status": "succeeded",
   "output": "hello sackfield",
   "error": ""
-}"""
+}
+"""
         )
     assert result.stdout == "Output written to: output.json\n"
+
+
+def test_predict_json_input_stdin_dash(cog_binary):
+    project_dir = Path(__file__).parent / "fixtures/string-project"
+
+    result = subprocess.run(
+        [
+            cog_binary,
+            "predict",
+            "--debug",
+            "--json",
+            "-",
+        ],
+        cwd=project_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120.0,
+        input='{"s": "sackfield"}',
+    )
+    assert result.returncode == 0
+    assert (
+        result.stdout
+        == """{
+  "status": "succeeded",
+  "output": "hello sackfield",
+  "error": ""
+}
+"""
+    )

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -620,7 +620,7 @@ def test_predict_tensorflow_project(docker_image, cog_binary):
     assert result.stdout == "2.10.0\n"
 
 
-def test_predict_json_input(docker_image, cog_binary):
+def test_predict_json_input(cog_binary):
     project_dir = Path(__file__).parent / "fixtures/string-project"
 
     result = subprocess.run(
@@ -638,4 +638,102 @@ def test_predict_json_input(docker_image, cog_binary):
         timeout=120.0,
     )
     assert result.returncode == 0
-    assert result.stdout == "2.10.0\n"
+    assert (
+        result.stdout
+        == """{
+  "status": "succeeded",
+  "output": "hello sackfield",
+  "error": ""
+}"""
+    )
+
+
+def test_predict_json_input_filename(cog_binary):
+    project_dir = Path(__file__).parent / "fixtures/string-project"
+
+    result = subprocess.run(
+        [
+            cog_binary,
+            "predict",
+            "--debug",
+            "--json",
+            "@input.json",
+        ],
+        cwd=project_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120.0,
+    )
+    assert result.returncode == 0
+    assert (
+        result.stdout
+        == """{
+  "status": "succeeded",
+  "output": "hello sackfield",
+  "error": ""
+}"""
+    )
+
+
+def test_predict_json_input_stdin(cog_binary):
+    project_dir = Path(__file__).parent / "fixtures/string-project"
+
+    result = subprocess.run(
+        [
+            cog_binary,
+            "predict",
+            "--debug",
+            "--json",
+            "@-",
+        ],
+        cwd=project_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120.0,
+        input='{"s": "sackfield"}',
+    )
+    assert result.returncode == 0
+    assert (
+        result.stdout
+        == """{
+  "status": "succeeded",
+  "output": "hello sackfield",
+  "error": ""
+}"""
+    )
+
+
+def test_predict_json_output(tmpdir_factory, cog_binary):
+    project_dir = Path(__file__).parent / "fixtures/string-project"
+    out_dir = pathlib.Path(tmpdir_factory.mktemp("project"))
+    shutil.copytree(project_dir, out_dir, dirs_exist_ok=True)
+
+    result = subprocess.run(
+        [
+            cog_binary,
+            "predict",
+            "--debug",
+            "--json",
+            '{"s": "sackfield"}',
+            "--output",
+            "output.json",
+        ],
+        cwd=out_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120.0,
+    )
+    assert result.returncode == 0
+    with open(out_dir / "output.json", encoding="utf-8") as f:
+        assert (
+            f.read()
+            == """{
+  "status": "succeeded",
+  "output": "hello sackfield",
+  "error": ""
+}"""
+        )
+    assert result.stdout == "Output written to: output.json\n"


### PR DESCRIPTION
This PR introduces `cog predict --json` that represents both input and output as JSON.

The intention behind this PR is to provide a better interface for machines to interface with `cog predict`. Such as running automated tests. In these cases trying to parse the existing unstable output is non-trivial. Having access to the full JSON prediction makes things much easier.

In order to do this correctly the PR also fixes a number of bugs with the `--output` behavior.

 * We now support passing a directory as an output value e.g. `--output ./outputs`
 * We now honor the `--output` flag for lists of files. Previously if a model returned a list of files they would all be `output.<idx>.<ext>` regardless of the --output flag.
 * We now error with a non-zero exit code if the prediction is not successful.

There are several ways to use `cog predict` with the `--json` flag:

 1. Passing a JSON string directly.
    ```
    cog predict --json '{"prompt": "make me a sandwich"}'
    ```
 1. Passing a path to a JSON file.
    ```
    cog predict --json @inputs.json
    ```
 1. Passing JSON via stdin, using the special `@-` reference.
    ```
    cog predict --json @- < inputs.json
    ```

The output will be the entire prediction printed to stdout by default.

```
cog predict --json '{"prompt": "make me a sandwich"}'
{"status": "successful", "output": "blah blah", error: null}
```

The output can also be written to a file:

```
cog predict --json '{"prompt": "make me a sandwich"}' --output output.json
Output written to: output.json
```
