### PR TITLE
Filter editable commands out of read requirements

### DIFF
--- a/pkg/requirements/requirements.go
+++ b/pkg/requirements/requirements.go
@@ -43,6 +43,8 @@ func CurrentRequirements(tmpDir string) (string, error) {
 }
 
 func ReadRequirements(path string) ([]string, error) {
+	re := regexp.MustCompile(`(?m)^\s*-e\s+\.\s*$`)
+
 	fh, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -60,6 +62,10 @@ func ReadRequirements(path string) ([]string, error) {
 
 		// Skip empty lines and comment lines
 		if strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if re.MatchString(line) {
 			continue
 		}
 

--- a/pkg/requirements/requirements_test.go
+++ b/pkg/requirements/requirements_test.go
@@ -423,6 +423,17 @@ func TestSplitPinnedPythonRequirement(t *testing.T) {
 	}
 }
 
+func TestReadRequirementsWithEditable(t *testing.T) {
+	srcDir := t.TempDir()
+	reqFile := path.Join(srcDir, "requirements.txt")
+	err := os.WriteFile(reqFile, []byte("-e .\ntorch==2.5.1"), 0o644)
+	require.NoError(t, err)
+
+	requirements, err := ReadRequirements(reqFile)
+	require.NoError(t, err)
+	require.Equal(t, []string{"torch==2.5.1"}, requirements)
+}
+
 func checkRequirements(t *testing.T, expected []string, actual []string) {
 	t.Helper()
 	for n, expectLine := range expected {


### PR DESCRIPTION
* Do not consider lines with editable commands as part of the read requirements output