### PR TITLE
In event of error, checking equality

### DIFF
--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -112,7 +112,15 @@ func Greater(v1 string, v2 string) bool {
 }
 
 func GreaterOrEqual(v1 string, v2 string) bool {
-	return MustVersion(v1).GreaterOrEqual(MustVersion(v2))
+	leftVersion, err := NewVersion(v1)
+	if err != nil {
+		return v1 == v2
+	}
+	rightVersion, err := NewVersion(v2)
+	if err != nil {
+		return v1 == v2
+	}
+	return leftVersion.GreaterOrEqual(rightVersion)
 }
 
 func (v *Version) Matches(other *Version) bool {

--- a/pkg/util/version/version_test.go
+++ b/pkg/util/version/version_test.go
@@ -79,3 +79,9 @@ func TestVersionMatchesModifier(t *testing.T) {
 	matchVersion := "2.3.2+cu118"
 	require.True(t, Matches(version, matchVersion))
 }
+
+func TestGreaterThanOrEqualToWithInvalidPatch(t *testing.T) {
+	leftVersion := "1.1.0b2"
+	rightVersion := "1.1.0b2"
+	require.True(t, GreaterOrEqual(leftVersion, rightVersion))
+}


### PR DESCRIPTION
* When checking if 2 version strings are greater or equal, if an error occurs parsing the version
fall back to string equality instead of panicking