### PR TITLE
Enable docker api client by default

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -2,15 +2,15 @@ package docker
 
 import (
 	"context"
-	"os"
 	"strconv"
 
 	"github.com/replicate/cog/pkg/docker/command"
+	"github.com/replicate/cog/pkg/util"
 	"github.com/replicate/cog/pkg/util/console"
 )
 
 func NewClient(ctx context.Context, opts ...Option) (command.Command, error) {
-	enabled, _ := strconv.ParseBool(os.Getenv("COG_DOCKER_SDK_CLIENT"))
+	enabled := util.GetEnvOrDefault("COG_DOCKER_SDK_CLIENT", true, strconv.ParseBool)
 	if enabled {
 		console.Debugf("Docker client: sdk")
 		return NewAPIClient(ctx, opts...)


### PR DESCRIPTION
Switches the default docker client to the new one introduced in #2327. It's been available for about a month by calling with `COG_DOCKER_SDK_CLIENT=1`. 

No show-stopping issues came up through internal testing or integration tests on CI, but if anything does arise users can revert to the previous behavior by running with `COG_DOCKER_SDK_CLIENT=0`, such as:

```
COG_DOCKER_SDK_CLIENT=0 cog build ...
```
