### PR TITLE
Fix flakey integration tests

### DIFF
--- a/test-integration/test_integration/conftest.py
+++ b/test-integration/test_integration/conftest.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from pathlib import Path
+from typing import Callable
 
 import pytest
 from _pytest.config import Config
@@ -49,3 +50,18 @@ def docker_image(docker_image_name: str) -> str:
     # We expect the image to exist by this point and will fail if it doesn't.
     # If you just need a name, use docker_image_name.
     remove_docker_image(docker_image_name)
+
+
+@pytest.fixture
+def fixture(tmp_path_factory: pytest.TempPathFactory) -> Callable[[str], Path]:
+    """
+    Return a function that gives each test an isolated copy of a fixture dir.
+    """
+
+    def _make(name: str) -> Path:
+        src = Path(__file__).parent / "fixtures" / name
+        dst = tmp_path_factory.mktemp(name)  # unique dir per test
+        shutil.copytree(src, dst, dirs_exist_ok=True)
+        return dst
+
+    return _make

--- a/test-integration/test_integration/test_build.py
+++ b/test-integration/test_integration/test_build.py
@@ -394,8 +394,8 @@ def test_cog_installs_apt_packages(docker_image, cog_binary):
     assert build_process.returncode == 0
 
 
-def test_fast_build(docker_image, cog_binary):
-    project_dir = Path(__file__).parent / "fixtures/fast-build"
+def test_fast_build(fixture, docker_image, cog_binary):
+    project_dir = fixture("fast-build")
     weights_file = os.path.join(project_dir, "weights.h5")
     with open(weights_file, "w", encoding="utf8") as handle:
         handle.seek(256 * 1024 * 1024)
@@ -406,8 +406,6 @@ def test_fast_build(docker_image, cog_binary):
         cwd=project_dir,
         capture_output=True,
     )
-
-    os.remove(weights_file)
 
     assert build_process.returncode == 0
 
@@ -464,8 +462,8 @@ def test_pydantic1_none(docker_image, cog_binary):
     assert build_process.returncode == 0
 
 
-def test_fast_build_with_local_image(docker_image, cog_binary):
-    project_dir = Path(__file__).parent / "fixtures/fast-build"
+def test_fast_build_with_local_image(fixture, docker_image, cog_binary):
+    project_dir = fixture("fast-build")
     weights_file = os.path.join(project_dir, "weights.h5")
     with open(weights_file, "w", encoding="utf8") as handle:
         handle.seek(256 * 1024 * 1024)
@@ -476,8 +474,6 @@ def test_fast_build_with_local_image(docker_image, cog_binary):
         cwd=project_dir,
         capture_output=True,
     )
-
-    os.remove(weights_file)
 
     assert build_process.returncode == 0
 

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -391,8 +391,8 @@ def test_predict_new_union_project(tmpdir_factory, cog_binary):
     assert result.stdout == "hello world\n"
 
 
-def test_predict_with_fast_build_with_local_image(docker_image, cog_binary):
-    project_dir = Path(__file__).parent / "fixtures/fast-build"
+def test_predict_with_fast_build_with_local_image(fixture, docker_image, cog_binary):
+    project_dir = fixture("fast-build")
     weights_file = os.path.join(project_dir, "weights.h5")
     with open(weights_file, "w", encoding="utf8") as handle:
         handle.seek(256 * 1024 * 1024)
@@ -417,7 +417,7 @@ def test_predict_with_fast_build_with_local_image(docker_image, cog_binary):
         cwd=project_dir,
         capture_output=True,
     )
-    os.remove(weights_file)
+
     assert build_process.returncode == 0
     assert result.returncode == 0
 
@@ -788,7 +788,7 @@ def test_predict_glb_file(cog_binary):
     )
     assert result.returncode == 0
 
- 
+
 def test_predict_future_annotations(cog_binary):
     project_dir = Path(__file__).parent / "fixtures/future-annotations-project"
 


### PR DESCRIPTION
We have a few integration tests that fail randomly due to a race, eg: 

```
FAILED test_integration/test_build.py::test_fast_build - IsADirectoryError: [Errno 21] Is a directory: '/home/runner/work/cog/cog/test-integration/test_integration/fixtures/fast-build/weights.h5'
```

The issue is that several integration tests alter the same fixture directory during a test. If the tests run concurrently, it's likely the weights.h5 file will be removed by the first before the second is done with it.

This PR adds a fixture helper that'll give each test a unique copy of a fixture that gets cleaned up automatically. I only updated the flakey tests, but this is probably good to add to the rest since things like `.cog` temp dirs often linger as well.