### PR TITLE
feat: add ability to skip files that already exist, overwrite or quit

### DIFF
--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -68,7 +68,7 @@ func initCommand(cmd *cobra.Command, args []string) error {
 		"requirements.txt":            requirementsTxtContent,
 	}
 
-	var globalChoice string
+	globalSkip := false
 
 	for filename, content := range fileContentMap {
 		filePath := path.Join(cwd, filename)
@@ -87,7 +87,7 @@ func initCommand(cmd *cobra.Command, args []string) error {
 				console.Infof("Overwriting existing %s", filename)
 			} else {
 				// Check if we have a global choice from previous prompts
-				if globalChoice == "S" {
+				if globalSkip {
 					console.Infof("Skipped existing %s", filename)
 					continue
 				}
@@ -106,7 +106,7 @@ func initCommand(cmd *cobra.Command, args []string) error {
 					console.Infof("Skipped existing %s", filename)
 					continue
 				case "skip-all":
-					globalChoice = "S"
+					globalSkip = true
 					console.Infof("Skipped existing %s (and will skip all remaining)", filename)
 					continue
 				case "quit":

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -28,22 +28,32 @@ var actionsWorkflowContent []byte
 //go:embed init-templates/requirements.txt
 var requirementsTxtContent []byte
 
+var (
+	skipExisting      bool
+	overwriteExisting bool
+)
+
 func newInitCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:        "init",
 		SuggestFor: []string{"new", "start"},
 		Short:      "Configure your project for use with Cog",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return initCommand(args)
-		},
-		Args: cobra.MaximumNArgs(0),
+		RunE:       initCommand,
+		Args:       cobra.MaximumNArgs(0),
 	}
+
+	cmd.Flags().BoolVarP(&skipExisting, "skip-existing", "s", false, "Skip all existing files without prompting")
+	cmd.Flags().BoolVarP(&overwriteExisting, "overwrite-existing", "o", false, "Overwrite all existing files without prompting")
 
 	return cmd
 }
 
-func initCommand(args []string) error {
+func initCommand(cmd *cobra.Command, args []string) error {
 	console.Infof("\nSetting up the current directory for use with Cog...\n")
+
+	if skipExisting && overwriteExisting {
+		return fmt.Errorf("Cannot specify both --skip-existing and --overwrite-existing")
+	}
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -58,6 +68,8 @@ func initCommand(args []string) error {
 		"requirements.txt":            requirementsTxtContent,
 	}
 
+	var globalChoice string
+
 	for filename, content := range fileContentMap {
 		filePath := path.Join(cwd, filename)
 		fileExists, err := files.Exists(filePath)
@@ -65,21 +77,58 @@ func initCommand(args []string) error {
 			return err
 		}
 
+		shouldWrite := true
 		if fileExists {
-			return fmt.Errorf("Found an existing %s.\nExiting without overwriting (to be on the safe side!)", filename)
+			if skipExisting {
+				console.Infof("Skipped existing %s", filename)
+				continue
+			}
+			if overwriteExisting {
+				console.Infof("Overwriting existing %s", filename)
+			} else {
+				// Check if we have a global choice from previous prompts
+				if globalChoice == "S" {
+					console.Infof("Skipped existing %s", filename)
+					continue
+				}
+				// Prompt for this specific file
+				choice, err := console.Interactive{
+					Prompt:  fmt.Sprintf("File %s already exists. What would you like to do?", filename),
+					Options: []string{"skip", "skip-all", "quit"},
+					Default: "skip",
+				}.Read()
+				if err != nil {
+					return err
+				}
+
+				switch choice {
+				case "skip":
+					console.Infof("Skipped existing %s", filename)
+					continue
+				case "skip-all":
+					globalChoice = "S"
+					console.Infof("Skipped existing %s (and will skip all remaining)", filename)
+					continue
+				case "quit":
+					console.Infof("Exiting without making changes")
+					return nil
+				}
+			}
 		}
 
-		dirPath := path.Dir(filePath)
-		err = os.MkdirAll(dirPath, os.ModePerm)
-		if err != nil {
-			return fmt.Errorf("Error creating directory %s: %w", dirPath, err)
-		}
+		if shouldWrite {
+			dirPath := path.Dir(filePath)
+			err = os.MkdirAll(dirPath, os.ModePerm)
+			if err != nil {
+				return fmt.Errorf("Error creating directory %s: %w", dirPath, err)
+			}
 
-		err = os.WriteFile(filePath, content, 0o644)
-		if err != nil {
-			return fmt.Errorf("Error writing %s: %w", filePath, err)
+			err = os.WriteFile(filePath, content, 0o644)
+			if err != nil {
+				return fmt.Errorf("Error writing %s: %w", filePath, err)
+			}
+			console.Infof("✅ Created %s", filePath)
 		}
-		console.Infof("✅ Created %s", filePath)
 	}
 
 	console.Infof("\nDone! For next steps, check out the docs at https://cog.run/getting-started")

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -28,11 +28,6 @@ var actionsWorkflowContent []byte
 //go:embed init-templates/requirements.txt
 var requirementsTxtContent []byte
 
-var (
-	skipExisting      bool
-	overwriteExisting bool
-)
-
 func newInitCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:        "init",
@@ -42,18 +37,11 @@ func newInitCommand() *cobra.Command {
 		Args:       cobra.MaximumNArgs(0),
 	}
 
-	cmd.Flags().BoolVarP(&skipExisting, "skip-existing", "s", false, "Skip all existing files without prompting")
-	cmd.Flags().BoolVarP(&overwriteExisting, "overwrite-existing", "o", false, "Overwrite all existing files without prompting")
-
 	return cmd
 }
 
 func initCommand(cmd *cobra.Command, args []string) error {
 	console.Infof("\nSetting up the current directory for use with Cog...\n")
-
-	if skipExisting && overwriteExisting {
-		return fmt.Errorf("Cannot specify both --skip-existing and --overwrite-existing")
-	}
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -68,8 +56,6 @@ func initCommand(cmd *cobra.Command, args []string) error {
 		"requirements.txt":            requirementsTxtContent,
 	}
 
-	globalSkip := false
-
 	for filename, content := range fileContentMap {
 		filePath := path.Join(cwd, filename)
 		fileExists, err := files.Exists(filePath)
@@ -77,58 +63,22 @@ func initCommand(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		shouldWrite := true
 		if fileExists {
-			if skipExisting {
-				console.Infof("Skipped existing %s", filename)
-				continue
-			}
-			if overwriteExisting {
-				console.Infof("Overwriting existing %s", filename)
-			} else {
-				// Check if we have a global choice from previous prompts
-				if globalSkip {
-					console.Infof("Skipped existing %s", filename)
-					continue
-				}
-				// Prompt for this specific file
-				choice, err := console.Interactive{
-					Prompt:  fmt.Sprintf("File %s already exists. What would you like to do?", filename),
-					Options: []string{"skip", "skip-all", "quit"},
-					Default: "skip",
-				}.Read()
-				if err != nil {
-					return err
-				}
-
-				switch choice {
-				case "skip":
-					console.Infof("Skipped existing %s", filename)
-					continue
-				case "skip-all":
-					globalSkip = true
-					console.Infof("Skipped existing %s (and will skip all remaining)", filename)
-					continue
-				case "quit":
-					console.Infof("Exiting without making changes")
-					return nil
-				}
-			}
+			console.Infof("Skipped existing %s", filename)
+			continue
 		}
 
-		if shouldWrite {
-			dirPath := path.Dir(filePath)
-			err = os.MkdirAll(dirPath, os.ModePerm)
-			if err != nil {
-				return fmt.Errorf("Error creating directory %s: %w", dirPath, err)
-			}
-
-			err = os.WriteFile(filePath, content, 0o644)
-			if err != nil {
-				return fmt.Errorf("Error writing %s: %w", filePath, err)
-			}
-			console.Infof("✅ Created %s", filePath)
+		dirPath := path.Dir(filePath)
+		err = os.MkdirAll(dirPath, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("Error creating directory %s: %w", dirPath, err)
 		}
+
+		err = os.WriteFile(filePath, content, 0o644)
+		if err != nil {
+			return fmt.Errorf("Error writing %s: %w", filePath, err)
+		}
+		console.Infof("✅ Created %s", filePath)
 	}
 
 	console.Infof("\nDone! For next steps, check out the docs at https://cog.run/getting-started")

--- a/pkg/cli/init_test.go
+++ b/pkg/cli/init_test.go
@@ -13,10 +13,6 @@ func TestInit(t *testing.T) {
 
 	require.NoError(t, os.Chdir(dir))
 
-	// Reset flags
-	skipExisting = false
-	overwriteExisting = false
-
 	err := initCommand(nil, []string{})
 	require.NoError(t, err)
 
@@ -29,10 +25,6 @@ func TestInitSkipExisting(t *testing.T) {
 	dir := t.TempDir()
 
 	require.NoError(t, os.Chdir(dir))
-
-	// Reset flags
-	skipExisting = false
-	overwriteExisting = false
 
 	// First run to create files
 	err := initCommand(nil, []string{})
@@ -47,9 +39,7 @@ func TestInitSkipExisting(t *testing.T) {
 	require.NoError(t, os.WriteFile(path.Join(dir, "predict.py"), []byte("test456"), 0o644))
 	require.NoError(t, os.WriteFile(path.Join(dir, ".dockerignore"), []byte("test789"), 0o644))
 
-	// Second run with skip-existing flag set
-	// mimics the behavior of `cog init --skip-existing`
-	skipExisting = true
+	// Second run should skip the files that already exist
 	err = initCommand(nil, []string{})
 	require.NoError(t, err)
 
@@ -69,50 +59,4 @@ func TestInitSkipExisting(t *testing.T) {
 	content, err = os.ReadFile(path.Join(dir, ".dockerignore"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("test789"), content)
-}
-
-func TestInitOverwriteExisting(t *testing.T) {
-	dir := t.TempDir()
-
-	require.NoError(t, os.Chdir(dir))
-
-	// Reset flags
-	skipExisting = false
-	overwriteExisting = false
-
-	// First run to create files
-	err := initCommand(nil, []string{})
-	require.NoError(t, err)
-
-	require.FileExists(t, path.Join(dir, ".dockerignore"))
-	require.FileExists(t, path.Join(dir, "cog.yaml"))
-	require.FileExists(t, path.Join(dir, "predict.py"))
-
-	// update the file to show that its the same file after the second run
-	require.NoError(t, os.WriteFile(path.Join(dir, "cog.yaml"), []byte("test123"), 0o644))
-	require.NoError(t, os.WriteFile(path.Join(dir, "predict.py"), []byte("test456"), 0o644))
-	require.NoError(t, os.WriteFile(path.Join(dir, ".dockerignore"), []byte("test789"), 0o644))
-
-	// Second run with overwrite-existing flag set
-	// mimics the behavior of `cog init --overwrite-existing`
-	overwriteExisting = true
-	err = initCommand(nil, []string{})
-	require.NoError(t, err)
-
-	require.FileExists(t, path.Join(dir, ".dockerignore"))
-	require.FileExists(t, path.Join(dir, "cog.yaml"))
-	require.FileExists(t, path.Join(dir, "predict.py"))
-
-	// check that the files are NOT the same as the first run
-	content, err := os.ReadFile(path.Join(dir, "cog.yaml"))
-	require.NoError(t, err)
-	require.NotEqual(t, []byte("test123"), content)
-
-	content, err = os.ReadFile(path.Join(dir, "predict.py"))
-	require.NoError(t, err)
-	require.NotEqual(t, []byte("test456"), content)
-
-	content, err = os.ReadFile(path.Join(dir, ".dockerignore"))
-	require.NoError(t, err)
-	require.NotEqual(t, []byte("test789"), content)
 }

--- a/pkg/cli/init_test.go
+++ b/pkg/cli/init_test.go
@@ -13,10 +13,106 @@ func TestInit(t *testing.T) {
 
 	require.NoError(t, os.Chdir(dir))
 
-	err := initCommand([]string{})
+	// Reset flags
+	skipExisting = false
+	overwriteExisting = false
+
+	err := initCommand(nil, []string{})
 	require.NoError(t, err)
 
 	require.FileExists(t, path.Join(dir, ".dockerignore"))
 	require.FileExists(t, path.Join(dir, "cog.yaml"))
 	require.FileExists(t, path.Join(dir, "predict.py"))
+}
+
+func TestInitSkipExisting(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.Chdir(dir))
+
+	// Reset flags
+	skipExisting = false
+	overwriteExisting = false
+
+	// First run to create files
+	err := initCommand(nil, []string{})
+	require.NoError(t, err)
+
+	require.FileExists(t, path.Join(dir, ".dockerignore"))
+	require.FileExists(t, path.Join(dir, "cog.yaml"))
+	require.FileExists(t, path.Join(dir, "predict.py"))
+
+	// update the file to show that its the same file after the second run
+	require.NoError(t, os.WriteFile(path.Join(dir, "cog.yaml"), []byte("test123"), 0o644))
+	require.NoError(t, os.WriteFile(path.Join(dir, "predict.py"), []byte("test456"), 0o644))
+	require.NoError(t, os.WriteFile(path.Join(dir, ".dockerignore"), []byte("test789"), 0o644))
+
+	// Second run with skip-existing flag set
+	// mimics the behavior of `cog init --skip-existing`
+	skipExisting = true
+	err = initCommand(nil, []string{})
+	require.NoError(t, err)
+
+	require.FileExists(t, path.Join(dir, ".dockerignore"))
+	require.FileExists(t, path.Join(dir, "cog.yaml"))
+	require.FileExists(t, path.Join(dir, "predict.py"))
+
+	// check that the files are the same as the first run
+	content, err := os.ReadFile(path.Join(dir, "cog.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("test123"), content)
+
+	content, err = os.ReadFile(path.Join(dir, "predict.py"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("test456"), content)
+
+	content, err = os.ReadFile(path.Join(dir, ".dockerignore"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("test789"), content)
+}
+
+func TestInitOverwriteExisting(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.Chdir(dir))
+
+	// Reset flags
+	skipExisting = false
+	overwriteExisting = false
+
+	// First run to create files
+	err := initCommand(nil, []string{})
+	require.NoError(t, err)
+
+	require.FileExists(t, path.Join(dir, ".dockerignore"))
+	require.FileExists(t, path.Join(dir, "cog.yaml"))
+	require.FileExists(t, path.Join(dir, "predict.py"))
+
+	// update the file to show that its the same file after the second run
+	require.NoError(t, os.WriteFile(path.Join(dir, "cog.yaml"), []byte("test123"), 0o644))
+	require.NoError(t, os.WriteFile(path.Join(dir, "predict.py"), []byte("test456"), 0o644))
+	require.NoError(t, os.WriteFile(path.Join(dir, ".dockerignore"), []byte("test789"), 0o644))
+
+	// Second run with overwrite-existing flag set
+	// mimics the behavior of `cog init --overwrite-existing`
+	overwriteExisting = true
+	err = initCommand(nil, []string{})
+	require.NoError(t, err)
+
+	require.FileExists(t, path.Join(dir, ".dockerignore"))
+	require.FileExists(t, path.Join(dir, "cog.yaml"))
+	require.FileExists(t, path.Join(dir, "predict.py"))
+
+	// check that the files are NOT the same as the first run
+	content, err := os.ReadFile(path.Join(dir, "cog.yaml"))
+	require.NoError(t, err)
+	require.NotEqual(t, []byte("test123"), content)
+
+	content, err = os.ReadFile(path.Join(dir, "predict.py"))
+	require.NoError(t, err)
+	require.NotEqual(t, []byte("test456"), content)
+
+	content, err = os.ReadFile(path.Join(dir, ".dockerignore"))
+	require.NoError(t, err)
+	require.NotEqual(t, []byte("test789"), content)
 }


### PR DESCRIPTION
This updates the `cog init` command to allow for skipping files that already exists either one by one or all at once

It also adds two cli flags `--skip-existing` and `--overwrite-existing` which will either:
1. skip all existing flags without prompting
2. overwrite all existing flags without prompting

I chose to not just skip existing by default as to be more consistent with the existing behavior, but I could also see the argument that we just want to always skip all existing files.. so would like to get feedback here

## Example Run

```
Setting up the current directory for use with Cog...

File cog.yaml already exists. What would you like to do? (default: skip, options: skip, skip-all, quit): skip
Skipped existing cog.yaml
✅ Created /Users/markphelps/workspace/replicate/pipelines-test/predict.py
File .dockerignore already exists. What would you like to do? (default: skip, options: skip, skip-all, quit): skip-all
Skipped existing .dockerignore (and will skip all remaining)
Skipped existing .github/workflows/push.yaml
Skipped existing requirements.txt

Done! For next steps, check out the docs at https://cog.run/getting-started
```