### PR TITLE
Bugfix: fix crash when put with the same id repeatly when use use concurrency and max > 1

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -425,6 +425,16 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
                     jsonable_encoder(task.result),
                     status_code=202,
                 )
+        else:
+            # even if not busy (use concurrency and max > 1) ,
+            # but someone put with the same prediction id repeatedly ,
+            # return its current state.
+            task = runner.get_predict_task(request.id)
+            if task:
+                return JSONResponse(
+                    jsonable_encoder(task.result),
+                    status_code=202,
+                )
 
         # TODO: spec-compliant parsing of Prefer header.
         respond_async = prefer == "respond-async"


### PR DESCRIPTION
When use async concurrency and max > 1, repeatedly put with the same prediction id ,will cause the cog server crash.
when put the same id ,we should return its current state , just like no concurrency or with concurrency but max = 1.
#2454 