### PR TITLE
Keep requirements.txt in sync for pipeline models

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,6 @@ github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxK
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnephin/pflag v1.0.7 h1:oxONGlWxhmUct0YzKTgrpQv9AUA1wtPBn7zuSjJqptk=
 github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Zm7OQE=
-github.com/docker/cli v28.1.1+incompatible h1:eyUemzeI45DY7eDPuwUcmDyDj1pM98oD5MdSpiItp8k=
-github.com/docker/cli v28.1.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v28.3.0+incompatible h1:s+ttruVLhB5ayeuf2BciwDVxYdKi+RoUlxmwNHV3Vfo=
 github.com/docker/cli v28.3.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/replicate/cog/pkg/env"
 	"github.com/replicate/cog/pkg/util/console"
 	"github.com/replicate/cog/pkg/util/files"
 )
@@ -133,6 +135,20 @@ func processTemplateFile(fs embed.FS, templateDir, filename, cwd string) error {
 		} else {
 			content = downloadedContent
 		}
+	} else if filename == "requirements.txt" && pipelineTemplate {
+		// Special handling for requirements.txt in pipeline templates - download from runtime
+		downloadedContent, err := downloadPipelineRequirementsFile()
+		if err != nil {
+			console.Infof("Failed to download pipeline requirements.txt: %v", err)
+			console.Infof("Using template version instead...")
+			// Fall back to template version
+			content, err = fs.ReadFile(path.Join(templateDir, filename))
+			if err != nil {
+				return fmt.Errorf("Error reading template %s: %w", filename, err)
+			}
+		} else {
+			content = downloadedContent
+		}
 	} else {
 		// Regular template file processing
 		content, err = fs.ReadFile(path.Join(templateDir, filename))
@@ -172,6 +188,40 @@ func downloadAgentsFile() ([]byte, error) {
 	}
 
 	return content, nil
+}
+
+func downloadPipelineRequirementsFile() ([]byte, error) {
+	requirementsURL := pipelinesRuntimeRequirementsURL()
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	resp, err := client.Get(requirementsURL.String())
+	if err != nil {
+		return nil, fmt.Errorf("%w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	return content, nil
+}
+
+func pipelinesRuntimeRequirementsURL() url.URL {
+	baseURL := url.URL{
+		Scheme: env.SchemeFromEnvironment(),
+		Host:   env.PipelinesRuntimeHostFromEnvironment(),
+	}
+	baseURL.Path = "requirements.txt"
+	return baseURL
 }
 
 func addPipelineInit(cmd *cobra.Command) {

--- a/pkg/docker/pipeline_push.go
+++ b/pkg/docker/pipeline_push.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/replicate/cog/pkg/api"
 	"github.com/replicate/cog/pkg/config"
@@ -16,25 +17,44 @@ import (
 )
 
 func PipelinePush(ctx context.Context, image string, projectDir string, apiClient *api.Client, client *http.Client, cfg *config.Config) error {
-	err := procedure.Validate(projectDir, client, cfg, false)
+	err := procedure.Validate(projectDir, client, cfg, true)
 	if err != nil {
 		return err
 	}
 
-	tarball, err := createTarball(projectDir)
+	tarball, err := createTarball(projectDir, cfg)
 	if err != nil {
 		return err
 	}
 	return apiClient.PostNewPipeline(ctx, image, tarball)
 }
 
-func createTarball(folder string) (*bytes.Buffer, error) {
+func createTarball(folder string, cfg *config.Config) (*bytes.Buffer, error) {
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
 
 	matcher, err := dockerignore.CreateMatcher(folder)
 	if err != nil {
 		return nil, err
+	}
+
+	// Track if we need to add downloaded requirements to the tarball
+	var downloadedRequirementsPath string
+	var downloadedRequirementsContent []byte
+
+	// If config points to downloaded requirements (outside project directory),
+	// we need to include them in the tarball as requirements.txt
+	if cfg.Build.PythonRequirements != "" {
+		reqPath := cfg.RequirementsFile(folder)
+		if !strings.HasPrefix(reqPath, folder) || strings.Contains(reqPath, ".cog") {
+			// This is a downloaded requirements file, read its content
+			content, err := os.ReadFile(reqPath)
+			if err != nil {
+				return nil, err
+			}
+			downloadedRequirementsPath = "requirements.txt"
+			downloadedRequirementsContent = content
+		}
 	}
 
 	err = dockerignore.Walk(folder, matcher, func(path string, info os.FileInfo, err error) error {
@@ -49,6 +69,12 @@ func createTarball(folder string) (*bytes.Buffer, error) {
 		relPath, err := filepath.Rel(folder, path)
 		if err != nil {
 			return err
+		}
+
+		// If this is the local requirements.txt and we have downloaded requirements,
+		// skip the local one (we'll add the downloaded version instead)
+		if downloadedRequirementsPath != "" && relPath == "requirements.txt" {
+			return nil
 		}
 
 		file, err := os.Open(path)
@@ -76,6 +102,25 @@ func createTarball(folder string) (*bytes.Buffer, error) {
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// Add downloaded requirements as requirements.txt if we have them
+	if downloadedRequirementsPath != "" {
+		header := &tar.Header{
+			Name: downloadedRequirementsPath,
+			Mode: 0644,
+			Size: int64(len(downloadedRequirementsContent)),
+		}
+
+		err = tw.WriteHeader(header)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = tw.Write(downloadedRequirementsContent)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if err := tw.Close(); err != nil {

--- a/pkg/procedure/validate.go
+++ b/pkg/procedure/validate.go
@@ -2,6 +2,7 @@ package procedure
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -177,6 +178,14 @@ func validateRequirements(projectDir string, client *http.Client, cfg *config.Co
 
 	if fill {
 		cfg.Build.PythonRequirements = requirementsFilePath
+		
+		// Also update the local requirements.txt to match the runtime requirements
+		// This ensures the local file stays in sync with what's actually available in production
+		err := updateLocalRequirementsFile(projectDir, requirementsFilePath)
+		if err != nil {
+			// Log warning but don't fail the build - the downloaded requirements will still be used
+			console.Warn(fmt.Sprintf("Failed to update local requirements.txt: %v", err))
+		}
 	}
 
 	return nil
@@ -241,6 +250,27 @@ func downloadRequirements(projectDir string, client *http.Client) (string, error
 	}
 
 	return requirementsFilePath, nil
+}
+
+// updateLocalRequirementsFile copies the downloaded requirements to the local requirements.txt file
+// This keeps the local file in sync with what's actually available in the runtime
+func updateLocalRequirementsFile(projectDir, downloadedRequirementsPath string) error {
+	// Read the downloaded requirements
+	downloadedPath := filepath.Join(projectDir, downloadedRequirementsPath)
+	downloadedContent, err := os.ReadFile(downloadedPath)
+	if err != nil {
+		return fmt.Errorf("failed to read downloaded requirements: %w", err)
+	}
+	
+	// Write to local requirements.txt
+	localRequirementsPath := filepath.Join(projectDir, "requirements.txt")
+	err = os.WriteFile(localRequirementsPath, downloadedContent, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write local requirements.txt: %w", err)
+	}
+	
+	console.Infof("Updated local requirements.txt with runtime requirements")
+	return nil
 }
 
 func requirementsURL() url.URL {

--- a/test-integration/test_integration/fixtures/pipeline-requirements-project/cog.yaml
+++ b/test-integration/test_integration/fixtures/pipeline-requirements-project/cog.yaml
@@ -1,0 +1,4 @@
+build:
+  python_version: "3.13"
+  python_requirements: "requirements.txt"
+predict: "predict.py:Predictor"

--- a/test-integration/test_integration/fixtures/pipeline-requirements-project/predict.py
+++ b/test-integration/test_integration/fixtures/pipeline-requirements-project/predict.py
@@ -1,0 +1,21 @@
+from cog import BasePredictor
+import importlib.metadata
+
+class Predictor(BasePredictor):
+    def predict(self) -> str:
+        """Test function that verifies downloaded requirements are available"""
+        
+        try:
+            # Get all installed packages and their versions
+            packages = []
+            for dist in importlib.metadata.distributions():
+                packages.append(f"{dist.metadata['name']}=={dist.version}")
+            
+            # Sort for consistent output
+            packages.sort()
+            
+            # Create output with prompt and all packages listed
+            return '\n'.join(packages)
+            
+        except Exception as e:
+            return f"ERROR: Unexpected error - {str(e)}"

--- a/test-integration/test_integration/fixtures/pipeline-requirements-project/requirements.txt
+++ b/test-integration/test_integration/fixtures/pipeline-requirements-project/requirements.txt
@@ -1,0 +1,8 @@
+# pipelines-runtime@sha256:d1b9fbd673288453fdf12806f4cba9e9e454f0f89b187eac2db5731792f71d60
+moviepy==v2.2.1
+numpy==v2.3.2
+pillow==v11.3.0
+pydantic==v1.10.22
+replicate==v2.0.0a22
+requests==v2.32.5
+scikit-learn==v1.7.1

--- a/test-integration/test_integration/test_predict.py
+++ b/test-integration/test_integration/test_predict.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import httpx
 import pytest
+from pytest_httpserver import HTTPServer
+from werkzeug import Request, Response
 
 from .util import cog_server_http_run
 
@@ -866,3 +868,80 @@ def test_predict_cog_runtime_int_negative(cog_binary):
     )
     assert result.returncode == 0
     assert result.stdout == "-20\n"
+
+
+def test_predict_pipeline_downloaded_requirements(cog_binary):
+    """Test that pipeline builds download runtime requirements and make dependencies available"""
+    project_dir = Path(__file__).parent / "fixtures/pipeline-requirements-project"
+
+    # Create a mock requirements file that includes basic packages needed for validation
+    mock_requirements = """# Mock runtime requirements for testing
+requests==2.32.5
+urllib3==2.0.4
+"""
+
+    # Set up a mock HTTP server to serve the requirements file
+    with HTTPServer(host="127.0.0.1", port=0) as httpserver:
+
+        def requirements_handler(request: Request) -> Response:
+            if request.path == "/requirements.txt":
+                # Include ETag header as expected by the requirements download logic
+                headers = {"ETag": '"mock-requirements-etag-123"'}
+                return Response(
+                    mock_requirements,
+                    status=200,
+                    headers=headers,
+                    content_type="text/plain",
+                )
+            return Response("Not Found", status=404)
+
+        httpserver.expect_request("/requirements.txt").respond_with_handler(
+            requirements_handler
+        )
+
+        # Get the server URL (context manager already started the server)
+        server_host = f"127.0.0.1:{httpserver.port}"
+
+        # Run prediction with pipeline flag and mock server
+        env = os.environ.copy()
+        env["R8_PIPELINES_RUNTIME_HOST"] = server_host
+        env["R8_SCHEME"] = "http"  # Use HTTP instead of HTTPS for testing
+
+        result = subprocess.run(
+            [cog_binary, "predict", "--x-pipeline", "--debug"],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=120.0,
+            env=env,
+        )
+
+        # Should succeed since packages should be available from downloaded requirements
+        assert result.returncode == 0
+
+        # The output should list all installed packages (one per line)
+        # No header since predict function was simplified to just return package list
+        assert len(result.stdout.strip().split('\n')) > 10  # Should have many packages
+
+        # Should not contain error messages
+        assert "ERROR:" not in result.stdout
+
+        # Verify that the mock requirements were downloaded by checking debug output
+        assert "Generated requirements.txt:" in result.stderr
+        # Should show requests from our mock requirements (proves download worked)
+        assert "requests==2.32.5" in result.stderr
+
+        # Verify that specific versions from mock are present in the installed packages list
+        # This proves the mock requirements were actually installed and used
+        assert "requests==2.32.5" in result.stdout
+        assert (
+            "urllib3==" in result.stdout
+        )  # Just check that urllib3 is present with some version
+        
+        # Verify that the local requirements.txt file was updated with mock requirements
+        local_requirements_path = project_dir / "requirements.txt"
+        with open(local_requirements_path, 'r') as f:
+            local_requirements_content = f.read()
+        # Should contain our mock requirements
+        assert "requests==2.32.5" in local_requirements_content
+        assert "# Mock runtime requirements for testing" in local_requirements_content


### PR DESCRIPTION
The packages installed in the pipelines-runtime image are drifting from what's specified by cog, which means that models may work locally but fail when deployed.

The proper fix for this is to bundle requirements/venv with the procedure. But that's out of scope. Until then this PR, which I admit is gross, will ensure the local requirements.txt file is always updated from the requirements.txt file generated by the pipelines-runtime build.