### PR TITLE
fix: update transformers to 4.55.2 for vllm compatibility

### DIFF
--- a/test-integration/test_integration/fixtures/granite-project/requirements.txt
+++ b/test-integration/test_integration/fixtures/granite-project/requirements.txt
@@ -382,7 +382,7 @@ tqdm==4.67.1
     #   outlines
     #   transformers
     #   vllm
-transformers==4.51.1
+transformers==4.55.2
     # via
     #   compressed-tensors
     #   vllm


### PR DESCRIPTION
## Summary
- Updates transformers from 4.51.1 to 4.55.2 in granite-project integration test fixture

## Problem
Integration tests were failing in CI with dependency conflicts:
```
vllm 0.10.2 depends on transformers>=4.55.2
```

But the granite-project fixture had `transformers==4.51.1` pinned in requirements.txt, causing pip to fail during Docker build.

## Solution
Updated transformers to 4.55.2 to satisfy vllm's minimum version requirement.

## Test plan
- CI integration tests should pass