### PR TITLE
Improve error message when docker credential helper fails

### DIFF
--- a/pkg/docker/credentials.go
+++ b/pkg/docker/credentials.go
@@ -131,7 +131,11 @@ func loadAuthFromCredentialsStore(ctx context.Context, credsStore string, regist
 	}
 	err = cmd.Wait()
 	if err != nil {
-		return nil, fmt.Errorf("exec wait error: %w", err)
+		output := strings.TrimSpace(out.String())
+		if output != "" {
+			return nil, fmt.Errorf("failed to get credentials for %q: %s", registryHost, output)
+		}
+		return nil, fmt.Errorf("failed to get credentials for %q: %w", registryHost, err)
 	}
 
 	var config CredentialHelperInput


### PR DESCRIPTION
If registry credentials can't be fetched from the credential helper (eg waiting for yubikey auth or an unexpected error) we show a suboptimal error message, like:

```
ⅹ exec wait error: exit status 1
```

now we'll show this:
```
ⅹ failed to get credentials for "r8.im": credentials not found in native keychain
```