### PR TITLE
Expose prediction IDs for model code

### DIFF
--- a/python/cog/server/runner.py
+++ b/python/cog/server/runner.py
@@ -113,6 +113,11 @@ class PredictionRunner:
         else:
             payload = prediction.input.copy()
 
+        if prediction.context is None:
+            prediction.context = {}
+        if prediction.id is not None:
+            prediction.context["id"] = prediction.id
+
         sid = self._worker.subscribe(task.handle_event, tag=tag)
         task.track(self._worker.predict(payload, context=prediction.context, tag=tag))
         task.add_done_callback(self._task_done_callback(tag, sid))


### PR DESCRIPTION
### Summary

We have a need in certain situations to have the model code be able to access the prediction ID. We are doing this by shoving it into the context, which in turn gets shoved into the scope, which the model code should be able to call using `cog.current_scope()["id"]`