### PR TITLE
Add COG_CA_CERT env var to inject custom CA certificates into builds

### DIFF
--- a/integration-tests/harness/harness.go
+++ b/integration-tests/harness/harness.go
@@ -26,6 +26,8 @@ type Harness struct {
 	CogBinary string
 	// realHome is captured at creation time before testscript overrides HOME
 	realHome string
+	// repoRoot is the path to the cog repository root
+	repoRoot string
 	// serverProcs tracks background cog serve processes for cleanup, keyed by work directory
 	serverProcs   map[string]*exec.Cmd
 	serverProcsMu sync.Mutex
@@ -37,9 +39,14 @@ func New() (*Harness, error) {
 	if err != nil {
 		return nil, err
 	}
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		return nil, err
+	}
 	return &Harness{
 		CogBinary:   cogBinary,
 		realHome:    os.Getenv("HOME"),
+		repoRoot:    repoRoot,
 		serverProcs: make(map[string]*exec.Cmd),
 	}, nil
 }
@@ -158,6 +165,7 @@ func (h *Harness) Commands() map[string]func(ts *testscript.TestScript, neg bool
 		"curl":       h.cmdCurl,
 		"wait-for":   h.cmdWaitFor,
 		"retry-curl": h.cmdRetryCurl,
+		"docker-run": h.cmdDockerRun,
 	}
 }
 
@@ -204,6 +212,9 @@ func (h *Harness) Setup(env *testscript.Env) error {
 	// Docker credential helpers (e.g., docker-credential-desktop) need the real HOME
 	// to access the macOS keychain.
 	env.Setenv("HOME", h.realHome)
+
+	// Export repo root for tests that need to reference files outside the work directory
+	env.Setenv("REPO_ROOT", h.repoRoot)
 
 	// Disable update checks during tests
 	env.Setenv("COG_NO_UPDATE_CHECK", "1")
@@ -708,6 +719,51 @@ func (h *Harness) cmdRetryCurl(ts *testscript.TestScript, neg bool, args []strin
 			}
 			ts.Logf("retry-curl: full response body: %s", lastBody)
 			ts.Fatalf("retry-curl: all %d attempts failed with status %d: %s", maxAttempts, lastStatus, errorMsg)
+		}
+	}
+}
+
+// cmdDockerRun implements the 'docker-run' command for testscript.
+// It runs a command inside a Docker container.
+// Usage:
+//
+//	docker-run <image> <command> [args...]
+//
+// The container is run with:
+//   - --rm (auto-remove after exit)
+//   - --add-host=host.docker.internal:host-gateway (for Linux compatibility)
+//   - Working directory mounted if needed
+func (h *Harness) cmdDockerRun(ts *testscript.TestScript, neg bool, args []string) {
+	if len(args) < 2 {
+		ts.Fatalf("docker-run: usage: docker-run <image> <command> [args...]")
+	}
+
+	image := os.Expand(args[0], ts.Getenv)
+	containerArgs := make([]string, len(args)-1)
+	for i, arg := range args[1:] {
+		containerArgs[i] = os.Expand(arg, ts.Getenv)
+	}
+
+	// Build docker run command
+	dockerArgs := []string{
+		"run", "--rm",
+		"--add-host=host.docker.internal:host-gateway",
+		image,
+	}
+	dockerArgs = append(dockerArgs, containerArgs...)
+
+	cmd := exec.Command("docker", dockerArgs...)
+	cmd.Stdout = ts.Stdout()
+	cmd.Stderr = ts.Stderr()
+
+	err := cmd.Run()
+	if neg {
+		if err == nil {
+			ts.Fatalf("docker-run: command succeeded unexpectedly")
+		}
+	} else {
+		if err != nil {
+			ts.Fatalf("docker-run: command failed: %v", err)
 		}
 	}
 }

--- a/integration-tests/tests/ca_cert.txtar
+++ b/integration-tests/tests/ca_cert.txtar
@@ -1,0 +1,127 @@
+# Test CA certificate injection via COG_CA_CERT
+#
+# This test verifies that custom CA certificates can be injected into
+# cog-built images, allowing HTTPS connections to servers using those CAs.
+
+# Build the HTTPS test server helper
+exec go build -C $REPO_ROOT/test-helpers/https-server -o $WORK/https-server .
+
+# Start the HTTPS test server in background using the embedded certs
+exec $WORK/https-server --cert=$WORK/certs/server.crt --key=$WORK/certs/server.key --addr=:8443 &
+
+# Wait for the server to be ready
+exec sh -c 'for i in 1 2 3 4 5 6 7 8 9 10; do curl -ksf https://localhost:8443/ && exit 0; sleep 1; done; exit 1'
+
+# Build a minimal cog image
+cog build -t $TEST_IMAGE
+
+# ============================================
+# Test 1: Without CA cert, HTTPS should FAIL
+# ============================================
+# The container tries to curl the HTTPS server, which uses a self-signed cert.
+# Without the CA cert installed, this should fail with a certificate error.
+! docker-run $TEST_IMAGE curl --fail --max-time 5 https://host.docker.internal:8443/
+
+# ============================================
+# Test 2: With COG_CA_CERT, HTTPS should WORK
+# ============================================
+# Set the CA cert environment variable and rebuild
+env COG_CA_CERT=$WORK/certs/ca.crt
+
+cog build -t $TEST_IMAGE-with-ca
+
+# Now the HTTPS request should succeed because the CA cert is installed
+docker-run $TEST_IMAGE-with-ca curl --fail --max-time 5 https://host.docker.internal:8443/
+stdout 'OK'
+
+# Verify the environment variables are set correctly in the image
+docker-run $TEST_IMAGE-with-ca printenv SSL_CERT_FILE
+stdout '/etc/ssl/certs/ca-certificates.crt'
+
+docker-run $TEST_IMAGE-with-ca printenv REQUESTS_CA_BUNDLE
+stdout '/etc/ssl/certs/ca-certificates.crt'
+
+-- cog.yaml --
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"
+
+-- predict.py --
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, text: str) -> str:
+        return text
+
+-- certs/ca.crt --
+-----BEGIN CERTIFICATE-----
+MIIDDTCCAfWgAwIBAgIUayiqAjIWvavCGAlFwU4CtOlDyjgwDQYJKoZIhvcNAQEL
+BQAwFjEUMBIGA1UEAwwLQ29nIFRlc3QgQ0EwHhcNMjYwMTE0MjAxMjE0WhcNMzYw
+MTEyMjAxMjE0WjAWMRQwEgYDVQQDDAtDb2cgVGVzdCBDQTCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAOanC1VJPLjZrfW+hLL6FmDsnNokMU1rI8KCWjrE
+G2BLWOODSOECd1TWuJ84leiwOKuqj9FXlHzf0wr/D6MnQq39R4yDHKdbHYVuwRBu
+uP3M3M3LWkqs7FDcXRz2htEoSoFAfoNo85Paj8rpFYwzLsuS/DtxX2yM5ja1UAZk
+SNjrWF7DY97cT9njLF2QYFLj1unWAlVKoR90cYZZ72S4QIWsTQXBNN3GR/GC80AJ
+vaxC83n4fCN94vJgO4reMAlojFNlXSgqQkEf8z+SMcuzHNcV/FkNOArTXHaYLeaB
+yKChtDIlHV9W0+Ifsr+qYkWCN2Aznw5Yz5bhXrFLd+BcHUcCAwEAAaNTMFEwHQYD
+VR0OBBYEFDAHM6Rgg47dX2D0h7gBw365IZ6kMB8GA1UdIwQYMBaAFDAHM6Rgg47d
+X2D0h7gBw365IZ6kMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEB
+AMd8xNa6BO7nZBfpwrPaijLMawIkv37ngM2dkNFKPMV/Vl9urAAnCDtjFq/pCXnC
+lXvja0vy6nFmRITmetabLdhBHeDe8lcV1OHgyksy6AnRT6zLu/Jw3cx5/U3zLwM7
+zLZkSylhYaNVpqaTRyzdFbP5V8h/QjpL+ffYTQgNMtRT0PphV4AvAqpfJJ18Jtcc
+K4jIXYMUKU4ZkAT9JUSTXa2aefudzjMMr9GwvZGn/6ZpU3Y8H/DmmizoHNQRuC97
+uGnxwufInGQ9W20UnUam9May0tsea654Ebtjw7QDzvMTFIsMFVOjBVOXMuB8PAfL
+ATgc+2ToYm+V3Z1f46mm/4U=
+-----END CERTIFICATE-----
+
+-- certs/server.crt --
+-----BEGIN CERTIFICATE-----
+MIIDRzCCAi+gAwIBAgIUa+aDQvQpf7Sq+7foxZ7MNjJKcnIwDQYJKoZIhvcNAQEL
+BQAwFjEUMBIGA1UEAwwLQ29nIFRlc3QgQ0EwHhcNMjYwMTE0MjAxMjE5WhcNMzYw
+MTEyMjAxMjE5WjAfMR0wGwYDVQQDDBRob3N0LmRvY2tlci5pbnRlcm5hbDCCASIw
+DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJuuQyShcfUyXWhVzYGZ2UTo2Do1
+TfHFrcHLsXB2UvuMnH67x3h1ylLM2gmMnMipVFVTL6OAhZQi9BHiRRoCepMyFJKU
+RKxkXpIF6knfsmB3FsAcTKale3PUYrzTj63BCGZmnS768Drv9e48A2ZvsPTBkyuN
+kjTgC8tIDt5b8xKMRDFG5ZhBxC2+nNBoLBB4ujBF32dWcxGWkFUWsIyN3oH3MsQp
+ydO2FnOlc+bQI/hlanl+4CnL/TczOe5O906TL/oC8Wq5nYooGgfG2ZDfSpw7/Ver
+lE0nc4Sy8+d8XL2fNWgM9ISL2sCJ1DT8dZVufmda5MIo0UMCRzCmy0Q6aqcCAwEA
+AaOBgzCBgDA+BgNVHREENzA1ghRob3N0LmRvY2tlci5pbnRlcm5hbIIJbG9jYWxo
+b3N0ggxodHRwcy1zZXJ2ZXKHBH8AAAEwHQYDVR0OBBYEFK/uLPc1TpgjXzMTPCMJ
+Qjfx52+6MB8GA1UdIwQYMBaAFDAHM6Rgg47dX2D0h7gBw365IZ6kMA0GCSqGSIb3
+DQEBCwUAA4IBAQBYvP1G1bJM6tOVixEqpxWkGd6Ghr3J/R4hzJDKtMfO8O4FdlZJ
+FG9OaAXJqWmlXszXF2cD2IcdOeayR1oTDTyaId464Y5Fi5WDhaIOAuwlepvAwQod
+p1xXbbI6k2n60sSvaCOT9KWwM/zMda94awc2oBYWAaqAJWtRqR+sHnpIe5PmVQN/
+kMfugBZCt21v6tvOEyc94xU6XgqYbbAyZlrFL33KbDpOhnEQzq4F0fKcWit3STR1
+oyzlcWaFNysaNOBjxBflBMIKMnpg3DvcK8SUHqCDYjGZzodtC/7f7/I/1zkBvouN
+AdvFtZREbY0xv0tnHl0Afx46Z+hR9rPtjzWh
+-----END CERTIFICATE-----
+
+-- certs/server.key --
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCbrkMkoXH1Ml1o
+Vc2BmdlE6Ng6NU3xxa3By7FwdlL7jJx+u8d4dcpSzNoJjJzIqVRVUy+jgIWUIvQR
+4kUaAnqTMhSSlESsZF6SBepJ37JgdxbAHEympXtz1GK804+twQhmZp0u+vA67/Xu
+PANmb7D0wZMrjZI04AvLSA7eW/MSjEQxRuWYQcQtvpzQaCwQeLowRd9nVnMRlpBV
+FrCMjd6B9zLEKcnTthZzpXPm0CP4ZWp5fuApy/03MznuTvdOky/6AvFquZ2KKBoH
+xtmQ30qcO/1Xq5RNJ3OEsvPnfFy9nzVoDPSEi9rAidQ0/HWVbn5nWuTCKNFDAkcw
+pstEOmqnAgMBAAECggEAC+dIJP3fK8NdFwQwgW9VCIrRNaoruofF4GKFv7acY7V9
+pccP2msPPEODjGVe+4zO8PM6WkMSc6A0j0WAyRtVafnTTt3dXl0SShH/twROrEeO
+ysOfLMLMbK/ZmNyISN3QmZvQ+u2e/rKoWD3oeKWjnyNJ8HOTsU1MOY/Z6zCWpl1K
+pAiVVvDVvUzrenMLVHlbyHXPYOS+oktctVd57bCNnipG4b/i4pqw08LAkP26jSCm
+yIOg0r+RocN4GhhbmzP4Plmv0JCXhQposIDhC7KfbXEWaa3nFF2nfR5QPVUF5tht
+xLPVrBMac8oT2owQoerhrgCQLi3b4Lmdloz7TwEcQQKBgQDVrwajIW1z5W+HdUm6
+VcJf6+I9v4vL0EXPMSK4+XwLzTkC/RCz0wPfrRGlhdrMZ1wU9zCqFw1LCp+ixsMN
+tC3MWGncFY5TOVf+jqom3PTESC5O9AySRAqI1jE9BwnmDkLpQ5zkYZaF/MAg07px
+CW5r43EKGL5AW4Umv0OEuAEExwKBgQC6grMIz4IuWnZhj03DPRqSx4AymyqrzMjp
+kNzCb1Wz6iKFMeIIPC8Mz0iju9QBVofh8Lxj1Bdqbh3kN4NyfT8nII3i/6Cvb9Ol
+agMgTq1q5BgcSl4jliDbn1gCMq9MCJf8y+xXDQCLIKNaJidXQjQZn1XK/bV1IkPx
+lkuG6znLIQKBgEVcV+Ix4o5hJi+pEbKLTdnG/pwehek1hMN5ZpT2Xp6SEfR3YqmM
+UFCVpAm/hkMdNdWUW1aKvwThwOmcbQoQt2ECPfJziMxY68g0VOTiig0AhQ+Zxk7g
+CS9bn4X4t+zWKj//c3jqeGqrnU3KjFVOw2n/3NxzJaZMTs9B/E+jTqlXAoGBALKc
+QanZVvjfBulM3BJxrMYNqZZNBGM8HNeYM+E7z54ZRW+6opRyVjh1NUIfuNqDLGPS
+MAeF79qrk5KfGxGEIfttcJOHbDE17UBGsrG4xthLkU9eZKK9vb+07ApG0ZsFy896
+1l1TBUc3PVgym5AzxUMYVIetyZ1f8CMmZDPThighAoGBAIaoc0LvNVW9O9wT74dr
+y1ThnmpgeIfg+4yyfY3Eel5wnfdOJ+J9g0vfV+PH/2B45Jdkr82L+XjPipzP3tqP
+fQnfvBCfWXqiCV5yTK4OcVCicKNRj25Oq0vUAgSua8tE6hFaIp5hnmbLYiLIyOAO
+ng5irDkEC4tQl7D4WoX1Viye
+-----END PRIVATE KEY-----

--- a/mise.toml
+++ b/mise.toml
@@ -9,3 +9,15 @@ _.file = [".env"]
 [settings]
 lockfile = true
 experimental = true
+
+[tasks.test-integration]
+description = "Run Go integration tests with optional filter"
+dir = "integration-tests"
+run = """
+#!/usr/bin/env bash
+if [ -n "$1" ]; then
+  go test -v -run "TestIntegration/$1" -timeout 10m
+else
+  go test -v -timeout 10m
+fi
+"""

--- a/pkg/dockerfile/cacert.go
+++ b/pkg/dockerfile/cacert.go
@@ -1,0 +1,168 @@
+package dockerfile
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/replicate/cog/pkg/util/console"
+)
+
+const (
+	// CACertEnvVar is the environment variable that specifies the CA certificate to inject
+	CACertEnvVar = "COG_CA_CERT"
+
+	// CACertFilename is the filename used for the CA cert in the build context and container
+	CACertFilename = "cog-ca-cert.crt"
+
+	// CACertContainerPath is where the cert is installed in the container
+	CACertContainerPath = "/usr/local/share/ca-certificates/" + CACertFilename
+
+	// SystemCertBundle is the path to the system certificate bundle after update-ca-certificates
+	SystemCertBundle = "/etc/ssl/certs/ca-certificates.crt"
+)
+
+// ReadCACert reads the CA certificate from the COG_CA_CERT environment variable.
+// It supports multiple input formats:
+//   - File path: /path/to/cert.crt
+//   - Directory: /path/to/certs/ (concatenates all *.crt and *.pem files)
+//   - Inline PEM: -----BEGIN CERTIFICATE-----...
+//   - Base64-encoded PEM: LS0tLS1CRUdJTi...
+//
+// Returns:
+//   - (nil, nil) if COG_CA_CERT is not set (no-op case)
+//   - (certBytes, nil) if a valid certificate was found
+//   - (nil, error) if the input is invalid
+func ReadCACert() ([]byte, error) {
+	value := os.Getenv(CACertEnvVar)
+	if value == "" {
+		return nil, nil
+	}
+
+	value = strings.TrimSpace(value)
+
+	// Check if it's a file path
+	if info, err := os.Stat(value); err == nil {
+		if info.IsDir() {
+			return readCACertDirectory(value)
+		}
+		return readCACertFile(value)
+	}
+
+	// Check if it's inline PEM
+	if strings.HasPrefix(value, "-----BEGIN") {
+		return validatePEM([]byte(value))
+	}
+
+	// Try base64 decoding
+	decoded, err := base64.StdEncoding.DecodeString(value)
+	if err == nil && strings.HasPrefix(string(decoded), "-----BEGIN") {
+		return validatePEM(decoded)
+	}
+
+	return nil, fmt.Errorf("%s: invalid value - must be a file path, directory, PEM certificate, or base64-encoded PEM", CACertEnvVar)
+}
+
+// readCACertFile reads a single certificate file
+func readCACertFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed to read file %s: %w", CACertEnvVar, path, err)
+	}
+	return validatePEM(data)
+}
+
+// readCACertDirectory reads all .crt and .pem files from a directory and concatenates them
+func readCACertDirectory(dir string) ([]byte, error) {
+	var certs []byte
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed to read directory %s: %w", CACertEnvVar, dir, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(entry.Name()))
+		if ext != ".crt" && ext != ".pem" {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("%s: failed to read file %s: %w", CACertEnvVar, path, err)
+		}
+
+		// Validate each cert
+		if _, err := validatePEM(data); err != nil {
+			return nil, fmt.Errorf("%s: invalid certificate in %s: %w", CACertEnvVar, path, err)
+		}
+
+		if len(certs) > 0 && !strings.HasSuffix(string(certs), "\n") {
+			certs = append(certs, '\n')
+		}
+		certs = append(certs, data...)
+	}
+
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("%s: no .crt or .pem files found in directory %s", CACertEnvVar, dir)
+	}
+
+	return certs, nil
+}
+
+// validatePEM checks that the data looks like a valid PEM certificate
+func validatePEM(data []byte) ([]byte, error) {
+	content := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(content, "-----BEGIN CERTIFICATE-----") {
+		return nil, fmt.Errorf("invalid PEM: must start with '-----BEGIN CERTIFICATE-----'")
+	}
+	if !strings.Contains(content, "-----END CERTIFICATE-----") {
+		return nil, fmt.Errorf("invalid PEM: must contain '-----END CERTIFICATE-----'")
+	}
+	return []byte(content + "\n"), nil
+}
+
+// GenerateCACertInstall generates the Dockerfile lines to install a CA certificate.
+// It writes the cert to the build context and returns the Dockerfile lines.
+//
+// The returned lines:
+//  1. COPY the cert to /usr/local/share/ca-certificates/
+//  2. RUN update-ca-certificates
+//  3. Set SSL_CERT_FILE and REQUESTS_CA_BUNDLE env vars
+//
+// Parameters:
+//   - certData: The PEM-encoded certificate data
+//   - writeTemp: Function to write a file to the build context (returns COPY lines and container path)
+//
+// Returns the Dockerfile lines to add, or error
+func GenerateCACertInstall(certData []byte, writeTemp func(filename string, contents []byte) ([]string, string, error)) (string, error) {
+	if len(certData) == 0 {
+		return "", nil
+	}
+
+	console.Infof("Injecting CA certificate from %s", CACertEnvVar)
+
+	// Write cert to build context
+	copyLines, _, err := writeTemp(CACertFilename, certData)
+	if err != nil {
+		return "", fmt.Errorf("failed to write CA certificate to build context: %w", err)
+	}
+
+	lines := []string{}
+	lines = append(lines, copyLines...)
+
+	// Copy to system CA directory, update the certificate store, and set env vars
+	lines = append(lines,
+		fmt.Sprintf("RUN cp /tmp/%s %s && update-ca-certificates", CACertFilename, CACertContainerPath),
+		fmt.Sprintf("ENV SSL_CERT_FILE=%s", SystemCertBundle),
+		fmt.Sprintf("ENV REQUESTS_CA_BUNDLE=%s", SystemCertBundle),
+	)
+
+	return strings.Join(lines, "\n"), nil
+}

--- a/pkg/dockerfile/cacert_test.go
+++ b/pkg/dockerfile/cacert_test.go
@@ -1,0 +1,181 @@
+package dockerfile
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testCertPEM = `-----BEGIN CERTIFICATE-----
+MIIBkTCB+wIJAKHBfpegPjMCMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBlRl
+c3RDQTAeFw0yNDAxMDEwMDAwMDBaFw0yNTAxMDEwMDAwMDBaMBExDzANBgNVBAMM
+BlRlc3RDQTBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC7o96WzE5gvnMXvPjNdXjH
+HwjE7F5Q4X5g5W5P5s5Q5Y5V5y5v5p5o5k5f5d5c5b5a5Z5X5W5U5T5S5R5P5N5L
+AgMBAAGjUzBRMB0GA1UdDgQWBBQExample1234567890ABCDEFGHIJKLMN
+MB8GA1UdIwQYMBaAFBQExample1234567890ABCDEFGHIJKLMNMA8GA1Ud
+EwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADQQBExample1234567890
+-----END CERTIFICATE-----`
+
+const testCertPEM2 = `-----BEGIN CERTIFICATE-----
+MIIBkTCB+wIJAKHBfpegPjMDMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBlRl
+c3RDQTAeFw0yNDAxMDEwMDAwMDBaFw0yNTAxMDEwMDAwMDBaMBExDzANBgNVBAMM
+BlRlc3RDQTBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC8p97XzF6hvoPYvQkOeYkI
+HxkF8G6Q5Y6h6X6Q6Z6W6z6w6q6p6l6g6e6d6c6b6a6Y6X6W6V6U6T6S6R6Q6O6M
+AgMBAAGjUzBRMB0GA1UdDgQWBBQExample2222222222ABCDEFGHIJKLMN
+MB8GA1UdIwQYMBaAFBQExample2222222222ABCDEFGHIJKLMNMA8GA1Ud
+EwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADQQBExample2222222222
+-----END CERTIFICATE-----`
+
+func TestReadCACert_NotSet(t *testing.T) {
+	os.Unsetenv(CACertEnvVar)
+
+	cert, err := ReadCACert()
+	require.NoError(t, err)
+	require.Nil(t, cert)
+}
+
+func TestReadCACert_FilePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	certPath := filepath.Join(tmpDir, "test.crt")
+	require.NoError(t, os.WriteFile(certPath, []byte(testCertPEM), 0o644))
+
+	t.Setenv(CACertEnvVar, certPath)
+
+	cert, err := ReadCACert()
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+	require.Contains(t, string(cert), "-----BEGIN CERTIFICATE-----")
+	require.Contains(t, string(cert), "-----END CERTIFICATE-----")
+}
+
+func TestReadCACert_Directory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write two cert files
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "cert1.crt"), []byte(testCertPEM), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "cert2.pem"), []byte(testCertPEM2), 0o644))
+	// Also write a non-cert file that should be ignored
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "readme.txt"), []byte("ignore me"), 0o644))
+
+	t.Setenv(CACertEnvVar, tmpDir)
+
+	cert, err := ReadCACert()
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+	// Should contain both certificates
+	require.Equal(t, 2, strings.Count(string(cert), "-----BEGIN CERTIFICATE-----"))
+	require.Equal(t, 2, strings.Count(string(cert), "-----END CERTIFICATE-----"))
+}
+
+func TestReadCACert_InlinePEM(t *testing.T) {
+	t.Setenv(CACertEnvVar, testCertPEM)
+
+	cert, err := ReadCACert()
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+	require.Contains(t, string(cert), "-----BEGIN CERTIFICATE-----")
+}
+
+func TestReadCACert_Base64EncodedPEM(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte(testCertPEM))
+	t.Setenv(CACertEnvVar, encoded)
+
+	cert, err := ReadCACert()
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+	require.Contains(t, string(cert), "-----BEGIN CERTIFICATE-----")
+}
+
+func TestReadCACert_InvalidPEM(t *testing.T) {
+	t.Setenv(CACertEnvVar, "not a valid certificate")
+
+	cert, err := ReadCACert()
+	require.Error(t, err)
+	require.Nil(t, cert)
+	require.Contains(t, err.Error(), "invalid value")
+}
+
+func TestReadCACert_MissingFile(t *testing.T) {
+	t.Setenv(CACertEnvVar, "/nonexistent/path/to/cert.crt")
+
+	cert, err := ReadCACert()
+	require.Error(t, err)
+	require.Nil(t, cert)
+	require.Contains(t, err.Error(), "invalid value")
+}
+
+func TestReadCACert_EmptyDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(CACertEnvVar, tmpDir)
+
+	cert, err := ReadCACert()
+	require.Error(t, err)
+	require.Nil(t, cert)
+	require.Contains(t, err.Error(), "no .crt or .pem files found")
+}
+
+func TestReadCACert_InvalidFileInDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Write an invalid cert file
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "bad.crt"), []byte("not a cert"), 0o644))
+
+	t.Setenv(CACertEnvVar, tmpDir)
+
+	cert, err := ReadCACert()
+	require.Error(t, err)
+	require.Nil(t, cert)
+	require.Contains(t, err.Error(), "invalid certificate")
+}
+
+func TestReadCACert_TrimsWhitespace(t *testing.T) {
+	// Test that whitespace is trimmed from the env var value
+	t.Setenv(CACertEnvVar, "  "+testCertPEM+"  \n")
+
+	cert, err := ReadCACert()
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+	require.True(t, strings.HasPrefix(string(cert), "-----BEGIN"))
+}
+
+func TestGenerateCACertInstall(t *testing.T) {
+	var writtenFilename string
+	var writtenContents []byte
+
+	mockWriteTemp := func(filename string, contents []byte) ([]string, string, error) {
+		writtenFilename = filename
+		writtenContents = contents
+		return []string{"COPY .cog/tmp/" + filename + " /tmp/" + filename}, "/tmp/" + filename, nil
+	}
+
+	result, err := GenerateCACertInstall([]byte(testCertPEM), mockWriteTemp)
+	require.NoError(t, err)
+
+	// Check that the cert was written
+	require.Equal(t, CACertFilename, writtenFilename)
+	require.Contains(t, string(writtenContents), "-----BEGIN CERTIFICATE-----")
+
+	// Check the generated Dockerfile lines
+	require.Contains(t, result, "COPY .cog/tmp/"+CACertFilename)
+	require.Contains(t, result, "update-ca-certificates")
+	require.Contains(t, result, "ENV SSL_CERT_FILE="+SystemCertBundle)
+	require.Contains(t, result, "ENV REQUESTS_CA_BUNDLE="+SystemCertBundle)
+}
+
+func TestGenerateCACertInstall_EmptyData(t *testing.T) {
+	mockWriteTemp := func(filename string, contents []byte) ([]string, string, error) {
+		t.Fatal("writeTemp should not be called for empty data")
+		return nil, "", nil
+	}
+
+	result, err := GenerateCACertInstall(nil, mockWriteTemp)
+	require.NoError(t, err)
+	require.Empty(t, result)
+
+	result, err = GenerateCACertInstall([]byte{}, mockWriteTemp)
+	require.NoError(t, err)
+	require.Empty(t, result)
+}

--- a/test-helpers/https-server/go.mod
+++ b/test-helpers/https-server/go.mod
@@ -1,0 +1,3 @@
+module github.com/replicate/cog/test-helpers/https-server
+
+go 1.21

--- a/test-helpers/https-server/main.go
+++ b/test-helpers/https-server/main.go
@@ -1,0 +1,50 @@
+// Package main provides a simple HTTPS server for testing CA certificate injection.
+// Usage: go run ./test-helpers/https-server --cert=server.crt --key=server.key --addr=:8443
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	cert := flag.String("cert", "", "Path to TLS certificate file")
+	key := flag.String("key", "", "Path to TLS key file")
+	addr := flag.String("addr", ":8443", "Address to listen on")
+	flag.Parse()
+
+	if *cert == "" || *key == "" {
+		fmt.Fprintln(os.Stderr, "Usage: https-server --cert=server.crt --key=server.key [--addr=:8443]")
+		os.Exit(1)
+	}
+
+	// Simple handler that returns OK
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "OK")
+	})
+
+	// Start server in a goroutine
+	server := &http.Server{Addr: *addr}
+	go func() {
+		log.Printf("Starting HTTPS server on %s", *addr)
+		if err := server.ListenAndServeTLS(*cert, *key); err != http.ErrServerClosed {
+			log.Fatalf("HTTPS server error: %v", err)
+		}
+	}()
+
+	// Print ready message for test synchronization
+	fmt.Println("READY")
+
+	// Wait for interrupt signal
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	<-sigChan
+
+	log.Println("Shutting down HTTPS server")
+}


### PR DESCRIPTION
## Summary

Adds support for injecting custom CA certificates into Cog-built images via the `COG_CA_CERT` environment variable. This is useful for users behind corporate proxies or VPNs that perform TLS interception.

## Changes

- **`pkg/dockerfile/cacert.go`** - Core logic to read CA cert from env var (supports file path, directory, inline PEM, base64-encoded PEM)
- **`pkg/dockerfile/standard_generator.go`** - Integrates CA cert installation early in Dockerfile (before tini, apt, pip)
- **`pkg/dockerfile/cacert_test.go`** - Unit tests for all input formats and error cases
- **Integration test** - E2E test with real HTTPS server using self-signed certs
- **`test-helpers/https-server/`** - Simple Go HTTPS server for testing
- **`mise.toml`** - Added `test-integration` task for running integration tests

## Usage

```bash
# Using a file path
export COG_CA_CERT=/path/to/corporate-ca.crt
cog build

# Using a directory (concatenates all .crt/.pem files)
export COG_CA_CERT=/path/to/certs/

# Using inline PEM
export COG_CA_CERT="-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----"

# Using base64-encoded PEM
export COG_CA_CERT="LS0tLS1CRUdJTi..."
```

When set, the certificate is:
1. Installed to `/usr/local/share/ca-certificates/cog-ca-cert.crt`
2. Added to the system certificate store via `update-ca-certificates`
3. Environment variables `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` are set

## Testing

```bash
# Run unit tests
go test ./pkg/dockerfile/... -run CACert -v

# Run integration test
mise run test-integration ca_cert
```