### PR TITLE
Skip Docker Hub login for forked PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,6 +172,8 @@ jobs:
           fetch-depth: 0
       - name: Login to Docker Hub
         uses: docker/login-action@v3
+        # Skip Docker Hub login for forked PRs (secrets not available)
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
         with:
           registry: index.docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -219,6 +221,8 @@ jobs:
           fetch-depth: 0 # needed for goreleaser version determination
       - name: Login to Docker Hub
         uses: docker/login-action@v3
+        # Skip Docker Hub login for forked PRs (secrets not available)
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
         with:
           registry: index.docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Summary

- Fixes integration tests failing for forked PRs due to missing Docker Hub credentials
- Makes Docker Hub login conditional to skip for forked PRs while keeping it for main repo
- Unblocks public contributions while maintaining rate limit protection for main repo PRs

## Background

GitHub secrets (`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`) are not accessible to workflows triggered by forked pull requests for security reasons. This causes the Docker login step to fail with "Username and password required", blocking CI for external contributors.

The Docker Hub login was added in #2443 to avoid rate limit (429) errors when pulling base images like `python:*` and `nvidia/cuda:*` during builds. While authenticated pulls have higher rate limits, anonymous pulls should be sufficient for most forked PRs.

## Changes

Added conditional logic to both Docker Hub login steps in CI:
```yaml
if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
```

This ensures:
- ✅ Forked PRs skip login and use anonymous Docker Hub pulls
- ✅ PRs from branches in the main repo use authenticated pulls  
- ✅ Push events, tags, and manual workflows use authenticated pulls

## Trade-offs

**Pros:**
- Unblocks external contributions
- Maintains rate limit protection for main repo
- Simple, safe implementation
- Standard practice for open-source projects

**Cons:**
- Forked PRs may occasionally hit Docker Hub's anonymous rate limits (~100 pulls per 6 hours per IP)
- This is an acceptable trade-off given the low likelihood and the importance of enabling public contributions

## Testing

This fix will allow PR #2619 (and other forked PRs) to run integration tests successfully.