### PR TITLE
Add Rust coglet integration to CI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,13 +165,15 @@ jobs:
   # Go-based integration tests using testscript framework
   test-integration:
     name: "Test integration (${{ matrix.runtime }})"
-    needs: build-python
+    needs: 
+      - build-python
+      - build-coglet-rust
     runs-on: ubuntu-latest-16-cores
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        runtime: [cog, coglet-alpha]
+        runtime: [cog, coglet-alpha, coglet-rust]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -197,9 +199,17 @@ jobs:
             integration-tests/go.sum
       - name: Build cog binary
         run: make cog
+      - name: Set COGLET_RUST_WHEEL for Rust testing
+        if: matrix.runtime == 'coglet-rust'
+        run: |
+          # Find the Rust coglet wheel
+          RUST_WHEEL=$(ls dist/coglet-*-cp38-abi3-*.whl | head -1)
+          echo "Found Rust coglet wheel: $RUST_WHEEL"
+          echo "COGLET_RUST_WHEEL=${PWD}/${RUST_WHEEL}" >> $GITHUB_ENV
       - name: Run integration tests
         env:
-          COG_WHEEL: ${{ matrix.runtime }}
+          COG_WHEEL: ${{ matrix.runtime != 'coglet-rust' && matrix.runtime || '' }}
+          COGLET_RUST_WHEEL: ${{ matrix.runtime == 'coglet-rust' && env.COGLET_RUST_WHEEL || '' }}
           COG_BINARY: ./cog
           TEST_PARALLEL: 4
           BUILDKIT_PROGRESS: 'quiet'

--- a/pkg/dockerfile/standard_generator.go
+++ b/pkg/dockerfile/standard_generator.go
@@ -469,20 +469,41 @@ func (g *StandardGenerator) installCog() (string, error) {
 	cogRuntimeEnabled := g.Config.Build.CogRuntime != nil && *g.Config.Build.CogRuntime
 	wheelConfig := wheels.GetWheelConfig(cogRuntimeEnabled)
 
+	var installLines string
+	var err error
+
 	switch wheelConfig.Source {
 	case wheels.WheelSourceCog:
-		return g.installEmbeddedCogWheel()
+		installLines, err = g.installEmbeddedCogWheel()
 	case wheels.WheelSourceCogletEmbedded:
-		return g.installEmbeddedCogletWheel()
+		installLines, err = g.installEmbeddedCogletWheel()
 	case wheels.WheelSourceCogletAlpha:
-		return g.installCogletAlpha()
+		installLines, err = g.installCogletAlpha()
 	case wheels.WheelSourceURL:
-		return g.installWheelFromURL(wheelConfig.URL)
+		installLines, err = g.installWheelFromURL(wheelConfig.URL)
 	case wheels.WheelSourceFile:
-		return g.installWheelFromFile(wheelConfig.Path)
+		installLines, err = g.installWheelFromFile(wheelConfig.Path)
 	default:
 		return "", fmt.Errorf("unknown wheel source: %v", wheelConfig.Source)
 	}
+
+	if err != nil {
+		return "", err
+	}
+
+	// Optionally install Rust coglet wheel alongside cog
+	// This allows testing the Rust HTTP server implementation
+	if rustWheelPath := os.Getenv("COGLET_RUST_WHEEL"); rustWheelPath != "" {
+		rustInstall, err := g.installRustCogletWheel(rustWheelPath)
+		if err != nil {
+			return "", fmt.Errorf("failed to install Rust coglet wheel: %w", err)
+		}
+		if rustInstall != "" {
+			installLines += "\n" + rustInstall
+		}
+	}
+
+	return installLines, nil
 }
 
 // installEmbeddedCogWheel installs the embedded cog wheel (default for cog_runtime: false)
@@ -612,6 +633,31 @@ func (g *StandardGenerator) installWheelFromFile(path string) (string, error) {
 	if g.strip {
 		pipInstallLine += " && " + StripDebugSymbolsCommand
 	}
+	lines = append(lines, CFlags, pipInstallLine, "ENV CFLAGS=")
+	return strings.Join(lines, "\n"), nil
+}
+
+// installRustCogletWheel installs the Rust coglet wheel from a local file as an additional package
+// This is used to test the Rust HTTP server implementation alongside the Python cog wheel
+func (g *StandardGenerator) installRustCogletWheel(path string) (string, error) {
+	// Read the Rust coglet wheel file
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read Rust coglet wheel %s: %w", path, err)
+	}
+
+	filename := filepath.Base(path)
+	lines, containerPath, err := g.writeTemp(filename, data)
+	if err != nil {
+		return "", err
+	}
+
+	// Install the Rust coglet wheel as an additional package (don't uninstall cog)
+	pipInstallLine := "RUN --mount=type=cache,target=/root/.cache/pip pip install --no-cache-dir " + containerPath
+	if g.strip {
+		pipInstallLine += " && " + StripDebugSymbolsCommand
+	}
+
 	lines = append(lines, CFlags, pipInstallLine, "ENV CFLAGS=")
 	return strings.Join(lines, "\n"), nil
 }

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -609,6 +609,69 @@ def _cpu_count() -> int:
 
 
 if __name__ == "__main__":
+    # Try to use Rust coglet server if available
+    try:
+        import coglet  # type: ignore
+
+        # Parse minimal args needed for Rust server
+        parser = argparse.ArgumentParser(description="Cog HTTP server")
+        parser.add_argument(
+            "-v", "--version", action="store_true", help="Show version and exit"
+        )
+        parser.add_argument(
+            "--host",
+            dest="host",
+            type=str,
+            default="0.0.0.0",
+            help="Host to bind to",
+        )
+        parser.add_argument(
+            "--await-explicit-shutdown",
+            dest="await_explicit_shutdown",
+            type=bool,
+            default=False,
+            help="Ignore SIGTERM and wait for a request to /shutdown (or a SIGINT) before exiting",
+        )
+        parser.add_argument(
+            "--x-mode",
+            dest="mode",
+            type=Mode,
+            default=Mode.PREDICT,
+            choices=list(Mode),
+            help="Experimental: Run in 'predict' or 'train' mode",
+        )
+        # Accept but ignore other args for compatibility
+        parser.add_argument("--threads", dest="threads", type=int, default=None)
+        parser.add_argument("--upload-url", dest="upload_url", type=str, default=None)
+        args = parser.parse_args()
+
+        if args.version:
+            print(f"coglet (Rust) {coglet.__version__}")
+            sys.exit(0)
+
+        port = int(os.getenv("PORT", "5000"))
+        is_train = args.mode == Mode.TRAIN
+
+        # Get predictor ref from config
+        config = Config()
+        predictor_ref = None
+        if config.predictor:
+            predictor_ref = f"{config.predictor}:Predictor"
+
+        log.info("Using Rust coglet server")
+        coglet.serve(
+            predictor_ref=predictor_ref,
+            host=args.host,
+            port=port,
+            await_explicit_shutdown=args.await_explicit_shutdown,
+            is_train=is_train,
+        )
+        sys.exit(0)
+    except ImportError:
+        # Fall back to Python HTTP server
+        log.info("Rust coglet not available, using Python HTTP server")
+        pass
+
     parser = argparse.ArgumentParser(description="Cog HTTP server")
     parser.add_argument(
         "-v", "--version", action="store_true", help="Show version and exit"


### PR DESCRIPTION
## Summary

This PR integrates the Rust coglet wheel into the CI integration tests to verify compatibility between the Rust and Python implementations.

## Changes

### 1. Python HTTP Server (python/cog/server/http.py)
- Added try/except block to prefer Rust `coglet.serve()` if available
- Falls back to Python FastAPI server if Rust coglet is not installed
- Logs which implementation is being used

### 2. Dockerfile Generator (pkg/dockerfile/standard_generator.go)
- Added support for `COGLET_RUST_WHEEL` environment variable
- When set, installs the Rust coglet wheel as an additional package after the cog wheel
- Added `installRustCogletWheel()` method

### 3. CI Workflow (.github/workflows/ci.yaml)
- Added `build-coglet-rust` job that builds the Rust coglet wheel
- Updated `test-integration` job to include `coglet-rust` in the matrix
- For `coglet-rust` tests: sets `COGLET_RUST_WHEEL` to the path of the Rust wheel

## How It Works

The test matrix now has three variants:

1. **`cog`** - Standard cog wheel only (Python HTTP server)
2. **`coglet-alpha`** - Python coglet from pinned URL
3. **`coglet-rust`** - Standard cog wheel + Rust coglet wheel (Rust HTTP server)

When `COGLET_RUST_WHEEL` is set, Docker builds install both wheels. The Python HTTP server code tries to `import coglet` - if successful (Rust wheel installed), it uses `coglet.serve()`, otherwise falls back to the Python implementation.

## Testing

This tests the HTTP server differences between Python and Rust implementations without needing package renaming.