### PR TITLE
Added conda package support

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -22,6 +22,50 @@ This stanza describes how to build the Docker image your model runs in. It conta
 
 <!-- Alphabetical order, please! -->
 
+### `conda_channels`
+
+Conda channels to search for packages. If not specified, defaults to `["conda-forge", "defaults"]`.
+
+For example:
+
+```yaml
+build:
+  conda_channels:
+    - conda-forge
+    - bioconda
+    - defaults
+  conda_packages:
+    - biopython
+```
+
+Channels are searched in the order specified.
+
+### `conda_packages`
+
+A list of packages to install via conda. This is useful for packages that are only available through conda-forge or have complex C/C++ dependencies better managed by conda.
+
+For example:
+
+```yaml
+build:
+  conda_packages:
+    - pythonocc-core
+    - rdkit
+  conda_channels:
+    - conda-forge
+```
+
+You can specify exact versions using the conda format:
+
+```yaml
+build:
+  conda_packages:
+    - numpy=1.24.0
+    - scipy>=1.10,<2.0
+```
+
+Conda packages are installed before pip packages, so you can use both `conda_packages` and `python_requirements` together. Pip will install on top of the conda environment.
+
 ### `cuda`
 
 Cog automatically picks the correct version of CUDA to install, but this lets you override it for whatever reason by specifying the minor (`11.8`) or patch (`11.8.0`) version of CUDA to use.

--- a/integration-tests/tests/conda_packages.txtar
+++ b/integration-tests/tests/conda_packages.txtar
@@ -1,0 +1,24 @@
+# Test that conda packages can be installed in cog builds
+
+cog build -t $TEST_IMAGE
+cog predict $TEST_IMAGE -i text='hello'
+stdout 'numpy version: 1.24'
+stdout 'conda packages work!'
+
+-- cog.yaml --
+build:
+  python_version: "3.11"
+  conda_packages:
+    - numpy=1.24.3
+  conda_channels:
+    - conda-forge
+predict: predict.py:Predictor
+
+-- predict.py --
+from cog import BasePredictor
+import numpy as np
+
+class Predictor(BasePredictor):
+    def predict(self, text: str) -> str:
+        numpy_version = np.__version__
+        return f"numpy version: {numpy_version}, conda packages work! input: {text}"

--- a/integration-tests/tests/conda_with_pip.txtar
+++ b/integration-tests/tests/conda_with_pip.txtar
@@ -1,0 +1,28 @@
+# Test that conda packages work together with pip packages
+
+cog build -t $TEST_IMAGE
+cog predict $TEST_IMAGE
+stdout 'numpy from conda'
+stdout 'requests from pip'
+
+-- cog.yaml --
+build:
+  python_version: "3.11"
+  conda_packages:
+    - numpy=1.24.3
+  conda_channels:
+    - conda-forge
+  python_requirements: requirements.txt
+predict: predict.py:Predictor
+
+-- requirements.txt --
+requests==2.31.0
+
+-- predict.py --
+from cog import BasePredictor
+import numpy as np
+import requests
+
+class Predictor(BasePredictor):
+    def predict(self) -> str:
+        return f"numpy from conda: {np.__version__}, requests from pip: {requests.__version__}"

--- a/pkg/config/data/config_schema_v1.0.json
+++ b/pkg/config/data/config_schema_v1.0.json
@@ -73,6 +73,42 @@
           "type": "string",
           "description": "A pip requirements file specifying the Python packages to install."
         },
+        "conda_packages": {
+          "$id": "#/properties/build/properties/conda_packages",
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "A list of packages to install via conda (e.g., conda-only packages from conda-forge).",
+          "additionalItems": true,
+          "items": {
+            "$id": "#/properties/build/properties/conda_packages/items",
+            "anyOf": [
+              {
+                "$id": "#/properties/build/properties/conda_packages/items/anyOf/0",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "conda_channels": {
+          "$id": "#/properties/build/properties/conda_channels",
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "Conda channels to use for package installation. Defaults to ['conda-forge', 'defaults'] if not specified.",
+          "additionalItems": true,
+          "items": {
+            "$id": "#/properties/build/properties/conda_channels/items",
+            "anyOf": [
+              {
+                "$id": "#/properties/build/properties/conda_channels/items/anyOf/0",
+                "type": "string"
+              }
+            ]
+          }
+        },
         "system_packages": {
           "$id": "#/properties/build/properties/system_packages",
           "type": [

--- a/pkg/dockerfile/standard_generator.go
+++ b/pkg/dockerfile/standard_generator.go
@@ -93,7 +93,7 @@ func NewStandardGenerator(config *config.Config, dir string, command command.Com
 		Config:           config,
 		Dir:              dir,
 		GOOS:             runtime.GOOS,
-		GOARCH:           runtime.GOOS,
+		GOARCH:           runtime.GOARCH,
 		tmpDir:           tmpDir,
 		relativeTmpDir:   relativeTmpDir,
 		fileWalker:       filepath.Walk,
@@ -158,6 +158,10 @@ func (g *StandardGenerator) GenerateInitialSteps(ctx context.Context) (string, e
 	if err != nil {
 		return "", err
 	}
+	condaInstalls, err := g.condaInstalls()
+	if err != nil {
+		return "", err
+	}
 	pipInstalls, err := g.pipInstalls()
 	if err != nil {
 		return "", err
@@ -182,6 +186,10 @@ func (g *StandardGenerator) GenerateInitialSteps(ctx context.Context) (string, e
 		if installCog != "" {
 			steps = append(steps, installCog)
 		}
+		// Install conda packages before pip packages
+		if condaInstalls != "" {
+			steps = append(steps, condaInstalls)
+		}
 		steps = append(steps, pipInstalls)
 		if g.precompile {
 			steps = append(steps, PrecompilePythonCommand)
@@ -200,9 +208,12 @@ func (g *StandardGenerator) GenerateInitialSteps(ctx context.Context) (string, e
 		envs,
 		aptInstalls,
 		installPython,
-		pipInstalls,
-		installCog,
 	}
+	// Install conda packages before pip packages
+	if condaInstalls != "" {
+		steps = append(steps, condaInstalls)
+	}
+	steps = append(steps, pipInstalls, installCog)
 	if g.precompile {
 		steps = append(steps, PrecompilePythonCommand)
 	}
@@ -675,6 +686,61 @@ func (g *StandardGenerator) pipInstalls() (string, error) {
 		pipInstallLine,
 		"ENV CFLAGS=",
 	}, "\n"), nil
+}
+
+// condaInstalls generates Dockerfile lines to install conda packages using micromamba.
+// Returns empty string if no conda packages are specified.
+// Micromamba is used instead of conda/miniconda for smaller image size (~10MB vs ~500MB).
+func (g *StandardGenerator) condaInstalls() (string, error) {
+	if len(g.Config.Build.CondaPackages) == 0 {
+		return "", nil
+	}
+
+	lines := []string{}
+
+	// Install bzip2 (required for extracting micromamba) and micromamba
+	// We use micromamba instead of full conda/miniconda for:
+	// - Smaller image size (micromamba is ~10MB vs conda ~500MB)
+	// - Faster installation
+	// - Drop-in replacement for conda commands
+	lines = append(lines, "RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq && apt-get install -qqy --no-install-recommends bzip2 && rm -rf /var/lib/apt/lists/*")
+
+	// Detect architecture within the Docker build context and download micromamba
+	// Pinned to version 2.5.0-1 for reproducible builds
+	// Downloads directly from GitHub releases for version pinning support
+	lines = append(lines, strings.Join([]string{
+		"RUN ARCH=$([ \"$(uname -m)\" = \"x86_64\" ] && echo \"linux-64\" || echo \"linux-aarch64\")",
+		"&& curl -Ls https://github.com/mamba-org/micromamba-releases/releases/download/2.5.0-1/micromamba-${ARCH}",
+		"--output /usr/local/bin/micromamba",
+		"&& chmod +x /usr/local/bin/micromamba",
+	}, " "))
+
+	// Configure channels
+	channelArgs := []string{}
+	for _, channel := range g.Config.Build.CondaChannels {
+		channelArgs = append(channelArgs, "-c "+channel)
+	}
+
+	// Install conda packages to /opt/conda and symlink to system Python
+	// This avoids needing to reinstall cog while allowing conda packages to work
+	packages := strings.Join(g.Config.Build.CondaPackages, " ")
+	pythonVersion := g.Config.Build.PythonVersion
+
+	lines = append(lines, fmt.Sprintf(
+		"RUN --mount=type=cache,target=/root/.mamba/pkgs micromamba create -y -p /opt/conda python=%s %s %s && micromamba clean -a -y",
+		pythonVersion,
+		strings.Join(channelArgs, " "),
+		packages,
+	))
+
+	// Symlink conda packages to system Python's site-packages
+	lines = append(lines, fmt.Sprintf(
+		"RUN for pkg in /opt/conda/lib/python%s/site-packages/*; do [ -e \"$pkg\" ] && ln -sf \"$pkg\" \"/usr/local/lib/python%s/site-packages/$(basename \"$pkg\")\" || true; done",
+		pythonVersion,
+		pythonVersion,
+	))
+
+	return strings.Join(lines, "\n"), nil
 }
 
 func (g *StandardGenerator) runCommands() (string, error) {

--- a/pkg/dockerfile/standard_generator_test.go
+++ b/pkg/dockerfile/standard_generator_test.go
@@ -1170,3 +1170,121 @@ predict: predict.py:Predictor
 	require.Contains(t, actual, "ENV R8_COG_VERSION=coglet")
 	require.Contains(t, actual, "ENV R8_PYTHON_VERSION=3.11")
 }
+
+func TestCondaInstalls(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	conf := &config.Config{
+		Build: &config.Build{
+			PythonVersion: "3.11",
+			CondaPackages: []string{"pythonocc-core", "numpy=1.24"},
+			CondaChannels: []string{"conda-forge"},
+		},
+	}
+
+	command := dockertest.NewMockCommand()
+	client := registrytest.NewMockRegistryClient()
+	gen, err := NewStandardGenerator(conf, tmpDir, command, client, true)
+	require.NoError(t, err)
+
+	output, err := gen.condaInstalls()
+	require.NoError(t, err)
+	require.Contains(t, output, "micromamba create")
+	require.Contains(t, output, "-c conda-forge")
+	require.Contains(t, output, "pythonocc-core")
+	require.Contains(t, output, "numpy=1.24")
+	require.Contains(t, output, "micromamba clean -a -y")
+	require.Contains(t, output, "site-packages")
+}
+
+func TestCondaInstallsEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	conf := &config.Config{
+		Build: &config.Build{
+			PythonVersion: "3.11",
+			CondaPackages: []string{},
+		},
+	}
+
+	command := dockertest.NewMockCommand()
+	client := registrytest.NewMockRegistryClient()
+	gen, err := NewStandardGenerator(conf, tmpDir, command, client, true)
+	require.NoError(t, err)
+
+	output, err := gen.condaInstalls()
+	require.NoError(t, err)
+	require.Equal(t, "", output)
+}
+
+func TestCondaInstallsMultipleChannels(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	conf := &config.Config{
+		Build: &config.Build{
+			PythonVersion: "3.11",
+			CondaPackages: []string{"biopython"},
+			CondaChannels: []string{"conda-forge", "bioconda", "defaults"},
+		},
+	}
+
+	command := dockertest.NewMockCommand()
+	client := registrytest.NewMockRegistryClient()
+	gen, err := NewStandardGenerator(conf, tmpDir, command, client, true)
+	require.NoError(t, err)
+
+	output, err := gen.condaInstalls()
+	require.NoError(t, err)
+	require.Contains(t, output, "-c conda-forge")
+	require.Contains(t, output, "-c bioconda")
+	require.Contains(t, output, "-c defaults")
+}
+
+func TestCondaInstallsArchitectureDetection(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	conf := &config.Config{
+		Build: &config.Build{
+			PythonVersion: "3.11",
+			CondaPackages: []string{"numpy"},
+			CondaChannels: []string{"conda-forge"},
+		},
+	}
+
+	command := dockertest.NewMockCommand()
+	client := registrytest.NewMockRegistryClient()
+	gen, err := NewStandardGenerator(conf, tmpDir, command, client, true)
+	require.NoError(t, err)
+
+	output, err := gen.condaInstalls()
+	require.NoError(t, err)
+	// Verify architecture detection using uname -m
+	require.Contains(t, output, "uname -m")
+	require.Contains(t, output, "linux-64")
+	require.Contains(t, output, "linux-aarch64")
+	// Verify download from GitHub releases with version pinning
+	require.Contains(t, output, "github.com/mamba-org/micromamba-releases/releases/download/2.5.0-1")
+	require.Contains(t, output, "micromamba-${ARCH}")
+}
+
+func TestCondaInstallsVersionPinned(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	conf := &config.Config{
+		Build: &config.Build{
+			PythonVersion: "3.11",
+			CondaPackages: []string{"numpy"},
+		},
+	}
+
+	command := dockertest.NewMockCommand()
+	client := registrytest.NewMockRegistryClient()
+	gen, err := NewStandardGenerator(conf, tmpDir, command, client, true)
+	require.NoError(t, err)
+
+	output, err := gen.condaInstalls()
+	require.NoError(t, err)
+	// Verify version is pinned (not using "latest")
+	require.Contains(t, output, "2.5.0-1")
+	require.NotContains(t, output, "latest")
+}


### PR DESCRIPTION
Adds support for installing conda packages during image builds using micromamba. This enables installation of packages only available through conda-forge and other conda channels.

Configuration:
- conda_packages: List of packages to install (supports version pinning)
- conda_channels: List of channels to use (defaults to conda-forge, defaults)

Implementation uses micromamba instead of full conda for smaller image size (~10MB vs ~500MB). Micromamba version pinned to 2.5.0-1 for reproducible builds. Architecture detection ensures compatibility with both amd64 (linux-64) and arm64 (linux-aarch64) platforms.

Conda packages are installed to /opt/conda and symlinked to system Python's site-packages, avoiding the need to reinstall cog while making conda packages accessible to the existing Python environment.

Fixes #2471