### PR TITLE
Fix: use tmpImageId for schema validation when pushing to r8.im

### DIFF
--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -213,7 +213,7 @@ func Build(
 		schemaJSON = data
 	} else {
 		console.Info("Validating model schema...")
-		schema, err := GenerateOpenAPISchema(ctx, dockerCommand, imageName, cfg.Build.GPU)
+		schema, err := GenerateOpenAPISchema(ctx, dockerCommand, tmpImageId, cfg.Build.GPU)
 		if err != nil {
 			return fmt.Errorf("Failed to get type signature: %w", err)
 		}
@@ -252,12 +252,12 @@ func Build(
 		return fmt.Errorf("Failed to convert config to JSON: %w", err)
 	}
 
-	pipFreeze, err := GeneratePipFreeze(ctx, dockerCommand, imageName, fastFlag)
+	pipFreeze, err := GeneratePipFreeze(ctx, dockerCommand, tmpImageId, fastFlag)
 	if err != nil {
 		return fmt.Errorf("Failed to generate pip freeze from image: %w", err)
 	}
 
-	modelDependencies, err := GenerateModelDependencies(ctx, dockerCommand, imageName, cfg)
+	modelDependencies, err := GenerateModelDependencies(ctx, dockerCommand, tmpImageId, cfg)
 	if err != nil {
 		return fmt.Errorf("Failed to generate model dependencies from image: %w", err)
 	}


### PR DESCRIPTION
When pushing to r8.im/*, commit 2ad2c7f6 introduced temporary image naming to fix OrbStack compatibility, but missed updating three function calls that run containers to extract metadata:

- GenerateOpenAPISchema
- GeneratePipFreeze
- GenerateModelDependencies

These functions were still using the original imageName (e.g., r8.im/replicate/model-test) instead of tmpImageId (cog-tmp:<hash>), causing 'No such image' errors during the 'Validating model schema' step.

This fix ensures all three functions use the temporary image ID that was actually built by Docker.