### PR TITLE
chore: drop coglet-alpha selection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -210,7 +210,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runtime: [cog, cog-dataclass, coglet-alpha, cog-rust, cog-dataclass-rust]
+        runtime: [cog, cog-dataclass, cog-rust, cog-dataclass-rust]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -245,9 +245,6 @@ jobs:
               ;;
             cog-dataclass)
               echo "COG_WHEEL=cog-dataclass" >> $GITHUB_ENV
-              ;;
-            coglet-alpha)
-              echo "COG_WHEEL=coglet-alpha" >> $GITHUB_ENV
               ;;
             cog-rust)
               RUST_WHEEL=$(ls dist/coglet-*-cp310-abi3-*.whl | head -1)

--- a/architecture/05-build-system.md
+++ b/architecture/05-build-system.md
@@ -195,7 +195,7 @@ The `COG_WHEEL` environment variable controls which wheel is installed:
 |-------|--------|
 | (unset) | Embedded `cog` wheel (default) |
 | `cog` | Embedded `cog` wheel |
-| `coglet` / `coglet-alpha` | Experimental runtime (temporary compatibility) |
+| `coglet` | Experimental runtime (temporary compatibility) |
 | `https://...` | Download wheel from URL |
 | `/path/to/file.whl` | Use local wheel file |
 

--- a/integration-tests/concurrent/concurrent_test.go
+++ b/integration-tests/concurrent/concurrent_test.go
@@ -31,13 +31,6 @@ func TestConcurrentPredictions(t *testing.T) {
 		t.Skip("skipping slow test in short mode")
 	}
 
-	// Skip for coglet-alpha runtime - it has a known bug with concurrent async predictions
-	// that causes predictions to return empty output. This is in the released version and
-	// cannot be fixed without a new release.
-	if cogWheel := os.Getenv("COG_WHEEL"); cogWheel == "coglet-alpha" {
-		t.Skip("skipping: coglet-alpha has a known bug with concurrent async predictions")
-	}
-
 	// Create a temp directory for our test project
 	tmpDir, err := os.MkdirTemp("", "cog-concurrent-test-*")
 	if err != nil {

--- a/integration-tests/suite_test.go
+++ b/integration-tests/suite_test.go
@@ -29,7 +29,7 @@ func TestIntegration(t *testing.T) {
 // condition provides custom conditions for testscript.
 // Supported conditions:
 //   - linux/linux_amd64/amd64: platform guards for specialized tests.
-//   - coglet_alpha: true when COG_WHEEL=coglet-alpha (old Go coglet)
+//   - coglet_alpha: deprecated (always false)
 //   - cog_dataclass: true when COG_WHEEL=cog-dataclass (Python 3.10+ only)
 //   - cog_rust: true when COG_WHEEL=cog and COGLET_RUST_WHEEL is set
 //   - cog_dataclass_rust: true when COG_WHEEL=cog-dataclass and COGLET_RUST_WHEEL is set
@@ -55,7 +55,7 @@ func condition(cond string) (bool, error) {
 	case "linux_amd64":
 		value = runtime.GOOS == "linux" && runtime.GOARCH == "amd64"
 	case "coglet_alpha":
-		value = cogWheel == "coglet-alpha"
+		value = false
 	case "cog_dataclass":
 		value = cogWheel == "cog-dataclass"
 	case "cog_rust":

--- a/pkg/dockerfile/fast_generator.go
+++ b/pkg/dockerfile/fast_generator.go
@@ -216,7 +216,7 @@ func (g *FastGenerator) generateMonobase(lines []string, tmpDir string) ([]strin
 	var envs []string
 
 	envs = append(envs, []string{
-		"ENV R8_COG_VERSION=" + PinnedCogletURL,
+		"ENV R8_COG_VERSION=cog-dataclass",
 	}...)
 
 	torchVersion, ok := g.Config.TorchVersion()

--- a/pkg/dockerfile/standard_generator_test.go
+++ b/pkg/dockerfile/standard_generator_test.go
@@ -925,7 +925,7 @@ predict: predict.py:Predictor
 }
 
 func TestCOGWheelDefaultCogRuntimeTrue(t *testing.T) {
-	// Default behavior with cog_runtime: true should use coglet-alpha (PinnedCogletURL)
+	// Default behavior with cog_runtime: true should use cog-dataclass
 	tmpDir := t.TempDir()
 
 	yaml := `
@@ -947,10 +947,11 @@ predict: predict.py:Predictor
 	_, actual, _, err := gen.GenerateModelBaseWithSeparateWeights(t.Context(), "r8.im/replicate/cog-test")
 	require.NoError(t, err)
 
-	// Should contain coglet-alpha/PinnedCogletURL install with cog uninstall prefix
-	require.Contains(t, actual, "RUN pip uninstall -y cog 2>/dev/null || true && pip install "+PinnedCogletURL)
-	require.Contains(t, actual, "ENV R8_COG_VERSION=coglet")
-	require.Contains(t, actual, "ENV R8_PYTHON_VERSION=3.11")
+	// Should contain the embedded cog-dataclass wheel install
+	require.Contains(t, actual, "/tmp/cog_dataclass-")
+	require.Contains(t, actual, ".whl")
+	require.NotContains(t, actual, "'pydantic>=1.9,<3'")
+	require.NotContains(t, actual, "R8_COG_VERSION=coglet")
 }
 
 func TestCOGWheelEnvCog(t *testing.T) {
@@ -987,7 +988,7 @@ predict: predict.py:Predictor
 }
 
 func TestCOGWheelEnvCogletAlpha(t *testing.T) {
-	// COG_WHEEL=coglet-alpha should use PinnedCogletURL even without cog_runtime: true
+	// COG_WHEEL=coglet-alpha should map to cog-dataclass
 	t.Setenv("COG_WHEEL", "coglet-alpha")
 
 	tmpDir := t.TempDir()
@@ -1010,10 +1011,11 @@ predict: predict.py:Predictor
 	_, actual, _, err := gen.GenerateModelBaseWithSeparateWeights(t.Context(), "r8.im/replicate/cog-test")
 	require.NoError(t, err)
 
-	// Should contain coglet-alpha/PinnedCogletURL install with cog uninstall prefix
-	require.Contains(t, actual, "RUN pip uninstall -y cog 2>/dev/null || true && pip install "+PinnedCogletURL)
-	require.Contains(t, actual, "ENV R8_COG_VERSION=coglet")
-	require.Contains(t, actual, "ENV R8_PYTHON_VERSION=3.11")
+	// Should contain the embedded cog-dataclass wheel install
+	require.Contains(t, actual, "/tmp/cog_dataclass-")
+	require.Contains(t, actual, ".whl")
+	require.NotContains(t, actual, "'pydantic>=1.9,<3'")
+	require.NotContains(t, actual, "R8_COG_VERSION=coglet")
 }
 
 func TestCOGWheelEnvURL(t *testing.T) {

--- a/pkg/wheels/wheels_test.go
+++ b/pkg/wheels/wheels_test.go
@@ -20,7 +20,6 @@ func TestWheelSourceString(t *testing.T) {
 		expected string
 	}{
 		{WheelSourceCog, "cog"},
-		{WheelSourceCogletAlpha, "coglet-alpha"},
 		{WheelSourceCogDataclass, "cog-dataclass"},
 		{WheelSourceURL, "url"},
 		{WheelSourceFile, "file"},
@@ -69,14 +68,19 @@ func TestParseCogWheel(t *testing.T) {
 			expected: &WheelConfig{Source: WheelSourceCog},
 		},
 		{
+			name:     "coglet keyword",
+			input:    "coglet",
+			expected: &WheelConfig{Source: WheelSourceCogDataclass},
+		},
+		{
 			name:     "coglet-alpha keyword",
 			input:    "coglet-alpha",
-			expected: &WheelConfig{Source: WheelSourceCogletAlpha},
+			expected: &WheelConfig{Source: WheelSourceCogDataclass},
 		},
 		{
 			name:     "coglet-alpha uppercase",
 			input:    "COGLET-ALPHA",
-			expected: &WheelConfig{Source: WheelSourceCogletAlpha},
+			expected: &WheelConfig{Source: WheelSourceCogDataclass},
 		},
 		{
 			name:     "cog with whitespace",
@@ -186,7 +190,7 @@ func TestGetWheelConfig(t *testing.T) {
 			name:              "default with cog_runtime true",
 			envValue:          "",
 			cogRuntimeEnabled: true,
-			expected:          &WheelConfig{Source: WheelSourceCogletAlpha},
+			expected:          &WheelConfig{Source: WheelSourceCogDataclass},
 		},
 
 		// Env var overrides cog_runtime
@@ -200,7 +204,7 @@ func TestGetWheelConfig(t *testing.T) {
 			name:              "env coglet-alpha overrides cog_runtime false",
 			envValue:          "coglet-alpha",
 			cogRuntimeEnabled: false,
-			expected:          &WheelConfig{Source: WheelSourceCogletAlpha},
+			expected:          &WheelConfig{Source: WheelSourceCogDataclass},
 		},
 		{
 			name:              "env URL overrides cog_runtime",


### PR DESCRIPTION
- Treat --x-fast / fast: true as deprecated: emit a warning and route to the standard generator instead of monobase, while explicitly defaulting cog_runtime to dataclass so “fast” users still get the dataclass SDK/runtime (pkg/dockerfile/generator_factory.go:12).
- Add a generator factory regression test that asserts the warning, standard generator selection, and dataclass runtime default when fast is requested (pkg/dockerfile/generator_factory_test.go:16).
- Fix a flaky double‑fork IPC fixture by writing .outbox atomically (.outbox.tmp + os.replace) to prevent partial reads under parallel load (integration-tests/tests/setup_subprocess_double_fork.txtar:120).
- Remove monobase‑specific txtar tests that no longer reflect supported behavior after deprecating fast/monobase:
  - integration-tests/tests/fast_build.txtar
  - integration-tests/tests/run_fast_build.txtar
  - integration-tests/tests/build_localimage.txtar
  - integration-tests/tests/predict_localimage.txtar
  - integration-tests/tests/build_base_image_sha.txtar
  - integration-tests/tests/build_cog_version_match.txtar
  - integration-tests/tests/build_python313_base_image.txtar
Rationale
- Monobase/fast builds are being phased out; keeping the fast flag but falling back avoids breaking callers while clearly signaling deprecation.
- The double‑fork fixture race was intermittent under TEST_PARALLEL>=4 (empty .outbox), and atomic rename removes the partial‑read window without adding sleeps or changing runtime behavior.
Testing
- script/lint
- go test ./pkg/dockerfile -run TestGeneratorFactory$
- COG_WHEEL=cog-dataclass COGLET_RUST_WHEEL=/Users/m/cf/cog2/dist/coglet-0.1.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl TEST_PARALLEL=4 COG_BINARY=/Users/m/cf/cog2/cog go test -run TestIntegration/setup_subprocess_double_fork -v (integration test; flaky on original fixture, stable with atomic outbox)


----

Extensive evaluation between `coglet-alpha` and the `cog-dataclass` python was done to determine meaningful behavioral differences. There are minor deltas that are real but for the most part will not cause breakages when someone is using `cog-dataclass` in lieu of `coglet-alpha` python code.

The high level summary is as follows:

# Coglet Behavior Comparison — High-Level Summary

## High-Level  Summary

The two implementations are structurally similar, but **not behavior-equivalent**. Core differences cluster around defaults handling, error types/messages, output validation rules, and schema generation. These are likely to surface as compatibility issues if callers rely on exact error text or schema shapes.

## Verdict

**Close, but not interchangeable.** You can treat them as conceptually similar, but exact behavior diverges in enough places to be considered breaking for strict clients.

## Top Risk Areas

1. **Defaults & AST validation**
   - `cog-runtime` enforces default-`None` guardrails via AST checks; `cog-dataclass` does not.
   - `cog-dataclass` adds `default_factory` and mutable-default normalization.

2. **Error types and message formats**
   - `cog-runtime` raises `AssertionError` with “invalid input value …” messages.
   - `cog-dataclass` raises `ValueError` with different, often shorter, message formats.

3. **Output model constraints**
   - `cog-runtime` requires output type named `Output` and forbids list fields.
   - `cog-dataclass` allows any `BaseModel` name and list fields.

4. **Schema generation strategy**
   - `cog-runtime` injects `Input`/`Output` into a static OpenAPI template.
   - `cog-dataclass` constructs full OpenAPI schema programmatically.


The key elements to specifically highlight are:
1. This should not impact any coglet-alpha users. This is more permissive
2. These are breaking changes. IT is a relatively MINOR difference but is real. We can consider adding aliases, the stringly text should not matter
3. This is a convention, `coglet-alpha` users if defined as `Output` will see `Output`, we however do not enforce this
4. Byte-for-Byte schema validation is not a guarantee between cog releases

Additionally use of some long deprecated types (`File`) will break under cog-dataclass.  This can be maintained by utilizing an older cog-sdk pre-dataclass.
