### PR TITLE
fix: allow spaces in environment variable values in cog.yaml schema

### DIFF
--- a/pkg/config/data/config_schema_v1.0.json
+++ b/pkg/config/data/config_schema_v1.0.json
@@ -209,7 +209,7 @@
       "items": {
         "$id": "#/properties/properties/environment/items",
         "type": "string",
-        "pattern": "^[A-Za-z_][A-Za-z0-9_]*=[^\\s]+$"
+        "pattern": "^[A-Za-z_][A-Za-z0-9_]*=.*$"
       }
     },
     "weights": {

--- a/pkg/config/env_variables_test.go
+++ b/pkg/config/env_variables_test.go
@@ -71,6 +71,11 @@ func TestEnvironmentConfig(t *testing.T) {
 				Expected: map[string]string{"NAME": "VALUE1\nVALUE2"},
 			},
 			{
+				Name:     "UserAgentWithSpaces",
+				Input:    []string{"COG_USER_AGENT=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"},
+				Expected: map[string]string{"COG_USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"},
+			},
+			{
 				Name:     "MultiplePairs",
 				Input:    []string{"NAME1=VALUE1", "NAME2=VALUE2"},
 				Expected: map[string]string{"NAME1": "VALUE1", "NAME2": "VALUE2"},

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -92,6 +92,26 @@ func TestValidateNullListsAllowed(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidateEnvironmentWithSpaces(t *testing.T) {
+	config := `build:
+  python_version: "3.10"
+environment:
+  - "COG_USER_AGENT=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"`
+
+	err := Validate(config, "1.0")
+	require.NoError(t, err)
+}
+
+func TestValidateEnvironmentWithEmptyValue(t *testing.T) {
+	config := `build:
+  python_version: "3.10"
+environment:
+  - "MY_VAR="`
+
+	err := Validate(config, "1.0")
+	require.NoError(t, err)
+}
+
 func TestValidateOutputsPropertyFromTypeError(t *testing.T) {
 	config := `build:
   gpu: true


### PR DESCRIPTION
## Summary

- Fixes the JSON schema regex pattern for environment variables to allow values containing spaces (e.g., browser user agent strings)
- Aligns the schema validation with the Go-level validation which already accepted these values
- Adds test coverage for environment variables with spaces and empty values

Fixes #2659