### PR TITLE
fix: cross-compile all coglet wheels from ubuntu using zig

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -182,8 +182,8 @@ Releases use a two-workflow system with manual approval via draft releases.
 │                             │    ┌───────────────┘                           │
 │                             ▼    │                                           │
 │                      ┌──────────────┐                                        │
-│                      │build-coglet- │  (4 platforms: linux x64/arm64,       │
-│                      │   wheels     │   macos x64/arm64)                     │
+│                      │build-coglet- │  (3 platforms: linux x64/arm64,       │
+│                      │   wheels     │   macos arm64; all via zig)            │
 │                      └──────────────┘                                        │
 └─────────────────────────────────────────────────────────────────────────────┘
                                         │
@@ -228,7 +228,7 @@ Triggered by version tags (`v*.*.*`). Builds artifacts and creates a draft relea
 |-----|---------|
 | `verify-tag` | Ensures tag is on main branch |
 | `build-sdk` | Build cog SDK wheel and sdist |
-| `build-coglet-wheels` | Build coglet wheels (4 platforms) |
+| `build-coglet-wheels` | Build coglet wheels (3 platforms via zig cross-compile) |
 | `create-draft-release` | Create draft GitHub release with all artifacts |
 
 **Security**: No secrets required - only builds artifacts.

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -130,24 +130,21 @@ jobs:
   build-coglet-wheels:
     name: Build coglet wheel (${{ matrix.target }})
     needs: verify-tag
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-gnu
             artifact-suffix: linux-x64
-          - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
+            manylinux: auto
+          - target: aarch64-unknown-linux-gnu
             artifact-suffix: linux-arm64
-          - os: macos-13
-            target: x86_64-apple-darwin
-            artifact-suffix: macos-x64
-          - os: macos-14
-            target: aarch64-apple-darwin
+            manylinux: auto
+          - target: aarch64-apple-darwin
             artifact-suffix: macos-arm64
+            manylinux: "off"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -170,8 +167,8 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          manylinux: ${{ contains(matrix.os, 'ubuntu') && 'auto' || 'off' }}
-          args: --release --out dist -m crates/coglet-python/Cargo.toml
+          manylinux: ${{ matrix.manylinux }}
+          args: --release --out dist -m crates/coglet-python/Cargo.toml --zig
 
       - name: Upload coglet wheel
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Drop macOS runners and macOS x64 target. Build linux-x64, linux-arm64, and macos-arm64 wheels from ubuntu-latest using maturin --zig.

Fixes uv cache error on ARM runners and reduces runner costs.