### PR TITLE
Update torch_compatibility.json

### DIFF
--- a/pkg/config/torch_compatibility.json
+++ b/pkg/config/torch_compatibility.json
@@ -1,5 +1,20 @@
 [
   {
+    "Torch": "2.10.0+cu128",
+    "Torchvision": "0.25.0",
+    "Torchaudio": "2.10.0",
+    "FindLinks": "",
+    "ExtraIndexURL": "https://download.pytorch.org/whl/cu128/",
+    "CUDA": "12.8",
+    "Pythons": [
+      "3.10",
+      "3.11",
+      "3.12",
+      "3.13",
+      "3.14"
+    ]
+  },
+  {
     "Torch": "2.8.0+cpu",
     "Torchvision": "0.23.0",
     "Torchaudio": "2.8.0",


### PR DESCRIPTION
Using pytorch 2.10.0 makes cog log the fact it doesn't know what CUDA to use.

Basing this change on 

- https://github.com/pytorch/pytorch/blob/main/RELEASE.md#pytorch-cuda-support-matrix
- https://github.com/pytorch/pytorch/wiki/PyTorch-Versions