### PR TITLE
fix: suppress verbose coglet logs during cog predict

### DIFF
--- a/crates/coglet-python/README.md
+++ b/crates/coglet-python/README.md
@@ -247,7 +247,7 @@ worker_bridge.setup()
 
 **Worker Startup:**
 1. `set_active()` - Mark as worker subprocess
-2. `init_tracing()` - Configure logging (stderr, COG_LOG env)
+2. `init_tracing()` - Configure logging (stderr, COG_LOG_LEVEL env)
 3. `install_slot_log_writers()` - Replace sys.stdout/stderr
 4. `install_audit_hook()` - Protect streams
 5. `install_signal_handler()` - SIGUSR1 for cancellation

--- a/crates/coglet-python/src/lib.rs
+++ b/crates/coglet-python/src/lib.rs
@@ -67,7 +67,7 @@ fn set_active() {
     ACTIVE.store(true, Ordering::SeqCst);
 }
 
-/// Initialize tracing with COG_LOG and LOG_FORMAT support.
+/// Initialize tracing with COG_LOG_LEVEL and LOG_FORMAT support.
 /// Returns optional receiver for draining setup logs.
 fn init_tracing(
     _to_stderr: bool,
@@ -76,7 +76,7 @@ fn init_tracing(
     let filter = if std::env::var("RUST_LOG").is_ok() {
         EnvFilter::from_default_env()
     } else {
-        let base_level = match std::env::var("COG_LOG").as_deref() {
+        let base_level = match std::env::var("COG_LOG_LEVEL").as_deref() {
             Ok("debug") => "debug",
             Ok("warn") | Ok("warning") => "warn",
             Ok("error") => "error",
@@ -84,7 +84,7 @@ fn init_tracing(
         };
 
         let filter_str = format!(
-            "coglet={level},coglet_worker={level},coglet_worker::schema=off,coglet_worker::protocol=off",
+            "coglet={level},coglet::setup=info,coglet::user=info,coglet_worker={level},coglet_worker::schema=off,coglet_worker::protocol=off",
             level = base_level
         );
 

--- a/crates/coglet/src/bridge/codec.rs
+++ b/crates/coglet/src/bridge/codec.rs
@@ -63,7 +63,7 @@ impl<T: Serialize> Encoder<T> for JsonCodec<T> {
         // a WorkerLog message from triggering another log that creates another WorkerLog, etc.
         tracing::trace!(json_size_bytes = json_len, "Encoding frame");
         if json_len > 100_000 {
-            tracing::warn!(
+            tracing::info!(
                 json_size_bytes = json_len,
                 json_size_kb = json_len / 1024,
                 "Large frame being encoded"

--- a/crates/coglet/src/worker.rs
+++ b/crates/coglet/src/worker.rs
@@ -102,7 +102,7 @@ fn init_worker_tracing(tx: mpsc::Sender<ControlResponse>) {
     let filter = if std::env::var("RUST_LOG").is_ok() {
         EnvFilter::from_default_env()
     } else {
-        let base_level = match std::env::var("COG_LOG").as_deref() {
+        let base_level = match std::env::var("COG_LOG_LEVEL").as_deref() {
             Ok("debug") => "debug",
             Ok("warn") | Ok("warning") => "warn",
             Ok("error") => "error",
@@ -110,7 +110,7 @@ fn init_worker_tracing(tx: mpsc::Sender<ControlResponse>) {
         };
 
         let filter_str = format!(
-            "coglet={level},coglet_worker={level},coglet_worker::schema=off,coglet_worker::protocol=off",
+            "coglet={level},coglet::setup=info,coglet::user=info,coglet_worker={level},coglet_worker::schema=off,coglet_worker::protocol=off",
             level = base_level
         );
 

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 import sys
 
@@ -6,11 +7,25 @@ import coglet
 import structlog
 
 from ..config import Config
+from ..logging import setup_logging
 from ..mode import Mode
 
 log = structlog.get_logger("cog.server.http")
 
+_COG_LOG_LEVELS = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "warn": logging.WARNING,
+    "error": logging.ERROR,
+}
+
 if __name__ == "__main__":
+    log_level = _COG_LOG_LEVELS.get(
+        os.environ.get("COG_LOG_LEVEL", "").lower(), logging.INFO
+    )
+    setup_logging(log_level=log_level)
+
     # Parse minimal args needed for Rust server
     parser = argparse.ArgumentParser(description="Cog HTTP server")
     parser.add_argument(
@@ -62,7 +77,7 @@ if __name__ == "__main__":
         )
         sys.exit(1)
 
-    log.info("Starting Rust coglet server")
+    log.debug("Starting Rust coglet server")
     coglet.server.serve(  # type: ignore[attr-defined]
         predictor_ref=predictor_ref,
         host=args.host,


### PR DESCRIPTION
## Summary
- Rename `COG_LOG` to `COG_LOG_LEVEL` in coglet Rust code to match the env var the Go CLI already sets
- Configure Python structlog from `COG_LOG_LEVEL` in the server entry point
- Demote "Starting Rust coglet server" to debug level
- Demote "Large frame being encoded" from warn to info

The Go CLI sets `COG_LOG_LEVEL=warning` by default and `COG_LOG_LEVEL=debug` with `--debug`, but coglet was reading `COG_LOG` instead, so the setting was ignored and all info-level JSON log lines were printed during `cog predict`.

## Test plan
- [ ] Run `cog predict` on a model — should no longer show coglet JSON log spam
- [ ] Run `cog predict --debug` — should show all log output including coglet info/debug lines
- [ ] Verify "Starting Rust coglet server" only appears with `--debug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)