### PR TITLE
fix(coglet): improve "not ready" error message

### DIFF
--- a/crates/coglet/src/predictor.rs
+++ b/crates/coglet/src/predictor.rs
@@ -66,7 +66,9 @@ pub enum PredictionError {
     #[error("Input validation error: {0}")]
     InvalidInput(String),
 
-    #[error("Predictor not ready")]
+    #[error(
+        "Setup has not finished yet. Wait until it has finished, or GET /health-check for status."
+    )]
     NotReady,
 
     #[error("Prediction was cancelled")]
@@ -120,6 +122,9 @@ mod tests {
         assert_eq!(format!("{}", err), "Input validation error: bad json");
 
         let err = PredictionError::NotReady;
-        assert_eq!(format!("{}", err), "Predictor not ready");
+        assert_eq!(
+            format!("{}", err),
+            "Setup has not finished yet. Wait until it has finished, or GET /health-check for status."
+        );
     }
 }

--- a/crates/coglet/src/transport/http/routes.rs
+++ b/crates/coglet/src/transport/http/routes.rs
@@ -287,16 +287,17 @@ async fn create_prediction_with_id(
     let mut slot = match service.create_prediction(prediction_id.clone(), None).await {
         Ok(p) => p,
         Err(CreatePredictionError::NotReady) => {
+            let msg = PredictionError::NotReady.to_string();
             supervisor.update_status(
                 &prediction_id,
                 PredictionStatus::Failed,
                 None,
-                Some("Predictor not ready".to_string()),
+                Some(msg.clone()),
             );
             return (
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(serde_json::json!({
-                    "error": "Predictor not ready",
+                    "error": msg,
                     "status": "failed"
                 })),
             );
@@ -421,15 +422,18 @@ async fn create_prediction_with_id(
                 "metrics": { "predict_time": predict_time }
             })),
         ),
-        Err(PredictionError::NotReady) => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({
-                "id": prediction_id,
-                "error": "Predictor not ready",
-                "logs": "",
-                "status": "failed"
-            })),
-        ),
+        Err(PredictionError::NotReady) => {
+            let msg = PredictionError::NotReady.to_string();
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "id": prediction_id,
+                    "error": msg,
+                    "logs": "",
+                    "status": "failed"
+                })),
+            )
+        }
         Err(PredictionError::Failed(msg)) => (
             // 200 for parity with Python - prediction failure is data, not HTTP error
             StatusCode::OK,
@@ -589,7 +593,12 @@ mod tests {
 
         let json = response_json(response).await;
         assert_eq!(json["status"], "failed");
-        assert!(json["error"].as_str().unwrap().contains("not ready"));
+        assert!(
+            json["error"]
+                .as_str()
+                .unwrap()
+                .contains("Setup has not finished yet")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Replaced the vague "Predictor not ready" error with an actionable message: "Setup has not finished yet. Wait until it has finished, or GET /health-check for status."
- Deduplicated the message string so it's defined once on `PredictionError::NotReady` and referenced via `.to_string()` in route handlers

## Test plan
- [x] `cargo check -p coglet` passes
- [ ] Existing unit tests pass (`mise run test:rust`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)