### PR TITLE
fix(coglet): return 503 from /health-check when not ready

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -214,8 +214,8 @@ If the upload fails, the server responds with an error.
 ### `GET /health-check`
 
 Returns the current health status of the model container.
-This endpoint always responds with `200 OK` —
-check the `status` field in the response body to determine readiness.
+Responds with `200 OK` when the model is ready,
+or `503 Service Unavailable` otherwise.
 
 The response body is a JSON object with the following fields:
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1409,8 +1409,8 @@ If the upload fails, the server responds with an error.
 ### `GET /health-check`
 
 Returns the current health status of the model container.
-This endpoint always responds with `200 OK` —
-check the `status` field in the response body to determine readiness.
+Responds with `200 OK` when the model is ready,
+or `503 Service Unavailable` otherwise.
 
 The response body is a JSON object with the following fields:
 

--- a/integration-tests/tests/healthcheck_async_exception.txtar
+++ b/integration-tests/tests/healthcheck_async_exception.txtar
@@ -7,8 +7,8 @@ cog build -t $TEST_IMAGE
 # Start the server
 cog serve
 
-# Test: Async healthcheck raising exception gives UNHEALTHY with error
-curl GET /health-check
+# Test: Async healthcheck raising exception gives UNHEALTHY with error (503)
+! curl GET /health-check
 stdout '"status":"UNHEALTHY"'
 stdout 'user_healthcheck_error'
 stdout 'Async healthcheck error'

--- a/integration-tests/tests/healthcheck_async_timeout.txtar
+++ b/integration-tests/tests/healthcheck_async_timeout.txtar
@@ -15,8 +15,8 @@ stdout '"status":"READY"'
 curl POST /predictions '{"input":{"text":"trigger_slow"}}'
 stdout '"status":"succeeded"'
 
-# Now healthcheck should timeout and return UNHEALTHY
-curl GET /health-check
+# Now healthcheck should timeout and return UNHEALTHY (503)
+! curl GET /health-check
 stdout '"status":"UNHEALTHY"'
 stdout 'user_healthcheck_error'
 stdout 'timed out after 5.0 seconds'

--- a/integration-tests/tests/healthcheck_async_unhealthy.txtar
+++ b/integration-tests/tests/healthcheck_async_unhealthy.txtar
@@ -7,8 +7,8 @@ cog build -t $TEST_IMAGE
 # Start the server
 cog serve
 
-# Test: Async healthcheck returning False gives UNHEALTHY
-curl GET /health-check
+# Test: Async healthcheck returning False gives UNHEALTHY (503)
+! curl GET /health-check
 stdout '"status":"UNHEALTHY"'
 stdout 'user_healthcheck_error'
 stdout 'returned False'

--- a/integration-tests/tests/healthcheck_exception.txtar
+++ b/integration-tests/tests/healthcheck_exception.txtar
@@ -7,8 +7,8 @@ cog build -t $TEST_IMAGE
 # Start the server
 cog serve
 
-# Exception in healthcheck should return UNHEALTHY with error message
-curl GET /health-check
+# Exception in healthcheck should return UNHEALTHY with error message (503)
+! curl GET /health-check
 stdout '"status":"UNHEALTHY"'
 stdout 'user_healthcheck_error'
 stdout 'Critical system error'

--- a/integration-tests/tests/healthcheck_timeout.txtar
+++ b/integration-tests/tests/healthcheck_timeout.txtar
@@ -15,8 +15,8 @@ stdout '"status":"READY"'
 curl POST /predictions '{"input":{"text":"trigger_slow"}}'
 stdout '"status":"succeeded"'
 
-# Now healthcheck should timeout and return UNHEALTHY
-curl GET /health-check
+# Now healthcheck should timeout and return UNHEALTHY (503)
+! curl GET /health-check
 stdout '"status":"UNHEALTHY"'
 stdout 'user_healthcheck_error'
 stdout 'timed out after 5.0 seconds'

--- a/integration-tests/tests/healthcheck_unhealthy.txtar
+++ b/integration-tests/tests/healthcheck_unhealthy.txtar
@@ -7,8 +7,8 @@ cog build -t $TEST_IMAGE
 # Start the server
 cog serve
 
-# Unhealthy healthcheck should return UNHEALTHY status
-curl GET /health-check
+# Unhealthy healthcheck should return UNHEALTHY status (503)
+! curl GET /health-check
 stdout '"status":"UNHEALTHY"'
 stdout 'user_healthcheck_error'
 stdout 'user-defined healthcheck returned False'


### PR DESCRIPTION
## Summary
- `/health-check` now returns `200` only when status is `READY`; all other statuses (`STARTING`, `BUSY`, `SETUP_FAILED`, `DEFUNCT`, `UNHEALTHY`) return `503`
- This lets load balancers and Kubernetes probes work without parsing the response body
- Updated docs and tests to match

Builds on #2731.

## Test plan
- [x] `cargo test -p coglet -- health_check` — 4 tests pass
- [ ] `mise run docs:llm:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)