### PR TITLE
fix: typo in CONTRIBUTING.md (supersedes #2141)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -358,7 +358,7 @@ git config --global commit.gpgsign true
 
 Prereleases are a useful way to give testers a way to try out new versions of Cog without affecting the documented `latest` download URL which people normally use to install Cog.
 
-To publish a prerelease version, append a [SemVer prerelease identifer](https://semver.org/#spec-item-9) like `-alpha` or `-beta` to the git tag name. Goreleaser will detect this and mark it as a prerelease in GitHub Releases.
+To publish a prerelease version, append a [SemVer prerelease identifier](https://semver.org/#spec-item-9) like `-alpha` or `-beta` to the git tag name. Goreleaser will detect this and mark it as a prerelease in GitHub Releases.
 
     git checkout some-prerelease-branch
     git fetch --all --tags


### PR DESCRIPTION
Fixes typo in CONTRIBUTING.md: 'identifer' → 'identifier'

This supersedes #2141 which had merge conflicts. The other two typo fixes from that PR were already resolved in main:
- test_worker.py: 'cancelations' → 'cancellations' (already fixed)
- fast_weights_test.go: File was deleted in main, typo no longer exists

Co-authored-by: Maxim Evtush <154841002+maximevtush@users.noreply.github.com>