### PR TITLE
feat: require python_version in cog.yaml build section

### DIFF
--- a/integration-tests/tests/secrets.txtar
+++ b/integration-tests/tests/secrets.txtar
@@ -8,6 +8,7 @@ cog build -t $TEST_IMAGE --secret id=file-secret,src=file-secret.txt --secret id
 
 -- cog.yaml --
 build:
+  python_version: "3.13"
   run:
     - command: >-
         ID="file-secret";

--- a/pkg/config/data/config_schema_v1.0.json
+++ b/pkg/config/data/config_schema_v1.0.json
@@ -147,6 +147,7 @@
           }
         }
       },
+      "required": ["python_version"],
       "additionalProperties": false
     },
     "image": {

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -107,8 +107,6 @@ func configFileToConfig(cfg *configFile) (*Config, error) {
 		}
 		if cfg.Build.PythonVersion != nil {
 			config.Build.PythonVersion = *cfg.Build.PythonVersion
-		} else {
-			config.Build.PythonVersion = DefaultPythonVersion
 		}
 		if cfg.Build.PythonRequirements != nil {
 			config.Build.PythonRequirements = *cfg.Build.PythonRequirements

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -145,8 +145,13 @@ func validateBuild(cfg *configFile, opts *validateOptions, result *ValidationRes
 
 	build := cfg.Build
 
-	// Validate Python version
-	if build.PythonVersion != nil && *build.PythonVersion != "" {
+	// Validate Python version is set and valid
+	if build.PythonVersion == nil || *build.PythonVersion == "" {
+		result.AddError(&ValidationError{
+			Field:   "build.python_version",
+			Message: "python_version is required. Add it to the build section of your cog.yaml, e.g. `python_version: \"3.13\"`",
+		})
+	} else {
 		if err := validatePythonVersion(*build.PythonVersion); err != nil {
 			result.AddError(err)
 		}

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -146,6 +146,36 @@ func TestValidateConfigFileDeprecatedPreInstall(t *testing.T) {
 	require.Contains(t, result.Warnings[0].Message, "build.run")
 }
 
+func TestValidateConfigFileMissingPythonVersion(t *testing.T) {
+	cfg := &configFile{
+		Build: &buildFile{
+			GPU: boolPtr(true),
+		},
+	}
+
+	result := ValidateConfigFile(cfg)
+	require.True(t, result.HasErrors())
+	require.Contains(t, result.Err().Error(), "python_version is required")
+}
+
+func TestValidateConfigFileMissingPythonVersionEmptyBuild(t *testing.T) {
+	cfg := &configFile{
+		Build: &buildFile{},
+	}
+
+	result := ValidateConfigFile(cfg)
+	require.True(t, result.HasErrors())
+	require.Contains(t, result.Err().Error(), "python_version is required")
+}
+
+func TestValidateConfigFileNilBuildSkipsPythonVersionCheck(t *testing.T) {
+	cfg := &configFile{}
+
+	result := ValidateConfigFile(cfg)
+	// No build section at all should not error about python_version
+	require.False(t, result.HasErrors(), "expected no errors for nil build, got: %v", result.Errors)
+}
+
 // Helper functions
 func boolPtr(b bool) *bool {
 	return &b


### PR DESCRIPTION
## Summary

- Make `python_version` a required field in the `build` section of `cog.yaml`, so models don't silently break when the default Python version is bumped in a future release
- Add a clear validation error guiding users to add the field
- Remove the silent fallback to `DefaultPythonVersion` in config parsing

I was considering adding a warning saying it will be required in a future version of Cog, but I have never seen anyone not use `python_version`, so I would consider it a minor breaking change. We're still in the 0.x wild west land and so long as we mention it in release notes maybe it's fine? 🤷

Closes #101