### PR TITLE
fix: add xattr workaround for macOS Gatekeeper warning

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,8 +19,20 @@ First, install Cog:
 ```bash
 sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
 sudo chmod +x /usr/local/bin/cog
+sudo xattr -d com.apple.quarantine /usr/local/bin/cog 2>/dev/null || true
 
 ```
+
+> [!NOTE]
+> **macOS: "cannot be opened because the developer cannot be verified"**
+>
+> If you see this Gatekeeper warning, it's because the binary isn't signed yet. The `xattr` command above clears the quarantine flag automatically. If you downloaded the binary via a browser instead, run this manually:
+>
+> ```bash
+> sudo xattr -d com.apple.quarantine /usr/local/bin/cog
+> ```
+>
+> Alternatively, you can install Cog via Homebrew (`brew install cog`) which builds from source and isn't affected.
 
 ## Create a project
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -729,8 +729,20 @@ First, install Cog:
 ```bash
 sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
 sudo chmod +x /usr/local/bin/cog
+sudo xattr -d com.apple.quarantine /usr/local/bin/cog 2>/dev/null || true
 
 ```
+
+> [!NOTE]
+> **macOS: "cannot be opened because the developer cannot be verified"**
+>
+> If you see this Gatekeeper warning, it's because the binary isn't signed yet. The `xattr` command above clears the quarantine flag automatically. If you downloaded the binary via a browser instead, run this manually:
+>
+> ```bash
+> sudo xattr -d com.apple.quarantine /usr/local/bin/cog
+> ```
+>
+> Alternatively, you can install Cog via Homebrew (`brew install cog`) which builds from source and isn't affected.
 
 ## Create a project
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -132,6 +132,12 @@ setup_cog() {
 
   $SUDO chmod +x $COG_LOCATION
 
+  # On macOS, remove the quarantine attribute that triggers Gatekeeper's
+  # "cannot be opened because the developer cannot be verified" warning.
+  if [ "$(uname -s)" = "Darwin" ]; then
+    $SUDO xattr -d com.apple.quarantine "$COG_LOCATION" 2>/dev/null || true
+  fi
+
   SHELL_NAME=$(basename "$SHELL")
   if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
     echo "Adding $INSTALL_DIR to PATH in .$SHELL_NAME"rc


### PR DESCRIPTION
## Summary

- Adds `xattr -d com.apple.quarantine` workaround to `tools/install.sh` and `docs/getting-started.md` to prevent the macOS Gatekeeper "cannot be opened because the developer cannot be verified" warning on unsigned binaries
- Adds a troubleshooting note in the getting started docs for users who download the binary via a browser

This is an immediate stopgap until proper code signing and notarization are added.

Closes #2738