### PR TITLE
fix: support Pydantic BaseModel as prediction output type in schema gen

### DIFF
--- a/integration-tests/tests/pydantic2_output.txtar
+++ b/integration-tests/tests/pydantic2_output.txtar
@@ -1,0 +1,37 @@
+# Test that Pydantic v2 BaseModel works as prediction output type.
+# Coglet's make_encodeable() must call model_dump() to serialize.
+
+# Build the image
+cog build -t $TEST_IMAGE
+
+# Predict returns structured Pydantic output
+cog predict $TEST_IMAGE -i name=alice -i score=0.95
+stdout '"name": "alice"'
+stdout '"score": 0.95'
+stdout '"tags"'
+stdout 'default'
+
+-- cog.yaml --
+build:
+  python_version: "3.12"
+  python_packages:
+    - "pydantic>2"
+predict: "predict.py:Predictor"
+
+-- predict.py --
+from typing import List
+
+from pydantic import BaseModel as PydanticBaseModel
+
+from cog import BasePredictor
+
+
+class Result(PydanticBaseModel):
+    name: str
+    score: float
+    tags: List[str]
+
+
+class Predictor(BasePredictor):
+    def predict(self, name: str, score: float = 0.5) -> Result:
+        return Result(name=name, score=score, tags=["default"])

--- a/pkg/schema/types.go
+++ b/pkg/schema/types.go
@@ -340,10 +340,10 @@ func (ctx *ImportContext) IsTypingType(name string) bool {
 	return false
 }
 
-// IsBaseModel returns true if name resolves to cog.BaseModel.
+// IsBaseModel returns true if name resolves to cog.BaseModel or pydantic.BaseModel.
 func (ctx *ImportContext) IsBaseModel(name string) bool {
 	if e, ok := ctx.Names.Get(name); ok {
-		return e.Module == "cog" && e.Original == "BaseModel"
+		return (e.Module == "cog" || e.Module == "pydantic" || e.Module == "pydantic.v1") && e.Original == "BaseModel"
 	}
 	return false
 }


### PR DESCRIPTION
The tree-sitter schema parser only recognized cog.BaseModel subclasses. Pydantic BaseModel subclasses failed with 'unsupported type' because:

1. IsBaseModel() only checked module=='cog', not 'pydantic'
2. inheritsFromBaseModel() only handled 'identifier' AST nodes, missing 'attribute' nodes for dotted access (pydantic.BaseModel)
3. parseImportFrom() only handled aliased_import inside import_list, missing top-level aliased imports (from X import Y as Z)

Now supports all three import styles:
  - from pydantic import BaseModel
  - from pydantic import BaseModel as PydanticBaseModel
  - import pydantic; class Foo(pydantic.BaseModel)

Includes 3 unit tests and 1 integration test.