### PR TITLE
Build right wheel and update build instructions to build all

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,29 +21,16 @@ uv venv
 uv sync --all-groups
 ```
 
-### Building
-
-Cog is composed of three components that are built separately:
-
-- **Python SDK** (`python/cog/`) — the Python library that model authors use. Built into a wheel that gets installed inside containers.
-- **Coglet** (`crates/`) — a Rust prediction server that runs inside containers. Cross-compiled into a Linux wheel.
-- **Cog CLI** (`cmd/cog/`, `pkg/`) — the Go command-line tool. Embeds the SDK wheel and picks up the coglet wheel from `dist/`.
+### Build & install
 
 ```sh
-# Build everything and install
-mise run build:sdk                        # build the Python SDK wheel
-mise run build:coglet:wheel:linux-x64     # cross-compile the coglet wheel for Linux containers
-mise run build:cog                        # build the Go CLI (embeds SDK, picks up coglet from dist/)
-sudo mise run install                     # symlink the binary to /usr/local/bin
+mise run build
+
+# symlink the binary to /usr/local/bin
+sudo mise run install                     
 ```
 
-After making changes, rebuild only the component you changed and then `build:cog`:
-
-```sh
-mise run build:sdk                        # after changing python/cog/
-mise run build:coglet:wheel:linux-x64     # after changing crates/
-mise run build:cog                        # after changing cmd/cog/ or pkg/, or to pick up new wheels
-```
+After making changes, run `mise run build` to rebuild and it will get picked up by the symlink.
 
 ### Common tasks
 

--- a/mise.toml
+++ b/mise.toml
@@ -14,7 +14,7 @@
 #
 # Cached tasks:
 #   - build:sdk              - skips if python/**/*.py unchanged
-#   - build:coglet:wheel*    - skips if crates/**/*.rs unchanged  
+#   - build:coglet:wheel*    - skips if crates/**/*.rs unchanged
 #   - generate:stubs         - skips if coglet-python source unchanged
 #   - generate:compat        - skips if tools/compatgen unchanged
 #   - docs                   - skips if docs/**/*.md unchanged
@@ -95,7 +95,7 @@ run = "rm -f dist/cog-*.whl dist/cog-*.tar.gz dist/coglet-*.whl"
 alias = "build:all"
 description = "Build all components"
 run = [
-  { tasks = ["build:cog", "build:coglet", "build:sdk"] },
+  { tasks = ["build:cog", "build:coglet:wheel:linux-x64", "build:sdk"] },
 ]
 
 [tasks.install]


### PR DESCRIPTION
Build seems quick enough to simplify instructions to just build all. But it didn't work - `build:coglet` built a macOS build on macOS.
