### PR TITLE
fix: skip adding labels to images for local-use commands (run/predict/serve/train)

### DIFF
--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -64,6 +64,7 @@ func serveBuildOptions(cmd *cobra.Command) model.BuildOptions {
 		UseCogBaseImage:  DetermineUseCogBaseImage(cmd),
 		ProgressOutput:   buildProgressOutput,
 		ExcludeSource:    true,
+		SkipLabels:       true,
 	}
 }
 

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -61,6 +61,7 @@ func Build(
 	precompile bool,
 	excludeSource bool,
 	skipSchemaValidation bool,
+	skipLabels bool,
 	annotations map[string]string,
 	dockerCommand command.Command,
 	client registry.Client) (string, error) {
@@ -240,6 +241,13 @@ func Build(
 				return "", fmt.Errorf("Failed to build Docker image: %w", err)
 			}
 		}
+	}
+
+	// When skipLabels is true (cog run/predict/serve/train), skip the expensive
+	// label-adding phase. This image is for local use only and won't be distributed,
+	// so we don't need metadata labels, pip freeze, schema bundling, or git info.
+	if skipLabels {
+		return tmpImageId, nil
 	}
 
 	// --- Post-build legacy schema generation ---

--- a/pkg/model/factory.go
+++ b/pkg/model/factory.go
@@ -56,6 +56,7 @@ func (f *DockerfileFactory) Build(ctx context.Context, src *Source, opts BuildOp
 		opts.Precompile,
 		opts.ExcludeSource,
 		opts.SkipSchemaValidation,
+		opts.SkipLabels,
 		opts.Annotations,
 		f.docker,
 		f.registry,

--- a/pkg/model/options.go
+++ b/pkg/model/options.go
@@ -61,6 +61,11 @@ type BuildOptions struct {
 	// Used by `cog run` which executes arbitrary commands and may not have
 	// a predictor or trainer defined in cog.yaml.
 	SkipSchemaValidation bool
+
+	// SkipLabels skips adding Cog metadata labels to the built image.
+	// Used by `cog run`, `cog predict`, `cog serve`, and `cog train` where
+	// the image is for local use only and not being distributed.
+	SkipLabels bool
 }
 
 // WithDefaults returns a copy of BuildOptions with defaults applied from Source.


### PR DESCRIPTION
## Summary

- Skip the expensive label-adding phase when building images for `cog run`, `cog predict`, `cog serve`, and `cog train` — these images are for local use only and don't need metadata labels
- Adds `SkipLabels` option to `BuildOptions` that short-circuits before pip freeze, git info, base image layer inspection, and the extra Docker build step

## Background

This was a regression introduced in 1525f7f8 (`feat(coglet): IPC bridge enhancements`) which replaced `resolver.BuildBase()` (no labels) with `resolver.Build()` (adds labels) for the serve/run/predict/train code paths. The original `image.BuildBase()` just built the Docker image and returned — no labels were added.

## Changes

- `pkg/model/options.go` — Add `SkipLabels bool` field to `BuildOptions`
- `pkg/cli/serve.go` — Set `SkipLabels: true` in `serveBuildOptions()` (used by run/predict/serve/train)
- `pkg/image/build.go` — Early return before label-adding when `skipLabels` is true
- `pkg/model/factory.go` — Pass `SkipLabels` through to `image.Build()`