### PR TITLE
fix: coglet wheel build — pin MINIMUM_PYTHON for ABI3, deduplicate version lists

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,9 @@ env:
   SUPPORTED_PYTHONS: '["3.10", "3.11", "3.12", "3.13"]'
   # Default Python version for non-matrix jobs
   PYTHON_VERSION: "3.13"
+  # Minimum supported Python — used for ABI3 wheel builds and glob patterns.
+  # Must match the lowest entry in SUPPORTED_PYTHONS.
+  MINIMUM_PYTHON: "3.10"
   # Number of runners to shard integration tests across (per runtime)
   # Slow tests ([short] skip) are distributed round-robin first, then fast tests fill in
   NUM_IT_RUNNER_SHARDS: "4"
@@ -59,6 +62,8 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       version_only: ${{ steps.filter.outputs.version_only }}
       version_changed: ${{ steps.filter.outputs.version_changed }}
+      # Pass through for matrix jobs (env context unavailable in strategy)
+      supported_pythons: ${{ env.SUPPORTED_PYTHONS }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -281,17 +286,26 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       # No mise needed - maturin-action bundles maturin and zig
+      # Explicitly request MINIMUM_PYTHON inside the manylinux container so
+      # maturin produces an ABI3 wheel (cp310-abi3). Without this, maturin
+      # picks up the container's default Python (3.8), which doesn't support
+      # ABI3, producing a cp38-cp38 wheel that the upload glob won't match.
       - name: Build coglet wheel (ABI3)
         uses: PyO3/maturin-action@v1
         with:
           target: x86_64-unknown-linux-gnu
-          args: --release --out dist -m crates/coglet-python/Cargo.toml
+          args: --release --out dist -m crates/coglet-python/Cargo.toml --interpreter python${{ env.MINIMUM_PYTHON }}
           manylinux: auto
+      - name: Verify ABI3 wheel exists
+        run: |
+          CPVER="cp${MINIMUM_PYTHON//.}"
+          ls -la dist/coglet-*-${CPVER}-abi3-*.whl
       - name: Upload coglet wheel
         uses: actions/upload-artifact@v6
         with:
           name: CogletRustWheel
-          path: dist/coglet-*-cp310-abi3-*.whl
+          # ABI3 wheels use cpXYZ-abi3 naming; just match any abi3 wheel
+          path: dist/coglet-*-abi3-*.whl
 
   build-cog:
     name: Build cog CLI
@@ -560,7 +574,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ${{ fromJSON(needs.changes.outputs.supported_pythons) }}
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v7
@@ -593,7 +607,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ${{ fromJSON(needs.changes.outputs.supported_pythons) }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = "2"
 anyhow = "1"
 
 # Python bindings
-pyo3 = { version = "0.27", features = ["auto-initialize", "abi3-py310"] }
+pyo3 = { version = "0.27", features = ["abi3-py310"] }
 pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }
 pyo3-stub-gen = "0.18"
 

--- a/crates/coglet-python/Cargo.toml
+++ b/crates/coglet-python/Cargo.toml
@@ -27,5 +27,8 @@ tracing-subscriber.workspace = true
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[dev-dependencies]
+pyo3 = { workspace = true, features = ["auto-initialize"] }
+
 [features]
 extension-module = ["pyo3/extension-module"]


### PR DESCRIPTION
## Summary

The manylinux container's default Python changed to 3.8, which doesn't support ABI3. This caused maturin to produce a `cp38-cp38` wheel instead of `cp310-abi3`, making the upload glob match nothing and silently uploading zero files. The downstream download step then fails with `Artifact not found for name: CogletRustWheel`, **blocking all integration tests on all PRs**.

## Changes

- **`MINIMUM_PYTHON: "3.10"`** — new global env var, single source of truth for the ABI3 floor
- **`--interpreter python${{ env.MINIMUM_PYTHON }}`** — explicitly requests Python 3.10 inside the manylinux container
- **Verify step** — `ls` that fails the build immediately if the expected wheel doesn't exist (no more silent zero-file uploads)
- **Matrix dedup** — `test-python` and `test-coglet-python` now use `fromJSON(env.SUPPORTED_PYTHONS)` instead of repeating `["3.10", "3.11", "3.12", "3.13"]`

## Python version sources (after this PR)

| Variable | Value | Used for |
|----------|-------|----------|
| `SUPPORTED_PYTHONS` | `["3.10", "3.11", "3.12", "3.13"]` | Test matrices |
| `PYTHON_VERSION` | `3.13` | Non-matrix jobs (lint, fmt, build-sdk, etc.) |
| `MINIMUM_PYTHON` | `3.10` | ABI3 wheel interpreter + verify glob |

No more hardcoded version lists scattered across jobs.