### PR TITLE
Remove orphaned tests property from cog.yaml schema

### DIFF
--- a/pkg/config/data/config_schema_v1.0.json
+++ b/pkg/config/data/config_schema_v1.0.json
@@ -191,19 +191,6 @@
         }
       }
     },
-    "tests": {
-      "$id": "#/properties/tests",
-      "type": [
-        "array",
-        "null"
-      ],
-      "description": "A list of test cog commands to run.",
-      "additionalItems": false,
-      "items": {
-        "type": "object",
-        "additionalItems": true
-      }
-    },
     "environment": {
       "$id": "#/properties/properties/environment",
       "type": [


### PR DESCRIPTION
## Summary
- Remove the orphaned `tests` property from the `cog.yaml` JSON schema (`pkg/config/data/config_schema_v1.0.json`)
- The `tests` config option was added in PR #2149 and the Go implementation was removed in PR #2181, but the schema definition was left behind
- This has no functional impact since the Go `Config` struct already ignores the field, but cleaning it up avoids confusion