### PR TITLE
docs: standardize Python version examples to 3.13 across all docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ build:
   system_packages:
     - "libgl1-mesa-glx"
     - "libglib2.0-0"
-  python_version: "3.12"
+  python_version: "3.13"
   python_requirements: requirements.txt
 predict: "predict.py:Predictor"
 ```

--- a/docs/getting-started-own-model.md
+++ b/docs/getting-started-own-model.md
@@ -36,7 +36,7 @@ For example:
 
 ```yaml
 build:
-  python_version: "3.12"
+  python_version: "3.13"
   python_requirements: requirements.txt
 ```
 
@@ -115,7 +115,7 @@ Next, add the line `predict: "predict.py:Predictor"` to your `cog.yaml`, so it l
 
 ```yaml
 build:
-  python_version: "3.12"
+  python_version: "3.13"
   python_requirements: requirements.txt
 predict: "predict.py:Predictor"
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,7 +58,7 @@ The first thing you need to do is create a file called `cog.yaml`:
 
 ```yaml
 build:
-  python_version: "3.12"
+  python_version: "3.13"
 ```
 
 Then, you can run any command inside this environment. For example, enter
@@ -135,7 +135,7 @@ Then update `cog.yaml` to look like this:
 
 ```yaml
 build:
-  python_version: "3.12"
+  python_version: "3.13"
   python_requirements: requirements.txt
 predict: "predict.py:Predictor"
 ```

--- a/docs/http.md
+++ b/docs/http.md
@@ -258,7 +258,7 @@ Content-Type: application/json
     "version": {
         "coglet": "0.17.0",
         "cog": "0.14.0",
-        "python": "3.12.0"
+        "python": "3.13.0"
     }
 }
 ```

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -28,7 +28,7 @@ build:
   system_packages:
     - "libgl1-mesa-glx"
     - "libglib2.0-0"
-  python_version: "3.12"
+  python_version: "3.13"
   python_requirements: requirements.txt
 predict: "predict.py:Predictor"
 ```
@@ -683,7 +683,7 @@ For example:
 
 ```yaml
 build:
-  python_version: "3.12"
+  python_version: "3.13"
   python_requirements: requirements.txt
 ```
 
@@ -762,7 +762,7 @@ Next, add the line `predict: "predict.py:Predictor"` to your `cog.yaml`, so it l
 
 ```yaml
 build:
-  python_version: "3.12"
+  python_version: "3.13"
   python_requirements: requirements.txt
 predict: "predict.py:Predictor"
 ```
@@ -870,7 +870,7 @@ The first thing you need to do is create a file called `cog.yaml`:
 
 ```yaml
 build:
-  python_version: "3.12"
+  python_version: "3.13"
 ```
 
 Then, you can run any command inside this environment. For example, enter
@@ -947,7 +947,7 @@ Then update `cog.yaml` to look like this:
 
 ```yaml
 build:
-  python_version: "3.12"
+  python_version: "3.13"
   python_requirements: requirements.txt
 predict: "predict.py:Predictor"
 ```
@@ -1307,7 +1307,7 @@ Content-Type: application/json
     "version": {
         "coglet": "0.17.0",
         "cog": "0.14.0",
-        "python": "3.12.0"
+        "python": "3.13.0"
     }
 }
 ```
@@ -2215,7 +2215,7 @@ If you've used Cog before, you've probably seen the [Predictor](./python.md) cla
 
 ```yaml
 build:
-  python_version: "3.10"
+  python_version: "3.13"
 train: "train.py:train"
 ```
 
@@ -2245,7 +2245,7 @@ You can also use classes if you want to run many model trainings and save on set
 
 ```yaml
 build:
-  python_version: "3.10"
+  python_version: "3.13"
 train: "train.py:Trainer"
 ```
 
@@ -2559,7 +2559,7 @@ It has three keys: [`build`](#build), [`image`](#image), and [`predict`](#predic
 
 ```yaml
 build:
-  python_version: "3.11"
+  python_version: "3.13"
   python_requirements: requirements.txt
   system_packages:
     - "ffmpeg"
@@ -2661,11 +2661,11 @@ Your `cog.yaml` file can set either `python_packages` or `python_requirements`, 
 
 ### `python_version`
 
-The minor (`3.11`) or patch (`3.11.1`) version of Python to use. For example:
+The minor (`3.13`) or patch (`3.13.1`) version of Python to use. For example:
 
 ```yaml
 build:
-  python_version: "3.11.1"
+  python_version: "3.13.1"
 ```
 
 Cog supports Python 3.10, 3.11, 3.12, and 3.13. If you don't define a version, Cog will use the latest version of Python 3.13 or a version of Python that is compatible with the versions of PyTorch or TensorFlow you specify.
@@ -2707,7 +2707,7 @@ Pin the version of the cog Python SDK installed in the container. Accepts a [PEP
 
 ```yaml
 build:
-  python_version: "3.12"
+  python_version: "3.13"
   sdk_version: "0.18.0"
 ```
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -13,7 +13,7 @@ If you've used Cog before, you've probably seen the [Predictor](./python.md) cla
 
 ```yaml
 build:
-  python_version: "3.10"
+  python_version: "3.13"
 train: "train.py:train"
 ```
 
@@ -43,7 +43,7 @@ You can also use classes if you want to run many model trainings and save on set
 
 ```yaml
 build:
-  python_version: "3.10"
+  python_version: "3.13"
 train: "train.py:Trainer"
 ```
 

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -6,7 +6,7 @@ It has three keys: [`build`](#build), [`image`](#image), and [`predict`](#predic
 
 ```yaml
 build:
-  python_version: "3.11"
+  python_version: "3.13"
   python_requirements: requirements.txt
   system_packages:
     - "ffmpeg"
@@ -108,11 +108,11 @@ Your `cog.yaml` file can set either `python_packages` or `python_requirements`, 
 
 ### `python_version`
 
-The minor (`3.11`) or patch (`3.11.1`) version of Python to use. For example:
+The minor (`3.13`) or patch (`3.13.1`) version of Python to use. For example:
 
 ```yaml
 build:
-  python_version: "3.11.1"
+  python_version: "3.13.1"
 ```
 
 Cog supports Python 3.10, 3.11, 3.12, and 3.13. If you don't define a version, Cog will use the latest version of Python 3.13 or a version of Python that is compatible with the versions of PyTorch or TensorFlow you specify.
@@ -154,7 +154,7 @@ Pin the version of the cog Python SDK installed in the container. Accepts a [PEP
 
 ```yaml
 build:
-  python_version: "3.12"
+  python_version: "3.13"
   sdk_version: "0.18.0"
 ```
 

--- a/pkg/config/data/config_schema_v1.0.json
+++ b/pkg/config/data/config_schema_v1.0.json
@@ -30,7 +30,7 @@
             "string",
             "number"
           ],
-          "description": "The minor (`3.8`) or patch (`3.8.1`) version of Python to use."
+          "description": "The minor (`3.13`) or patch (`3.13.1`) version of Python to use."
         },
         "python_packages": {
           "$id": "#/properties/build/properties/python_packages",


### PR DESCRIPTION
## Summary

- Standardizes all `python_version` examples in documentation and README to use `3.13`, matching the default defined in `pkg/config/config.go:35`
- Updates the JSON schema (`config_schema_v1.0.json`) description which still referenced `3.8`/`3.8.1` as examples — now uses `3.13`/`3.13.1`
- Regenerates `docs/llms.txt`

## Details

Previously, different docs used different Python versions in examples:

| File | Old version |
|------|-------------|
| `docs/yaml.md` | 3.11, 3.11.1, 3.12 |
| `docs/training.md` | 3.10 |
| `docs/getting-started.md` | 3.12 |
| `docs/getting-started-own-model.md` | 3.12 |
| `docs/http.md` | 3.12.0 |
| `README.md` | 3.12 |
| `config_schema_v1.0.json` | 3.8, 3.8.1 |

All now consistently use `3.13` (the current default).