### PR TITLE
fix: clarify env variable deny-list error message

### DIFF
--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -41,13 +41,13 @@ func validateEnvName(name string) error {
 	for _, pattern := range environmentVariableDenyList {
 		// Check for exact match
 		if pattern == name {
-			return fmt.Errorf("environment variable %q is not allowed", name)
+			return fmt.Errorf("environment variable %q is not allowed: reserved for internal use", name)
 		}
 
 		// Check for wildcard pattern
 		if strings.HasSuffix(pattern, "*") {
 			if strings.HasPrefix(name, pattern[:len(pattern)-1]) {
-				return fmt.Errorf("environment variable %q is not allowed", name)
+				return fmt.Errorf("environment variable %q is not allowed: reserved for internal use", name)
 			}
 		}
 	}

--- a/pkg/config/env_variables_test.go
+++ b/pkg/config/env_variables_test.go
@@ -125,7 +125,7 @@ func TestEnvironmentConfig(t *testing.T) {
 				input := fmt.Sprintf("%s=VALUE", pattern)
 				_, err := parseAndValidateEnvironment([]string{input})
 				require.Error(t, err)
-				require.ErrorContains(t, err, fmt.Sprintf("environment variable %q is not allowed", pattern))
+				require.ErrorContains(t, err, fmt.Sprintf("environment variable %q is not allowed: reserved for internal use", pattern))
 			})
 
 			// test that prefix matches are rejected
@@ -135,7 +135,7 @@ func TestEnvironmentConfig(t *testing.T) {
 					input := fmt.Sprintf("%s=VALUE", name)
 					_, err := parseAndValidateEnvironment([]string{input})
 					require.Error(t, err)
-					require.ErrorContains(t, err, fmt.Sprintf("environment variable %q is not allowed", name))
+					require.ErrorContains(t, err, fmt.Sprintf("environment variable %q is not allowed: reserved for internal use", name))
 				})
 			}
 		}


### PR DESCRIPTION
## Summary

- Changes the environment variable deny-list error from the opaque `"environment variable %q is not allowed"` to `"environment variable %q is not allowed: reserved for internal use"`, so users understand *why* the variable is rejected.
- Updates corresponding test assertions in `env_variables_test.go` to match.