### PR TITLE
docs: remove obsolete queue worker reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ You can deploy your packaged model to your own infrastructure, or to [Replicate]
 
 - 🎁 **Automatic HTTP prediction server**: Your model's types are used to dynamically generate a RESTful HTTP API using a high-performance Rust/Axum server.
 
-- 🥞 **Automatic queue worker.** Long-running deep learning models or batch processing is best architected with a queue. Cog models do this out of the box. Redis is currently supported, with more in the pipeline.
-
 - 🚀 **Ready for production.** Deploy your model anywhere that Docker images run. Your own infrastructure, or [Replicate](https://replicate.com).
 
 ## How it works

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -14,8 +14,6 @@ You can deploy your packaged model to your own infrastructure, or to [Replicate]
 
 - 🎁 **Automatic HTTP prediction server**: Your model's types are used to dynamically generate a RESTful HTTP API using a high-performance Rust/Axum server.
 
-- 🥞 **Automatic queue worker.** Long-running deep learning models or batch processing is best architected with a queue. Cog models do this out of the box. Redis is currently supported, with more in the pipeline.
-
 - 🚀 **Ready for production.** Deploy your model anywhere that Docker images run. Your own infrastructure, or [Replicate](https://replicate.com).
 
 ## How it works


### PR DESCRIPTION
## Summary

- Removes the "Automatic queue worker" bullet point from the README highlights section, which advertised Redis queue support that has been removed from the codebase.
- Regenerates `docs/llms.txt` to stay in sync.

## Context

The README listed "Automatic queue worker" with Redis support as a feature, but the Redis queue API has been fully removed from both the Python SDK and Go CLI. This could mislead users evaluating Cog into expecting queue functionality that no longer exists. The docs already have a note explicitly stating the Redis queue API is no longer supported.