### PR TITLE
fix: remove hardcoded 300s setup timeout, add COG_SETUP_TIMEOUT env var

### DIFF
--- a/crates/coglet-python/src/lib.rs
+++ b/crates/coglet-python/src/lib.rs
@@ -161,6 +161,27 @@ fn read_max_concurrency() -> usize {
     }
 }
 
+fn read_setup_timeout() -> Option<std::time::Duration> {
+    match std::env::var("COG_SETUP_TIMEOUT") {
+        Ok(val) => match val.parse::<u64>() {
+            Ok(0) => {
+                warn!("COG_SETUP_TIMEOUT=0 would cause immediate timeout, ignoring");
+                None
+            }
+            Ok(secs) => Some(std::time::Duration::from_secs(secs)),
+            Err(e) => {
+                warn!(
+                    value = %val,
+                    error = %e,
+                    "Invalid COG_SETUP_TIMEOUT value, ignoring (no timeout will be applied)"
+                );
+                None
+            }
+        },
+        Err(_) => None,
+    }
+}
+
 // =============================================================================
 // coglet.server — frozen Server object with serve() and active property
 // =============================================================================
@@ -323,10 +344,12 @@ fn serve_subprocess(
         "Configuring subprocess worker via orchestrator"
     );
 
+    let setup_timeout = read_setup_timeout();
     let orch_config = coglet_core::orchestrator::OrchestratorConfig::new(pred_ref)
         .with_num_slots(max_concurrency)
         .with_train(is_train)
-        .with_upload_url(upload_url);
+        .with_upload_url(upload_url)
+        .with_setup_timeout(setup_timeout);
 
     let service = Arc::new(
         PredictionService::new_no_pool()

--- a/crates/coglet/src/orchestrator.rs
+++ b/crates/coglet/src/orchestrator.rs
@@ -296,7 +296,7 @@ pub struct OrchestratorConfig {
     pub num_slots: usize,
     pub is_train: bool,
     pub is_async: bool,
-    pub setup_timeout: Duration,
+    pub setup_timeout: Option<Duration>,
     pub spawner: Arc<dyn WorkerSpawner>,
     /// Upload URL prefix for file outputs (from --upload-url CLI arg).
     pub upload_url: Option<String>,
@@ -309,7 +309,7 @@ impl OrchestratorConfig {
             num_slots: 1,
             is_train: false,
             is_async: false,
-            setup_timeout: Duration::from_secs(300),
+            setup_timeout: None,
             spawner: Arc::new(SimpleSpawner),
             upload_url: None,
         }
@@ -335,7 +335,7 @@ impl OrchestratorConfig {
         self
     }
 
-    pub fn with_setup_timeout(mut self, timeout: Duration) -> Self {
+    pub fn with_setup_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.setup_timeout = timeout;
         self
     }
@@ -505,7 +505,7 @@ pub async fn spawn_worker(
         .map_err(|e| OrchestratorError::Spawn(format!("failed to accept connections: {}", e)))?;
 
     tracing::debug!("Waiting for Ready from worker");
-    let ready_result = tokio::time::timeout(config.setup_timeout, async {
+    let setup_fut = async {
         loop {
             match ctrl_reader.next().await {
                 Some(Ok(ControlResponse::Ready { slots, schema })) => {
@@ -516,15 +516,23 @@ pub async fn spawn_worker(
                         tracing::info!(target: "coglet::setup", source = ?source, "{}", line);
                     }
                 }
-                Some(Ok(ControlResponse::WorkerLog { target, level, message })) => {
+                Some(Ok(ControlResponse::WorkerLog {
+                    target,
+                    level,
+                    message,
+                })) => {
                     emit_worker_log(&target, &level, &message);
                 }
-                Some(Ok(ControlResponse::DroppedLogs { count, interval_millis })) => {
+                Some(Ok(ControlResponse::DroppedLogs {
+                    count,
+                    interval_millis,
+                })) => {
                     tracing::trace!(count, interval_millis, "Received DroppedLogs during setup");
                     let interval_secs = interval_millis as f64 / 1000.0;
                     tracing::warn!(
                         "Log production exceeds consumption rate during setup. {} logs dropped in last {:.1}s",
-                        count, interval_secs
+                        count,
+                        interval_secs
                     );
                 }
                 Some(Ok(ControlResponse::Failed { slot, error })) => {
@@ -553,13 +561,15 @@ pub async fn spawn_worker(
                 }
             }
         }
-    })
-    .await;
+    };
 
-    let (slot_ids, schema) = match ready_result {
-        Ok(Ok((slots, schema))) => (slots, schema),
-        Ok(Err(e)) => return Err(e),
-        Err(_) => return Err(OrchestratorError::SetupTimeout),
+    let (slot_ids, schema) = match config.setup_timeout {
+        Some(timeout) => match tokio::time::timeout(timeout, setup_fut).await {
+            Ok(Ok((slots, schema))) => (slots, schema),
+            Ok(Err(e)) => return Err(e),
+            Err(_) => return Err(OrchestratorError::SetupTimeout),
+        },
+        None => setup_fut.await?,
     };
 
     let setup_logs = crate::setup_log_accumulator::drain_accumulated_logs(setup_log_rx);

--- a/integration-tests/harness/harness.go
+++ b/integration-tests/harness/harness.go
@@ -322,6 +322,20 @@ func (h *Harness) Setup(env *testscript.Env) error {
 		}
 	}
 
+	// Auto-detect wheels from dist/ if not explicitly set via env vars.
+	// CI sets these env vars; locally we need to find them ourselves.
+	distDir := filepath.Join(h.repoRoot, "dist")
+	if os.Getenv("COGLET_WHEEL") == "" {
+		if matches, _ := filepath.Glob(filepath.Join(distDir, "coglet-*.whl")); len(matches) > 0 {
+			env.Setenv("COGLET_WHEEL", distDir)
+		}
+	}
+	if os.Getenv("COG_SDK_WHEEL") == "" {
+		if matches, _ := filepath.Glob(filepath.Join(distDir, "cog-*.whl")); len(matches) > 0 {
+			env.Setenv("COG_SDK_WHEEL", distDir)
+		}
+	}
+
 	// Generate unique image name for this test run
 	imageName := generateUniqueImageName()
 	env.Setenv("TEST_IMAGE", imageName)
@@ -378,10 +392,6 @@ func removeDockerImage(imageName string) {
 // Usage: cog serve [flags]
 // Exports $SERVER_URL environment variable with the server address.
 func (h *Harness) cmdCogServe(ts *testscript.TestScript, neg bool, args []string) {
-	if neg {
-		ts.Fatalf("serve command does not support negation")
-	}
-
 	workDir := ts.Getenv("WORK")
 
 	// Check if server is already running
@@ -445,9 +455,18 @@ func (h *Harness) cmdCogServe(ts *testscript.TestScript, neg bool, args []string
 	ts.Setenv("SERVER_URL", serverURL)
 
 	if !waitForServer(serverURL, 60*time.Second) {
+		if neg {
+			// Test expected the server to fail setup — keep it running
+			// so the test can inspect the health-check status.
+			return
+		}
 		// Try to get server output for debugging
 		_ = cmd.Process.Kill()
 		ts.Fatalf("server did not become healthy within timeout")
+	}
+
+	if neg {
+		ts.Fatalf("server became healthy, but expected setup failure")
 	}
 }
 

--- a/integration-tests/tests/setup_slow_serial.txtar
+++ b/integration-tests/tests/setup_slow_serial.txtar
@@ -1,0 +1,35 @@
+[short] skip 'slow test - skip in short mode'
+
+# Test that a slow setup() completes successfully without being killed by
+# an internal timeout. Coglet should not impose its own setup timeout —
+# the external orchestrator (director) is the authority on setup timeouts.
+
+# Build the image
+cog build -t $TEST_IMAGE
+
+# Start the server — setup takes ~15s but should complete fine
+cog serve
+
+# Verify the server is healthy and predictions work
+curl POST /predictions '{"input":{"s":"hello"}}'
+stdout '"output":"hello hello"'
+
+-- cog.yaml --
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"
+
+-- predict.py --
+import time
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def setup(self) -> None:
+        print("Starting slow setup...")
+        time.sleep(15)
+        print("Slow setup complete.")
+
+    def predict(self, s: str) -> str:
+        return "hello " + s

--- a/integration-tests/tests/setup_timeout_serial.txtar
+++ b/integration-tests/tests/setup_timeout_serial.txtar
@@ -1,0 +1,36 @@
+[short] skip 'slow test - skip in short mode'
+
+# Test that COG_SETUP_TIMEOUT env var is respected. When set to a value
+# shorter than the actual setup duration, setup should fail with SETUP_FAILED.
+
+# Build the image
+cog build -t $TEST_IMAGE
+
+# Start the server — setup takes ~15s but timeout is 10s, so it should fail
+! cog serve
+
+# Verify the server reports SETUP_FAILED
+curl GET /health-check
+stdout 'SETUP_FAILED'
+
+-- cog.yaml --
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"
+environment:
+  - COG_SETUP_TIMEOUT=10
+
+-- predict.py --
+import time
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def setup(self) -> None:
+        print("Starting slow setup...")
+        time.sleep(15)
+        print("Slow setup complete.")
+
+    def predict(self, s: str) -> str:
+        return "hello " + s

--- a/mise.toml
+++ b/mise.toml
@@ -291,7 +291,7 @@ echo "All fuzz targets passed."
 
 [tasks."test:integration"]
 description = "Run integration tests (skips slow tests by default, set SHORT=0 for full suite)"
-depends = ["build:cog", "build:sdk", "build:coglet:wheel:linux-x64"]
+depends = ["clean:integration", "build:cog", "build:sdk", "build:coglet:wheel:linux-x64"]
 run = """
 #!/usr/bin/env bash
 set -e
@@ -529,7 +529,7 @@ run = "ty check crates/coglet-python/coglet/__init__.pyi"
 [tasks.clean]
 description = "Clean all build artifacts"
 run = [
-  { tasks = ["clean:go", "clean:rust", "clean:python"] },
+  { tasks = ["clean:go", "clean:rust", "clean:python", "clean:integration"] },
   { task = "_clean_dist" },
 ]
 
@@ -544,6 +544,10 @@ run = "cd crates && cargo clean"
 [tasks."clean:python"]
 description = "Clean Python build artifacts"
 run = "rm -rf .tox build python/cog.egg-info .venv crates/coglet-python/.venv crates/coglet-python/coglet/*.so"
+
+[tasks."clean:integration"]
+description = "Clean cached integration test binary and embedded wheels"
+run = "rm -f integration-tests/.bin/cog pkg/wheels/cog-*.whl pkg/wheels/coglet-*.whl"
 
 # =============================================================================
 # Docs tasks


### PR DESCRIPTION
## Summary

- Remove the hardcoded 300-second internal setup timeout in coglet that was killing model `setup()` before the external orchestrator (director) timeout could fire
- Default to no internal timeout — director is the sole authority on setup timeouts (matches old Python server behavior)
- Add `COG_SETUP_TIMEOUT` env var (seconds) as an opt-in for cases where an internal timeout is desired

## Problem

A flux-dev model's setup was being killed at 5 minutes by coglet even though director was configured with a 10-minute timeout. The root cause was `Duration::from_secs(300)` hardcoded in `OrchestratorConfig::new()`.

## Changes

### Core fix (`crates/coglet/src/orchestrator.rs`)
- `OrchestratorConfig.setup_timeout`: `Duration` → `Option<Duration>`, default `None`
- `spawn_worker`: conditionally applies `tokio::time::timeout` only when `Some(timeout)` is set
- No timeout = wait forever for setup (let director handle it)

### Env var (`crates/coglet-python/src/lib.rs`)
- `read_setup_timeout()` reads `COG_SETUP_TIMEOUT` env var
- Warns on invalid values (non-numeric) and `0` (instant timeout) instead of silently ignoring

### Integration tests
- `setup_slow_serial.txtar` — 15s setup completes without being killed (happy path)
- `setup_timeout_serial.txtar` — `COG_SETUP_TIMEOUT=10` kills 15s setup, verifies `SETUP_FAILED`

### Test harness improvements
- Auto-detect coglet and SDK wheels from `dist/` when env vars not set
- Support `! cog serve` (negation) for testing setup failures
- Add `clean:integration` mise task to prevent stale binary/wheel issues

## Migration note

The default behavior changes from a 300s timeout to no timeout. Users who want to restore the old behavior can set `COG_SETUP_TIMEOUT=300`. In practice, director already manages setup timeouts externally, so most users won't notice a difference.