### PR TITLE
chore: add cargo ecosystem to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       interval: "weekly"
     allow:
       - dependency-type: "direct"
+  - package-ecosystem: "cargo"
+    directory: "/crates"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Adds the `cargo` package ecosystem to Dependabot, pointing at the `/crates` workspace directory
- Ensures Rust dependencies in `coglet` and `coglet-python` get automated update PRs alongside the existing Go, pip, and GitHub Actions ecosystems