### PR TITLE
fix: add -R flag to gh release download in publish workflow

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: Download coglet wheels from release
         run: |
           mkdir -p dist
-          gh release download "$TAG" -p "coglet-*.whl" -D dist
+          gh release download "$TAG" -p "coglet-*.whl" -D dist -R "${{ github.repository }}"
         env:
           TAG: ${{ github.event.release.tag_name }}
           GH_TOKEN: ${{ github.token }}
@@ -136,8 +136,8 @@ jobs:
       - name: Download SDK artifacts from release
         run: |
           mkdir -p dist
-          gh release download "$TAG" -p "cog-*.whl" -D dist
-          gh release download "$TAG" -p "cog-*.tar.gz" -D dist
+          gh release download "$TAG" -p "cog-*.whl" -D dist -R "${{ github.repository }}"
+          gh release download "$TAG" -p "cog-*.tar.gz" -D dist -R "${{ github.repository }}"
         env:
           TAG: ${{ github.event.release.tag_name }}
           GH_TOKEN: ${{ github.token }}
@@ -166,7 +166,7 @@ jobs:
           repositories: homebrew-tap
 
       - name: Download checksums from release
-        run: gh release download "$TAG" -p checksums.txt
+        run: gh release download "$TAG" -p checksums.txt -R "${{ github.repository }}"
         env:
           TAG: ${{ github.event.release.tag_name }}
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- The `publish-pypi-coglet`, `publish-pypi-sdk`, and `update-homebrew-tap` jobs in `release-publish.yaml` use `gh release download` without a repo checkout
- `gh` CLI tries to infer the repo from the local git directory, which doesn't exist, causing `fatal: not a git repository`
- Fix: pass `-R ${{ github.repository }}` to all `gh release download` calls

Failed run: https://github.com/replicate/cog/actions/runs/23023505546/job/66865664599