### PR TITLE
fix(ci): handle merge_group events in change detection for merge queue support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,9 +72,12 @@ jobs:
       - name: Detect changed paths
         id: filter
         run: |
-          # For PRs, compare against base; for pushes, compare against previous commit
+          # For PRs, compare against base; for pushes, compare against previous commit;
+          # for merge_group, compare against the merge group base.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE="${{ github.event.pull_request.base.sha }}"
+          elif [ "${{ github.event_name }}" = "merge_group" ]; then
+            BASE="${{ github.event.merge_group.base_sha }}"
           else
             BASE="${{ github.event.before }}"
             # Handle initial push (no before)


### PR DESCRIPTION
## Summary

- Fixes the CI change detection logic to correctly handle `merge_group` events, which are triggered by GitHub's merge queue feature.

## Problem

The change detection script in CI only handled `pull_request` and `push` events. For `merge_group` events, `github.event.before` is empty, causing the git diff base to be unset. This would cause jobs to be skipped or error out when a PR is added to the merge queue.

## Fix

Added an `elif` branch for `merge_group` events that uses `github.event.merge_group.base_sha` as the diff base.

## Enabling the Merge Queue

The workflow already has `merge_group` in its trigger list and the concurrency settings are merge-queue-aware. After merging this PR, a repo admin needs to enable the merge queue in GitHub settings:

1. Go to **Settings → Rules → Rulesets** (or **Settings → Branches** for the older branch protection interface)
2. Edit (or create) the ruleset for `main`
3. Enable **"Require merge queue"**
4. Set the required status check to **`CI Complete`** (the gate job that aggregates all CI results)
5. Recommended merge queue settings:
   - **Merge method**: Match your current preference (squash/merge/rebase)
   - **Build concurrency**: `5` (tune based on runner availability)
   - **Only merge non-failing PRs**: Enabled
   - **Status check timeout**: `60 minutes` (longest job is ~30min for integration tests)
   - **Merge limits**: Start with defaults (min 1, max 1); increase max later for batched merges

Once enabled, the "Merge" button on PRs changes to **"Merge when ready"**, which adds the PR to the queue.

## Docs

- [Managing a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
- [Merging a PR with a merge queue](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue)