### PR TITLE
feat(coglet): restore GET / root discovery endpoint

### DIFF
--- a/crates/coglet/src/service.rs
+++ b/crates/coglet/src/service.rs
@@ -240,6 +240,16 @@ impl PredictionService {
         self
     }
 
+    /// Get the runtime version info.
+    pub fn version(&self) -> &VersionInfo {
+        &self.version
+    }
+
+    /// Whether the model supports training (has a TrainingInput schema).
+    pub async fn supports_training(&self) -> bool {
+        self.train_validator.read().await.is_some()
+    }
+
     /// Get the permit pool from orchestrator.
     pub async fn pool(&self) -> Option<Arc<PermitPool>> {
         if let Some(ref state) = *self.orchestrator.read().await {

--- a/crates/coglet/src/transport/http/routes.rs
+++ b/crates/coglet/src/transport/http/routes.rs
@@ -98,6 +98,41 @@ fn generate_prediction_id() -> String {
     format!("pred_{:x}", timestamp)
 }
 
+/// Root discovery endpoint — returns a map of available API endpoints.
+///
+/// Restores the `GET /` endpoint from cog <= 0.16.x for service discovery.
+/// `cog_version` reports the Python SDK version when available (matching the
+/// old Python server behaviour), falling back to the coglet runtime version.
+async fn root(State(service): State<Arc<PredictionService>>) -> Json<serde_json::Value> {
+    let version = service.version();
+    let cog_version = version.python_sdk.as_deref().unwrap_or(version.coglet);
+    let mut doc = serde_json::json!({
+        "cog_version": cog_version,
+        "docs_url": "/docs",
+        "openapi_url": "/openapi.json",
+        "shutdown_url": "/shutdown",
+        "healthcheck_url": "/health-check",
+        "predictions_url": "/predictions",
+        "predictions_idempotent_url": "/predictions/{prediction_id}",
+        "predictions_cancel_url": "/predictions/{prediction_id}/cancel",
+    });
+
+    if service.supports_training().await {
+        let obj = doc.as_object_mut().expect("doc is an object");
+        obj.insert("trainings_url".to_string(), serde_json::json!("/trainings"));
+        obj.insert(
+            "trainings_idempotent_url".to_string(),
+            serde_json::json!("/trainings/{training_id}"),
+        );
+        obj.insert(
+            "trainings_cancel_url".to_string(),
+            serde_json::json!("/trainings/{training_id}/cancel"),
+        );
+    }
+
+    Json(doc)
+}
+
 async fn health_check(State(service): State<Arc<PredictionService>>) -> Json<HealthCheckResponse> {
     tracing::trace!("Health check endpoint called");
     let snapshot = service.health().await;
@@ -604,6 +639,7 @@ const MAX_HTTP_BODY_SIZE: usize = 100 * 1024 * 1024;
 
 pub fn routes(service: Arc<PredictionService>) -> Router {
     Router::new()
+        .route("/", get(root))
         .route("/health-check", get(health_check))
         .route("/openapi.json", get(openapi_schema))
         .route("/shutdown", post(shutdown))
@@ -1111,5 +1147,99 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         rx.changed().await.unwrap();
         assert!(*rx.borrow());
+    }
+
+    #[tokio::test]
+    async fn root_returns_discovery_document() {
+        let service = Arc::new(PredictionService::new_no_pool());
+        let app = routes(service);
+
+        let response = app
+            .oneshot(Request::get("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get("content-type").unwrap(),
+            "application/json"
+        );
+
+        let json = response_json(response).await;
+        // Without a python_sdk version set, falls back to coglet version
+        assert_eq!(json["cog_version"], crate::version::COGLET_VERSION);
+        assert_eq!(json["docs_url"], "/docs");
+        assert_eq!(json["openapi_url"], "/openapi.json");
+        assert_eq!(json["shutdown_url"], "/shutdown");
+        assert_eq!(json["healthcheck_url"], "/health-check");
+        assert_eq!(json["predictions_url"], "/predictions");
+        assert_eq!(
+            json["predictions_idempotent_url"],
+            "/predictions/{prediction_id}"
+        );
+        assert_eq!(
+            json["predictions_cancel_url"],
+            "/predictions/{prediction_id}/cancel"
+        );
+        // No training URLs without a TrainingInput schema
+        assert!(json.get("trainings_url").is_none());
+        assert!(json.get("trainings_idempotent_url").is_none());
+        assert!(json.get("trainings_cancel_url").is_none());
+    }
+
+    #[tokio::test]
+    async fn root_includes_training_urls_when_schema_has_training() {
+        let service = Arc::new(PredictionService::new_no_pool());
+        // Set a schema that includes a TrainingInput component
+        service
+            .set_schema(serde_json::json!({
+                "openapi": "3.0.2",
+                "info": {"title": "Cog", "version": "0.1.0"},
+                "components": {
+                    "schemas": {
+                        "TrainingInput": {
+                            "type": "object",
+                            "properties": {
+                                "data": {"type": "string"}
+                            }
+                        }
+                    }
+                }
+            }))
+            .await;
+        let app = routes(service);
+
+        let response = app
+            .oneshot(Request::get("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let json = response_json(response).await;
+        // Base fields still present
+        assert_eq!(json["predictions_url"], "/predictions");
+        // Training URLs included
+        assert_eq!(json["trainings_url"], "/trainings");
+        assert_eq!(json["trainings_idempotent_url"], "/trainings/{training_id}");
+        assert_eq!(
+            json["trainings_cancel_url"],
+            "/trainings/{training_id}/cancel"
+        );
+    }
+
+    #[tokio::test]
+    async fn root_cog_version_prefers_python_sdk() {
+        let version = VersionInfo::new().with_python_sdk("0.14.0".to_string());
+        let service = Arc::new(PredictionService::new_no_pool().with_version(version));
+        let app = routes(service);
+
+        let response = app
+            .oneshot(Request::get("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let json = response_json(response).await;
+        assert_eq!(json["cog_version"], "0.14.0");
     }
 }


### PR DESCRIPTION
## Summary

- Restores the `GET /` root discovery endpoint that existed in cog <= 0.16.x and was dropped when the Python HTTP server was replaced by coglet in v0.17.0
- Returns a JSON document listing all available API endpoints for service discovery
- Training URLs (`/trainings`, `/trainings/{training_id}`, `/trainings/{training_id}/cancel`) are conditionally included only when the model's OpenAPI schema contains a `TrainingInput` component
- `cog_version` reports the Python SDK version when available, falling back to the coglet runtime version

## Example response

```json
{
  "cog_version": "0.14.0",
  "docs_url": "/docs",
  "openapi_url": "/openapi.json",
  "shutdown_url": "/shutdown",
  "healthcheck_url": "/health-check",
  "predictions_url": "/predictions",
  "predictions_idempotent_url": "/predictions/{prediction_id}",
  "predictions_cancel_url": "/predictions/{prediction_id}/cancel",
  "trainings_url": "/trainings",
  "trainings_idempotent_url": "/trainings/{training_id}",
  "trainings_cancel_url": "/trainings/{training_id}/cancel"
}
```

## Testing

- 3 new unit tests covering base discovery fields, conditional training URLs, and `cog_version` preference logic
- All 168 Rust tests pass, clippy clean, fmt clean