### PR TITLE
fix: harden integration timing and SIGTERM assertions

### DIFF
--- a/integration-tests/concurrent/concurrent_test.go
+++ b/integration-tests/concurrent/concurrent_test.go
@@ -4,6 +4,7 @@ package concurrent_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -501,7 +502,22 @@ class Predictor(BasePredictor):
 
 	select {
 	case err := <-done:
-		t.Logf("Server exited: %v", err)
+		if err == nil {
+			t.Fatal("server exited cleanly after SIGTERM; expected termination by signal")
+		}
+
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("server exited with unexpected error type after SIGTERM: %T (%v)", err, err)
+		}
+
+		ws, ok := exitErr.Sys().(syscall.WaitStatus)
+		if !ok {
+			t.Fatalf("server exited after SIGTERM but wait status was unavailable: %v", err)
+		}
+		if !ws.Signaled() || ws.Signal() != syscall.SIGTERM {
+			t.Fatalf("server exit = %v, want signal %v", ws, syscall.SIGTERM)
+		}
 	case <-time.After(15 * time.Second):
 		serveCmd.Process.Kill()
 		t.Fatal("server did not exit within 15s after SIGTERM")

--- a/integration-tests/tests/async_generator_precollect.txtar
+++ b/integration-tests/tests/async_generator_precollect.txtar
@@ -10,8 +10,8 @@ curl POST /predictions '{"input":{}}'
 stdout '"status":"succeeded"'
 # All 5 items should be present in the output
 stdout '"output":\["chunk-0","chunk-1","chunk-2","chunk-3","chunk-4"\]'
-# predict_time should be a positive number (at least 0.5s for 5 items × 0.1s each)
-stdout '"predict_time":[0-9]+\.[0-9]'
+# predict_time should reflect full generation time (at least ~0.5s)
+stdout '"predict_time":(0\.[5-9][0-9]*|[1-9][0-9]*(\.[0-9]+)?)'
 
 -- cog.yaml --
 build:

--- a/integration-tests/tests/webhook_delivery_failure.txtar
+++ b/integration-tests/tests/webhook_delivery_failure.txtar
@@ -10,12 +10,9 @@ cog serve --upload-url http://unused/
 # Async prediction with a bogus webhook URL — delivery will fail
 curl -H Prefer:respond-async POST /predictions '{"id":"webhook-fail-test","webhook":"http://host.docker.internal:1/nonexistent","webhook_events_filter":["completed"]}'
 
-# Give coglet time to attempt delivery and fail (it retries with backoff)
-exec sleep 5
-
-# Server should still be healthy
-curl GET /health-check
-stdout '"status":"READY"'
+# Server should remain healthy while webhook delivery retries/fails.
+# Poll repeatedly instead of sleeping a fixed duration.
+exec bash -c 'for i in {1..10}; do curl -sf $SERVER_URL/health-check | grep -q "\"status\":\"READY\"" || exit 1; sleep 0.5; done'
 
 # A new sync prediction should still work
 curl POST /predictions '{"input":{}}'


### PR DESCRIPTION
## Summary
- replace fixed sleep in `webhook_delivery_failure` with health-check polling to reduce timing flake
- tighten `async_generator_precollect` to assert `predict_time` reflects full generation duration
- strengthen `TestSIGTERMDuringSetup` to assert termination is specifically caused by `SIGTERM`

## Test Plan
- [x] Attempted: `go test -tags integration ./integration-tests/concurrent -run TestSIGTERMDuringSetup -count=1`
- [ ] Blocked locally by environment permissions while building wheels (`python/cog.egg-info` and `crates/target/release/.cargo-lock` permission denied)