### PR TITLE
refactor: use testify assertions in integration tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,3 +284,22 @@ Tools disabled in CI are listed in `MISE_DISABLE_TOOLS` in `ci.yaml`.
 - Tests use real Docker operations (no mocking Docker API)
 - Always run `mise run build:sdk` after making Python changes before testing Go code
 - Python 3.10-3.13 compatibility is required
+
+### Go Test Conventions
+All Go tests must use [testify](https://github.com/stretchr/testify) for assertions. Do **not** use raw `if` checks with `t.Fatal`/`t.Errorf` — use `require` and `assert` instead.
+
+- **`require`** — for fatal assertions that should stop the test (setup failures, preconditions):
+  ```go
+  require.NoError(t, err, "failed to create client")
+  require.Equal(t, expected, actual)
+  require.True(t, condition, "server should be ready")
+  ```
+- **`assert`** — for non-fatal checks where the test should continue (e.g. validating multiple fields in a loop):
+  ```go
+  assert.Equal(t, http.StatusOK, resp.StatusCode)
+  assert.Contains(t, output, "expected substring")
+  assert.NoError(t, err, "prediction %d failed", i)
+  ```
+- Use `require` for errors in setup/teardown and `assert` for the actual test expectations
+- Prefer specific assertions (`Equal`, `Contains`, `NoError`, `Len`, `Less`) over generic `True`/`False` — they produce better failure messages
+- Prefer table-driven tests for testing multiple similar cases

--- a/integration-tests/concurrent/concurrent_test.go
+++ b/integration-tests/concurrent/concurrent_test.go
@@ -16,6 +16,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/replicate/cog/integration-tests/harness"
 )
 
@@ -36,24 +39,18 @@ func TestConcurrentPredictions(t *testing.T) {
 
 	// Create a temp directory for our test project
 	tmpDir, err := os.MkdirTemp("", "cog-concurrent-test-*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
+	require.NoError(t, err, "failed to create temp dir")
 	defer os.RemoveAll(tmpDir)
 
 	// Write the async-sleep predictor fixture
-	if err := os.WriteFile(filepath.Join(tmpDir, "cog.yaml"), []byte(cogYAML), 0o644); err != nil {
-		t.Fatalf("failed to write cog.yaml: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(tmpDir, "predict.py"), []byte(predictPy), 0o644); err != nil {
-		t.Fatalf("failed to write predict.py: %v", err)
-	}
+	err = os.WriteFile(filepath.Join(tmpDir, "cog.yaml"), []byte(cogYAML), 0o644)
+	require.NoError(t, err, "failed to write cog.yaml")
+	err = os.WriteFile(filepath.Join(tmpDir, "predict.py"), []byte(predictPy), 0o644)
+	require.NoError(t, err, "failed to write predict.py")
 
 	// Get the cog binary
 	cogBinary, err := harness.ResolveCogBinary()
-	if err != nil {
-		t.Fatalf("failed to resolve cog binary: %v", err)
-	}
+	require.NoError(t, err, "failed to resolve cog binary")
 
 	// Generate unique image name
 	imageName := fmt.Sprintf("cog-concurrent-test-%d", time.Now().UnixNano())
@@ -66,24 +63,20 @@ func TestConcurrentPredictions(t *testing.T) {
 	buildCmd := exec.Command(cogBinary, "build", "-t", imageName)
 	buildCmd.Dir = tmpDir
 	buildCmd.Env = append(os.Environ(), "COG_NO_UPDATE_CHECK=1")
-	if output, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build image: %v\n%s", err, output)
-	}
+	output, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "failed to build image\n%s", output)
 
 	// Start the server
 	t.Log("Starting server...")
 	port, err := allocatePort()
-	if err != nil {
-		t.Fatalf("failed to allocate port: %v", err)
-	}
+	require.NoError(t, err, "failed to allocate port")
 
 	serveCmd := exec.Command(cogBinary, "serve", "-p", fmt.Sprintf("%d", port))
 	serveCmd.Dir = tmpDir
 	serveCmd.Env = append(os.Environ(), "COG_NO_UPDATE_CHECK=1")
 
-	if err := serveCmd.Start(); err != nil {
-		t.Fatalf("failed to start server: %v", err)
-	}
+	err = serveCmd.Start()
+	require.NoError(t, err, "failed to start server")
 	defer func() {
 		serveCmd.Process.Kill()
 		serveCmd.Wait()
@@ -93,9 +86,7 @@ func TestConcurrentPredictions(t *testing.T) {
 
 	// Wait for server to be ready
 	t.Log("Waiting for server to be ready...")
-	if !waitForServerReady(serverURL, 60*time.Second) {
-		t.Fatal("server did not become ready within timeout")
-	}
+	require.True(t, waitForServerReady(serverURL, 60*time.Second), "server did not become ready within timeout")
 
 	// Fire 5 concurrent predictions
 	t.Log("Starting concurrent predictions...")
@@ -132,24 +123,18 @@ func TestConcurrentPredictions(t *testing.T) {
 	t.Logf("All predictions completed in %v", elapsed)
 
 	// Verify timing - should be < 3s if running concurrently (each sleeps 1s)
-	if elapsed >= 3*time.Second {
-		t.Errorf("predictions took too long (%v), expected < 3s for concurrent execution", elapsed)
-	}
+	assert.Less(t, elapsed, 3*time.Second, "predictions took too long (%v), expected < 3s for concurrent execution", elapsed)
 
 	// Verify all predictions succeeded with correct output
 	for i, result := range results {
-		if result.err != nil {
-			t.Errorf("prediction %d failed: %v", i, result.err)
+		if !assert.NoError(t, result.err, "prediction %d failed", i) {
 			continue
 		}
-		if result.statusCode != http.StatusOK {
-			t.Errorf("prediction %d returned status %d, want %d", i, result.statusCode, http.StatusOK)
+		if !assert.Equal(t, http.StatusOK, result.statusCode, "prediction %d returned unexpected status", i) {
 			continue
 		}
 		expectedOutput := fmt.Sprintf("wake up sleepyhead%d", i)
-		if result.output != expectedOutput {
-			t.Errorf("prediction %d output = %q, want %q", i, result.output, expectedOutput)
-		}
+		assert.Equal(t, expectedOutput, result.output, "prediction %d output mismatch", i)
 	}
 }
 
@@ -294,22 +279,16 @@ func TestConcurrentAboveLimit(t *testing.T) {
 	}
 
 	tmpDir, err := os.MkdirTemp("", "cog-above-limit-test-*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
+	require.NoError(t, err, "failed to create temp dir")
 	defer os.RemoveAll(tmpDir)
 
-	if err := os.WriteFile(filepath.Join(tmpDir, "cog.yaml"), []byte(aboveLimitCogYAML), 0o644); err != nil {
-		t.Fatalf("failed to write cog.yaml: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(tmpDir, "predict.py"), []byte(predictPy), 0o644); err != nil {
-		t.Fatalf("failed to write predict.py: %v", err)
-	}
+	err = os.WriteFile(filepath.Join(tmpDir, "cog.yaml"), []byte(aboveLimitCogYAML), 0o644)
+	require.NoError(t, err, "failed to write cog.yaml")
+	err = os.WriteFile(filepath.Join(tmpDir, "predict.py"), []byte(predictPy), 0o644)
+	require.NoError(t, err, "failed to write predict.py")
 
 	cogBinary, err := harness.ResolveCogBinary()
-	if err != nil {
-		t.Fatalf("failed to resolve cog binary: %v", err)
-	}
+	require.NoError(t, err, "failed to resolve cog binary")
 
 	imageName := fmt.Sprintf("cog-above-limit-test-%d", time.Now().UnixNano())
 	defer func() {
@@ -320,23 +299,19 @@ func TestConcurrentAboveLimit(t *testing.T) {
 	buildCmd := exec.Command(cogBinary, "build", "-t", imageName)
 	buildCmd.Dir = tmpDir
 	buildCmd.Env = append(os.Environ(), "COG_NO_UPDATE_CHECK=1")
-	if output, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build image: %v\n%s", err, output)
-	}
+	output, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "failed to build image\n%s", output)
 
 	t.Log("Starting server...")
 	port, err := allocatePort()
-	if err != nil {
-		t.Fatalf("failed to allocate port: %v", err)
-	}
+	require.NoError(t, err, "failed to allocate port")
 
 	serveCmd := exec.Command(cogBinary, "serve", "-p", fmt.Sprintf("%d", port))
 	serveCmd.Dir = tmpDir
 	serveCmd.Env = append(os.Environ(), "COG_NO_UPDATE_CHECK=1")
 
-	if err := serveCmd.Start(); err != nil {
-		t.Fatalf("failed to start server: %v", err)
-	}
+	err = serveCmd.Start()
+	require.NoError(t, err, "failed to start server")
 	defer func() {
 		serveCmd.Process.Kill()
 		serveCmd.Wait()
@@ -345,9 +320,7 @@ func TestConcurrentAboveLimit(t *testing.T) {
 	serverURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 
 	t.Log("Waiting for server to be ready...")
-	if !waitForServerReady(serverURL, 60*time.Second) {
-		t.Fatal("server did not become ready within timeout")
-	}
+	require.True(t, waitForServerReady(serverURL, 60*time.Second), "server did not become ready within timeout")
 
 	// Fill all 2 slots with long-running predictions (each sleeps 1s)
 	const maxConcurrency = 2
@@ -372,9 +345,7 @@ func TestConcurrentAboveLimit(t *testing.T) {
 			"application/json",
 			strings.NewReader(extraBody),
 		)
-		if err != nil {
-			t.Fatalf("failed to send extra prediction: %v", err)
-		}
+		require.NoError(t, err, "failed to send extra prediction")
 		if resp.StatusCode == http.StatusConflict {
 			break
 		}
@@ -384,23 +355,16 @@ func TestConcurrentAboveLimit(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusConflict {
-		t.Fatalf("extra prediction status = %d, want %d (409 Conflict); slots never filled within timeout", resp.StatusCode, http.StatusConflict)
-	}
+	require.Equal(t, http.StatusConflict, resp.StatusCode, "extra prediction status = %d, want %d (409 Conflict); slots never filled within timeout", resp.StatusCode, http.StatusConflict)
 
 	var errResp struct {
 		Error  string `json:"error"`
 		Status string `json:"status"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
-		t.Fatalf("failed to decode error response: %v", err)
-	}
-	if errResp.Status != "failed" {
-		t.Errorf("error response status = %q, want \"failed\"", errResp.Status)
-	}
-	if !strings.Contains(strings.ToLower(errResp.Error), "capacity") {
-		t.Errorf("error response error = %q, want string containing \"capacity\"", errResp.Error)
-	}
+	err = json.NewDecoder(resp.Body).Decode(&errResp)
+	require.NoError(t, err, "failed to decode error response")
+	assert.Equal(t, "failed", errResp.Status, "error response status mismatch")
+	assert.Contains(t, strings.ToLower(errResp.Error), "capacity", "error response error = %q, want string containing \"capacity\"", errResp.Error)
 
 	wg.Wait()
 }
@@ -419,9 +383,7 @@ func TestSIGTERMDuringSetup(t *testing.T) {
 	}
 
 	tmpDir, err := os.MkdirTemp("", "cog-sigterm-setup-test-*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
+	require.NoError(t, err, "failed to create temp dir")
 	defer os.RemoveAll(tmpDir)
 
 	slowSetupCogYAML := `build:
@@ -439,17 +401,13 @@ class Predictor(BasePredictor):
         return "hello " + s
 `
 
-	if err := os.WriteFile(filepath.Join(tmpDir, "cog.yaml"), []byte(slowSetupCogYAML), 0o644); err != nil {
-		t.Fatalf("failed to write cog.yaml: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(tmpDir, "predict.py"), []byte(slowSetupPredictPy), 0o644); err != nil {
-		t.Fatalf("failed to write predict.py: %v", err)
-	}
+	err = os.WriteFile(filepath.Join(tmpDir, "cog.yaml"), []byte(slowSetupCogYAML), 0o644)
+	require.NoError(t, err, "failed to write cog.yaml")
+	err = os.WriteFile(filepath.Join(tmpDir, "predict.py"), []byte(slowSetupPredictPy), 0o644)
+	require.NoError(t, err, "failed to write predict.py")
 
 	cogBinary, err := harness.ResolveCogBinary()
-	if err != nil {
-		t.Fatalf("failed to resolve cog binary: %v", err)
-	}
+	require.NoError(t, err, "failed to resolve cog binary")
 
 	t.Log("Building image...")
 	imageName := fmt.Sprintf("cog-sigterm-setup-test-%d", time.Now().UnixNano())
@@ -460,23 +418,19 @@ class Predictor(BasePredictor):
 	buildCmd := exec.Command(cogBinary, "build", "-t", imageName)
 	buildCmd.Dir = tmpDir
 	buildCmd.Env = append(os.Environ(), "COG_NO_UPDATE_CHECK=1")
-	if output, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build image: %v\n%s", err, output)
-	}
+	output, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "failed to build image\n%s", output)
 
 	t.Log("Starting server...")
 	port, err := allocatePort()
-	if err != nil {
-		t.Fatalf("failed to allocate port: %v", err)
-	}
+	require.NoError(t, err, "failed to allocate port")
 
 	serveCmd := exec.Command(cogBinary, "serve", "-p", fmt.Sprintf("%d", port))
 	serveCmd.Dir = tmpDir
 	serveCmd.Env = append(os.Environ(), "COG_NO_UPDATE_CHECK=1")
 
-	if err := serveCmd.Start(); err != nil {
-		t.Fatalf("failed to start server: %v", err)
-	}
+	err = serveCmd.Start()
+	require.NoError(t, err, "failed to start server")
 
 	// Poll health-check until setup has begun (status STARTING),
 	// rather than a fixed sleep that can be too short on cold Docker pulls.
@@ -489,9 +443,8 @@ class Predictor(BasePredictor):
 
 	// Send SIGTERM
 	t.Log("Sending SIGTERM during setup...")
-	if err := serveCmd.Process.Signal(syscall.SIGTERM); err != nil {
-		t.Fatalf("failed to send signal: %v", err)
-	}
+	err = serveCmd.Process.Signal(syscall.SIGTERM)
+	require.NoError(t, err, "failed to send signal")
 
 	// Wait for process to exit with a timeout
 	done := make(chan error, 1)

--- a/integration-tests/login/login_test.go
+++ b/integration-tests/login/login_test.go
@@ -27,6 +27,8 @@ import (
 	"time"
 
 	"github.com/creack/pty"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog/integration-tests/harness"
 )
@@ -45,9 +47,7 @@ func TestLoginGenericRegistryPTY(t *testing.T) {
 
 	// Get cog binary
 	cogBinary, err := harness.ResolveCogBinary()
-	if err != nil {
-		t.Fatalf("failed to resolve cog binary: %v", err)
-	}
+	require.NoError(t, err, "failed to resolve cog binary")
 
 	// Test login to a fake generic registry
 	// Note: This will fail at the Docker credential save step, but we can verify
@@ -58,9 +58,7 @@ func TestLoginGenericRegistryPTY(t *testing.T) {
 
 		// Start with a PTY
 		ptmx, err := pty.Start(cmd)
-		if err != nil {
-			t.Fatalf("failed to start PTY: %v", err)
-		}
+		require.NoError(t, err, "failed to start PTY")
 		defer func() {
 			ptmx.Close()
 			cmd.Process.Kill()
@@ -124,32 +122,22 @@ func TestLoginGenericRegistryPTY(t *testing.T) {
 		output, found := waitForPattern("username", 5*time.Second)
 		t.Logf("Output after start: %q", output)
 
-		if !strings.Contains(output, "fake-registry.example.com") {
-			t.Errorf("expected output to mention registry host, got: %q", output)
-		}
-		if !found {
-			t.Errorf("expected username prompt, got: %q", output)
-		}
+		assert.Contains(t, output, "fake-registry.example.com", "expected output to mention registry host")
+		assert.True(t, found, "expected username prompt, got: %q", output)
 
 		// Send username
 		_, err = ptmx.Write([]byte("testuser\n"))
-		if err != nil {
-			t.Fatalf("failed to write username: %v", err)
-		}
+		require.NoError(t, err, "failed to write username")
 
 		// Wait for password prompt
 		output, found = waitForPattern("password", 3*time.Second)
 		t.Logf("Output after username: %q", output)
 
-		if !found {
-			t.Errorf("expected password prompt, got: %q", output)
-		}
+		assert.True(t, found, "expected password prompt, got: %q", output)
 
 		// Send password (will fail at Docker credential save, but we've verified the flow)
 		_, err = ptmx.Write([]byte("testpass\n"))
-		if err != nil {
-			t.Fatalf("failed to write password: %v", err)
-		}
+		require.NoError(t, err, "failed to write password")
 
 		// Read final output briefly (expect failure since we can't actually save credentials)
 		time.Sleep(2 * time.Second)
@@ -162,9 +150,7 @@ func TestLoginGenericRegistryPTY(t *testing.T) {
 		cmd.Env = append(os.Environ(), "COG_NO_UPDATE_CHECK=1")
 
 		ptmx, err := pty.Start(cmd)
-		if err != nil {
-			t.Fatalf("failed to start PTY: %v", err)
-		}
+		require.NoError(t, err, "failed to start PTY")
 		defer func() {
 			ptmx.Close()
 			cmd.Process.Kill()
@@ -215,15 +201,11 @@ func TestLoginGenericRegistryPTY(t *testing.T) {
 		}
 
 		output := getOutput()
-		if !strings.Contains(strings.ToLower(output), "username") {
-			t.Fatalf("did not get username prompt: %q", output)
-		}
+		require.Contains(t, strings.ToLower(output), "username", "did not get username prompt: %q", output)
 
 		// Send empty username
 		_, err = ptmx.Write([]byte("\n"))
-		if err != nil {
-			t.Fatalf("failed to write empty username: %v", err)
-		}
+		require.NoError(t, err, "failed to write empty username")
 
 		// Wait for error about empty username
 		deadline = time.Now().Add(5 * time.Second)
@@ -239,9 +221,9 @@ func TestLoginGenericRegistryPTY(t *testing.T) {
 		t.Logf("Output: %q", output)
 
 		// Verify we got an error about empty username
-		if !strings.Contains(strings.ToLower(output), "empty") && !strings.Contains(strings.ToLower(output), "cannot") {
-			t.Errorf("expected error about empty username, got: %q", output)
-		}
+		lowerOutput := strings.ToLower(output)
+		assert.True(t, strings.Contains(lowerOutput, "empty") || strings.Contains(lowerOutput, "cannot"),
+			"expected error about empty username, got: %q", output)
 	})
 }
 
@@ -258,9 +240,7 @@ func TestLoginProviderRouting(t *testing.T) {
 	}
 
 	cogBinary, err := harness.ResolveCogBinary()
-	if err != nil {
-		t.Fatalf("failed to resolve cog binary: %v", err)
-	}
+	require.NoError(t, err, "failed to resolve cog binary")
 
 	tests := []struct {
 		name            string
@@ -306,9 +286,7 @@ func TestLoginProviderRouting(t *testing.T) {
 
 			// Start with a PTY to handle interactive prompts
 			ptmx, err := pty.Start(cmd)
-			if err != nil {
-				t.Fatalf("failed to start PTY: %v", err)
-			}
+			require.NoError(t, err, "failed to start PTY")
 			defer func() {
 				ptmx.Close()
 				cmd.Process.Kill()
@@ -344,13 +322,10 @@ func TestLoginProviderRouting(t *testing.T) {
 
 			output := buf.String()
 			if tc.expectReplicate {
-				if strings.Contains(output, "Username:") {
-					t.Errorf("expected Replicate provider, but got Generic provider with Username prompt")
-				}
+				assert.NotContains(t, output, "Username:", "expected Replicate provider, but got Generic provider with Username prompt")
 			} else {
-				if !strings.Contains(output, "Username") && !strings.Contains(strings.ToLower(output), "logging in") {
-					t.Errorf("expected Generic provider prompts, got: %q", output)
-				}
+				assert.True(t, strings.Contains(output, "Username") || strings.Contains(strings.ToLower(output), "logging in"),
+					"expected Generic provider prompts, got: %q", output)
 			}
 		})
 	}
@@ -368,9 +343,7 @@ func TestLoginEnvironmentVariable(t *testing.T) {
 	}
 
 	cogBinary, err := harness.ResolveCogBinary()
-	if err != nil {
-		t.Fatalf("failed to resolve cog binary: %v", err)
-	}
+	require.NoError(t, err, "failed to resolve cog binary")
 
 	t.Run("COG_REGISTRY_HOST sets default registry", func(t *testing.T) {
 		cmd := exec.Command(cogBinary, "login")
@@ -381,9 +354,7 @@ func TestLoginEnvironmentVariable(t *testing.T) {
 
 		// Start with a PTY
 		ptmx, err := pty.Start(cmd)
-		if err != nil {
-			t.Fatalf("failed to start PTY: %v", err)
-		}
+		require.NoError(t, err, "failed to start PTY")
 		defer func() {
 			ptmx.Close()
 			cmd.Process.Kill()
@@ -410,9 +381,7 @@ func TestLoginEnvironmentVariable(t *testing.T) {
 		t.Logf("Output: %s", output)
 
 		// Verify the custom registry is mentioned in output
-		if !strings.Contains(output, "custom-registry.example.com") {
-			t.Errorf("expected custom registry in output, got: %s", output)
-		}
+		assert.Contains(t, output, "custom-registry.example.com", "expected custom registry in output")
 
 		// Since custom-registry.example.com is not r8.im, it should use generic provider
 		if !strings.Contains(output, "Username") {
@@ -429,9 +398,7 @@ func TestLoginEnvironmentVariable(t *testing.T) {
 
 		// Start with a PTY
 		ptmx, err := pty.Start(cmd)
-		if err != nil {
-			t.Fatalf("failed to start PTY: %v", err)
-		}
+		require.NoError(t, err, "failed to start PTY")
 		defer func() {
 			ptmx.Close()
 			cmd.Process.Kill()
@@ -458,29 +425,21 @@ func TestLoginEnvironmentVariable(t *testing.T) {
 		t.Logf("Output: %s", output)
 
 		// Verify the override registry is used, not the env var one
-		if !strings.Contains(output, "override-registry.example.com") {
-			t.Errorf("expected override registry in output, got: %s", output)
-		}
-		if strings.Contains(output, "ignored-registry.example.com") {
-			t.Errorf("env var registry should have been overridden, but it appeared in output")
-		}
+		assert.Contains(t, output, "override-registry.example.com", "expected override registry in output")
+		assert.NotContains(t, output, "ignored-registry.example.com", "env var registry should have been overridden, but it appeared in output")
 	})
 }
 
 // TestLoginHelp tests that the login command shows appropriate help text.
 func TestLoginHelp(t *testing.T) {
 	cogBinary, err := harness.ResolveCogBinary()
-	if err != nil {
-		t.Fatalf("failed to resolve cog binary: %v", err)
-	}
+	require.NoError(t, err, "failed to resolve cog binary")
 
 	cmd := exec.Command(cogBinary, "login", "--help")
 	cmd.Env = append(os.Environ(), "COG_NO_UPDATE_CHECK=1")
 
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("help command failed: %v", err)
-	}
+	require.NoError(t, err, "help command failed")
 
 	helpText := string(output)
 	t.Logf("Help text:\n%s", helpText)
@@ -494,26 +453,20 @@ func TestLoginHelp(t *testing.T) {
 	}
 
 	for _, expected := range expectedStrings {
-		if !strings.Contains(strings.ToLower(helpText), strings.ToLower(expected)) {
-			t.Errorf("expected help to contain %q", expected)
-		}
+		assert.True(t, strings.Contains(strings.ToLower(helpText), strings.ToLower(expected)),
+			"expected help to contain %q", expected)
 	}
 
 	// Verify help mentions both Replicate and generic registry support
-	if !strings.Contains(helpText, "Replicate") {
-		t.Errorf("expected help to mention Replicate")
-	}
-	if !strings.Contains(helpText, "other registries") || !strings.Contains(helpText, "username and password") {
-		t.Errorf("expected help to mention generic registry login with username/password")
-	}
+	assert.Contains(t, helpText, "Replicate", "expected help to mention Replicate")
+	assert.True(t, strings.Contains(helpText, "other registries") && strings.Contains(helpText, "username and password"),
+		"expected help to mention generic registry login with username/password")
 }
 
 // TestLoginSuggestFor tests that similar commands are suggested.
 func TestLoginSuggestFor(t *testing.T) {
 	cogBinary, err := harness.ResolveCogBinary()
-	if err != nil {
-		t.Fatalf("failed to resolve cog binary: %v", err)
-	}
+	require.NoError(t, err, "failed to resolve cog binary")
 
 	// Test that "cog auth" suggests "cog login"
 	cmd := exec.Command(cogBinary, "auth")

--- a/integration-tests/suite_test.go
+++ b/integration-tests/suite_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/rogpeppe/go-internal/testscript"
+	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog/integration-tests/harness"
 )
@@ -37,14 +38,10 @@ func TestIntegration(t *testing.T) {
 	dir := "tests"
 
 	h, err := harness.New()
-	if err != nil {
-		t.Fatalf("failed to create harness: %v", err)
-	}
+	require.NoError(t, err, "failed to create harness")
 
 	files, err := filepath.Glob(filepath.Join(dir, "*.txtar"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	sort.Strings(files)
 	for _, f := range files {
 		name := strings.TrimSuffix(filepath.Base(f), filepath.Ext(f))


### PR DESCRIPTION
## Summary

- Replace manual `if`/`t.Fatal`/`t.Errorf` assertion patterns with testify `require` and `assert` across the 3 remaining integration test files that weren't using testify
- Add "Go Test Conventions" section to `AGENTS.md` documenting when to use `require` vs `assert`, with examples

### Files changed

| File | Assertions converted |
|------|---------------------|
| `integration-tests/concurrent/concurrent_test.go` | 33 |
| `integration-tests/login/login_test.go` | 27 |
| `integration-tests/suite_test.go` | 2 |
| `AGENTS.md` | New section added |

All other 66 `_test.go` files in the repo already used testify. This brings the codebase to 100% testify adoption.