### PR TITLE
fix(sdk): restore emit_metric as deprecated compat shim

### DIFF
--- a/integration-tests/tests/emit_metric_deprecated.txtar
+++ b/integration-tests/tests/emit_metric_deprecated.txtar
@@ -1,0 +1,33 @@
+# Test that a predictor using the deprecated emit_metric() still builds,
+# runs, and records metrics correctly.
+#
+# emit_metric() was dropped without a compat shim in 0.17.0, causing a hard
+# ImportError on startup for models that use it. This test covers the two
+# call styles used across replicate/* models:
+#
+#   from cog import emit_metric; emit_metric("key", value)
+#   cog.emit_metric("key", value)
+
+cog serve
+
+# Prediction works and the metric appears in the response
+curl POST /predictions '{"input":{}}'
+stdout '"status":"succeeded"'
+stdout '"output_tokens":42'
+
+-- cog.yaml --
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"
+
+-- predict.py --
+import cog
+from cog import BasePredictor, emit_metric
+
+
+class Predictor(BasePredictor):
+    def predict(self) -> str:
+        # Both call styles should work
+        emit_metric("output_tokens", 42)
+        cog.emit_metric("input_tokens", 10)
+        return "ok"

--- a/python/cog/__init__.py
+++ b/python/cog/__init__.py
@@ -72,6 +72,20 @@ def __getattr__(name: str) -> object:
         # the deprecation message prints at most once.
         globals()["ExperimentalFeatureWarning"] = _ExperimentalFeatureWarning
         return _ExperimentalFeatureWarning
+    if name == "emit_metric":
+        print(
+            "cog: emit_metric() is deprecated and will be removed in a future release. "
+            "Use current_scope().record_metric(name, value) instead.",
+            file=_sys.stderr,
+        )
+
+        def emit_metric(name: str, value: float) -> None:  # noqa: A002 — name is the metric name here, not the module attr
+            current_scope().record_metric(name, value)  # type: ignore[attr-defined]
+
+        # Cache so __getattr__ is not called again — the deprecation message
+        # prints at most once (on first import), not on every call.
+        globals()["emit_metric"] = emit_metric
+        return emit_metric
     raise AttributeError(f"module 'cog' has no attribute {name!r}")
 
 
@@ -119,4 +133,5 @@ __all__ = [
     "current_scope",
     # Deprecated compat shims
     "ExperimentalFeatureWarning",
+    "emit_metric",
 ]

--- a/python/tests/test_emit_metric.py
+++ b/python/tests/test_emit_metric.py
@@ -1,0 +1,83 @@
+"""Tests for the emit_metric backwards-compatibility shim."""
+
+import subprocess
+import sys
+
+
+class TestEmitMetric:
+    """Tests for the deprecated emit_metric import."""
+
+    def test_import_succeeds(self) -> None:
+        """Importing emit_metric should not raise."""
+        result = subprocess.run(
+            [sys.executable, "-c", "from cog import emit_metric"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"Import failed: {result.stderr}"
+
+    def test_attribute_access_succeeds(self) -> None:
+        """Accessing cog.emit_metric as a module attribute should not raise."""
+        result = subprocess.run(
+            [sys.executable, "-c", "import cog; cog.emit_metric"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"Attribute access failed: {result.stderr}"
+
+    def test_prints_deprecation_to_stderr(self) -> None:
+        """First import should print a deprecation message to stderr."""
+        result = subprocess.run(
+            [sys.executable, "-c", "from cog import emit_metric"],
+            capture_output=True,
+            text=True,
+        )
+        assert "emit_metric() is deprecated" in result.stderr
+
+    def test_message_prints_once(self) -> None:
+        """The deprecation message should print only once per process, not on every call."""
+        code = "from cog import emit_metric\nfrom cog import emit_metric\n"
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+        )
+        assert result.stderr.count("emit_metric() is deprecated") == 1
+
+    def test_callable(self) -> None:
+        """emit_metric should be callable and not raise outside a prediction context."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from cog import emit_metric; emit_metric('output_tokens', 42)",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"Call failed: {result.stderr}"
+
+    def test_module_attribute_callable(self) -> None:
+        """cog.emit_metric(...) style (used in cog-triton, cog-arctic, etc.) should work."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import cog; cog.emit_metric('input_token_count', 100)",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"Call via module attribute failed: {result.stderr}"
+        )
+
+    def test_unknown_attr_still_raises(self) -> None:
+        """Adding emit_metric shim should not break AttributeError for unknown attrs."""
+        result = subprocess.run(
+            [sys.executable, "-c", "import cog; cog.NoSuchAttribute"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "AttributeError" in result.stderr


### PR DESCRIPTION
Models that call `emit_metric()` get a hard `ImportError` on startup with cog 0.17.0. It was dropped when the Python HTTP server was replaced by coglet, but unlike `ExperimentalFeatureWarning` it didn't get a backwards-compat shim. It's used across a bunch of replicate/* models -- cog-whisper, cog-triton, cog-vllm, cog-arctic, cog-real-esrgan, cog-proxy.

Discovered via [hello-concurrency](https://github.com/replicate/cog-examples/tree/main/hello-concurrency).

The fix restores `emit_metric` as a shim that delegates to `current_scope().record_metric()`, following the same pattern already established for `ExperimentalFeatureWarning`: print to stderr once on first import (can't be silenced by `warnings.filterwarnings`), cache in globals so `__getattr__` never fires again. No overhead on repeated calls.

Both call styles used across the org work:

```python
from cog import emit_metric
emit_metric("output_tokens", 42)  # prints deprecation once, then silent
```

```python
import cog
cog.emit_metric("input_token_count", n_tokens)  # same
```
