### PR TITLE
docs: restructure documentation using Diataxis framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ If you're using macOS, you can install Cog using Homebrew:
 brew install replicate/tap/cog
 ```
 
-You can also download and install the latest release using our 
+You can also download and install the latest release using our
 [install script](https://cog.run/install):
 
 ```sh
@@ -143,7 +143,7 @@ wget -qO- https://cog.run/install.sh
 sh ./install.sh
 ```
 
-You can manually install the latest release of Cog directly from GitHub 
+You can manually install the latest release of Cog directly from GitHub
 by running the following commands in a terminal:
 
 ```console

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,7 +24,6 @@ https://github.com/replicate/cog
       --no-color   Disable colored output
       --version    Show version of Cog
 ```
-
 ## `cog build`
 
 Build a Docker image from the cog.yaml in the current directory.
@@ -67,7 +66,6 @@ cog build [flags]
       --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
 ```
-
 ## `cog init`
 
 Create a cog.yaml and predict.py in the current directory.
@@ -91,7 +89,6 @@ cog init [flags]
 ```
   -h, --help   help for init
 ```
-
 ## `cog login`
 
 Log in to a container registry.
@@ -112,7 +109,6 @@ cog login [flags]
   -h, --help          help for login
       --token-stdin   Pass login token on stdin instead of opening a browser. You can find your Replicate login token at https://replicate.com/auth/token
 ```
-
 ## `cog predict`
 
 Run a prediction.
@@ -165,7 +161,6 @@ cog predict [image] [flags]
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
       --use-replicate-token          Pass REPLICATE_API_TOKEN from local environment into the model context
 ```
-
 ## `cog push`
 
 Build a Docker image from cog.yaml and push it to a container registry.
@@ -203,7 +198,6 @@ cog push [IMAGE] [flags]
       --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
 ```
-
 ## `cog run`
 
 Run a command inside a Docker environment defined by cog.yaml.
@@ -244,7 +238,6 @@ cog run <command> [arg...] [flags]
       --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
 ```
-
 ## `cog serve`
 
 Run a prediction HTTP server.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,7 @@ https://github.com/replicate/cog
       --no-color   Disable colored output
       --version    Show version of Cog
 ```
+
 ## `cog build`
 
 Build a Docker image from the cog.yaml in the current directory.
@@ -66,6 +67,7 @@ cog build [flags]
       --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
 ```
+
 ## `cog init`
 
 Create a cog.yaml and predict.py in the current directory.
@@ -89,6 +91,7 @@ cog init [flags]
 ```
   -h, --help   help for init
 ```
+
 ## `cog login`
 
 Log in to a container registry.
@@ -109,6 +112,7 @@ cog login [flags]
   -h, --help          help for login
       --token-stdin   Pass login token on stdin instead of opening a browser. You can find your Replicate login token at https://replicate.com/auth/token
 ```
+
 ## `cog predict`
 
 Run a prediction.
@@ -161,6 +165,7 @@ cog predict [image] [flags]
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
       --use-replicate-token          Pass REPLICATE_API_TOKEN from local environment into the model context
 ```
+
 ## `cog push`
 
 Build a Docker image from cog.yaml and push it to a container registry.
@@ -198,6 +203,7 @@ cog push [IMAGE] [flags]
       --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
 ```
+
 ## `cog run`
 
 Run a command inside a Docker environment defined by cog.yaml.
@@ -238,6 +244,7 @@ cog run <command> [arg...] [flags]
       --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
 ```
+
 ## `cog serve`
 
 Run a prediction HTTP server.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -93,6 +93,5 @@ See the [`cog.yaml` reference](yaml.md#concurrency) for more details.
 You can configure runtime behavior with environment variables:
 
 - `COG_SETUP_TIMEOUT`: Maximum time in seconds for the `setup()` method (default: no timeout).
-- `COG_WEIGHTS`: URL or path to model weights, passed to `setup(weights=)`.
 
 See the [environment variables reference](environment.md) for the full list.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,11 +1,14 @@
 # Deploy models with Cog
 
-Cog containers are Docker containers that serve an HTTP server 
-for running predictions on your model. 
+Cog containers are Docker containers that serve an HTTP server
+for running predictions on your model.
 You can deploy them anywhere that Docker containers run.
 
-This guide assumes you have a model packaged with Cog. 
-If you don't, [follow our getting started guide](getting-started-own-model.md), 
+The server inside Cog containers is **coglet**, a Rust-based prediction server
+that handles HTTP requests, worker process management, and prediction execution.
+
+This guide assumes you have a model packaged with Cog.
+If you don't, [follow our getting started guide](getting-started-own-model.md),
 or use [an example model](https://github.com/replicate/cog-examples).
 
 ## Getting started
@@ -16,7 +19,15 @@ First, build your model:
 cog build -t my-model
 ```
 
-Then, start the Docker container:
+You can serve predictions locally with `cog serve`:
+
+```console
+cog serve
+# or, from a built image:
+cog serve my-model
+```
+
+Alternatively, start the Docker container directly:
 
 ```shell
 # If your model uses a CPU:
@@ -24,16 +35,13 @@ docker run -d -p 5001:5000 my-model
 
 # If your model uses a GPU:
 docker run -d -p 5001:5000 --gpus all my-model
-
-# If you're on an M1 Mac:
-docker run -d -p 5001:5000 --platform=linux/amd64 my-model
 ```
 
-The server is now running locally on port 5001.
+The server listens on port 5000 inside the container (mapped to 5001 above).
 
-To view the OpenAPI schema, 
-open [localhost:5001/openapi.json](http://localhost:5001/openapi.json) 
-in your browser 
+To view the OpenAPI schema,
+open [localhost:5001/openapi.json](http://localhost:5001/openapi.json)
+in your browser
 or use cURL to make a request:
 
 ```console
@@ -46,8 +54,8 @@ To stop the server, run:
 docker kill my-model
 ```
 
-To run a prediction on the model, 
-call the `/predictions` endpoint, 
+To run a prediction on the model,
+call the `/predictions` endpoint,
 passing input in the format expected by your model:
 
 ```console
@@ -56,29 +64,35 @@ curl http://localhost:5001/predictions -X POST \
     --data '{"input": {"image": "https://.../input.jpg"}}'
 ```
 
-For more details about the HTTP API, 
+For more details about the HTTP API,
 see the [HTTP API reference documentation](http.md).
 
-## Options
+## Health checks
 
-Cog Docker images have `python -m cog.server.http` set as the default command, which gets overridden if you pass a command to `docker run`. When you use command-line options, you need to pass in the full command before the options.
+The server exposes a `GET /health-check` endpoint that returns the current status of the model container. Use this for readiness probes in orchestration systems like Kubernetes.
 
-### `--threads`
+```console
+curl http://localhost:5001/health-check
+```
 
-This controls how many threads are used by Cog, which determines how many requests Cog serves in parallel. If your model uses a CPU, this is the number of CPUs on your machine. If your model uses a GPU, this is 1, because typically a GPU can only be used by one process.
+The response includes a `status` field with values like `STARTING`, `READY`, `BUSY`, `SETUP_FAILED`, or `DEFUNCT`. See the [HTTP API reference](http.md#get-health-check) for full details.
 
-You might need to adjust this if you want to control how much memory your model uses, or other similar constraints. To do this, you can use the `--threads` option.
+## Concurrency
 
-For example:
+By default, the server processes one prediction at a time. To enable concurrent predictions, set the `concurrency.max` option in `cog.yaml`:
 
-    docker run -d -p 5000:5000 my-model python -m cog.server.http --threads=10
+```yaml
+concurrency:
+  max: 4
+```
 
-### `--host`
+See the [`cog.yaml` reference](yaml.md#concurrency) for more details.
 
-By default, Cog serves to `0.0.0.0`.
-You can override this using the `--host` option.
+## Environment variables
 
-For example, 
-to serve Cog on an IPv6 address, run:
+You can configure runtime behavior with environment variables:
 
-    docker run -d -p 5000:5000 my-model python -m cog.server.http --host="::"
+- `COG_SETUP_TIMEOUT`: Maximum time in seconds for the `setup()` method (default: no timeout).
+- `COG_WEIGHTS`: URL or path to model weights, passed to `setup(weights=)`.
+
+See the [environment variables reference](environment.md) for the full list.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -86,10 +86,30 @@ Set to `0` to disable the timeout (same as default). Invalid values are ignored 
 $ COG_SETUP_TIMEOUT=300 docker run -p 5000:5000 my-model  # 5-minute setup timeout
 ```
 
-### `COG_WEIGHTS`
+### `COG_CA_CERT`
 
-Specifies a URL or local path for model weights. This is useful for testing fine-tuned models locally — the value is passed to your predictor's `setup(weights=)` method.
+Injects a custom CA certificate into the Docker image during `cog build`. This is useful when building behind a corporate proxy or VPN that uses custom certificate authorities (e.g. Cloudflare WARP).
+
+**Supported values:**
+
+| Value                            | Description                                                 |
+| -------------------------------- | ----------------------------------------------------------- |
+| `/path/to/cert.crt`              | Path to a single PEM certificate file                       |
+| `/path/to/certs/`                | Directory of `.crt` and `.pem` files (all are concatenated) |
+| `-----BEGIN CERTIFICATE-----...` | Inline PEM certificate                                      |
+| `LS0tLS1CRUdJTi...`              | Base64-encoded PEM certificate                              |
+
+The certificate is installed into the system CA store and the `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` environment variables are set automatically in the built image.
+
+**Examples:**
 
 ```console
-$ cog predict -e COG_WEIGHTS=https://example.com/weights.tar -i prompt="hello"
+# From a file
+$ COG_CA_CERT=/usr/local/share/ca-certificates/corporate-ca.crt cog build
+
+# From a directory of certs
+$ COG_CA_CERT=/etc/custom-certs/ cog build
+
+# Inline (e.g. from a CI secret)
+$ COG_CA_CERT="$(cat /path/to/cert.pem)" cog build
 ```

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -10,13 +10,13 @@ Controls which cog Python SDK wheel is installed in the Docker image during `cog
 
 **Supported values:**
 
-| Value | Description |
-|-------|-------------|
-| `pypi` | Install latest version from PyPI |
-| `pypi:0.12.0` | Install specific version from PyPI |
-| `dist` | Use wheel from `dist/` directory (requires git repo) |
-| `https://...` | Install from URL |
-| `/path/to/wheel.whl` | Install from local file path |
+| Value                | Description                                          |
+| -------------------- | ---------------------------------------------------- |
+| `pypi`               | Install latest version from PyPI                     |
+| `pypi:0.12.0`        | Install specific version from PyPI                   |
+| `dist`               | Use wheel from `dist/` directory (requires git repo) |
+| `https://...`        | Install from URL                                     |
+| `/path/to/wheel.whl` | Install from local file path                         |
 
 **Default behavior:**
 
@@ -37,6 +37,7 @@ $ COG_SDK_WHEEL=https://example.com/cog-0.12.0-py3-none-any.whl cog build
 ```
 
 The `dist` option searches for wheels in:
+
 1. `./dist/` (current directory)
 2. `$REPO_ROOT/dist/` (if REPO_ROOT is set)
 3. `<git-repo-root>/dist/` (via `git rev-parse`, useful when running from subdirectories)
@@ -63,12 +64,32 @@ $ COGLET_WHEEL=pypi:0.1.0 cog build
 
 ### `COG_NO_UPDATE_CHECK`
 
-By default, Cog automatically checks for updates 
+By default, Cog automatically checks for updates
 and notifies you if there is a new version available.
 
-To disable this behavior, 
+To disable this behavior,
 set the `COG_NO_UPDATE_CHECK` environment variable to any value.
 
 ```console
 $ COG_NO_UPDATE_CHECK=1 cog build  # runs without automatic update check
+```
+
+### `COG_SETUP_TIMEOUT`
+
+Controls the maximum time (in seconds) allowed for the model's `setup()` method to complete. If setup exceeds this timeout, the server will report a setup failure.
+
+By default, there is no timeout — setup runs indefinitely.
+
+Set to `0` to disable the timeout (same as default). Invalid values are ignored with a warning.
+
+```console
+$ COG_SETUP_TIMEOUT=300 docker run -p 5000:5000 my-model  # 5-minute setup timeout
+```
+
+### `COG_WEIGHTS`
+
+Specifies a URL or local path for model weights. This is useful for testing fine-tuned models locally — the value is passed to your predictor's `setup(weights=)` method.
+
+```console
+$ cog predict -e COG_WEIGHTS=https://example.com/weights.tar -i prompt="hello"
 ```

--- a/docs/explanation/cuda-compat.md
+++ b/docs/explanation/cuda-compat.md
@@ -1,0 +1,138 @@
+# CUDA and GPU compatibility
+
+Running machine learning models on GPUs requires a stack of interdependent software components, each with strict version requirements. Managing this stack manually is one of the most common sources of frustration in ML deployment. Cog automates it, but understanding the underlying problem -- and how Cog's solution works -- helps you diagnose issues and make informed choices when the defaults are not sufficient.
+
+## The compatibility challenge
+
+GPU-accelerated machine learning involves a chain of dependencies, each constrained by the others:
+
+```
+Your model code
+    -> PyTorch / TensorFlow (specific version)
+        -> CUDA toolkit (specific version range)
+            -> cuDNN (specific version range)
+                -> NVIDIA driver (minimum version)
+                    -> GPU hardware (compute capability)
+```
+
+Every link in this chain must be compatible with its neighbours. For example:
+
+- PyTorch 2.1 supports CUDA 11.8 and CUDA 12.1, but not CUDA 11.7 or CUDA 12.0
+- CUDA 12.1 requires cuDNN 8.9 or later
+- CUDA 12.1 requires an NVIDIA driver version 530.30.02 or later
+- The driver must support the compute capability of your specific GPU
+
+A mismatch at any level produces errors that range from helpful ("CUDA driver version is insufficient for CUDA runtime version") to baffling (silent incorrect results, segfaults, or processes that hang during GPU operations). The difficulty is compounded by the fact that the same symptoms can result from completely different root causes.
+
+The reason this problem is so persistent in the ML community is that the version matrix is large, not well documented in a single place, and changes with every new release. A setup that works today may break when you upgrade PyTorch, even if you do not consciously change anything about your CUDA configuration, because the new PyTorch version may have dropped support for your CUDA version.
+
+## How Cog solves this
+
+When you set `gpu: true` in your `cog.yaml`, Cog takes over the entire CUDA dependency chain. The approach has three parts.
+
+### 1. A maintained compatibility matrix
+
+Cog maintains a compatibility matrix that maps combinations of Python version, PyTorch version, and TensorFlow version to the correct CUDA toolkit version, cuDNN version, and nvidia base image. This matrix is generated and tested by the Cog maintainers and updated with each release.
+
+The reason Cog uses a curated matrix rather than simply reading version requirements from PyTorch's metadata is that the published compatibility information is often incomplete or ambiguous. PyTorch may list "CUDA 11.8" as supported, but there are nuances about specific patch versions, cuDNN requirements, and base image availability that are not captured in a `requires` field. The matrix encodes this hard-won knowledge.
+
+### 2. Automatic version detection
+
+When you run `cog build`, Cog examines your Python requirements (from `python_requirements` or `python_packages`) and identifies which ML frameworks you are using and at which versions. It then looks up the correct CUDA configuration in the compatibility matrix.
+
+For example, if your `requirements.txt` contains `torch==2.1.0`, Cog will:
+
+1. Identify that PyTorch 2.1.0 is present
+2. Look up the compatible CUDA version (e.g., CUDA 12.1)
+3. Determine the matching cuDNN version
+4. Select the correct nvidia base image (e.g., `nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04`)
+
+This happens transparently. You do not need to specify CUDA versions, cuDNN versions, or base images -- Cog derives them from your Python dependencies.
+
+### 3. Pre-configured base images
+
+Cog uses NVIDIA's official CUDA base images as the foundation for GPU-enabled containers. These images come with the CUDA toolkit, cuDNN, and related libraries pre-installed and correctly configured. By selecting the right base image tag, Cog ensures that the CUDA runtime inside your container matches the requirements of your ML framework.
+
+Cog also provides its own pre-built base images (`r8.im/cog-base`) that include not just the CUDA stack but also common Python versions and PyTorch installations. These base images speed up builds significantly because the most time-consuming parts of the installation are already done. See [Docker image layer strategy](image-layers.md) for more on how base images affect build and deployment performance.
+
+## When you need to override
+
+In most cases, Cog's automatic detection works correctly. But there are situations where you may need to intervene.
+
+### Using the `cuda` option
+
+The `build.cuda` field in `cog.yaml` lets you explicitly specify a CUDA version:
+
+```yaml
+build:
+  gpu: true
+  cuda: "11.8"
+```
+
+This is useful when:
+
+- **You are using a framework Cog does not recognise.** If your requirements include a CUDA-dependent library that is not PyTorch or TensorFlow (for example, a custom CUDA kernel or a less common framework like JAX), Cog cannot auto-detect the correct CUDA version. Specifying it manually ensures the right base image is used.
+
+- **You need a specific CUDA version for compatibility with your host driver.** If your deployment target has an older NVIDIA driver that does not support the latest CUDA version, you may need to pin CUDA to an older version that your driver supports. The CUDA toolkit is forward-compatible (newer drivers support older CUDA), but not backward-compatible (older drivers do not support newer CUDA).
+
+- **You are troubleshooting a compatibility issue.** If you suspect Cog's auto-detection has chosen the wrong CUDA version, explicitly setting it can help isolate the problem.
+
+You can specify a minor version (`11.8`) or a patch version (`11.8.0`). If you specify a minor version, Cog selects the latest patch release for that minor version.
+
+### The `--use-cuda-base-image` flag
+
+When building, you can pass `--use-cuda-base-image=false` to skip the NVIDIA CUDA base image entirely and use a plain Python base image instead:
+
+```
+cog build --use-cuda-base-image=false
+```
+
+The tradeoff is clear: you get a significantly smaller image (CUDA base images add several gigabytes), but you lose the pre-installed CUDA toolkit. This can be effective for models that bundle their own CUDA dependencies (some PyTorch distributions include CUDA libraries in the pip package itself), but it may cause problems for frameworks that expect system-level CUDA installations.
+
+Some teams prefer this approach because smaller images are faster to push and pull, which matters for deployment pipelines where cold start time is critical. However, the risk of subtle runtime failures from missing CUDA components means you should test thoroughly before deploying images built this way.
+
+## The NVIDIA container runtime
+
+Even with the correct CUDA version installed inside the container, the container needs access to the host's GPU hardware. This is handled by the [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker) (formerly known as nvidia-docker).
+
+When you run a Cog container with GPU support, you must pass the `--gpus` flag to Docker:
+
+```
+docker run --gpus all my-model
+```
+
+This flag tells Docker to use the NVIDIA container runtime, which does several things:
+
+- Mounts the host's NVIDIA driver libraries into the container
+- Makes GPU devices visible inside the container
+- Sets up the necessary environment variables for CUDA to find the driver
+
+Cog's `cog predict` and `cog run` commands pass `--gpus all` automatically when `build.gpu` is true. When you run a Docker image directly, you must pass this flag yourself.
+
+The reason the driver comes from the host rather than being included in the container is that the GPU driver is tightly coupled to the host's kernel. You cannot install an arbitrary driver version inside a container -- it must match the kernel module loaded on the host. The NVIDIA Container Toolkit solves this by injecting the host's driver at container runtime, so the container only needs the CUDA user-space libraries (which are included in the base image).
+
+This architecture has an important implication: **the host's NVIDIA driver must be at least as new as the CUDA version inside the container requires.** CUDA 12.1 requires driver 530.30.02 or later. If the host has an older driver, the container will fail at runtime with a "CUDA driver version is insufficient" error, even if everything inside the container is correctly configured. This is the one part of the CUDA stack that Cog cannot control, because it depends on the deployment environment.
+
+## Multiple frameworks
+
+Some models use both PyTorch and TensorFlow, or use PyTorch alongside other CUDA-dependent libraries. Cog handles this by selecting a CUDA version that is compatible with all detected frameworks. If no single CUDA version satisfies all constraints, the build will fail with an error explaining the conflict.
+
+In practice, this situation is uncommon because most models use a single primary framework. When it does occur, the resolution is usually to update one of the frameworks to a version that shares a common CUDA requirement, or to explicitly specify a CUDA version with `build.cuda` that you have verified works with all your dependencies.
+
+## The driver compatibility model
+
+NVIDIA's compatibility model is worth understanding because it affects what you can deploy and where:
+
+- **Forward compatibility**: A newer host driver supports older CUDA versions. A host with driver 535 can run containers built for CUDA 11.8, 12.0, or 12.1.
+- **No backward compatibility**: An older host driver cannot run containers with newer CUDA requirements. A host with driver 520 cannot run a container built for CUDA 12.1.
+
+This means you should generally aim for the **oldest CUDA version that your framework supports**, unless you need specific features from a newer CUDA release. The older the CUDA version in your container, the wider the range of host driver versions it will work on.
+
+Cog's auto-detection takes this into account and generally selects a CUDA version that balances compatibility with framework support. But if you control your deployment infrastructure and know exactly which driver version is installed, you can use `build.cuda` to select the most appropriate version.
+
+## Further reading
+
+- [How Cog works](how-cog-works.md) -- the build pipeline that resolves CUDA versions
+- [Docker image layer strategy](image-layers.md) -- how CUDA base images affect image size and build time
+- [`cog.yaml` reference](../yaml.md#cuda) -- the `cuda` and `gpu` configuration options
+- [NVIDIA CUDA Compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) -- NVIDIA's official documentation on driver and toolkit compatibility

--- a/docs/explanation/how-cog-works.md
+++ b/docs/explanation/how-cog-works.md
@@ -1,0 +1,121 @@
+# How Cog works
+
+Cog turns your machine learning model into a production-ready Docker container. Understanding what happens behind the scenes -- from `cog.yaml` to a running prediction server -- helps you make better decisions about how to structure your project, troubleshoot build issues, and optimise performance.
+
+## The build pipeline
+
+When you run `cog build`, a multi-stage pipeline transforms your configuration and code into a Docker image. The pipeline has three main phases.
+
+### Phase 1: Configuration parsing
+
+Cog reads your `cog.yaml` and resolves the full environment specification. The reason this is a separate phase -- rather than just templating a Dockerfile directly -- is that Cog needs to make several interdependent decisions:
+
+- Which Python version to use (specified, or inferred from framework compatibility)
+- Whether a GPU base image is needed (based on `build.gpu`)
+- Which CUDA and cuDNN versions to install (auto-detected from your PyTorch or TensorFlow version)
+- Which base image to start from (an nvidia CUDA image, a Cog pre-built base image, or a plain Python image)
+
+These decisions depend on one another. For example, PyTorch 2.x requires CUDA 11.8 or 12.1, which in turn constrains the nvidia base image tag. Cog's compatibility matrix handles this resolution automatically, which is one of the main reasons cog.yaml exists rather than asking you to write Dockerfiles directly.
+
+### Phase 2: Dockerfile generation
+
+Cog generates a Dockerfile from the resolved configuration. This is not a simple template -- the generator produces an optimised, multi-stage Dockerfile that follows Docker best practices:
+
+- System packages are installed early (they change infrequently)
+- Python dependencies come next (they change occasionally)
+- Your model code is copied last (it changes often)
+
+This ordering is deliberate. Docker caches layers, and by placing infrequently-changing steps first, Cog ensures that rebuilds after code changes are fast -- typically seconds rather than minutes. See [Docker image layer strategy](image-layers.md) for a deeper discussion of why layer ordering matters.
+
+The generated Dockerfile also installs two Cog components into the image:
+
+- **The Cog Python SDK** (`cog` package) -- provides `BasePredictor`, `Input`, `Path`, and other types your model code imports
+- **Coglet** -- the prediction server that handles HTTP requests, manages your model process, and orchestrates predictions
+
+### Phase 3: Docker image build
+
+Cog invokes Docker Buildx to build the image. The build context is your project directory (filtered by `.dockerignore`), and the result is a standard Docker image you can run anywhere.
+
+If you have specified an `image` name in `cog.yaml`, the image is tagged accordingly. Otherwise, Cog generates a name from your directory.
+
+The entire pipeline is deterministic for a given set of inputs: the same `cog.yaml`, requirements, and code will produce the same Dockerfile and, in most cases, the same image.
+
+## What is inside a Cog container
+
+A built Cog image contains everything needed to serve predictions as an HTTP API. When a container starts, it runs the coglet prediction server, which manages your model's lifecycle.
+
+### The two-process architecture
+
+Cog containers use a parent-child process architecture:
+
+- **Parent process (coglet)**: A Rust-based HTTP server built on the Axum web framework. It handles incoming HTTP requests, manages health checks, orchestrates predictions, and delivers webhooks. The reason this is written in Rust rather than Python is performance and reliability -- the HTTP server needs to remain responsive even when the Python process is fully occupied with a GPU-intensive prediction.
+
+- **Worker subprocess**: A Python process that loads and runs your model. This is where your `setup()` and `predict()` methods execute. The worker communicates with the parent through an inter-process communication (IPC) protocol.
+
+The reason for this separation is isolation. If your model code crashes, exhausts memory, or enters a bad state, the parent process survives and can report the failure, restart the worker, or return appropriate error responses. A single-process design would mean that a segfault in a CUDA operation could silently kill the entire server with no error reported.
+
+### How a container starts up
+
+When a container starts, the following sequence occurs:
+
+1. The coglet parent process starts and immediately begins serving HTTP on port 5000
+2. The health check endpoint returns `STARTING` -- the model is not yet ready
+3. Coglet spawns the Python worker subprocess
+4. The worker loads your predictor class and calls `setup()` -- this is where you load model weights, initialise pipelines, and perform other one-time work
+5. Once `setup()` completes, the worker signals readiness to the parent
+6. The health check now returns `READY`, and the server begins accepting predictions
+
+The fact that the HTTP server starts before `setup()` completes is a deliberate design choice. It allows orchestration systems like Kubernetes to monitor the container's health from the moment it starts. They can distinguish between "still loading" (`STARTING`) and "something went wrong" (`SETUP_FAILED`), which is essential for reliable deployments.
+
+## How `cog predict` works
+
+`cog predict` is a convenience command that combines several steps:
+
+1. **Build** the Docker image (if needed) -- this is identical to `cog build`
+2. **Run** the container with your project directory mounted as a volume
+3. **Wait** for the server to become `READY`
+4. **Send** a prediction request with your `-i` inputs
+5. **Stream** the output back to your terminal
+6. **Stop** the container
+
+The volume mount means your local code changes are reflected inside the container without rebuilding. However, changes to `cog.yaml` or your Python dependencies will trigger a rebuild.
+
+When you pass `-i image=@photo.jpg`, the `@` prefix tells Cog to read the file from disk and upload it to the running container. Inputs without `@` are passed as literal values.
+
+## How `cog serve` works
+
+`cog serve` builds (if needed) and starts the container, then keeps it running so you can send requests manually with `curl` or other HTTP clients. Unlike `cog predict`, it does not send a prediction -- it just exposes the server.
+
+By default, the server listens on port 5000 inside the container. You can map it to a different host port with `-p`:
+
+```
+cog serve -p 8080
+```
+
+This is useful during development when you want to test your model's HTTP API interactively, inspect the OpenAPI schema at `/openapi.json`, or integrate with other local services.
+
+## How predictions are routed
+
+When a prediction request arrives at the HTTP server, coglet acquires a "slot" -- a communication channel to the worker process. By default, there is one slot, meaning predictions run sequentially. If you configure [`concurrency.max`](../yaml.md#max) in `cog.yaml`, multiple slots are created, each backed by its own Unix domain socket, allowing concurrent predictions.
+
+The slot-based design avoids head-of-line blocking: each concurrent prediction has its own communication channel, so a slow prediction does not delay the delivery of another prediction's streaming output or logs.
+
+For more detail on what happens during a prediction, see [The prediction lifecycle](prediction-lifecycle.md).
+
+## The role of the OpenAPI schema
+
+Cog inspects your `predict()` method's type annotations and `Input()` descriptors at startup to generate an [OpenAPI](https://swagger.io/specification/) schema. This schema serves multiple purposes:
+
+- **Input validation**: The server validates incoming JSON against the schema before calling your code, catching type errors and constraint violations early
+- **Documentation**: The schema at `/openapi.json` describes your model's API in a machine-readable format
+- **Client generation**: Tools can use the schema to generate typed client libraries for your model
+
+The reason Cog derives the schema from Python types rather than requiring a separate schema file is to keep the source of truth in one place. Your `predict()` signature *is* the API definition -- there is no separate specification to keep in sync.
+
+## Further reading
+
+- [The prediction lifecycle](prediction-lifecycle.md) -- what happens from request to response
+- [CUDA and GPU compatibility](cuda-compat.md) -- how Cog manages the GPU stack
+- [Docker image layer strategy](image-layers.md) -- how layers are structured for efficient builds and pushes
+- [`cog.yaml` reference](../yaml.md) -- full configuration reference
+- [Prediction interface reference](../python.md) -- the Python API for defining models

--- a/docs/explanation/image-layers.md
+++ b/docs/explanation/image-layers.md
@@ -1,0 +1,161 @@
+# Docker image layer strategy
+
+Docker images are not monolithic files -- they are composed of layers, each representing a set of filesystem changes. The order, content, and size of these layers directly affect how fast your image builds, how fast it pushes and pulls from registries, and how quickly your model starts serving predictions on a new machine. Cog structures its layers deliberately to optimise all three.
+
+## How Docker layers work
+
+Every instruction in a Dockerfile that modifies the filesystem (installing packages, copying files, running scripts) creates a new layer. When Docker builds an image, it caches each layer and reuses it as long as the inputs to that instruction have not changed.
+
+The caching rule is strict and sequential: if layer N changes, all layers after N are invalidated and must be rebuilt, even if their own inputs have not changed. This means the order of operations in a Dockerfile has a profound impact on build performance.
+
+Consider a naive Dockerfile that copies your code first, then installs Python packages:
+
+```dockerfile
+COPY . /src
+RUN pip install -r requirements.txt
+```
+
+Every time you change a single line of Python code, Docker invalidates the `COPY` layer, which invalidates the `pip install` layer, which reinstalls all your packages from scratch. For a model with heavy dependencies like PyTorch (several gigabytes), this turns a 5-second code change into a 10-minute rebuild.
+
+## Cog's layer ordering
+
+Cog generates Dockerfiles with a carefully chosen layer order that maximises cache hits during iterative development:
+
+```
+1. Base image (OS + CUDA + system libraries)
+2. System packages (apt-get install)
+3. Python installation
+4. Python packages (pip install)
+5. Cog SDK and coglet
+6. Build-time commands (the `run` stanza in cog.yaml)
+7. Your model code
+```
+
+The reason for this specific ordering is that it follows the frequency of change, from least to most:
+
+- **Base image and system packages** almost never change. Once you have settled on your OS, CUDA version, and system dependencies, these layers remain cached indefinitely.
+- **Python packages** change occasionally -- when you add a new dependency or upgrade a version. But between those changes, the layer is cached.
+- **Your model code** changes constantly during development. By placing it last, code changes never invalidate the expensive package installation layers above.
+
+This means that during normal development, `cog build` only needs to re-execute the final `COPY` step. Rebuilds take seconds, not minutes.
+
+## The `--separate-weights` flag
+
+Model weights are a unique challenge for Docker images. A single model's weights can be anywhere from hundreds of megabytes to tens of gigabytes. Without special handling, these weights are baked into the same layer as your code, which creates two problems:
+
+1. **Every code change re-uploads the weights.** When you push an image to a registry, Docker pushes only the layers that have changed. If your weights and code are in the same layer, changing one line of your `predict.py` forces a re-push of the entire layer, including all the weights. For a model with 7 GB of weights, this turns a quick code fix into a lengthy upload.
+
+2. **Layer deduplication is lost.** If you have multiple versions of the same model that share the same weights but differ in code, Docker cannot deduplicate the weights because they are mixed in with different code in each version.
+
+The `--separate-weights` flag solves this by placing model weights in a dedicated layer, separate from your code:
+
+```
+cog build --separate-weights -t my-model
+```
+
+With this flag, Cog generates a multi-stage build where:
+
+- **Weights layer**: Contains your model weight files (large, changes rarely)
+- **Code layer**: Contains your Python code and other non-weight files (small, changes often)
+
+Cog uses file naming patterns to identify which files are likely weights (e.g., `.pth`, `.bin`, `.safetensors`, `.gguf`, and others). It also examines directories in your project to distinguish model data from code. The classification is based on heuristics, and the `.dockerignore` file is temporarily modified during the build to exclude weights from the code layer and vice versa.
+
+The practical benefit is significant. After the initial push of a model with large weights, subsequent code-only changes result in pushes of just a few megabytes rather than several gigabytes. For teams iterating quickly on model code, this can reduce push times from minutes to seconds.
+
+### When to use `--separate-weights`
+
+Using `--separate-weights` is beneficial when:
+
+- Your model weights are stored in the image (as opposed to being downloaded during `setup()`)
+- The weights are significantly larger than your code
+- You expect to iterate on code without changing weights
+
+It is less useful when your weights are downloaded during `setup()` (they are not in the image at all), or when your weights change as often as your code (the weights layer would be invalidated anyway).
+
+Some teams prefer to download weights during `setup()` to keep image sizes small. Others prefer to bake weights into the image for faster cold starts and better reproducibility. The `--separate-weights` flag is designed for the latter approach, mitigating its main disadvantage (large pushes on code changes) while preserving its benefits (self-contained images, no external dependencies at runtime). See the [`setup()` documentation](../python.md#predictorsetup) for a more detailed discussion of these trade-offs.
+
+## Cog base images
+
+Cog provides pre-built base images (`r8.im/cog-base`) that include the operating system, CUDA toolkit, Python, and common ML framework installations. These base images exist to solve two performance problems.
+
+### Faster builds
+
+Without a base image, every `cog build` must install the CUDA toolkit, Python, and your framework from scratch. For a GPU model using PyTorch, this can take 5-15 minutes even with good network connectivity. With a Cog base image, these components are already installed in the base layer, and `cog build` only needs to install your additional Python packages and copy your code.
+
+The base image is tagged with its exact configuration -- for example, `r8.im/cog-base:cuda12.1-python3.12-torch2.3.1`. Cog selects the appropriate tag based on your `cog.yaml` configuration. If no matching base image exists (because you are using an unusual combination of versions), Cog falls back to building from a standard NVIDIA CUDA base image.
+
+### Faster cold starts
+
+When a container is pulled to a new machine for the first time, Docker must download all layers of the image. With a Cog base image, the base layers are likely already present on the machine if it has previously run other Cog models with the same Python and CUDA configuration. Docker only needs to download the layers unique to your model.
+
+This is particularly valuable in deployment environments where many different models run on a shared pool of machines. The base image layers are effectively shared infrastructure, amortised across all models that use them.
+
+### The `--use-cog-base-image` flag
+
+Cog uses base images by default. You can disable this with:
+
+```
+cog build --use-cog-base-image=false
+```
+
+The reason you might want to disable base images is control. Base images are maintained by the Cog team and updated on their release schedule. If you need a specific patch version of a system library, or want to audit every component in your image, building from the raw NVIDIA base image gives you that control at the cost of longer build times.
+
+## The `--use-cuda-base-image` flag
+
+This flag controls whether Cog starts from an NVIDIA CUDA base image or a plain Python base image:
+
+```
+cog build --use-cuda-base-image=false
+```
+
+The tradeoff is straightforward: CUDA base images add several gigabytes to your image because they include the full CUDA toolkit and cuDNN. Some PyTorch distributions ship their own CUDA libraries bundled in the pip package, which means the system-level CUDA installation is technically redundant.
+
+By using `--use-cuda-base-image=false`, you can produce significantly smaller images. Smaller images are faster to push, pull, and store. However, this approach carries risk: if any part of your dependency chain expects system-level CUDA (a custom CUDA kernel, a library compiled against system CUDA, or a future PyTorch version that changes its bundling strategy), your model will fail at runtime.
+
+Some teams use this flag aggressively for deployment speed and accept the risk. Others prefer the safety of the full CUDA base image. There is no universally correct answer -- it depends on your specific dependencies and how thoroughly you can test the resulting image.
+
+## How `.dockerignore` affects the image
+
+Docker sends your entire project directory as the "build context" to the Docker daemon. The `.dockerignore` file controls which files are excluded from this context, and therefore which files can end up in your image.
+
+A well-configured `.dockerignore` is important for two reasons:
+
+1. **Build performance.** Sending unnecessary files (training data, datasets, logs, `.git` directories) to the Docker daemon slows down the build, even if those files are not ultimately copied into the image.
+
+2. **Image size.** Files that are copied into the image but not needed at runtime (test files, documentation, training scripts) waste space in the final image and in every subsequent push and pull.
+
+When you run `cog init`, Cog generates a `.dockerignore` file with sensible defaults. During builds with `--separate-weights`, Cog temporarily modifies the `.dockerignore` to separate weight files from code files across the two build stages. This modification is reverted after the build completes.
+
+As a general principle, your `.dockerignore` should exclude everything that is not needed to run predictions. This typically includes:
+
+- `.git/` (repository history)
+- Training data and datasets
+- Notebooks and training scripts (unless referenced by your predictor)
+- Test files
+- Documentation
+- Virtual environments and local build artifacts
+
+## Putting it all together
+
+The layer strategy in a typical Cog image looks like this for a GPU model with `--separate-weights`:
+
+```
+Layer 1:  Base image (OS + CUDA + Python + PyTorch) [shared across models]
+Layer 2:  System packages from cog.yaml              [changes rarely]
+Layer 3:  Python packages from requirements.txt      [changes occasionally]
+Layer 4:  Cog SDK + coglet                            [tied to cog version]
+Layer 5:  Build commands from `run` stanza            [changes rarely]
+Layer 6:  Model weights                               [changes rarely]
+Layer 7:  Your model code                             [changes frequently]
+```
+
+During development, only layer 7 changes. When you push to a registry, only the changed layers are uploaded. When a new machine pulls the image, shared base layers may already be cached. The result is that the most common operations -- rebuilding after a code change, pushing a code update, pulling to a machine that has run similar models -- are all fast.
+
+This is not accidental. The layer ordering reflects a deliberate design philosophy: optimise for the common case (iterative code changes) while making the uncommon case (changing dependencies or weights) as painless as possible.
+
+## Further reading
+
+- [How Cog works](how-cog-works.md) -- the build pipeline that generates these layers
+- [CUDA and GPU compatibility](cuda-compat.md) -- how base image selection relates to CUDA version management
+- [`cog.yaml` reference](../yaml.md) -- configuration options that affect the generated Dockerfile
+- [Deploy models with Cog](../deploy.md) -- running the built images in production

--- a/docs/explanation/prediction-lifecycle.md
+++ b/docs/explanation/prediction-lifecycle.md
@@ -1,0 +1,168 @@
+# The prediction lifecycle
+
+A prediction in Cog passes through a well-defined sequence of states, from container startup through model loading, request handling, output delivery, and completion. Understanding this lifecycle helps you design your predictor for reliability and performance, diagnose issues when predictions fail, and integrate with Cog's HTTP API effectively.
+
+## Container startup and setup
+
+Before any prediction can run, the container must complete its startup sequence. This is not a simple "start the server" step -- it involves two processes coordinating to bring the model online.
+
+### The startup sequence
+
+1. **HTTP server starts immediately.** The coglet parent process begins listening on port 5000 as soon as the container starts. The health check endpoint (`GET /health-check`) is available right away, returning `STARTING` status. The reason for starting the HTTP server before the model is ready is to give orchestration systems (like Kubernetes readiness probes) a way to monitor progress.
+
+2. **Worker subprocess spawns.** Coglet spawns a Python subprocess that will host your model. This process is separate from the HTTP server for isolation -- if your model crashes during setup, the HTTP server survives to report the failure.
+
+3. **Your predictor loads.** The worker imports your predictor module (e.g., `predict.py`) and instantiates your `Predictor` class.
+
+4. **`setup()` runs.** If your predictor defines a `setup()` method, it is called now. This is where you load model weights, initialise pipelines, download resources, or perform other expensive one-time work. Setup can take anywhere from milliseconds to several minutes depending on the model.
+
+5. **Worker signals readiness.** Once `setup()` completes successfully, the worker sends a "ready" message to the parent process along with the OpenAPI schema derived from your `predict()` method's type annotations.
+
+6. **Server becomes READY.** The health check now returns `READY`, and the server begins accepting prediction requests.
+
+### What happens when setup fails
+
+If `setup()` raises an exception, the health check transitions to `SETUP_FAILED`. The server remains running -- it continues to respond to health checks and will return errors for prediction requests -- but it will not attempt to run predictions. This is by design: a clean failure state is more useful for debugging than a container that silently restarts in a loop.
+
+You can set a setup timeout using the `COG_SETUP_TIMEOUT` environment variable. If setup exceeds this duration, it is treated as a failure. By default, there is no timeout.
+
+## Health check states
+
+The health check endpoint (`GET /health-check`) always returns HTTP 200, with a `status` field in the response body that indicates the container's true state. The reason it always returns 200 -- rather than using HTTP status codes to signal readiness -- is that different orchestration systems interpret non-200 responses differently. A consistent 200 with a status field works reliably across all platforms.
+
+The possible states are:
+
+| Status | Meaning |
+|--------|---------|
+| `STARTING` | The model's `setup()` method is still running. The container is alive but not ready for predictions. |
+| `READY` | Setup succeeded and the server is accepting predictions. |
+| `BUSY` | The model is healthy, but all prediction slots are currently occupied. New requests will receive a `409 Conflict` response. |
+| `SETUP_FAILED` | The `setup()` method raised an exception. The container will not accept predictions. |
+| `DEFUNCT` | An unrecoverable error occurred (e.g., the worker process crashed and could not be restarted). |
+| `UNHEALTHY` | The model is nominally ready, but a user-defined `healthcheck()` method returned `False`. |
+
+The distinction between `BUSY` and `READY` matters for load balancers. A `BUSY` container is healthy but temporarily unable to accept work -- the load balancer should route to a different instance. A `SETUP_FAILED` or `DEFUNCT` container should be replaced entirely.
+
+## The prediction request
+
+When a prediction request arrives at `POST /predictions`, a sequence of steps occurs before your `predict()` method is ever called.
+
+### Input validation
+
+The server validates the incoming JSON against the OpenAPI schema derived from your `predict()` method's type annotations and `Input()` descriptors. This happens in the Rust HTTP server, before any Python code runs.
+
+The reason validation happens at this level is performance and safety. Rejecting malformed requests before they reach the Python worker avoids wasting GPU time on inputs that will inevitably fail. It also provides clear, structured error messages to the client -- rather than a Python traceback from a type error deep in your model code.
+
+For example, if your `predict()` signature includes `scale: float = Input(ge=1.0, le=10.0)` and a request sends `scale: 15.0`, the server returns a validation error immediately. Your Python code never sees the request.
+
+### Slot acquisition
+
+After validation, the server attempts to acquire a prediction slot. By default there is one slot, meaning predictions run sequentially. With `concurrency.max` configured, multiple slots are available.
+
+If no slot is available, the behaviour depends on the request type:
+
+- **Synchronous requests**: Return `409 Conflict` immediately
+- **Asynchronous requests** (with `Prefer: respond-async` header): Also return `409 Conflict`
+
+The reason Cog does not queue requests is simplicity and predictability. Queuing introduces complex questions about queue depth, timeouts, ordering guarantees, and back-pressure. By returning 409, Cog pushes queuing responsibility to the client or orchestration layer, where it can be managed with full knowledge of the broader system architecture.
+
+### Dispatch to worker
+
+Once a slot is acquired, the prediction is dispatched to the Python worker over a Unix domain socket dedicated to that slot. Each slot has its own socket, which avoids head-of-line blocking -- a slow prediction on one slot does not delay communication for another.
+
+The request includes the prediction ID and the validated input payload. The worker sets up the execution context (for log routing and metrics collection) and then calls your `predict()` method.
+
+## Prediction execution
+
+Your `predict()` method runs in the Python worker subprocess. From your code's perspective, it is a normal Python function call. But several things are happening around it.
+
+### Output handling
+
+The output of `predict()` is handled differently depending on the return type:
+
+- **Simple values** (strings, numbers, booleans): Returned directly in the response.
+- **`cog.Path` or `cog.File` objects**: The file is read and either base64-encoded into a data URL or uploaded to a configured URL. The response contains the URL, not the file contents.
+- **Iterators** (`Iterator[T]`): Each yielded value is streamed to the client as it is produced. This is particularly important for language models, where tokens can be delivered incrementally rather than waiting for the entire response.
+- **`ConcatenateIterator`**: A special case of iterator output where the yielded values are meant to be concatenated into a single string. This is a hint for display purposes -- platforms like Replicate show the output as accumulating text rather than a list of fragments.
+
+### Log capture
+
+Everything your code writes to `stdout` and `stderr` during a prediction is captured and attributed to that specific prediction. The reason logs are per-prediction rather than global is to support concurrent predictions -- when multiple predictions run simultaneously, you need to know which log line belongs to which prediction.
+
+Coglet achieves this through a `ContextVar`-based routing mechanism. Even if your code spawns async tasks or threads, logs are routed to the correct prediction as long as the context propagates.
+
+### Metrics
+
+The runtime automatically records `predict_time` for every prediction. You can record additional metrics using `self.record_metric()` inside your `predict()` method. Metrics appear in the prediction response alongside the output.
+
+Metrics support accumulation modes (`incr` for counters, `append` for arrays), nested keys via dot-path notation, and type safety -- once a metric key has a type, it cannot be silently changed to a different type. These features are designed for instrumenting model inference at a level of detail that matters for production monitoring.
+
+## Synchronous vs. asynchronous predictions
+
+Cog supports two modes of prediction creation, and understanding the difference is important for choosing the right integration pattern.
+
+### Synchronous predictions
+
+A synchronous request (`POST /predictions` without special headers) blocks until the prediction completes. The server holds the HTTP connection open and returns the full result in the response body. This is the simplest integration pattern and works well for predictions that complete in seconds.
+
+The tradeoff is that long-running predictions tie up the HTTP connection. If the client has a short timeout, or if a load balancer or proxy sits between the client and the server, the connection may be dropped before the prediction finishes.
+
+### Asynchronous predictions
+
+An asynchronous request (with the `Prefer: respond-async` header) returns immediately with `202 Accepted`. The server processes the prediction in the background and delivers results via webhooks.
+
+The reason Cog uses webhooks rather than polling is efficiency and timeliness. With polling, the client must repeatedly ask "is it done yet?", wasting bandwidth and adding latency. With webhooks, the server pushes updates to the client as they happen.
+
+Webhook events are fired at specific moments:
+
+- `start`: When the prediction begins processing (once)
+- `output`: Each time the predict function yields or returns output (debounced to at most once per 500ms)
+- `logs`: Each time the predict function writes to stdout (debounced to at most once per 500ms)
+- `completed`: When the prediction reaches a terminal state -- `succeeded`, `failed`, or `canceled` (once)
+
+The 500ms debounce for `output` and `logs` is a fixed interval, chosen to balance responsiveness against webhook volume. For streaming models that produce many small outputs, this prevents overwhelming the webhook receiver with hundreds of requests per second.
+
+You can filter which events trigger webhooks using the `webhook_events_filter` field in the request. For example, if you only care about the final result, specifying `["completed"]` avoids intermediate webhook traffic.
+
+## Cancellation
+
+Predictions can be cancelled by sending `POST /predictions/<id>/cancel`. Cancellation is only available for asynchronous predictions (those created with the `Prefer: respond-async` header and an explicit `id`).
+
+When a cancellation request arrives:
+
+1. The parent process sends a cancel signal to the worker
+2. For **sync predictors** (`def predict`), a `CancelationException` is raised in the running predict function. This is a `BaseException` subclass -- not an `Exception` subclass -- so it will not be caught by generic `except Exception` handlers. This is deliberate: it matches the semantics of `KeyboardInterrupt` and ensures cancellation propagates cleanly through most code.
+3. For **async predictors** (`async def predict`), an `asyncio.CancelledError` is raised, following standard Python async conventions.
+
+If your code needs to perform cleanup on cancellation (releasing GPU memory, closing file handles), you can catch the exception, perform cleanup, and re-raise it. You *must* re-raise it -- swallowing the cancellation exception prevents the runtime from marking the prediction as cancelled and may result in the container being terminated.
+
+The design of cancellation reflects a practical constraint: there is no reliable way to interrupt arbitrary Python code from outside the process. The signal-based approach (SIGUSR1 for sync predictors) is the most portable mechanism available, and raising an exception at the Python level gives your code a chance to clean up gracefully.
+
+## Terminal states
+
+A prediction ends in one of three states:
+
+- **`succeeded`**: The `predict()` method returned or yielded its final output normally
+- **`failed`**: The `predict()` method raised an unhandled exception, or input validation failed
+- **`canceled`**: The prediction was cancelled via the cancel endpoint
+
+Once a prediction reaches a terminal state, its slot is released and becomes available for the next request. If webhooks are configured, a `completed` event is sent with the final prediction state, output, and any error information.
+
+## The bigger picture
+
+The prediction lifecycle is designed around a few core principles:
+
+**Separation of concerns.** The HTTP server handles networking, validation, and routing. The Python worker handles model execution. Neither needs to know the details of the other's implementation.
+
+**Observability.** Every stage of the lifecycle is visible through the health check endpoint, prediction status fields, structured logs, and metrics. When something goes wrong, there is always a way to determine what happened and where.
+
+**Graceful degradation.** Setup failures, prediction errors, and worker crashes all result in well-defined states with clear error messages, rather than silent failures or hanging connections.
+
+These properties matter less when you are running `cog predict` on your laptop and more when you are running a model in production handling thousands of requests. But they are baked into the lifecycle from the start, so the model you test locally behaves the same way when deployed.
+
+## Further reading
+
+- [How Cog works](how-cog-works.md) -- the overall architecture of Cog containers
+- [HTTP API reference](../http.md) -- endpoints, request formats, and response schemas
+- [Prediction interface reference](../python.md) -- defining `setup()`, `predict()`, inputs, and outputs
+- [Deploy models with Cog](../deploy.md) -- running Cog containers in production

--- a/docs/explanation/why-containers.md
+++ b/docs/explanation/why-containers.md
@@ -1,0 +1,114 @@
+# Why containers for machine learning?
+
+Shipping a machine learning model to production is a fundamentally different problem from training one. Training is exploratory -- you iterate on data, architectures, and hyperparameters in a notebook or script. Deployment demands reproducibility, portability, and a well-defined interface. The gap between these two worlds is where most ML engineering pain lives, and it is the problem Cog was built to solve.
+
+## The deployment problem
+
+Consider what it takes to run someone else's ML model. You need:
+
+- The correct Python version (and often a specific patch release)
+- The right versions of PyTorch, TensorFlow, or other frameworks
+- Compatible CUDA and cuDNN libraries, if the model uses a GPU
+- System-level dependencies like `ffmpeg`, `libgl`, or custom C libraries
+- The model weights, which may be gigabytes in size
+- Pre-processing and post-processing code that transforms raw inputs into model-ready tensors and back
+- Some way to actually invoke the model -- a script, a Flask server, a gRPC endpoint
+
+Every one of these is a potential source of failure. Python version mismatches cause subtle bugs. CUDA version conflicts produce cryptic errors or silent incorrect results. Missing system libraries crash the process at import time. And even when everything is installed correctly, there is no standard way to call the model -- every project has its own bespoke invocation pattern.
+
+The result is that researchers routinely spend days helping engineers deploy their models, and engineers spend days debugging environment issues that worked fine on the researcher's machine. This is not a niche problem. Companies like Uber, Spotify, and others have built internal platforms specifically to address it.
+
+## Why Docker is the right foundation
+
+Docker containers solve the environment problem by packaging an entire filesystem -- operating system, libraries, Python, CUDA drivers, and application code -- into a single, portable artifact. A container built on one machine runs identically on another, regardless of the host's configuration.
+
+For ML specifically, Docker provides several properties that matter:
+
+**Reproducibility.** A Docker image is a snapshot of a working environment. If a model works in the image today, it will work in the same image a year from now, even if upstream packages have changed or been removed. This is stronger than pinning versions in a `requirements.txt`, because the image captures the entire operating system state, not just Python packages.
+
+**Portability.** Docker images run on any machine with a Docker runtime -- your laptop, a cloud VM, a Kubernetes cluster, or a specialised ML inference platform. The same image you test locally is the same image that runs in production. There is no "it works on my machine" problem.
+
+**Isolation.** Each container has its own filesystem and process space. You can run multiple models with conflicting dependencies on the same host without interference. A model that requires CUDA 11.8 and another that requires CUDA 12.1 can coexist without any conflict.
+
+**Ecosystem.** Docker has mature tooling for building, pushing, pulling, and orchestrating images. Container registries, CI/CD pipelines, and orchestration platforms like Kubernetes all speak Docker natively. Choosing Docker means you inherit this entire ecosystem rather than building custom deployment tooling.
+
+## What Cog adds on top of Docker
+
+Docker solves the environment problem, but introduces its own complexity. Writing a Dockerfile for an ML model is not straightforward:
+
+- You need to know which nvidia base image tag corresponds to your CUDA version
+- You need to layer your dependencies in the right order for efficient caching
+- You need to write an HTTP server to handle prediction requests
+- You need to define an API schema for your model's inputs and outputs
+- You need to handle file uploads and downloads, streaming output, health checks, and graceful shutdown
+
+Cog eliminates this complexity. Instead of writing a Dockerfile, you write a `cog.yaml` that declares your dependencies, and a `predict.py` that defines your model's interface using standard Python types. Cog handles everything else.
+
+### No Dockerfile authoring
+
+Cog generates an optimised Dockerfile from your `cog.yaml`. The generated Dockerfile follows best practices that most ML engineers would not know to implement: efficient layer ordering for cache utilisation, multi-stage builds for smaller images, and correct nvidia base image selection.
+
+### Automatic CUDA management
+
+Specifying `gpu: true` in `cog.yaml` is enough. Cog maintains a [compatibility matrix](cuda-compat.md) of Python, PyTorch, TensorFlow, CUDA, and cuDNN versions, and automatically selects the right combination. This eliminates an entire category of environment bugs that are notoriously difficult to debug.
+
+### A typed prediction API
+
+By defining your `predict()` method with Python type annotations and `Input()` descriptors, Cog generates an OpenAPI schema and a validated HTTP API automatically. Your model's interface is defined in one place -- your Python code -- and the HTTP server, input validation, and API documentation all derive from it.
+
+### A production-grade HTTP server
+
+Every Cog container includes coglet, a Rust-based prediction server. It handles synchronous and asynchronous predictions, webhook delivery, streaming output, cancellation, health checks, concurrency control, and file uploads. Building this from scratch for every model would be a significant engineering effort.
+
+### Consistent invocation
+
+Every Cog model is invoked the same way: `cog predict -i input=value` for local testing, or `POST /predictions` for HTTP. There is no need to figure out how each model's ad-hoc prediction script works.
+
+## Alternative approaches and their tradeoffs
+
+Cog is not the only way to deploy ML models. Understanding the alternatives helps clarify when Cog is and is not the right choice.
+
+### Manual Dockerfiles
+
+Writing your own Dockerfile gives you maximum control. You can choose any base image, install any software, and structure layers however you like. Some teams prefer this when they have unusual requirements or deep Docker expertise.
+
+The tradeoff is effort and maintenance. You must manage CUDA compatibility yourself, write your own HTTP server, implement health checks, and ensure your layer ordering is efficient. For a single model, this is manageable. For a team shipping many models, the duplicated effort and inconsistency across Dockerfiles becomes a real cost.
+
+### Virtual environments and conda
+
+Tools like `venv`, `conda`, and `poetry` solve Python dependency isolation, but they do not solve the full deployment problem. They do not capture system packages, CUDA libraries, or operating system state. A `conda` environment that works on your Ubuntu 22.04 laptop may fail on a cloud VM running Amazon Linux, because a system library is missing.
+
+These tools are excellent for development and training, but they are a partial solution for deployment. Some teams combine them with Docker -- using conda inside a container -- but this adds complexity without clear benefit over Cog's approach.
+
+### Cloud-specific solutions
+
+Most cloud providers offer ML-specific deployment services: AWS SageMaker, Google Vertex AI, Azure ML, and so on. These services handle infrastructure, scaling, and often provide their own model packaging formats.
+
+The tradeoff is portability. A model packaged for SageMaker cannot run on Vertex AI, and vice versa. If you later switch cloud providers, or want to run inference on your own hardware, you must repackage the model. Cog produces standard Docker images that run anywhere, avoiding lock-in to any single platform.
+
+That said, cloud-specific services often provide features that Cog does not, such as auto-scaling, A/B testing, and integrated monitoring. Some teams use Cog to package their models and then deploy the resulting Docker images to a cloud service, getting the benefits of both approaches.
+
+### Model serving frameworks
+
+Frameworks like TensorFlow Serving, TorchServe, and Triton Inference Server are designed specifically for serving ML models at scale. They offer advanced features like dynamic batching, model versioning, and GPU memory management.
+
+These frameworks are best suited for teams with dedicated ML infrastructure engineers and models that fit their supported formats. They require more configuration and infrastructure knowledge than Cog, and they typically expect models in specific serialised formats (SavedModel, TorchScript, ONNX) rather than arbitrary Python code.
+
+Cog occupies a different niche: it is designed for individual researchers or small teams who want to deploy a model with minimal infrastructure work. If you are running a single model and your primary goal is getting it into production quickly, Cog is simpler. If you are managing hundreds of models at scale with complex routing and batching requirements, a dedicated serving framework may be more appropriate.
+
+## The broader perspective
+
+The reason Cog exists is a belief that the gap between ML research and production deployment is unnecessarily wide. Researchers should not need to become Docker experts or backend engineers to ship their work. Engineers should not need to reverse-engineer a researcher's ad-hoc environment setup.
+
+Cog's creators -- Andreas Jansson (previously at Spotify, where he built internal ML deployment tools) and Ben Firshman (creator of Docker Compose) -- observed that many companies were independently building similar tools internally. Cog is the open-source version of that pattern: a standard way to package ML models in Docker containers with a typed prediction API.
+
+The design reflects pragmatic choices. Cog uses Docker because Docker is ubiquitous, not because it is theoretically optimal. It uses Python type annotations for the API because Python is the language ML researchers already use, not because type annotations are the best schema language. It generates Dockerfiles rather than using a custom image format because Dockerfiles are understood by existing tooling.
+
+These choices optimise for adoption and compatibility over theoretical purity, which is appropriate for a tool whose value comes from standardisation.
+
+## Further reading
+
+- [How Cog works](how-cog-works.md) -- the architecture of Cog containers
+- [CUDA and GPU compatibility](cuda-compat.md) -- how Cog manages the GPU dependency chain
+- [Getting started](../getting-started.md) -- try Cog with an example model
+- [Getting started with your own model](../getting-started-own-model.md) -- package your own model

--- a/docs/getting-started-own-model.md
+++ b/docs/getting-started-own-model.md
@@ -11,6 +11,14 @@ This guide will show you how to put your own machine learning model in a Docker 
 
 First, install Cog if you haven't already:
 
+**macOS (recommended):**
+
+```sh
+brew install replicate/tap/cog
+```
+
+**Linux or macOS (manual):**
+
 ```sh
 sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
 sudo chmod +x /usr/local/bin/cog
@@ -46,7 +54,7 @@ With a `requirements.txt` containing your dependencies:
 torch==2.6.0
 ```
 
-This will generate a Docker image with Python 3.12 and PyTorch 2 installed, for both CPU and GPU, with the correct version of CUDA, and various other sensible best-practices.
+This will generate a Docker image with Python 3.13 and PyTorch 2 installed, for both CPU and GPU, with the correct version of CUDA, and various other sensible best-practices.
 
 To run a command inside this environment, prefix it with `cog run`:
 
@@ -56,7 +64,7 @@ $ cog run python
 Running 'python' in Docker with the current directory mounted as a volume...
 ────────────────────────────────────────────────────────────────────────────────────────
 
-Python 3.12.0 (main, Oct  2 2023, 15:45:55)
+Python 3.13.x (main, ...)
 [GCC 12.2.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>>
@@ -98,7 +106,7 @@ You also need to define the inputs to your model as arguments to the `predict()`
 - `int`: an integer
 - `float`: a floating point number
 - `bool`: a boolean
-- `cog.File`: a file-like object representing a file
+- `cog.File`: a file-like object representing a file (deprecated — use `cog.Path` instead)
 - `cog.Path`: a path to a file on disk
 
 You can provide more information about the input with the `Input()` function, as shown above. It takes these basic arguments:
@@ -107,7 +115,11 @@ You can provide more information about the input with the `Input()` function, as
 - `default`: A default value to set the input to. If this argument is not passed, the input is required. If it is explicitly set to `None`, the input is optional.
 - `ge`: For `int` or `float` types, the value should be greater than or equal to this number.
 - `le`: For `int` or `float` types, the value should be less than or equal to this number.
+- `min_length`: For `str` types, the minimum length of the string.
+- `max_length`: For `str` types, the maximum length of the string.
+- `regex`: For `str` types, the string must match this regular expression.
 - `choices`: For `str` or `int` types, a list of possible values for this input.
+- `deprecated`: Mark this input as deprecated with a message explaining what to use instead.
 
 There are some more advanced options you can pass, too. For more details, [take a look at the prediction interface documentation](python.md).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,7 +75,7 @@ and you'll get an interactive Python shell:
 Running 'python' in Docker with the current directory mounted as a volume...
 ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
-Python 3.12.0 (main, Oct  2 2023, 15:45:55)
+Python 3.13.x (main, ...)
 [GCC 12.2.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>>

--- a/docs/how-to/ci-cd.md
+++ b/docs/how-to/ci-cd.md
@@ -1,0 +1,161 @@
+# How to set up CI/CD
+
+This guide shows you how to build and push Cog images automatically in continuous integration pipelines.
+
+## Install Cog in CI
+
+Download the Cog binary in your CI job. This example uses GitHub Actions, but the approach works in any CI system:
+
+```yaml
+- name: Install Cog
+  run: |
+    curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m)"
+    chmod +x /usr/local/bin/cog
+```
+
+## Build and push with GitHub Actions
+
+A complete workflow that builds a Cog image and pushes it to Replicate:
+
+```yaml
+name: Build and push model
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Cog
+        run: |
+          curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m)"
+          chmod +x /usr/local/bin/cog
+
+      - name: Push to Replicate
+        env:
+          REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
+        run: |
+          cog login --token-stdin <<< "$REPLICATE_API_TOKEN"
+          cog push r8.im/your-username/my-model
+```
+
+To push to a different registry, replace the login and push steps:
+
+```yaml
+      - name: Log in to registry
+        run: echo "${{ secrets.REGISTRY_PASSWORD }}" | docker login registry.example.com -u ${{ secrets.REGISTRY_USERNAME }} --password-stdin
+
+      - name: Build and push
+        run: |
+          cog build -t registry.example.com/your-org/my-model:${{ github.sha }}
+          docker push registry.example.com/your-org/my-model:${{ github.sha }}
+```
+
+## Test the built image
+
+To verify the image works before pushing, build it locally and run a test prediction:
+
+```yaml
+      - name: Build image
+        run: cog build -t my-model:test
+
+      - name: Test prediction
+        run: |
+          docker run -d --name test-model -p 5001:5000 my-model:test
+          
+          # Wait for model to be ready
+          for i in $(seq 1 60); do
+            status=$(curl -sf http://localhost:5001/health-check | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])" 2>/dev/null)
+            if [ "$status" = "READY" ]; then break; fi
+            sleep 5
+          done
+          
+          # Run a prediction
+          curl -sf http://localhost:5001/predictions \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d '{"input": {"prompt": "test"}}' | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['status']=='succeeded', f'Prediction failed: {d}'"
+          
+          docker stop test-model
+```
+
+If your model requires a GPU, you will need a CI runner with GPU access (e.g. a self-hosted runner with NVIDIA drivers), or skip the test prediction step in CI and rely on a staging environment instead.
+
+## Cache Docker layers for faster builds
+
+Cog uses Docker BuildKit under the hood. To cache layers between CI runs, use Docker's built-in layer caching:
+
+```yaml
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build with cache
+        run: cog build -t my-model:latest
+```
+
+If builds are still slow because a dependency changed, you can force a clean build:
+
+```console
+cog build --no-cache -t my-model:latest
+```
+
+## Build only on relevant changes
+
+To avoid unnecessary builds, use path filters to trigger the workflow only when model code changes:
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths:
+      - "predict.py"
+      - "cog.yaml"
+      - "requirements.txt"
+      - "weights/**"
+```
+
+If your weights are stored outside the repository and downloaded in `setup()`, you can exclude the `weights/**` path.
+
+## Use separate-weights for faster pushes
+
+If your model includes weights in the image, use `--separate-weights` so that code-only changes do not re-upload the weights layer:
+
+```yaml
+      - name: Push to Replicate
+        run: cog push r8.im/your-username/my-model --separate-weights
+```
+
+This significantly reduces push time when only your prediction code changed.
+
+## Pin the Cog version
+
+To ensure reproducible builds, pin the Cog version in your CI workflow:
+
+```yaml
+      - name: Install Cog
+        run: |
+          COG_VERSION=0.14.0
+          curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/download/v${COG_VERSION}/cog_$(uname -s)_$(uname -m)"
+          chmod +x /usr/local/bin/cog
+```
+
+## Pin the SDK version
+
+To ensure the same Python SDK version is installed in every build, set `sdk_version` in your `cog.yaml`:
+
+```yaml
+build:
+  python_version: "3.12"
+  sdk_version: "0.18.0"
+```
+
+This prevents unexpected behaviour from SDK upgrades between builds. See the [`cog.yaml` reference](../yaml.md#sdk_version) for details.
+
+## Next steps
+
+- See [How to deploy to production](deploy.md) for running your built image in production.
+- See the [CLI reference](../cli.md) for all `cog build` and `cog push` options.
+- See [How to debug build failures](debug-builds.md) if your CI builds are failing.

--- a/docs/how-to/concurrency.md
+++ b/docs/how-to/concurrency.md
@@ -1,0 +1,122 @@
+# How to run concurrent predictions
+
+This guide shows you how to configure your Cog model to process multiple predictions at the same time, reducing latency when your model can handle parallel requests.
+
+Concurrent predictions require Cog 0.14.0 or later.
+
+## Set the concurrency limit
+
+Add `concurrency.max` to your `cog.yaml` to specify how many predictions can run simultaneously:
+
+```yaml
+build:
+  gpu: true
+  python_version: "3.12"
+  python_requirements: requirements.txt
+concurrency:
+  max: 4
+predict: "predict.py:Predictor"
+```
+
+The value should match what your model can handle given available GPU memory and compute. Start low and increase based on testing.
+
+## Make predict() async
+
+When `concurrency.max` is set, your `predict()` method must be `async`. Change `def predict` to `async def predict`:
+
+```python
+from cog import BasePredictor, Input
+
+class Predictor(BasePredictor):
+    def setup(self):
+        self.model = load_model()
+
+    async def predict(self, prompt: str = Input(description="Input prompt")) -> str:
+        result = await self.model.generate(prompt)
+        return result
+```
+
+If your model's inference code is synchronous (which is common for most ML frameworks), use `asyncio.to_thread` to run it without blocking other predictions:
+
+```python
+import asyncio
+from cog import BasePredictor, Input, Path
+
+class Predictor(BasePredictor):
+    def setup(self):
+        self.model = load_model()
+
+    async def predict(self, prompt: str = Input(description="Input prompt")) -> str:
+        result = await asyncio.to_thread(self.model.generate, prompt)
+        return result
+```
+
+`asyncio.to_thread` runs the synchronous function in a thread pool, allowing other async predictions to proceed while one is blocked on inference.
+
+## Make setup() async (optional)
+
+If your setup involves async operations (downloading weights from multiple sources in parallel, for example), you can also make `setup()` async:
+
+```python
+import asyncio
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    async def setup(self):
+        self.tokenizer, self.model = await asyncio.gather(
+            download_tokenizer(),
+            download_model(),
+        )
+```
+
+Async `setup()` is optional. You only need it if your setup code benefits from concurrency.
+
+## Handle 409 Conflict responses
+
+When all prediction slots are in use, the server returns `409 Conflict`. Your client should handle this by retrying after a delay:
+
+```python
+import time
+import requests
+
+def predict_with_retry(url, data, max_retries=5):
+    for attempt in range(max_retries):
+        response = requests.post(url, json=data)
+        if response.status_code == 409:
+            time.sleep(0.5 * (attempt + 1))
+            continue
+        response.raise_for_status()
+        return response.json()
+    raise RuntimeError("All prediction slots busy after retries")
+```
+
+If you use the idempotent `PUT /predictions/<id>` endpoint, retries are safe by design -- the server will not create duplicate predictions for the same ID.
+
+## Combine concurrency with streaming
+
+Async predictors can stream output using `AsyncIterator` or `AsyncConcatenateIterator`:
+
+```python
+from cog import AsyncConcatenateIterator, BasePredictor, Input
+
+class Predictor(BasePredictor):
+    async def predict(self, prompt: str = Input(description="Input prompt")) -> AsyncConcatenateIterator[str]:
+        async for token in self.model.generate_stream(prompt):
+            yield token
+```
+
+Each concurrent prediction streams independently. See [How to stream output](streaming.md) for more detail.
+
+## Choose the right concurrency limit
+
+- For GPU models, the limit depends on how much VRAM each prediction uses. If each prediction uses 4 GB and you have 24 GB available, `max: 5` is a reasonable starting point.
+- For CPU-bound models, the limit depends on the number of cores and how much parallelism your framework supports.
+- For models that primarily wait on external API calls, the limit can be much higher (tens or hundreds) since the bottleneck is network I/O, not compute.
+
+Monitor GPU memory usage and prediction latency to find the right value. A concurrency limit that is too high will cause out-of-memory errors or degraded performance.
+
+## Next steps
+
+- See the [`cog.yaml` reference](../yaml.md#concurrency) for concurrency configuration.
+- See the [prediction interface reference](../python.md#async-predictors-and-concurrency) for async predictor details.
+- See the [HTTP API reference](../http.md) for endpoint behaviour under concurrency.

--- a/docs/how-to/debug-builds.md
+++ b/docs/how-to/debug-builds.md
@@ -1,0 +1,175 @@
+# How to debug build failures
+
+This guide shows you how to diagnose and fix common issues when `cog build` fails.
+
+## Read the full build output
+
+By default, Cog uses a compact build output format. To see the full output from every build step, use `--progress=plain`:
+
+```console
+cog build --progress=plain -t my-model
+```
+
+This shows the complete output from each Docker build step, including pip install logs, compilation output, and error messages that the default view may truncate.
+
+## Inspect the build environment
+
+If the build succeeds but the model does not work as expected, use `cog run` to open a shell inside the built environment:
+
+```console
+cog run bash
+```
+
+This drops you into an interactive shell with the same packages, system libraries, and Python version as the built image. You can inspect installed packages, test imports, and check file paths:
+
+```console
+# Inside the container
+python -c "import torch; print(torch.__version__)"
+pip list
+ls /src
+```
+
+If you want to run a specific script:
+
+```console
+cog run python debug_script.py
+```
+
+## Bypass stale cache layers
+
+If a build fails in a way that does not make sense (for example, a package that should be available is missing), a stale cache layer may be the cause. Force a clean rebuild:
+
+```console
+cog build --no-cache -t my-model
+```
+
+This is also useful when an external dependency has been updated but Docker is reusing a cached layer that installed the old version.
+
+## Fix common errors
+
+### Python version conflicts
+
+**Symptom**: A package fails to install with a message like `requires Python >=3.11` or `no matching distribution found`.
+
+**Fix**: Check that your `python_version` in `cog.yaml` is compatible with all your dependencies. Some packages only support certain Python versions:
+
+```yaml
+build:
+  python_version: "3.12"
+```
+
+Cog supports Python 3.10, 3.11, 3.12, and 3.13. If you are unsure which version a package requires, check its PyPI page.
+
+### Missing system packages
+
+**Symptom**: A Python package fails to compile with errors like `fatal error: xyz.h: No such file or directory` or `ModuleNotFoundError` at runtime for packages that depend on shared libraries.
+
+**Fix**: Add the required system package to `system_packages` in `cog.yaml`. Common examples:
+
+```yaml
+build:
+  system_packages:
+    - "libgl1"          # for OpenCV
+    - "libglib2.0-0"    # for OpenCV
+    - "ffmpeg"           # for audio/video processing
+    - "libsndfile1"      # for audio libraries
+    - "git"              # for pip packages installed from git
+```
+
+To find which package provides a missing header file, use `cog run` to search:
+
+```console
+cog run bash -c "apt-get update && apt-file search missing_header.h"
+```
+
+If `apt-file` is not available, install it first:
+
+```console
+cog run bash -c "apt-get update && apt-get install -y apt-file && apt-file update && apt-file search missing_header.h"
+```
+
+### CUDA version mismatches
+
+**Symptom**: The build succeeds but the model fails at runtime with errors like `CUDA error: no kernel image is available` or `undefined symbol`.
+
+**Fix**: In most cases, remove any explicit `cuda` setting from `cog.yaml` and let Cog auto-detect the correct version based on your PyTorch or TensorFlow version:
+
+```yaml
+build:
+  gpu: true
+  # Do NOT set cuda: unless you have a specific reason
+```
+
+If you must pin a CUDA version, verify it is compatible with your ML framework. See [How to use GPUs](gpu.md) for details.
+
+### pip install timeouts or network errors
+
+**Symptom**: `pip install` fails with connection timeout or SSL errors.
+
+**Fix**: If you are behind a corporate proxy or VPN, set the `COG_CA_CERT` environment variable to inject your CA certificate:
+
+```console
+COG_CA_CERT=/path/to/corporate-ca.crt cog build -t my-model
+```
+
+If the issue is a slow network, increase pip's timeout using a `build.run` command:
+
+```yaml
+build:
+  run:
+    - pip config set global.timeout 120
+```
+
+### Private package installation
+
+**Symptom**: `pip install` fails with `401 Unauthorized` or `403 Forbidden` when installing from a private index.
+
+**Fix**: Use secret mounts in `build.run` to pass credentials without baking them into the image:
+
+```yaml
+build:
+  run:
+    - command: pip install -r requirements-private.txt
+      mounts:
+        - type: secret
+          id: pip
+          target: /etc/pip.conf
+```
+
+Then pass the secret at build time:
+
+```console
+cog build --secret id=pip,src=$HOME/.pip/pip.conf -t my-model
+```
+
+## Check Docker logs for runtime failures
+
+If the image builds but the container crashes at startup, check the Docker logs:
+
+```console
+docker run -d --name debug-model -p 5001:5000 my-model
+docker logs debug-model
+```
+
+If setup fails, the `/health-check` endpoint reports `SETUP_FAILED` with logs:
+
+```console
+curl http://localhost:5001/health-check | python3 -m json.tool
+```
+
+## Enable debug output
+
+For more verbose output from the Cog CLI itself:
+
+```console
+cog --debug build -t my-model
+```
+
+This shows additional information about Dockerfile generation, build arguments, and Docker API calls.
+
+## Next steps
+
+- See [How to use GPUs](gpu.md) for GPU-specific troubleshooting.
+- See [How to optimise Docker image size](image-size.md) to address slow builds.
+- See the [`cog.yaml` reference](../yaml.md) for all build configuration options.
+- See the [environment variables reference](../environment.md) for build-time variables.

--- a/docs/how-to/deploy.md
+++ b/docs/how-to/deploy.md
@@ -1,0 +1,225 @@
+# How to deploy to production
+
+This guide shows you how to build a Cog image, run it in production environments, push it to container registries, and configure it for production workloads.
+
+## Build the image
+
+Build a tagged Docker image from your `cog.yaml`:
+
+```console
+cog build -t my-model:latest
+```
+
+If you want weights in a separate layer for faster subsequent pushes:
+
+```console
+cog build -t my-model:latest --separate-weights
+```
+
+## Run with Docker
+
+### CPU models
+
+```console
+docker run -d -p 5001:5000 my-model:latest
+```
+
+### GPU models
+
+Pass the `--gpus` flag to give the container access to GPUs:
+
+```console
+docker run -d -p 5001:5000 --gpus all my-model:latest
+```
+
+The server listens on port 5000 inside the container. Map it to any host port you need.
+
+### Test the running container
+
+Wait for the model to finish setup, then send a prediction:
+
+```console
+# Check readiness
+curl http://localhost:5001/health-check
+
+# Send a prediction
+curl http://localhost:5001/predictions -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"input": {"prompt": "hello world"}}'
+```
+
+## Configure health checks
+
+The `/health-check` endpoint returns the current status of the container. Use it for readiness and liveness probes.
+
+The response always returns `200 OK` -- check the `status` field in the body to determine readiness:
+
+| Status | Meaning |
+|---|---|
+| `STARTING` | `setup()` is still running |
+| `READY` | Ready to accept predictions |
+| `BUSY` | Ready but all prediction slots are in use |
+| `SETUP_FAILED` | `setup()` raised an exception |
+| `DEFUNCT` | Unrecoverable error |
+
+For Kubernetes, configure a readiness probe that checks for `READY`:
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /health-check
+    port: 5000
+  initialDelaySeconds: 10
+  periodSeconds: 5
+livenessProbe:
+  httpGet:
+    path: /health-check
+    port: 5000
+  initialDelaySeconds: 30
+  periodSeconds: 10
+```
+
+Your readiness check logic should parse the JSON response and only mark the pod as ready when `status` is `READY`. A simple shell check:
+
+```console
+curl -sf http://localhost:5000/health-check | python3 -c "import sys,json; sys.exit(0 if json.load(sys.stdin)['status']=='READY' else 1)"
+```
+
+## Set runtime environment variables
+
+Configure runtime behaviour with environment variables passed to `docker run`:
+
+```console
+docker run -d -p 5001:5000 \
+    -e COG_SETUP_TIMEOUT=300 \
+    my-model:latest
+```
+
+Key runtime variables:
+
+- `COG_SETUP_TIMEOUT`: Maximum seconds for `setup()` to complete (default: no timeout).
+
+See the [environment variables reference](../environment.md) for the full list.
+
+## Push to a container registry
+
+### Push to Replicate
+
+Authenticate first, then push:
+
+```console
+cog login
+cog push r8.im/your-username/my-model
+```
+
+If you set `image` in your `cog.yaml`, you can push without specifying the target:
+
+```yaml
+image: "r8.im/your-username/my-model"
+```
+
+```console
+cog push
+```
+
+### Push to other registries
+
+Cog can push to any OCI-compliant registry. Authenticate with Docker first:
+
+```console
+docker login registry.example.com
+cog push registry.example.com/your-org/my-model
+```
+
+Or build and push separately:
+
+```console
+cog build -t registry.example.com/your-org/my-model:latest
+docker push registry.example.com/your-org/my-model:latest
+```
+
+## Configure webhooks for async predictions
+
+For long-running predictions, use async mode with webhooks so clients do not need to hold open a connection:
+
+```console
+curl http://localhost:5001/predictions -X POST \
+    -H "Content-Type: application/json" \
+    -H "Prefer: respond-async" \
+    -d '{
+        "input": {"prompt": "a photo of a cat"},
+        "webhook": "https://your-app.example.com/webhook",
+        "webhook_events_filter": ["start", "completed"]
+    }'
+```
+
+The server returns `202 Accepted` immediately and delivers results to your webhook URL. Available webhook events are `start`, `output`, `logs`, and `completed`.
+
+If your model produces file output and you use async predictions, configure the upload URL when starting the server:
+
+```console
+docker run -d -p 5001:5000 my-model:latest \
+    --upload-url https://your-storage.example.com/upload
+```
+
+See the [HTTP API reference on webhooks](../http.md#webhooks) for the full protocol.
+
+## Deploy on Kubernetes
+
+A minimal Kubernetes deployment for a GPU model:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-model
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-model
+  template:
+    metadata:
+      labels:
+        app: my-model
+    spec:
+      containers:
+        - name: my-model
+          image: registry.example.com/your-org/my-model:latest
+          ports:
+            - containerPort: 5000
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+          readinessProbe:
+            httpGet:
+              path: /health-check
+              port: 5000
+            initialDelaySeconds: 30
+            periodSeconds: 5
+          env:
+            - name: COG_SETUP_TIMEOUT
+              value: "300"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-model
+spec:
+  selector:
+    app: my-model
+  ports:
+    - port: 80
+      targetPort: 5000
+```
+
+This requires the [NVIDIA device plugin](https://github.com/NVIDIA/k8s-device-plugin) to be installed on your cluster for GPU support.
+
+If your model has a slow `setup()` (e.g. downloading weights), set `initialDelaySeconds` high enough that the pod is not killed before setup completes.
+
+## Next steps
+
+- See the [HTTP API reference](../http.md) for the full API specification.
+- See [How to run concurrent predictions](concurrency.md) to increase throughput.
+- See [How to set up CI/CD](ci-cd.md) to automate builds and pushes.
+- See the [CLI reference](../cli.md) for all `cog build` and `cog push` options.

--- a/docs/how-to/file-io.md
+++ b/docs/how-to/file-io.md
@@ -1,0 +1,151 @@
+# How to handle file inputs and outputs
+
+This guide shows you how to accept files as input to your model, return files as output, and configure where output files are uploaded.
+
+## Accept a file as input
+
+Use `cog.Path` as the type annotation for any input that should be a file. When the model is called via the HTTP API, clients pass a URL and Cog downloads the file automatically:
+
+```python
+from cog import BasePredictor, Input, Path
+
+class Predictor(BasePredictor):
+    def predict(self, image: Path = Input(description="Image to process")) -> str:
+        # image is a Path pointing to the downloaded file on disk
+        with open(image, "rb") as f:
+            data = f.read()
+        return f"Received {len(data)} bytes"
+```
+
+`cog.Path` is a subclass of Python's `pathlib.Path`, so you can use all standard `pathlib` methods on it -- `open()`, `read_bytes()`, `suffix`, etc.
+
+When testing locally with the CLI, prefix file inputs with `@`:
+
+```console
+cog predict -i image=@photo.jpg
+```
+
+## Accept multiple file inputs
+
+To accept a list of files, use `list[Path]`:
+
+```python
+from cog import BasePredictor, Input, Path
+
+class Predictor(BasePredictor):
+    def predict(self, images: list[Path] = Input(description="Images to process")) -> str:
+        return f"Received {len(images)} images"
+```
+
+On the CLI, repeat the input name for each file:
+
+```console
+cog predict -i images=@photo1.jpg -i images=@photo2.jpg
+```
+
+## Return a single file
+
+To return a file from `predict()`, create a temporary file, write to it, and return a `cog.Path` pointing to it. Cog automatically cleans up temporary files after they have been sent to the client:
+
+```python
+import tempfile
+from cog import BasePredictor, Input, Path
+
+class Predictor(BasePredictor):
+    def predict(self, prompt: str = Input(description="Input prompt")) -> Path:
+        image = self.model.generate(prompt)
+
+        output_path = Path(tempfile.mkdtemp()) / "output.png"
+        image.save(output_path)
+        return output_path
+```
+
+The file extension on the output path determines the content type in the response.
+
+## Return multiple files
+
+To return multiple files, annotate the return type as `list[Path]`:
+
+```python
+import tempfile
+from cog import BasePredictor, Input, Path
+
+class Predictor(BasePredictor):
+    def predict(self, prompt: str = Input(description="Input prompt"), count: int = Input(default=3)) -> list[Path]:
+        output = []
+        for i in range(count):
+            image = self.model.generate(prompt, seed=i)
+            out_path = Path(tempfile.mkdtemp()) / f"output-{i}.png"
+            image.save(out_path)
+            output.append(out_path)
+        return output
+```
+
+Files are named in the format `output.<index>.<extension>` in the response (e.g. `output.0.png`, `output.1.png`).
+
+## Return files alongside other data
+
+To return files alongside scalar values, define an `Output` object:
+
+```python
+import tempfile
+from cog import BaseModel, BasePredictor, Input, Path
+from typing import Optional
+
+class Output(BaseModel):
+    image: Path
+    caption: str
+    confidence: float
+
+class Predictor(BasePredictor):
+    def predict(self, prompt: str = Input(description="Input prompt")) -> Output:
+        image = self.model.generate(prompt)
+        out_path = Path(tempfile.mkdtemp()) / "output.png"
+        image.save(out_path)
+        return Output(image=out_path, caption="Generated image", confidence=0.95)
+```
+
+## Configure file uploads
+
+By default, file outputs are returned as base64-encoded data URLs in the JSON response. For large files, this is impractical.
+
+### Per-request upload URL (synchronous predictions)
+
+Set `output_file_prefix` in the request body to upload files to a remote URL instead:
+
+```console
+curl http://localhost:5001/predictions -X POST \
+    -H "Content-Type: application/json" \
+    -d '{
+        "input": {"prompt": "a cat"},
+        "output_file_prefix": "https://example.com/upload"
+    }'
+```
+
+Cog sends a `PUT` request with the file to the specified URL. The response `output` field contains the uploaded file's URL instead of a data URL.
+
+### Server-wide upload URL (asynchronous predictions)
+
+For asynchronous predictions (using the `Prefer: respond-async` header), you must configure the upload URL when starting the server:
+
+```console
+cog serve --upload-url https://example.com/upload
+```
+
+Or when running the Docker container directly:
+
+```console
+docker run -d -p 5001:5000 my-model --upload-url https://example.com/upload
+```
+
+See the [HTTP API reference on file uploads](../http.md#file-uploads) for the full upload protocol.
+
+## A note on `cog.File`
+
+`cog.File` is deprecated. Use `cog.Path` for all new models. `cog.File` represents a file handle rather than a path on disk, which makes it harder to work with in practice. Existing models using `cog.File` will continue to work, but new code should use `cog.Path`.
+
+## Next steps
+
+- See the [prediction interface reference](../python.md#path) for full `cog.Path` documentation.
+- See [How to stream output](streaming.md) to stream files as they are generated.
+- See the [HTTP API reference](../http.md#file-uploads) for the file upload protocol.

--- a/docs/how-to/gpu.md
+++ b/docs/how-to/gpu.md
@@ -1,0 +1,95 @@
+# How to use GPUs
+
+This guide shows you how to enable GPU support in your Cog model, configure CUDA versions, and troubleshoot common GPU issues.
+
+## Enable GPU support
+
+To run your model on a GPU, set `gpu: true` in your `cog.yaml`:
+
+```yaml
+build:
+  gpu: true
+  python_version: "3.12"
+  python_requirements: requirements.txt
+predict: "predict.py:Predictor"
+```
+
+When `gpu: true` is set, Cog uses an NVIDIA CUDA base image and automatically installs the correct versions of CUDA and cuDNN based on your Python, PyTorch, and TensorFlow versions.
+
+## Let Cog auto-detect the CUDA version
+
+In most cases, you do not need to specify a CUDA version. Cog inspects your `requirements.txt` for PyTorch or TensorFlow and selects a compatible CUDA version automatically.
+
+For example, if your `requirements.txt` contains:
+
+```
+torch==2.1.0
+```
+
+Cog will select a CUDA version that is compatible with PyTorch 2.1.0. This is the recommended approach.
+
+## Override the CUDA version
+
+If you need a specific CUDA version -- for example, to match a pre-compiled library -- set the `cuda` field explicitly:
+
+```yaml
+build:
+  gpu: true
+  cuda: "11.8"
+```
+
+You can specify a minor version (`11.8`) or a patch version (`11.8.0`).
+
+Only override CUDA when you have a specific reason to. Letting Cog auto-detect avoids version mismatches between CUDA, cuDNN, and your ML framework.
+
+## Test locally with GPU
+
+When you use `cog predict` or `cog run`, Cog automatically passes the `--gpus=all` flag to Docker. No extra configuration is needed:
+
+```console
+cog predict -i prompt="hello world"
+```
+
+If you want to specify a particular GPU device:
+
+```console
+cog predict --gpus='"device=0"' -i prompt="hello world"
+```
+
+When running a built image directly with `docker run`, you must pass the GPU flag yourself:
+
+```console
+docker run -d -p 5001:5000 --gpus all my-model
+```
+
+## Troubleshoot common GPU issues
+
+### CUDA version mismatch
+
+If you see errors like `CUDA error: no kernel image is available for execution on the device`, your CUDA version does not match what your ML framework expects.
+
+To fix this:
+
+1. Remove the explicit `cuda` setting from `cog.yaml` and let Cog auto-detect.
+2. If you must pin CUDA, check the compatibility matrix for your framework (e.g. [PyTorch's CUDA compatibility](https://pytorch.org/get-started/previous-versions/)).
+
+### Out of memory errors
+
+If you see `CUDA out of memory` errors:
+
+- Reduce your batch size or input resolution.
+- Use `torch.cuda.empty_cache()` between predictions if your model accumulates GPU memory.
+- Check that your `setup()` method is not loading multiple copies of the model.
+
+### GPU not detected inside the container
+
+If `torch.cuda.is_available()` returns `False` inside the container:
+
+1. Confirm `gpu: true` is set in `cog.yaml`.
+2. Confirm the NVIDIA Container Toolkit is installed on your host: `nvidia-smi` should work.
+3. If running `docker run` directly, confirm you passed `--gpus all`.
+
+## Next steps
+
+- See the [`cog.yaml` reference](../yaml.md) for full details on `gpu`, `cuda`, and other build options.
+- See [How to debug build failures](debug-builds.md) if your GPU-enabled build is failing.

--- a/docs/how-to/image-size.md
+++ b/docs/how-to/image-size.md
@@ -1,0 +1,144 @@
+# How to optimise Docker image size
+
+This guide shows you how to reduce the size of your Cog-built Docker images to speed up builds, pushes, and cold starts.
+
+## Use a Python base image instead of CUDA
+
+By default, GPU-enabled models use an NVIDIA CUDA base image, which is several gigabytes. If your model uses PyTorch, the CUDA runtime is already bundled in the PyTorch wheel, so you can use a smaller Python base image instead:
+
+```console
+cog build --use-cuda-base-image=false -t my-model
+```
+
+This produces a significantly smaller image. However, it may not work for non-PyTorch projects that depend on system CUDA libraries. Test your model after switching.
+
+This flag also works with `cog push`:
+
+```console
+cog push r8.im/your-username/my-model --use-cuda-base-image=false
+```
+
+## Pin exact package versions
+
+Unpinned dependencies pull in the latest version on every build, which can bloat the image with unnecessary transitive dependencies. Pin every package in your `requirements.txt`:
+
+```
+torch==2.1.0
+transformers==4.35.0
+Pillow==10.1.0
+```
+
+To generate a pinned requirements file from your current environment:
+
+```console
+pip freeze > requirements.txt
+```
+
+This also makes builds reproducible, which helps with layer caching.
+
+## Clean up in build.run commands
+
+Each `build.run` command creates a Docker layer. Clean up temporary files in the same command to avoid bloating the layer:
+
+```yaml
+build:
+  run:
+    - apt-get update && apt-get install -y --no-install-recommends libgl1 && rm -rf /var/lib/apt/lists/*
+    - pip install flash-attn --no-build-isolation && pip cache purge
+```
+
+If you download and extract an archive, remove it in the same step:
+
+```yaml
+build:
+  run:
+    - curl -L https://example.com/data.tar.gz -o /tmp/data.tar.gz && tar xzf /tmp/data.tar.gz -C /opt/data && rm /tmp/data.tar.gz
+```
+
+## Use .dockerignore
+
+Cog copies your entire project directory into the image. Exclude files that are not needed at runtime:
+
+```
+# .dockerignore
+.git
+.github
+*.md
+tests/
+notebooks/
+__pycache__
+*.pyc
+.env
+```
+
+If you store weights in the repository but download them in `setup()`, exclude them too:
+
+```
+weights/
+*.safetensors
+*.bin
+```
+
+## Separate weights from code
+
+If your weights are baked into the image, use `--separate-weights` to store them in a dedicated Docker layer:
+
+```console
+cog build --separate-weights -t my-model
+```
+
+This does not reduce the total image size, but it means code-only changes only push a small layer instead of re-uploading gigabytes of weights. This makes iterative development and CI/CD much faster.
+
+## Choose minimal system packages
+
+Only install the system packages your model actually needs. Each package adds to the image size and pulls in its own dependencies.
+
+Instead of:
+
+```yaml
+build:
+  system_packages:
+    - "ffmpeg"
+    - "imagemagick"
+    - "libopencv-dev"
+    - "vim"
+```
+
+Use only what is required:
+
+```yaml
+build:
+  system_packages:
+    - "ffmpeg"
+```
+
+If you need a library but not the full development headers, use the runtime package instead of the `-dev` variant. For example, `libgl1` instead of `libgl1-mesa-dev`.
+
+## Avoid unnecessary Python dependencies
+
+Review your `requirements.txt` for packages that are only used during development or testing:
+
+- Remove `jupyter`, `matplotlib`, `tensorboard`, etc. if they are not used at prediction time.
+- If a package is only needed for training (not inference), do not include it.
+
+## Inspect image size
+
+To see what is taking up space in your image:
+
+```console
+docker images my-model
+```
+
+For a detailed breakdown of layer sizes:
+
+```console
+docker history my-model:latest
+```
+
+If a specific layer is unexpectedly large, check the corresponding build step for leftover temporary files or unnecessary packages.
+
+## Next steps
+
+- See [How to manage model weights](model-weights.md) for weight storage strategies.
+- See [How to debug build failures](debug-builds.md) for troubleshooting build issues.
+- See the [`cog.yaml` reference](../yaml.md) for all build configuration options.

--- a/docs/how-to/model-weights.md
+++ b/docs/how-to/model-weights.md
@@ -1,0 +1,131 @@
+# How to manage model weights
+
+This guide shows you how to include model weights in your Cog image and choose between baking them into the image or downloading them at runtime.
+
+## Decide where to store weights
+
+There are two approaches, each with different tradeoffs:
+
+| Approach | Image size | Build time | Setup time | Reproducibility |
+|---|---|---|---|---|
+| Weights in the image | Larger | Slower | Fast | Self-contained |
+| Download in `setup()` | Smaller | Faster | Slower | Depends on external host |
+
+If your weights are small (under a few GB) or you need fully reproducible, self-contained images, bake them into the image. If your weights are very large or change rarely while your code changes often, download them in `setup()`.
+
+## Bake weights into the image
+
+Place your weight files in the same directory as your `cog.yaml`. Cog copies the entire directory into the image during build.
+
+```
+my-model/
+  cog.yaml
+  predict.py
+  weights/
+    model.safetensors
+```
+
+Make sure your `.dockerignore` does not exclude the weights directory. If you have a `.dockerignore`, check that it does not contain a line like `weights/` or `*.safetensors`.
+
+Load the weights from their local path in `setup()`:
+
+```python
+from cog import BasePredictor
+import torch
+
+class Predictor(BasePredictor):
+    def setup(self):
+        self.model = torch.load("weights/model.safetensors")
+```
+
+### Use `--separate-weights` for faster pushes
+
+When weights are baked into the image, every code change rebuilds a layer that contains both code and weights. To avoid re-uploading gigabytes of weights on every push, use the `--separate-weights` flag:
+
+```console
+cog build --separate-weights -t my-model
+```
+
+This stores model weights in a separate Docker layer from your code. When you push, only the layers that changed are uploaded. If you only changed code, the weights layer is skipped entirely.
+
+This flag works with both `cog build` and `cog push`:
+
+```console
+cog push r8.im/your-username/my-model --separate-weights
+```
+
+## Download weights in `setup()`
+
+If you prefer smaller images, download weights at container start time. This is common for models hosted on Hugging Face, S3, or similar services.
+
+### Using pget for fast parallel downloads
+
+[pget](https://github.com/replicate/pget) is a fast file downloader that supports parallel chunk downloads. Install it via `build.run` in your `cog.yaml`:
+
+```yaml
+build:
+  python_version: "3.12"
+  gpu: true
+  python_requirements: requirements.txt
+  run:
+    - curl -o /usr/local/bin/pget -L "https://github.com/replicate/pget/releases/latest/download/pget_$(uname -s)_$(uname -m)" && chmod +x /usr/local/bin/pget
+predict: "predict.py:Predictor"
+```
+
+Then download in `setup()`:
+
+```python
+import subprocess
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def setup(self):
+        url = "https://weights.replicate.delivery/default/my-model/weights.tar"
+        subprocess.check_call(["pget", "-x", url, "weights/"])
+        self.model = load_model("weights/")
+```
+
+### Using urllib for simple downloads
+
+For smaller files or when you want no extra dependencies:
+
+```python
+import urllib.request
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def setup(self):
+        url = "https://example.com/model-weights.bin"
+        urllib.request.urlretrieve(url, "weights.bin")
+        self.model = load_model("weights.bin")
+```
+
+### Using Hugging Face hub
+
+If your model is hosted on Hugging Face, add `huggingface_hub` to your `requirements.txt` and download in `setup()`:
+
+```python
+from huggingface_hub import snapshot_download
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def setup(self):
+        self.model_path = snapshot_download(repo_id="your-org/your-model")
+        self.model = load_model(self.model_path)
+```
+
+## Control setup timeout
+
+If downloading weights takes a long time, you may need to increase the setup timeout. Set the `COG_SETUP_TIMEOUT` environment variable when running the container:
+
+```console
+COG_SETUP_TIMEOUT=600 docker run -p 5001:5000 my-model
+```
+
+By default there is no timeout. See the [environment variables reference](../environment.md) for details.
+
+## Next steps
+
+- See [How to optimise Docker image size](image-size.md) for more strategies to reduce image bloat.
+- See the [`cog.yaml` reference](../yaml.md) for full build configuration options.
+- See the [prediction interface reference](../python.md#predictorsetup) for `setup()` documentation.

--- a/docs/how-to/notebooks.md
+++ b/docs/how-to/notebooks.md
@@ -1,0 +1,57 @@
+# How to use Jupyter notebooks
+
+This guide shows you how to run Jupyter notebooks inside Cog's Docker environment and how to import notebook code into your predictor.
+
+## Add JupyterLab to your dependencies
+
+Add `jupyterlab` to your `requirements.txt`:
+
+```
+jupyterlab
+```
+
+Reference it in [`cog.yaml`](../yaml.md):
+
+```yaml
+build:
+  python_requirements: requirements.txt
+```
+
+## Run a notebook
+
+Start JupyterLab inside the Cog environment:
+
+```sh
+cog run -p 8888 jupyter lab --allow-root --ip=0.0.0.0
+```
+
+This forwards port 8888 from the container to your host machine. Open the URL printed in the terminal to access the notebook interface.
+
+If you prefer a different notebook environment, you can use `cog run` to launch it the same way. For example, to run the classic Jupyter Notebook server:
+
+```sh
+cog run -p 8888 jupyter notebook --allow-root --ip=0.0.0.0
+```
+
+## Use notebook code in your predictor
+
+To import functions or variables from a notebook into your [predictor](../python.md), first export the notebook to a Python file:
+
+```sh
+jupyter nbconvert --to script my_notebook.ipynb  # creates my_notebook.py
+```
+
+Then import the exported module in your `predict.py`:
+
+```python
+from cog import BasePredictor, Input
+
+import my_notebook
+
+class Predictor(BasePredictor):
+    def predict(self, prompt: str = Input(description="string prompt")) -> str:
+        output = my_notebook.do_stuff(prompt)
+        return output
+```
+
+Any functions or variables defined in the notebook will be available to your predictor.

--- a/docs/how-to/private-registry.md
+++ b/docs/how-to/private-registry.md
@@ -1,0 +1,48 @@
+# How to use private package registries
+
+This guide shows you how to build a Cog Docker image that fetches Python packages from a private registry, without baking credentials into the image.
+
+## Create a pip.conf file
+
+In a directory **outside** your Cog project, create a `pip.conf` file with your registry credentials:
+
+```conf
+[global]
+index-url = https://username:password@my-private-registry.com
+```
+
+> **Warning**
+> Do not commit secrets to Git or include them in Docker images. If your Cog project contains sensitive files, add them to `.gitignore` and `.dockerignore`.
+
+## Configure cog.yaml
+
+Add a `run` command that mounts the pip configuration as a secret:
+
+```yaml
+build:
+  run:
+    - command: pip install
+      mounts:
+        - type: secret
+          id: pip
+          target: /etc/pip.conf
+```
+
+The secret mount makes the credentials available during build without persisting them in the final image. For full details on the `run` and `mounts` syntax, see the [`cog.yaml` reference](../yaml.md).
+
+## Build with the secret
+
+Pass the `--secret` option when building or pushing, with an `id` matching the one in `cog.yaml`:
+
+```console
+cog build --secret id=pip,source=/path/to/pip.conf
+```
+
+## Cache behaviour
+
+If you change the contents of a secret source file after building, subsequent builds will use the cached version and ignore your changes.
+
+To pick up updated secrets, either:
+
+- Change the `id` value in both `cog.yaml` and the `--secret` option, or
+- Pass `--no-cache` to bypass the build cache entirely

--- a/docs/how-to/setup-own-model.md
+++ b/docs/how-to/setup-own-model.md
@@ -1,0 +1,137 @@
+# How to set up your own model
+
+This guide shows you how to package your own machine learning model with Cog. It assumes you already have Cog and Docker installed. If not, see the [installation instructions](https://github.com/replicate/cog).
+
+## Initialize your project
+
+Run `cog init` in your model's directory to generate the two required files:
+
+```sh
+cd path/to/your/model
+cog init
+```
+
+This creates:
+
+- [`cog.yaml`](../yaml.md) -- defines the Docker environment (Python version, dependencies, system packages)
+- [`predict.py`](../python.md) -- defines the prediction interface for your model
+
+## Configure cog.yaml
+
+Edit `cog.yaml` to specify your Python version and dependencies:
+
+```yaml
+build:
+  python_version: "3.13"
+  python_requirements: requirements.txt
+```
+
+Add your model's dependencies to `requirements.txt`:
+
+```
+torch==2.6.0
+```
+
+Cog builds a Docker image with the correct versions of CUDA and cuDNN based on your dependencies. For all available configuration options, see the [`cog.yaml` reference](../yaml.md).
+
+To verify the environment works, run a command inside it:
+
+```sh
+cog run python
+```
+
+## Write your predict.py
+
+Edit `predict.py` to load your model and define its prediction interface:
+
+```python
+from cog import BasePredictor, Path, Input
+import torch
+
+class Predictor(BasePredictor):
+    def setup(self):
+        """Load the model into memory to make running multiple predictions efficient"""
+        self.net = torch.load("weights.pth")
+
+    def predict(self,
+            image: Path = Input(description="Image to enlarge"),
+            scale: float = Input(description="Factor to scale image by", default=1.5)
+    ) -> Path:
+        """Run a single prediction on the model"""
+        # ... pre-processing ...
+        output = self.net(input)
+        # ... post-processing ...
+        return output
+```
+
+### Define inputs
+
+Each argument to `predict()` must have a type annotation. Supported types:
+
+- `str`, `int`, `float`, `bool`
+- `cog.Path` -- a path to a file on disk
+- `cog.File` -- a file-like object (deprecated; use `cog.Path` instead)
+
+Use `Input()` to add constraints and metadata:
+
+- `description` -- describes the input for users
+- `default` -- sets a default value. If omitted, the input is required. If set to `None`, the input is optional.
+- `ge` / `le` -- minimum/maximum for `int` or `float`
+- `min_length` / `max_length` -- length bounds for `str`
+- `regex` -- pattern match for `str`
+- `choices` -- allowed values for `str` or `int`
+
+For the full list of options, see the [prediction interface reference](../python.md).
+
+### Define outputs
+
+The return type annotation on `predict()` determines the output type. Return `Path` for files, `str` for text, or other supported types.
+
+### Connect predict.py to cog.yaml
+
+Add the `predict` directive to `cog.yaml`:
+
+```yaml
+build:
+  python_version: "3.13"
+  python_requirements: requirements.txt
+predict: "predict.py:Predictor"
+```
+
+If your `Predictor` class is in a different file or has a different name, adjust the path accordingly.
+
+## Test predictions
+
+Run a prediction to verify everything works:
+
+```sh
+cog predict -i image=@input.jpg
+```
+
+To pass multiple inputs:
+
+```sh
+cog predict -i image=@input.jpg -i scale=2.0
+```
+
+Use `@` before file paths. Scalar values (numbers, strings) don't need the prefix.
+
+## Enable GPU support
+
+If your model requires a GPU, add `gpu: true` to the `build` section:
+
+```yaml
+build:
+  gpu: true
+  python_version: "3.13"
+  python_requirements: requirements.txt
+predict: "predict.py:Predictor"
+```
+
+Cog automatically selects the correct CUDA and cuDNN versions based on your Python and framework versions. For details, see the [`gpu` section of the `cog.yaml` reference](../yaml.md#gpu).
+
+## Next steps
+
+- [Deploy your model](../deploy.md)
+- [`cog.yaml` reference](../yaml.md)
+- [Python SDK reference](../python.md)

--- a/docs/how-to/streaming.md
+++ b/docs/how-to/streaming.md
@@ -1,0 +1,131 @@
+# How to stream output
+
+This guide shows you how to stream prediction output from your Cog model so clients receive partial results as they are generated, rather than waiting for the entire prediction to complete.
+
+## Stream text tokens
+
+To stream text output token by token, annotate your `predict()` method with `Iterator[str]` and use `yield` instead of `return`:
+
+```python
+from cog import BasePredictor, Input
+from typing import Iterator
+
+class Predictor(BasePredictor):
+    def setup(self):
+        self.model = load_model()
+
+    def predict(self, prompt: str = Input(description="Input prompt")) -> Iterator[str]:
+        for token in self.model.generate(prompt):
+            yield token
+```
+
+Each `yield` sends the value to the client immediately. The HTTP response contains a list of all yielded values.
+
+## Concatenate streamed text
+
+If you want the final output to be a single concatenated string rather than a list of tokens, use `ConcatenateIterator`. This is useful for language models where the consumer wants the full text as a single string:
+
+```python
+from cog import BasePredictor, ConcatenateIterator, Input
+
+class Predictor(BasePredictor):
+    def predict(self, prompt: str = Input(description="Input prompt")) -> ConcatenateIterator[str]:
+        for token in self.model.generate(prompt):
+            yield token + " "
+```
+
+With `ConcatenateIterator`, platforms like Replicate display the output as a single string instead of an array.
+
+## Stream files
+
+To stream multiple files as they are generated (for example, intermediate images from a diffusion model), use `Iterator[Path]`:
+
+```python
+import tempfile
+from cog import BasePredictor, Input, Path
+from typing import Iterator
+
+class Predictor(BasePredictor):
+    def predict(self, prompt: str = Input(description="Input prompt")) -> Iterator[Path]:
+        for i, image in enumerate(self.model.generate_steps(prompt)):
+            output_path = Path(tempfile.mkdtemp()) / f"step-{i}.png"
+            image.save(output_path)
+            yield output_path
+```
+
+Each yielded `Path` is sent to the client as a separate file output. Cog automatically cleans up temporary files after they have been returned.
+
+## Stream from async predictors
+
+If your predictor uses `async def predict()`, use `AsyncIterator` and `AsyncConcatenateIterator` from the `cog` package instead of `typing.Iterator`:
+
+### Async text streaming
+
+```python
+from cog import AsyncIterator, BasePredictor, Input
+
+class Predictor(BasePredictor):
+    async def predict(self, prompt: str = Input(description="Input prompt")) -> AsyncIterator[str]:
+        async for token in self.model.generate(prompt):
+            yield token
+```
+
+### Async concatenated text streaming
+
+```python
+from cog import AsyncConcatenateIterator, BasePredictor, Input
+
+class Predictor(BasePredictor):
+    async def predict(self, prompt: str = Input(description="Input prompt")) -> AsyncConcatenateIterator[str]:
+        async for token in self.model.generate(prompt):
+            yield token + " "
+```
+
+### Async file streaming
+
+```python
+import tempfile
+from cog import AsyncIterator, BasePredictor, Input, Path
+
+class Predictor(BasePredictor):
+    async def predict(self, prompt: str = Input(description="Input prompt")) -> AsyncIterator[Path]:
+        async for i, image in self.model.generate_steps(prompt):
+            output_path = Path(tempfile.mkdtemp()) / f"step-{i}.png"
+            image.save(output_path)
+            yield output_path
+```
+
+## Receive streaming output via webhooks
+
+When calling the HTTP API asynchronously, streaming output is delivered through webhooks. Each time `predict()` yields a value, the server sends a webhook with the `output` event type.
+
+```console
+curl http://localhost:5001/predictions -X POST \
+    -H "Content-Type: application/json" \
+    -H "Prefer: respond-async" \
+    -d '{
+        "input": {"prompt": "hello"},
+        "webhook": "https://example.com/webhook",
+        "webhook_events_filter": ["output", "completed"]
+    }'
+```
+
+Webhook requests for `output` events are batched and sent at most once every 500ms. See the [HTTP API reference](../http.md#webhooks) for full details.
+
+## Supported types for streaming
+
+You can stream any of these types with `Iterator` or `AsyncIterator`:
+
+- `str`
+- `int`
+- `float`
+- `bool`
+- `cog.Path`
+
+`ConcatenateIterator` and `AsyncConcatenateIterator` are only meaningful with `str`.
+
+## Next steps
+
+- See the [prediction interface reference](../python.md#streaming-output) for the full streaming API.
+- See [How to run concurrent predictions](concurrency.md) to combine streaming with async concurrency.
+- See the [HTTP API reference](../http.md) for details on how streaming output is delivered over HTTP.

--- a/docs/how-to/training.md
+++ b/docs/how-to/training.md
@@ -1,0 +1,195 @@
+# How to fine-tune with the training API
+
+This guide shows you how to define a training interface for your Cog model so users can bring their own data to create fine-tuned model weights.
+
+> **Note**: The `cog train` CLI command is deprecated and will be removed in a future version. The training API itself is still fully supported and can be used through the HTTP API's `/trainings` endpoint.
+
+## Define a train function
+
+The simplest way to add training support is to define a standalone `train` function. Create a `train.py` file and point to it in your `cog.yaml`:
+
+`cog.yaml`:
+
+```yaml
+build:
+  gpu: true
+  python_version: "3.12"
+  python_requirements: requirements.txt
+train: "train.py:train"
+predict: "predict.py:Predictor"
+```
+
+`train.py`:
+
+```python
+from cog import Input, Path
+
+def train(
+    train_data: Path = Input(description="Training data file"),
+    learning_rate: float = Input(description="Learning rate", default=1e-4, ge=0),
+    epochs: int = Input(description="Number of training epochs", default=10, ge=1),
+    seed: int = Input(description="Random seed", default=42),
+) -> Path:
+    model = load_base_model()
+    model.train(train_data, lr=learning_rate, epochs=epochs, seed=seed)
+
+    output_path = Path("/tmp/trained-weights.safetensors")
+    model.save(output_path)
+    return output_path
+```
+
+The `train` function works like `predict`: it takes typed inputs annotated with `Input()` and returns an output. The return value is typically a `Path` to the trained weights file.
+
+## Use a Trainer class with setup()
+
+If training involves loading a large base model, use a class with a `setup()` method to avoid reloading it on every training run:
+
+`cog.yaml`:
+
+```yaml
+train: "train.py:Trainer"
+```
+
+`train.py`:
+
+```python
+from cog import Input, Path
+
+class Trainer:
+    def setup(self):
+        self.base_model = load_base_model()
+
+    def train(
+        self,
+        train_data: Path = Input(description="Training data file"),
+        learning_rate: float = Input(description="Learning rate", default=1e-4, ge=0),
+        epochs: int = Input(description="Number of training epochs", default=10, ge=1),
+    ) -> Path:
+        self.base_model.finetune(train_data, lr=learning_rate, epochs=epochs)
+
+        output_path = Path("/tmp/trained-weights.safetensors")
+        self.base_model.save(output_path)
+        return output_path
+```
+
+The `setup()` method is called once when the container starts. Subsequent training requests reuse the loaded base model.
+
+## Define training inputs
+
+Use `Input()` to annotate each parameter of your `train()` function with descriptions, defaults, and validation constraints:
+
+```python
+from cog import Input, Path
+
+def train(
+    train_data: Path = Input(description="Archive of training images"),
+    num_train_epochs: int = Input(description="Number of training epochs", default=100, ge=1, le=1000),
+    train_batch_size: int = Input(description="Batch size", default=4, choices=[1, 2, 4, 8, 16]),
+    learning_rate: float = Input(description="Learning rate", default=1e-4, ge=0),
+    seed: int = Input(description="Random seed", default=None),
+    resolution: int = Input(description="Image resolution for training", default=512, choices=[256, 512, 768, 1024]),
+) -> Path:
+    # ...
+```
+
+Supported types are the same as for `predict()`: `str`, `int`, `float`, `bool`, `cog.Path`, and `cog.Secret`. See the [prediction interface reference](../python.md#input-and-output-types) for the full list.
+
+## Return structured training output
+
+If you need to return multiple files or metadata alongside the weights, define a `TrainingOutput` object:
+
+```python
+from cog import BaseModel, Input, Path
+
+class TrainingOutput(BaseModel):
+    weights: Path
+    training_log: Path
+
+def train(
+    train_data: Path = Input(description="Training data"),
+    epochs: int = Input(description="Epochs", default=10),
+) -> TrainingOutput:
+    model = load_and_train(train_data, epochs=epochs)
+
+    weights_path = Path("/tmp/weights.safetensors")
+    log_path = Path("/tmp/training.log")
+    model.save(weights_path)
+    save_log(log_path)
+
+    return TrainingOutput(weights=weights_path, training_log=log_path)
+```
+
+## Run training locally
+
+Use the `cog train` CLI command to test training locally:
+
+```console
+cog train -i train_data=@my-training-data.zip -i learning_rate=0.001 -i epochs=5
+```
+
+File inputs are prefixed with `@`, just like `cog predict`.
+
+## Test the trained weights with predict
+
+To verify that your model's `predict()` function works with fine-tuned weights, pass the weights URL using the `COG_WEIGHTS` environment variable:
+
+```console
+cog predict -e COG_WEIGHTS=https://example.com/trained-weights.tar -i prompt="a photo of TOK"
+```
+
+Your `predict.py` should check for this environment variable in `setup()` and load the fine-tuned weights if present:
+
+```python
+import os
+from cog import BasePredictor, Input, Path
+
+class Predictor(BasePredictor):
+    def setup(self):
+        weights_url = os.environ.get("COG_WEIGHTS")
+        if weights_url:
+            self.model = load_model(download(weights_url))
+        else:
+            self.model = load_model("default-weights/")
+
+    def predict(self, prompt: str = Input(description="Input prompt")) -> Path:
+        return self.model.generate(prompt)
+```
+
+## Use the HTTP training endpoint
+
+When a Cog image is built with a `train` configuration, the HTTP server exposes a `/trainings` endpoint that works like `/predictions`:
+
+```console
+curl http://localhost:5001/trainings -X POST \
+    -H "Content-Type: application/json" \
+    -d '{
+        "input": {
+            "train_data": "https://example.com/data.zip",
+            "learning_rate": 0.001,
+            "epochs": 10
+        }
+    }'
+```
+
+The response follows the same format as predictions, with `status`, `output`, and `metrics` fields.
+
+For async training with webhooks:
+
+```console
+curl http://localhost:5001/trainings -X POST \
+    -H "Content-Type: application/json" \
+    -H "Prefer: respond-async" \
+    -d '{
+        "input": {
+            "train_data": "https://example.com/data.zip",
+            "epochs": 10
+        },
+        "webhook": "https://your-app.example.com/training-complete"
+    }'
+```
+
+## Next steps
+
+- See the [training interface reference](../training.md) for the full training API documentation.
+- See the [prediction interface reference](../python.md#inputkwargs) for `Input()` parameter details.
+- See the [HTTP API reference](../http.md) for endpoint details.

--- a/docs/how-to/wsl2.md
+++ b/docs/how-to/wsl2.md
@@ -1,0 +1,164 @@
+# How to set up Cog on Windows with WSL 2
+
+This guide shows you how to install and run Cog on Windows 11 using WSL 2, with GPU passthrough for NVIDIA GPUs.
+
+Windows 10 is not officially supported -- GPU passthrough requires an insider build.
+
+## Prerequisites
+
+- Windows 11
+- An NVIDIA GPU (RTX 2000/3000 series, or Kepler/Tesla/Volta/Ampere series). Other configurations are not guaranteed to work.
+
+## Install the NVIDIA GPU driver
+
+Install the latest Game Ready drivers for your GPU from the [NVIDIA driver download page](https://www.nvidia.com/download/index.aspx).
+
+Select your GPU model and download the driver:
+
+![A form showing the correct model number selected for an RTX 2070 Super](../wsl2/images/nvidia_driver_select.png)
+
+Restart your computer after the driver finishes installing.
+
+## Enable WSL 2 and virtualization
+
+Open Windows Terminal as an administrator (search for "Terminal", right-click, and select "Run as administrator").
+
+### Enable the Windows Subsystem for Linux
+
+```powershell
+dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart
+```
+
+If you see a permissions error, confirm you are running the terminal as administrator.
+
+### Enable the Virtual Machine Platform
+
+```powershell
+dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart
+```
+
+If this fails, [enable virtualization in your BIOS/UEFI](https://docs.microsoft.com/en-us/windows/wsl/troubleshooting#error-0x80370102-the-virtual-machine-could-not-be-started-because-a-required-feature-is-not-installed).
+
+A successful output reads `The operation completed successfully.`
+
+![Output from running the above commands successfully](../wsl2/images/enable_feature_success.png)
+
+### Reboot
+
+Reboot your computer so that WSL 2 and virtualization are available.
+
+## Update the WSL 2 Linux kernel
+
+Download and run the [WSL2 Linux kernel update package for x64 machines](https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi). Approve elevated permissions when prompted.
+
+Verify the kernel version in an administrator terminal:
+
+```powershell
+wsl cat /proc/version
+```
+
+You should see at least `Linux version 5.10.43.3` or later.
+
+If the kernel version is outdated, go to **Settings > Windows Update > Advanced options** and enable **Receive updates for other Microsoft products**, then check for updates.
+
+## Configure WSL 2
+
+Set WSL 2 as the default version:
+
+```powershell
+wsl --set-default-version 2
+```
+
+Install Ubuntu from the [Microsoft Store](https://www.microsoft.com/store/apps/9N9TNGVNDL3Q), then launch the "Ubuntu" app from the Start Menu. Create a Linux user account when prompted.
+
+## Install the CUDA toolkit for WSL-Ubuntu
+
+> **Important**: Do not install CUDA using generic Linux instructions. In WSL 2, always use the WSL-Ubuntu-specific CUDA toolkit package.
+
+Enter your WSL 2 VM from PowerShell:
+
+```powershell
+wsl.exe
+```
+
+Install the CUDA toolkit (adjust the CUDA version if your GPU requires a different one):
+
+```sh
+sudo apt-key del 7fa2af80  # safe to ignore if this fails
+wget https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/cuda-wsl-ubuntu.pin
+sudo mv cuda-wsl-ubuntu.pin /etc/apt/preferences.d/cuda-repository-pin-600
+wget https://developer.download.nvidia.com/compute/cuda/11.7.0/local_installers/cuda-repo-wsl-ubuntu-11-7-local_11.7.0-1_amd64.deb
+sudo dpkg -i cuda-repo-wsl-ubuntu-11-7-local_11.7.0-1_amd64.deb
+sudo cp /var/cuda-repo-wsl-ubuntu-11-7-local/cuda-B81839D3-keyring.gpg /usr/share/keyrings/
+sudo apt-get update
+sudo apt-get -y install cuda-toolkit-11-7
+```
+
+## Install Docker
+
+Download and install [Docker Desktop for Windows](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe).
+
+After installation, open Docker Desktop and go to **Settings > General**. Ensure **Use the WSL 2 based engine** is checked:
+
+!["Use the WSL 2 based engine" is checked](../wsl2/images/wsl2-enable.png)
+
+Click **Apply & Restart**, then reboot your computer.
+
+## Install Cog
+
+Open Windows Terminal and enter WSL 2:
+
+```powershell
+wsl.exe
+```
+
+Download and install Cog:
+
+```bash
+sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
+sudo chmod +x /usr/local/bin/cog
+```
+
+Verify the installation:
+
+```bash
+which cog        # should output /usr/local/bin/cog
+cog --version    # should output the version number
+```
+
+## Test a prediction
+
+Run a prediction to confirm everything works:
+
+```bash
+cog predict 'r8.im/afiaka87/glid-3-xl' -i prompt="a fresh avocado floating in the water" -o prediction.json
+```
+
+![Output from a running Cog prediction in Windows Terminal](../wsl2/images/cog_model_output.png)
+
+You can monitor GPU memory usage in Task Manager while the prediction runs:
+
+![Windows Task Manager showing shared host/guest GPU memory](../wsl2/images/memory-usage.png)
+
+If the model returns JSON output (e.g. base64-encoded images), you can extract and decode it with `jq`:
+
+```bash
+sudo apt install jq
+jq -cs '.[0][0][0]' prediction.json | cut --delimiter "," --field 2 | base64 --ignore-garbage --decode > prediction.png
+```
+
+To open the result from WSL 2, use Windows binaries with the `.exe` extension:
+
+```bash
+explorer.exe prediction.png
+```
+
+![A square image of an avocado, generated by the model](../wsl2/images/glide_out.png)
+
+## References
+
+- [NVIDIA CUDA on WSL User Guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html)
+- [NVIDIA CUDA Downloads for WSL-Ubuntu](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0)
+- [Docker WSL 2 GPU Support](https://www.docker.com/blog/wsl-2-gpu-support-for-docker-desktop-on-nvidia-gpus/)
+- [WSL Linux Kernel Update](https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-4---download-the-linux-kernel-update-package)
+- [Cog on GitHub](https://github.com/replicate/cog)

--- a/docs/http.md
+++ b/docs/http.md
@@ -1,36 +1,36 @@
 # HTTP API
 
 > [!TIP]
-> For information about how to run the HTTP server, 
+> For information about how to run the HTTP server,
 > see [our documentation on deploying models](deploy.md).
 
-When you run a Docker image built by Cog, 
+When you run a Docker image built by Cog,
 it serves an HTTP API for making predictions.
 
 The server supports both synchronous and asynchronous prediction creation:
 
-- **Synchronous**: 
+- **Synchronous**:
   The server waits until the prediction is completed
   and responds with the result.
-- **Asynchronous**: 
-  The server immediately returns a response 
-  and processes the prediction in the background. 
+- **Asynchronous**:
+  The server immediately returns a response
+  and processes the prediction in the background.
 
 The client can create a prediction asynchronously
 by setting the `Prefer: respond-async` header in their request.
-When provided, the server responds immediately after starting the prediction 
+When provided, the server responds immediately after starting the prediction
 with `202 Accepted` status and a prediction object in status `processing`.
 
 > [!NOTE]
 > The only supported way to receive updates on the status of predictions
-> started asynchronously is using [webhooks](#webhooks). 
+> started asynchronously is using [webhooks](#webhooks).
 > Polling for prediction status is not currently supported.
 
 You can also use certain server endpoints to create predictions idempotently,
-such that if a client calls this endpoint more than once with the same ID 
-(for example, due to a network interruption) 
-while the prediction is still running, 
-no new prediction is created. 
+such that if a client calls this endpoint more than once with the same ID
+(for example, due to a network interruption)
+while the prediction is still running,
+no new prediction is created.
 Instead, the client receives a `202 Accepted` response
 with the initial state of the prediction.
 
@@ -48,9 +48,9 @@ Here's a summary of the prediction creation endpoints:
 Choose the endpoint that best fits your needs:
 
 - Use synchronous endpoints when you want to wait for the prediction result.
-- Use asynchronous endpoints when you want to start a prediction 
+- Use asynchronous endpoints when you want to start a prediction
   and receive updates via webhooks.
-- Use idempotent endpoints when you need to safely retry requests 
+- Use idempotent endpoints when you need to safely retry requests
   without creating duplicate predictions.
 
 ## Webhooks
@@ -73,27 +73,27 @@ The server makes requests to the provided URL
 with the current state of the prediction object in the request body
 at the following times.
 
-- `start`: 
+- `start`:
   Once, when the prediction starts
   (`status` is `starting`).
-- `output`: 
-  Each time a predict function generates an output 
+- `output`:
+  Each time a predict function generates an output
   (either once using `return` or multiple times using `yield`)
-- `logs`: 
+- `logs`:
   Each time the predict function writes to `stdout`
-- `completed`: 
-  Once, when the prediction reaches a terminal state 
+- `completed`:
+  Once, when the prediction reaches a terminal state
   (`status` is `succeeded`, `canceled`, or `failed`)
 
-Webhook requests for `start` and `completed` event types 
+Webhook requests for `start` and `completed` event types
 are sent immediately.
-Webhook requests for `output` and `logs` event types 
+Webhook requests for `output` and `logs` event types
 are sent at most once every 500ms.
 This interval is not configurable.
 
-By default, the server sends requests for all event types. 
-Clients can specify which events trigger webhook requests 
-with the `webhook_events_filter` parameter in the prediction request body. 
+By default, the server sends requests for all event types.
+Clients can specify which events trigger webhook requests
+with the `webhook_events_filter` parameter in the prediction request body.
 For example,
 the following request specifies that webhooks are sent by the server
 only at the start and end of the prediction:
@@ -114,9 +114,11 @@ Prefer: respond-async
 
 Endpoints for creating and canceling a prediction idempotently
 accept a `prediction_id` parameter in their path.
-The server can run only one prediction at a time.
-The client must ensure that the running prediction is complete
-before creating a new one with a different ID.
+By default, the server runs one prediction at a time,
+but this can be increased with the [`concurrency.max`](yaml.md#concurrency) setting.
+When all prediction slots are in use, the server returns `409 Conflict`.
+The client should ensure prediction slots are available
+before creating a new prediction with a different ID.
 
 Clients are responsible for providing unique prediction IDs.
 We recommend generating a UUIDv4 or [UUIDv7](https://uuid7.com),
@@ -137,7 +139,7 @@ A model's `predict` function can produce file output by yielding or returning
 a `cog.Path` or `cog.File` value.
 
 By default,
-files are returned as a base64-encoded 
+files are returned as a base64-encoded
 [data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
 
 ```http
@@ -204,12 +206,35 @@ Content-Type: application/json
 If the upload fails, the server responds with an error.
 
 > [!IMPORTANT]  
-> File uploads for predictions created asynchronously 
+> File uploads for predictions created asynchronously
 > require `--upload-url` to be specified when starting the HTTP server.
 
 <a id="api"></a>
 
 ## Endpoints
+
+### `GET /`
+
+Returns a discovery document listing available API endpoints, the OpenAPI schema URL, and version information.
+
+```http
+GET / HTTP/1.1
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "cog_version": "0.17.0",
+    "docs_url": "/openapi.json",
+    "openapi_url": "/openapi.json",
+    "predictions_url": "/predictions",
+    "health_check_url": "/health-check"
+}
+```
+
+If training is configured, the response also includes a `trainings_url` field.
 
 ### `GET /health-check`
 
@@ -265,8 +290,8 @@ Content-Type: application/json
 
 ### `GET /openapi.json`
 
-The [OpenAPI](https://swagger.io/specification/) specification of the API, 
-which is derived from the input and output types specified in your model's 
+The [OpenAPI](https://swagger.io/specification/) specification of the API,
+which is derived from the input and output types specified in your model's
 [Predictor](python.md) and [Training](training.md) objects.
 
 ### `POST /predictions`
@@ -275,8 +300,8 @@ Makes a single prediction.
 
 The request body is a JSON object with the following fields:
 
-- `input`: 
-  A JSON object with the same keys as the 
+- `input`:
+  A JSON object with the same keys as the
   [arguments to the `predict()` function](python.md).
   Any `File` or `Path` inputs are passed as URLs.
 
@@ -316,7 +341,7 @@ Content-Type: application/json
 ```
 
 If the client sets the `Prefer: respond-async` header in their request,
-the server responds immediately after starting the prediction 
+the server responds immediately after starting the prediction
 with `202 Accepted` status and a prediction object in status `processing`.
 
 ```http
@@ -363,7 +388,7 @@ Content-Type: application/json
 ```
 
 If the client sets the `Prefer: respond-async` header in their request,
-the server responds immediately after starting the prediction 
+the server responds immediately after starting the prediction
 with `202 Accepted` status and a prediction object in status `processing`.
 
 ```http
@@ -392,7 +417,7 @@ A client can cancel an asynchronous prediction by making a
 `POST /predictions/<prediction_id>/cancel` request
 using the prediction `id` provided when the prediction was created.
 
-For example, 
+For example,
 if the client creates a prediction by sending the request:
 
 ```http
@@ -429,12 +454,13 @@ After cleanup, the exception must be re-raised using a bare `raise` statement.
 Failure to re-raise the exception may result in the termination of the container.
 
 ```python
-from cog import CancelationException, Path
+from cog import BasePredictor, CancelationException, Input, Path
 
-def predict(image: Path) -> Path:
-    try:
-        return process(image)
-    except CancelationException:
-        cleanup()
-        raise  # always re-raise
+class Predictor(BasePredictor):
+    def predict(self, image: Path = Input(description="Image to process")) -> Path:
+        try:
+            return self.process(image)
+        except CancelationException:
+            self.cleanup()
+            raise  # always re-raise
 ```

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -128,7 +128,7 @@ If you're using macOS, you can install Cog using Homebrew:
 brew install replicate/tap/cog
 ```
 
-You can also download and install the latest release using our 
+You can also download and install the latest release using our
 [install script](https://cog.run/install):
 
 ```sh
@@ -143,7 +143,7 @@ wget -qO- https://cog.run/install.sh
 sh ./install.sh
 ```
 
-You can manually install the latest release of Cog directly from GitHub 
+You can manually install the latest release of Cog directly from GitHub
 by running the following commands in a terminal:
 
 ```console
@@ -220,7 +220,6 @@ https://github.com/replicate/cog
       --no-color   Disable colored output
       --version    Show version of Cog
 ```
-
 ## `cog build`
 
 Build a Docker image from the cog.yaml in the current directory.
@@ -263,7 +262,6 @@ cog build [flags]
       --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
 ```
-
 ## `cog init`
 
 Create a cog.yaml and predict.py in the current directory.
@@ -287,7 +285,6 @@ cog init [flags]
 ```
   -h, --help   help for init
 ```
-
 ## `cog login`
 
 Log in to a container registry.
@@ -308,7 +305,6 @@ cog login [flags]
   -h, --help          help for login
       --token-stdin   Pass login token on stdin instead of opening a browser. You can find your Replicate login token at https://replicate.com/auth/token
 ```
-
 ## `cog predict`
 
 Run a prediction.
@@ -361,7 +357,6 @@ cog predict [image] [flags]
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
       --use-replicate-token          Pass REPLICATE_API_TOKEN from local environment into the model context
 ```
-
 ## `cog push`
 
 Build a Docker image from cog.yaml and push it to a container registry.
@@ -399,7 +394,6 @@ cog push [IMAGE] [flags]
       --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
 ```
-
 ## `cog run`
 
 Run a command inside a Docker environment defined by cog.yaml.
@@ -440,7 +434,6 @@ cog run <command> [arg...] [flags]
       --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
 ```
-
 ## `cog serve`
 
 Run a prediction HTTP server.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -672,12 +672,12 @@ Injects a custom CA certificate into the Docker image during `cog build`. This i
 
 **Supported values:**
 
-| Value | Description |
-| ----- | ----------- |
-| `/path/to/cert.crt` | Path to a single PEM certificate file |
-| `/path/to/certs/` | Directory of `.crt` and `.pem` files (all are concatenated) |
-| `-----BEGIN CERTIFICATE-----...` | Inline PEM certificate |
-| `LS0tLS1CRUdJTi...` | Base64-encoded PEM certificate |
+| Value                            | Description                                                 |
+| -------------------------------- | ----------------------------------------------------------- |
+| `/path/to/cert.crt`              | Path to a single PEM certificate file                       |
+| `/path/to/certs/`                | Directory of `.crt` and `.pem` files (all are concatenated) |
+| `-----BEGIN CERTIFICATE-----...` | Inline PEM certificate                                      |
+| `LS0tLS1CRUdJTi...`              | Base64-encoded PEM certificate                              |
 
 The certificate is installed into the system CA store and the `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` environment variables are set automatically in the built image.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -572,7 +572,6 @@ See the [`cog.yaml` reference](yaml.md#concurrency) for more details.
 You can configure runtime behavior with environment variables:
 
 - `COG_SETUP_TIMEOUT`: Maximum time in seconds for the `setup()` method (default: no timeout).
-- `COG_WEIGHTS`: URL or path to model weights, passed to `setup(weights=)`.
 
 See the [environment variables reference](environment.md) for the full list.
 
@@ -667,12 +666,32 @@ Set to `0` to disable the timeout (same as default). Invalid values are ignored 
 $ COG_SETUP_TIMEOUT=300 docker run -p 5000:5000 my-model  # 5-minute setup timeout
 ```
 
-### `COG_WEIGHTS`
+### `COG_CA_CERT`
 
-Specifies a URL or local path for model weights. This is useful for testing fine-tuned models locally — the value is passed to your predictor's `setup(weights=)` method.
+Injects a custom CA certificate into the Docker image during `cog build`. This is useful when building behind a corporate proxy or VPN that uses custom certificate authorities (e.g. Cloudflare WARP).
+
+**Supported values:**
+
+| Value | Description |
+| ----- | ----------- |
+| `/path/to/cert.crt` | Path to a single PEM certificate file |
+| `/path/to/certs/` | Directory of `.crt` and `.pem` files (all are concatenated) |
+| `-----BEGIN CERTIFICATE-----...` | Inline PEM certificate |
+| `LS0tLS1CRUdJTi...` | Base64-encoded PEM certificate |
+
+The certificate is installed into the system CA store and the `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` environment variables are set automatically in the built image.
+
+**Examples:**
 
 ```console
-$ cog predict -e COG_WEIGHTS=https://example.com/weights.tar -i prompt="hello"
+# From a file
+$ COG_CA_CERT=/usr/local/share/ca-certificates/corporate-ca.crt cog build
+
+# From a directory of certs
+$ COG_CA_CERT=/etc/custom-certs/ cog build
+
+# Inline (e.g. from a CI secret)
+$ COG_CA_CERT="$(cat /path/to/cert.pem)" cog build
 ```
 
 
@@ -2269,17 +2288,10 @@ test2
 
 ---
 
-# Redis queue API
-
-> **Note:** The Redis queue API is no longer supported and has been removed from Cog. Use the [HTTP API](http.md) instead, which supports both synchronous and asynchronous predictions with webhooks.
-
-
----
-
 # Training interface reference
 
 > [!WARNING]  
-> The `cog train` command is deprecated and will be removed in a future version of Cog. The training API described below may still be used with the HTTP API's `/trainings` endpoint, but the CLI command is no longer recommended for new projects.
+> The `cog train` command is deprecated and will be removed in the next version of Cog. The training API described below may still be used with the HTTP API's `/trainings` endpoint, but the CLI command is no longer recommended for new projects.
 
 Cog's training API allows you to define a fine-tuning interface for an existing Cog model, so users of the model can bring their own training data to create derivative fine-tuned models. Real-world examples of this API in use include [fine-tuning SDXL with images](https://replicate.com/blog/fine-tune-sdxl) or [fine-tuning Llama 2 with structured text](https://replicate.com/blog/fine-tune-llama-2).
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -483,6 +483,9 @@ Cog containers are Docker containers that serve an HTTP server
 for running predictions on your model. 
 You can deploy them anywhere that Docker containers run.
 
+The server inside Cog containers is **coglet**, a Rust-based prediction server
+that handles HTTP requests, worker process management, and prediction execution.
+
 This guide assumes you have a model packaged with Cog. 
 If you don't, [follow our getting started guide](getting-started-own-model.md), 
 or use [an example model](https://github.com/replicate/cog-examples).
@@ -495,7 +498,15 @@ First, build your model:
 cog build -t my-model
 ```
 
-Then, start the Docker container:
+You can serve predictions locally with `cog serve`:
+
+```console
+cog serve
+# or, from a built image:
+cog serve my-model
+```
+
+Alternatively, start the Docker container directly:
 
 ```shell
 # If your model uses a CPU:
@@ -503,12 +514,9 @@ docker run -d -p 5001:5000 my-model
 
 # If your model uses a GPU:
 docker run -d -p 5001:5000 --gpus all my-model
-
-# If you're on an M1 Mac:
-docker run -d -p 5001:5000 --platform=linux/amd64 my-model
 ```
 
-The server is now running locally on port 5001.
+The server listens on port 5000 inside the container (mapped to 5001 above).
 
 To view the OpenAPI schema, 
 open [localhost:5001/openapi.json](http://localhost:5001/openapi.json) 
@@ -538,29 +546,35 @@ curl http://localhost:5001/predictions -X POST \
 For more details about the HTTP API, 
 see the [HTTP API reference documentation](http.md).
 
-## Options
+## Health checks
 
-Cog Docker images have `python -m cog.server.http` set as the default command, which gets overridden if you pass a command to `docker run`. When you use command-line options, you need to pass in the full command before the options.
+The server exposes a `GET /health-check` endpoint that returns the current status of the model container. Use this for readiness probes in orchestration systems like Kubernetes.
 
-### `--threads`
+```console
+curl http://localhost:5001/health-check
+```
 
-This controls how many threads are used by Cog, which determines how many requests Cog serves in parallel. If your model uses a CPU, this is the number of CPUs on your machine. If your model uses a GPU, this is 1, because typically a GPU can only be used by one process.
+The response includes a `status` field with values like `STARTING`, `READY`, `BUSY`, `SETUP_FAILED`, or `DEFUNCT`. See the [HTTP API reference](http.md#get-health-check) for full details.
 
-You might need to adjust this if you want to control how much memory your model uses, or other similar constraints. To do this, you can use the `--threads` option.
+## Concurrency
 
-For example:
+By default, the server processes one prediction at a time. To enable concurrent predictions, set the `concurrency.max` option in `cog.yaml`:
 
-    docker run -d -p 5000:5000 my-model python -m cog.server.http --threads=10
+```yaml
+concurrency:
+  max: 4
+```
 
-### `--host`
+See the [`cog.yaml` reference](yaml.md#concurrency) for more details.
 
-By default, Cog serves to `0.0.0.0`.
-You can override this using the `--host` option.
+## Environment variables
 
-For example, 
-to serve Cog on an IPv6 address, run:
+You can configure runtime behavior with environment variables:
 
-    docker run -d -p 5000:5000 my-model python -m cog.server.http --host="::"
+- `COG_SETUP_TIMEOUT`: Maximum time in seconds for the `setup()` method (default: no timeout).
+- `COG_WEIGHTS`: URL or path to model weights, passed to `setup(weights=)`.
+
+See the [environment variables reference](environment.md) for the full list.
 
 
 ---
@@ -640,6 +654,26 @@ set the `COG_NO_UPDATE_CHECK` environment variable to any value.
 $ COG_NO_UPDATE_CHECK=1 cog build  # runs without automatic update check
 ```
 
+### `COG_SETUP_TIMEOUT`
+
+Controls the maximum time (in seconds) allowed for the model's `setup()` method to complete. If setup exceeds this timeout, the server will report a setup failure.
+
+By default, there is no timeout — setup runs indefinitely.
+
+Set to `0` to disable the timeout (same as default). Invalid values are ignored with a warning.
+
+```console
+$ COG_SETUP_TIMEOUT=300 docker run -p 5000:5000 my-model  # 5-minute setup timeout
+```
+
+### `COG_WEIGHTS`
+
+Specifies a URL or local path for model weights. This is useful for testing fine-tuned models locally — the value is passed to your predictor's `setup(weights=)` method.
+
+```console
+$ cog predict -e COG_WEIGHTS=https://example.com/weights.tar -i prompt="hello"
+```
+
 
 ---
 
@@ -655,6 +689,14 @@ This guide will show you how to put your own machine learning model in a Docker 
 ## Initialization
 
 First, install Cog if you haven't already:
+
+**macOS (recommended):**
+
+```sh
+brew install replicate/tap/cog
+```
+
+**Linux or macOS (manual):**
 
 ```sh
 sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
@@ -691,7 +733,7 @@ With a `requirements.txt` containing your dependencies:
 torch==2.6.0
 ```
 
-This will generate a Docker image with Python 3.12 and PyTorch 2 installed, for both CPU and GPU, with the correct version of CUDA, and various other sensible best-practices.
+This will generate a Docker image with Python 3.13 and PyTorch 2 installed, for both CPU and GPU, with the correct version of CUDA, and various other sensible best-practices.
 
 To run a command inside this environment, prefix it with `cog run`:
 
@@ -701,7 +743,7 @@ $ cog run python
 Running 'python' in Docker with the current directory mounted as a volume...
 ────────────────────────────────────────────────────────────────────────────────────────
 
-Python 3.12.0 (main, Oct  2 2023, 15:45:55)
+Python 3.13.x (main, ...)
 [GCC 12.2.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>>
@@ -743,7 +785,7 @@ You also need to define the inputs to your model as arguments to the `predict()`
 - `int`: an integer
 - `float`: a floating point number
 - `bool`: a boolean
-- `cog.File`: a file-like object representing a file
+- `cog.File`: a file-like object representing a file (deprecated — use `cog.Path` instead)
 - `cog.Path`: a path to a file on disk
 
 You can provide more information about the input with the `Input()` function, as shown above. It takes these basic arguments:
@@ -752,7 +794,11 @@ You can provide more information about the input with the `Input()` function, as
 - `default`: A default value to set the input to. If this argument is not passed, the input is required. If it is explicitly set to `None`, the input is optional.
 - `ge`: For `int` or `float` types, the value should be greater than or equal to this number.
 - `le`: For `int` or `float` types, the value should be less than or equal to this number.
+- `min_length`: For `str` types, the minimum length of the string.
+- `max_length`: For `str` types, the maximum length of the string.
+- `regex`: For `str` types, the string must match this regular expression.
 - `choices`: For `str` or `int` types, a list of possible values for this input.
+- `deprecated`: Mark this input as deprecated with a message explaining what to use instead.
 
 There are some more advanced options you can pass, too. For more details, [take a look at the prediction interface documentation](python.md).
 
@@ -885,7 +931,7 @@ and you'll get an interactive Python shell:
 Running 'python' in Docker with the current directory mounted as a volume...
 ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
-Python 3.12.0 (main, Oct  2 2023, 15:45:55)
+Python 3.13.x (main, ...)
 [GCC 12.2.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>>
@@ -1161,9 +1207,11 @@ Prefer: respond-async
 
 Endpoints for creating and canceling a prediction idempotently
 accept a `prediction_id` parameter in their path.
-The server can run only one prediction at a time.
-The client must ensure that the running prediction is complete
-before creating a new one with a different ID.
+By default, the server runs one prediction at a time,
+but this can be increased with the [`concurrency.max`](yaml.md#concurrency) setting.
+When all prediction slots are in use, the server returns `409 Conflict`.
+The client should ensure prediction slots are available
+before creating a new prediction with a different ID.
 
 Clients are responsible for providing unique prediction IDs.
 We recommend generating a UUIDv4 or [UUIDv7](https://uuid7.com),
@@ -1257,6 +1305,29 @@ If the upload fails, the server responds with an error.
 <a id="api"></a>
 
 ## Endpoints
+
+### `GET /`
+
+Returns a discovery document listing available API endpoints, the OpenAPI schema URL, and version information.
+
+```http
+GET / HTTP/1.1
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "cog_version": "0.17.0",
+    "docs_url": "/openapi.json",
+    "openapi_url": "/openapi.json",
+    "predictions_url": "/predictions",
+    "health_check_url": "/health-check"
+}
+```
+
+If training is configured, the response also includes a `trainings_url` field.
 
 ### `GET /health-check`
 
@@ -1476,14 +1547,15 @@ After cleanup, the exception must be re-raised using a bare `raise` statement.
 Failure to re-raise the exception may result in the termination of the container.
 
 ```python
-from cog import CancelationException, Path
+from cog import BasePredictor, CancelationException, Input, Path
 
-def predict(image: Path) -> Path:
-    try:
-        return process(image)
-    except CancelationException:
-        cleanup()
-        raise  # always re-raise
+class Predictor(BasePredictor):
+    def predict(self, image: Path = Input(description="Image to process")) -> Path:
+        try:
+            return self.process(image)
+        except CancelationException:
+            self.cleanup()
+            raise  # always re-raise
 ```
 
 
@@ -1499,7 +1571,7 @@ First, add `jupyterlab` to your `requirements.txt` file and reference it in [`co
 
 `requirements.txt`:
 ```
-jupyterlab==3.3.4
+jupyterlab
 ```
 
 `cog.yaml`:
@@ -2193,15 +2265,15 @@ test2
 
 # Redis queue API
 
-> **Note:** The redis queue API is no longer supported and has been removed from Cog.
+> **Note:** The Redis queue API is no longer supported and has been removed from Cog. Use the [HTTP API](http.md) instead, which supports both synchronous and asynchronous predictions with webhooks.
 
 
 ---
 
 # Training interface reference
 
-> [!NOTE]  
-> The training API is still experimental, and is subject to change.
+> [!WARNING]  
+> The `cog train` command is deprecated and will be removed in a future version of Cog. The training API described below may still be used with the HTTP API's `/trainings` endpoint, but the CLI command is no longer recommended for new projects.
 
 Cog's training API allows you to define a fine-tuning interface for an existing Cog model, so users of the model can bring their own training data to create derivative fine-tuned models. Real-world examples of this API in use include [fine-tuning SDXL with images](https://replicate.com/blog/fine-tune-sdxl) or [fine-tuning Llama 2 with structured text](https://replicate.com/blog/fine-tune-llama-2).
 
@@ -2292,7 +2364,7 @@ Each parameter of the `train()` function must be annotated with a type like `str
 Using the `Input` function provides better documentation and validation constraints to the users of your model, but it is not strictly required. You can also specify default values for your parameters using plain Python, or omit default assignment entirely:
 
 ```py
-def predict(self,
+def train(self,
   training_data: str = "foo bar", # this is valid
   iterations: int                 # also valid
 ) -> str:

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -220,6 +220,7 @@ https://github.com/replicate/cog
       --no-color   Disable colored output
       --version    Show version of Cog
 ```
+
 ## `cog build`
 
 Build a Docker image from the cog.yaml in the current directory.
@@ -262,6 +263,7 @@ cog build [flags]
       --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
 ```
+
 ## `cog init`
 
 Create a cog.yaml and predict.py in the current directory.
@@ -285,6 +287,7 @@ cog init [flags]
 ```
   -h, --help   help for init
 ```
+
 ## `cog login`
 
 Log in to a container registry.
@@ -305,6 +308,7 @@ cog login [flags]
   -h, --help          help for login
       --token-stdin   Pass login token on stdin instead of opening a browser. You can find your Replicate login token at https://replicate.com/auth/token
 ```
+
 ## `cog predict`
 
 Run a prediction.
@@ -357,6 +361,7 @@ cog predict [image] [flags]
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
       --use-replicate-token          Pass REPLICATE_API_TOKEN from local environment into the model context
 ```
+
 ## `cog push`
 
 Build a Docker image from cog.yaml and push it to a container registry.
@@ -394,6 +399,7 @@ cog push [IMAGE] [flags]
       --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
 ```
+
 ## `cog run`
 
 Run a command inside a Docker environment defined by cog.yaml.
@@ -434,6 +440,7 @@ cog run <command> [arg...] [flags]
       --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
       --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
 ```
+
 ## `cog serve`
 
 Run a prediction HTTP server.
@@ -479,15 +486,15 @@ cog serve [flags]
 
 # Deploy models with Cog
 
-Cog containers are Docker containers that serve an HTTP server 
-for running predictions on your model. 
+Cog containers are Docker containers that serve an HTTP server
+for running predictions on your model.
 You can deploy them anywhere that Docker containers run.
 
 The server inside Cog containers is **coglet**, a Rust-based prediction server
 that handles HTTP requests, worker process management, and prediction execution.
 
-This guide assumes you have a model packaged with Cog. 
-If you don't, [follow our getting started guide](getting-started-own-model.md), 
+This guide assumes you have a model packaged with Cog.
+If you don't, [follow our getting started guide](getting-started-own-model.md),
 or use [an example model](https://github.com/replicate/cog-examples).
 
 ## Getting started
@@ -518,9 +525,9 @@ docker run -d -p 5001:5000 --gpus all my-model
 
 The server listens on port 5000 inside the container (mapped to 5001 above).
 
-To view the OpenAPI schema, 
-open [localhost:5001/openapi.json](http://localhost:5001/openapi.json) 
-in your browser 
+To view the OpenAPI schema,
+open [localhost:5001/openapi.json](http://localhost:5001/openapi.json)
+in your browser
 or use cURL to make a request:
 
 ```console
@@ -533,8 +540,8 @@ To stop the server, run:
 docker kill my-model
 ```
 
-To run a prediction on the model, 
-call the `/predictions` endpoint, 
+To run a prediction on the model,
+call the `/predictions` endpoint,
 passing input in the format expected by your model:
 
 ```console
@@ -543,7 +550,7 @@ curl http://localhost:5001/predictions -X POST \
     --data '{"input": {"image": "https://.../input.jpg"}}'
 ```
 
-For more details about the HTTP API, 
+For more details about the HTTP API,
 see the [HTTP API reference documentation](http.md).
 
 ## Health checks
@@ -591,13 +598,13 @@ Controls which cog Python SDK wheel is installed in the Docker image during `cog
 
 **Supported values:**
 
-| Value | Description |
-|-------|-------------|
-| `pypi` | Install latest version from PyPI |
-| `pypi:0.12.0` | Install specific version from PyPI |
-| `dist` | Use wheel from `dist/` directory (requires git repo) |
-| `https://...` | Install from URL |
-| `/path/to/wheel.whl` | Install from local file path |
+| Value                | Description                                          |
+| -------------------- | ---------------------------------------------------- |
+| `pypi`               | Install latest version from PyPI                     |
+| `pypi:0.12.0`        | Install specific version from PyPI                   |
+| `dist`               | Use wheel from `dist/` directory (requires git repo) |
+| `https://...`        | Install from URL                                     |
+| `/path/to/wheel.whl` | Install from local file path                         |
 
 **Default behavior:**
 
@@ -618,6 +625,7 @@ $ COG_SDK_WHEEL=https://example.com/cog-0.12.0-py3-none-any.whl cog build
 ```
 
 The `dist` option searches for wheels in:
+
 1. `./dist/` (current directory)
 2. `$REPO_ROOT/dist/` (if REPO_ROOT is set)
 3. `<git-repo-root>/dist/` (via `git rev-parse`, useful when running from subdirectories)
@@ -644,10 +652,10 @@ $ COGLET_WHEEL=pypi:0.1.0 cog build
 
 ### `COG_NO_UPDATE_CHECK`
 
-By default, Cog automatically checks for updates 
+By default, Cog automatically checks for updates
 and notifies you if there is a new version available.
 
-To disable this behavior, 
+To disable this behavior,
 set the `COG_NO_UPDATE_CHECK` environment variable to any value.
 
 ```console
@@ -1094,36 +1102,36 @@ Those are the basics! Next, you might want to take a look at:
 # HTTP API
 
 > [!TIP]
-> For information about how to run the HTTP server, 
+> For information about how to run the HTTP server,
 > see [our documentation on deploying models](deploy.md).
 
-When you run a Docker image built by Cog, 
+When you run a Docker image built by Cog,
 it serves an HTTP API for making predictions.
 
 The server supports both synchronous and asynchronous prediction creation:
 
-- **Synchronous**: 
+- **Synchronous**:
   The server waits until the prediction is completed
   and responds with the result.
-- **Asynchronous**: 
-  The server immediately returns a response 
-  and processes the prediction in the background. 
+- **Asynchronous**:
+  The server immediately returns a response
+  and processes the prediction in the background.
 
 The client can create a prediction asynchronously
 by setting the `Prefer: respond-async` header in their request.
-When provided, the server responds immediately after starting the prediction 
+When provided, the server responds immediately after starting the prediction
 with `202 Accepted` status and a prediction object in status `processing`.
 
 > [!NOTE]
 > The only supported way to receive updates on the status of predictions
-> started asynchronously is using [webhooks](#webhooks). 
+> started asynchronously is using [webhooks](#webhooks).
 > Polling for prediction status is not currently supported.
 
 You can also use certain server endpoints to create predictions idempotently,
-such that if a client calls this endpoint more than once with the same ID 
-(for example, due to a network interruption) 
-while the prediction is still running, 
-no new prediction is created. 
+such that if a client calls this endpoint more than once with the same ID
+(for example, due to a network interruption)
+while the prediction is still running,
+no new prediction is created.
 Instead, the client receives a `202 Accepted` response
 with the initial state of the prediction.
 
@@ -1141,9 +1149,9 @@ Here's a summary of the prediction creation endpoints:
 Choose the endpoint that best fits your needs:
 
 - Use synchronous endpoints when you want to wait for the prediction result.
-- Use asynchronous endpoints when you want to start a prediction 
+- Use asynchronous endpoints when you want to start a prediction
   and receive updates via webhooks.
-- Use idempotent endpoints when you need to safely retry requests 
+- Use idempotent endpoints when you need to safely retry requests
   without creating duplicate predictions.
 
 ## Webhooks
@@ -1166,27 +1174,27 @@ The server makes requests to the provided URL
 with the current state of the prediction object in the request body
 at the following times.
 
-- `start`: 
+- `start`:
   Once, when the prediction starts
   (`status` is `starting`).
-- `output`: 
-  Each time a predict function generates an output 
+- `output`:
+  Each time a predict function generates an output
   (either once using `return` or multiple times using `yield`)
-- `logs`: 
+- `logs`:
   Each time the predict function writes to `stdout`
-- `completed`: 
-  Once, when the prediction reaches a terminal state 
+- `completed`:
+  Once, when the prediction reaches a terminal state
   (`status` is `succeeded`, `canceled`, or `failed`)
 
-Webhook requests for `start` and `completed` event types 
+Webhook requests for `start` and `completed` event types
 are sent immediately.
-Webhook requests for `output` and `logs` event types 
+Webhook requests for `output` and `logs` event types
 are sent at most once every 500ms.
 This interval is not configurable.
 
-By default, the server sends requests for all event types. 
-Clients can specify which events trigger webhook requests 
-with the `webhook_events_filter` parameter in the prediction request body. 
+By default, the server sends requests for all event types.
+Clients can specify which events trigger webhook requests
+with the `webhook_events_filter` parameter in the prediction request body.
 For example,
 the following request specifies that webhooks are sent by the server
 only at the start and end of the prediction:
@@ -1232,7 +1240,7 @@ A model's `predict` function can produce file output by yielding or returning
 a `cog.Path` or `cog.File` value.
 
 By default,
-files are returned as a base64-encoded 
+files are returned as a base64-encoded
 [data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
 
 ```http
@@ -1299,7 +1307,7 @@ Content-Type: application/json
 If the upload fails, the server responds with an error.
 
 > [!IMPORTANT]  
-> File uploads for predictions created asynchronously 
+> File uploads for predictions created asynchronously
 > require `--upload-url` to be specified when starting the HTTP server.
 
 <a id="api"></a>
@@ -1383,8 +1391,8 @@ Content-Type: application/json
 
 ### `GET /openapi.json`
 
-The [OpenAPI](https://swagger.io/specification/) specification of the API, 
-which is derived from the input and output types specified in your model's 
+The [OpenAPI](https://swagger.io/specification/) specification of the API,
+which is derived from the input and output types specified in your model's
 [Predictor](python.md) and [Training](training.md) objects.
 
 ### `POST /predictions`
@@ -1393,8 +1401,8 @@ Makes a single prediction.
 
 The request body is a JSON object with the following fields:
 
-- `input`: 
-  A JSON object with the same keys as the 
+- `input`:
+  A JSON object with the same keys as the
   [arguments to the `predict()` function](python.md).
   Any `File` or `Path` inputs are passed as URLs.
 
@@ -1434,7 +1442,7 @@ Content-Type: application/json
 ```
 
 If the client sets the `Prefer: respond-async` header in their request,
-the server responds immediately after starting the prediction 
+the server responds immediately after starting the prediction
 with `202 Accepted` status and a prediction object in status `processing`.
 
 ```http
@@ -1481,7 +1489,7 @@ Content-Type: application/json
 ```
 
 If the client sets the `Prefer: respond-async` header in their request,
-the server responds immediately after starting the prediction 
+the server responds immediately after starting the prediction
 with `202 Accepted` status and a prediction object in status `processing`.
 
 ```http
@@ -1510,7 +1518,7 @@ A client can cancel an asynchronous prediction by making a
 `POST /predictions/<prediction_id>/cancel` request
 using the prediction `id` provided when the prediction was created.
 
-For example, 
+For example,
 if the client creates a prediction by sending the request:
 
 ```http
@@ -1570,16 +1578,17 @@ Cog plays nicely with Jupyter notebooks.
 First, add `jupyterlab` to your `requirements.txt` file and reference it in [`cog.yaml`](yaml.md):
 
 `requirements.txt`:
+
 ```
 jupyterlab
 ```
 
 `cog.yaml`:
+
 ```yaml
 build:
   python_requirements: requirements.txt
 ```
-
 
 ## Run a notebook
 
@@ -1765,7 +1774,7 @@ The `predict()` method takes an arbitrary list of named arguments, where each ar
 
 > Added in cog 0.14.0.
 
-You may specify your `predict()` method as `async def predict(...)`.  In
+You may specify your `predict()` method as `async def predict(...)`. In
 addition, if you have an async `predict()` function you may also have an async
 `setup()` function:
 
@@ -1995,13 +2004,13 @@ Metrics appear in the prediction response `metrics` field:
 
 ```json
 {
-    "status": "succeeded",
-    "output": "...",
-    "metrics": {
-        "temperature": 0.7,
-        "token_count": 42,
-        "predict_time": 1.23
-    }
+  "status": "succeeded",
+  "output": "...",
+  "metrics": {
+    "temperature": 0.7,
+    "token_count": 42,
+    "predict_time": 1.23
+  }
 }
 ```
 
@@ -2045,13 +2054,13 @@ This produces nested JSON:
 
 ```json
 {
-    "metrics": {
-        "timing": {
-            "preprocess": 0.12,
-            "inference": 0.85
-        },
-        "predict_time": 1.23
-    }
+  "metrics": {
+    "timing": {
+      "preprocess": 0.12,
+      "inference": 0.85
+    },
+    "predict_time": 1.23
+  }
 }
 ```
 
@@ -2076,9 +2085,9 @@ Outside an active prediction, `self.record_metric()` and `self.scope` are silent
 
 When a prediction is canceled (via the [cancel HTTP endpoint](http.md#post-predictionsprediction_idcancel) or a dropped connection), the Cog runtime interrupts the running `predict()` function. The exception raised depends on whether the predictor is sync or async:
 
-| Predictor type | Exception raised |
-|---|---|
-| Sync (`def predict`) | `CancelationException` |
+| Predictor type              | Exception raised         |
+| --------------------------- | ------------------------ |
+| Sync (`def predict`)        | `CancelationException`   |
 | Async (`async def predict`) | `asyncio.CancelledError` |
 
 ### `CancelationException`
@@ -2185,7 +2194,7 @@ from cog import BasePredictor, Secret
 class Predictor(BasePredictor):
     def predict(self, api_token: Secret) -> None:
         # Prints '**********'
-        print(api_token)        
+        print(api_token)
 
         # Use get_secret_value method to see the secret's content.
         print(api_token.get_secret_value())
@@ -2197,7 +2206,7 @@ A predictor's `Secret` inputs are represented in OpenAPI with the following sche
 {
   "type": "string",
   "format": "password",
-  "x-cog-secret": true,
+  "x-cog-secret": true
 }
 ```
 
@@ -2206,7 +2215,7 @@ When you create a prediction on Replicate,
 any value passed to a `Secret` input is redacted after being sent to the model.
 
 > [!WARNING]  
-> Passing secret values to untrusted models can result in 
+> Passing secret values to untrusted models can result in
 > unintended disclosure, exfiltration, or misuse of sensitive data.
 
 ## `Optional`
@@ -2239,6 +2248,7 @@ Note that the error prone usage of `prompt: str=Input(default=None)` might throw
 The List type is also supported in inputs. It can hold any supported type.
 
 Example for **List[Path]**:
+
 ```py
 class Predictor(BasePredictor):
    def predict(self, paths: list[Path]) -> str:
@@ -2248,7 +2258,9 @@ class Predictor(BasePredictor):
              output_parts.append(f.read())
        return "".join(output_parts)
 ```
+
 The corresponding cog command:
+
 ```bash
 $ echo test1 > 1.txt
 $ echo test2 > 2.txt
@@ -2258,6 +2270,7 @@ test1
 
 test2
 ```
+
 - Note the repeated inputs with the same name "paths" which constitute the list
 
 
@@ -2686,6 +2699,7 @@ This follows the standard [requirements.txt](https://pip.pypa.io/en/stable/refer
 To install Git-hosted Python packages, add `git` to the `system_packages` list, then use the `git+https://` syntax to specify the package name. For example:
 
 `cog.yaml`:
+
 ```yaml
 build:
   system_packages:
@@ -2694,6 +2708,7 @@ build:
 ```
 
 `requirements.txt`:
+
 ```
 git+https://github.com/huggingface/transformers
 ```
@@ -2701,6 +2716,7 @@ git+https://github.com/huggingface/transformers
 You can also pin Python package installations to a specific git commit:
 
 `cog.yaml`:
+
 ```yaml
 build:
   system_packages:
@@ -2709,6 +2725,7 @@ build:
 ```
 
 `requirements.txt`:
+
 ```
 git+https://github.com/huggingface/transformers@2d1602a
 ```
@@ -2814,7 +2831,7 @@ This stanza describes the concurrency capabilities of the model. It has one opti
 
 ### `max`
 
-The maximum number of concurrent predictions the model can process.  If this is set, the model must specify an [async `predict()` method](python.md#async-predictors-and-concurrency).
+The maximum number of concurrent predictions the model can process. If this is set, the model must specify an [async `predict()` method](python.md#async-predictors-and-concurrency).
 
 For example:
 
@@ -2837,7 +2854,7 @@ r8.im is Replicate's registry, but this can be any Docker registry.
 
 If you don't set this, then a name will be generated from the directory name.
 
-If you set this, then you can run `cog push` without specifying the model name. 
+If you set this, then you can run `cog push` without specifying the model name.
 
 If you specify an image name argument when pushing (like `cog push your-username/custom-model-name`), the argument will be used and the value of `image` in cog.yaml will be ignored.
 

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -7,16 +7,17 @@ Cog plays nicely with Jupyter notebooks.
 First, add `jupyterlab` to your `requirements.txt` file and reference it in [`cog.yaml`](yaml.md):
 
 `requirements.txt`:
+
 ```
-jupyterlab==3.3.4
+jupyterlab
 ```
 
 `cog.yaml`:
+
 ```yaml
 build:
   python_requirements: requirements.txt
 ```
-
 
 ## Run a notebook
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -102,7 +102,7 @@ The `predict()` method takes an arbitrary list of named arguments, where each ar
 
 > Added in cog 0.14.0.
 
-You may specify your `predict()` method as `async def predict(...)`.  In
+You may specify your `predict()` method as `async def predict(...)`. In
 addition, if you have an async `predict()` function you may also have an async
 `setup()` function:
 
@@ -332,13 +332,13 @@ Metrics appear in the prediction response `metrics` field:
 
 ```json
 {
-    "status": "succeeded",
-    "output": "...",
-    "metrics": {
-        "temperature": 0.7,
-        "token_count": 42,
-        "predict_time": 1.23
-    }
+  "status": "succeeded",
+  "output": "...",
+  "metrics": {
+    "temperature": 0.7,
+    "token_count": 42,
+    "predict_time": 1.23
+  }
 }
 ```
 
@@ -382,13 +382,13 @@ This produces nested JSON:
 
 ```json
 {
-    "metrics": {
-        "timing": {
-            "preprocess": 0.12,
-            "inference": 0.85
-        },
-        "predict_time": 1.23
-    }
+  "metrics": {
+    "timing": {
+      "preprocess": 0.12,
+      "inference": 0.85
+    },
+    "predict_time": 1.23
+  }
 }
 ```
 
@@ -413,9 +413,9 @@ Outside an active prediction, `self.record_metric()` and `self.scope` are silent
 
 When a prediction is canceled (via the [cancel HTTP endpoint](http.md#post-predictionsprediction_idcancel) or a dropped connection), the Cog runtime interrupts the running `predict()` function. The exception raised depends on whether the predictor is sync or async:
 
-| Predictor type | Exception raised |
-|---|---|
-| Sync (`def predict`) | `CancelationException` |
+| Predictor type              | Exception raised         |
+| --------------------------- | ------------------------ |
+| Sync (`def predict`)        | `CancelationException`   |
 | Async (`async def predict`) | `asyncio.CancelledError` |
 
 ### `CancelationException`
@@ -522,7 +522,7 @@ from cog import BasePredictor, Secret
 class Predictor(BasePredictor):
     def predict(self, api_token: Secret) -> None:
         # Prints '**********'
-        print(api_token)        
+        print(api_token)
 
         # Use get_secret_value method to see the secret's content.
         print(api_token.get_secret_value())
@@ -534,7 +534,7 @@ A predictor's `Secret` inputs are represented in OpenAPI with the following sche
 {
   "type": "string",
   "format": "password",
-  "x-cog-secret": true,
+  "x-cog-secret": true
 }
 ```
 
@@ -543,7 +543,7 @@ When you create a prediction on Replicate,
 any value passed to a `Secret` input is redacted after being sent to the model.
 
 > [!WARNING]  
-> Passing secret values to untrusted models can result in 
+> Passing secret values to untrusted models can result in
 > unintended disclosure, exfiltration, or misuse of sensitive data.
 
 ## `Optional`
@@ -576,6 +576,7 @@ Note that the error prone usage of `prompt: str=Input(default=None)` might throw
 The List type is also supported in inputs. It can hold any supported type.
 
 Example for **List[Path]**:
+
 ```py
 class Predictor(BasePredictor):
    def predict(self, paths: list[Path]) -> str:
@@ -585,7 +586,9 @@ class Predictor(BasePredictor):
              output_parts.append(f.read())
        return "".join(output_parts)
 ```
+
 The corresponding cog command:
+
 ```bash
 $ echo test1 > 1.txt
 $ echo test2 > 2.txt
@@ -595,4 +598,5 @@ test1
 
 test2
 ```
+
 - Note the repeated inputs with the same name "paths" which constitute the list

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -1,3 +1,0 @@
-# Redis queue API
-
-> **Note:** The Redis queue API is no longer supported and has been removed from Cog. Use the [HTTP API](http.md) instead, which supports both synchronous and asynchronous predictions with webhooks.

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -1,3 +1,3 @@
 # Redis queue API
 
-> **Note:** The redis queue API is no longer supported and has been removed from Cog.
+> **Note:** The Redis queue API is no longer supported and has been removed from Cog. Use the [HTTP API](http.md) instead, which supports both synchronous and asynchronous predictions with webhooks.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,281 @@
+# CLI reference
+
+> This reference is auto-generated from the CLI source code. For practical usage guides, see the [how-to guides](../how-to/).
+
+<!-- This file is auto-generated. Do not edit manually. -->
+
+## `cog`
+
+Containers for machine learning.
+
+To get started, take a look at the documentation:
+https://github.com/replicate/cog
+
+**Examples**
+
+```
+   To run a command inside a Docker environment defined with Cog:
+      $ cog run echo hello world
+```
+
+**Options**
+
+```
+      --debug      Show debugging output
+  -h, --help       help for cog
+      --no-color   Disable colored output
+      --version    Show version of Cog
+```
+## `cog build`
+
+Build a Docker image from the cog.yaml in the current directory.
+
+The generated image contains your model code, dependencies, and the Cog
+runtime. It can be run locally with 'cog predict' or pushed to a registry
+with 'cog push'.
+
+```
+cog build [flags]
+```
+
+**Examples**
+
+```
+  # Build with default settings
+  cog build
+
+  # Build and tag the image
+  cog build -t my-model:latest
+
+  # Build without using the cache
+  cog build --no-cache
+
+  # Build with model weights in a separate layer
+  cog build --separate-weights -t my-model:v1
+```
+
+**Options**
+
+```
+  -f, --file string                  The name of the config file. (default "cog.yaml")
+  -h, --help                         help for build
+      --no-cache                     Do not use cache when building the image
+      --openapi-schema string        Load OpenAPI schema from a file
+      --progress string              Set type of build progress output, 'auto' (default), 'tty', 'plain', or 'quiet' (default "auto")
+      --secret stringArray           Secrets to pass to the build environment in the form 'id=foo,src=/path/to/file'
+      --separate-weights             Separate model weights from code in image layers
+  -t, --tag string                   A name for the built image in the form 'repository:tag'
+      --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
+      --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
+```
+## `cog init`
+
+Create a cog.yaml and predict.py in the current directory.
+
+These files provide a starting template for defining your model's environment
+and prediction interface. Edit them to match your model's requirements.
+
+```
+cog init [flags]
+```
+
+**Examples**
+
+```
+  # Set up a new Cog project in the current directory
+  cog init
+```
+
+**Options**
+
+```
+  -h, --help   help for init
+```
+## `cog login`
+
+Log in to a container registry.
+
+For Replicate's registry (r8.im), this command handles authentication
+through Replicate's token-based flow.
+
+For other registries, this command prompts for username and password,
+then stores credentials using Docker's credential system.
+
+```
+cog login [flags]
+```
+
+**Options**
+
+```
+  -h, --help          help for login
+      --token-stdin   Pass login token on stdin instead of opening a browser. You can find your Replicate login token at https://replicate.com/auth/token
+```
+## `cog predict`
+
+Run a prediction.
+
+If 'image' is passed, it will run the prediction on that Docker image.
+It must be an image that has been built by Cog.
+
+Otherwise, it will build the model in the current directory and run
+the prediction on that.
+
+```
+cog predict [image] [flags]
+```
+
+**Examples**
+
+```
+  # Run a prediction with named inputs
+  cog predict -i prompt="a photo of a cat"
+
+  # Pass a file as input
+  cog predict -i image=@photo.jpg
+
+  # Save output to a file
+  cog predict -i image=@input.jpg -o output.png
+
+  # Pass multiple inputs
+  cog predict -i prompt="sunset" -i width=1024 -i height=768
+
+  # Run against a pre-built image
+  cog predict r8.im/your-username/my-model -i prompt="hello"
+
+  # Pass inputs as JSON
+  echo '{"prompt": "a cat"}' | cog predict --json @-
+```
+
+**Options**
+
+```
+  -e, --env stringArray              Environment variables, in the form name=value
+  -f, --file string                  The name of the config file. (default "cog.yaml")
+      --gpus docker run --gpus       GPU devices to add to the container, in the same format as docker run --gpus.
+  -h, --help                         help for predict
+  -i, --input stringArray            Inputs, in the form name=value. if value is prefixed with @, then it is read from a file on disk. E.g. -i path=@image.jpg
+      --json string                  Pass inputs as JSON object, read from file (@inputs.json) or via stdin (@-)
+  -o, --output string                Output path
+      --progress string              Set type of build progress output, 'auto' (default), 'tty', 'plain', or 'quiet' (default "auto")
+      --setup-timeout uint32         The timeout for a container to setup (in seconds). (default 300)
+      --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
+      --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
+      --use-replicate-token          Pass REPLICATE_API_TOKEN from local environment into the model context
+```
+## `cog push`
+
+Build a Docker image from cog.yaml and push it to a container registry.
+
+Cog can push to any OCI-compliant registry. When pushing to Replicate's
+registry (r8.im), run 'cog login' first to authenticate.
+
+```
+cog push [IMAGE] [flags]
+```
+
+**Examples**
+
+```
+  # Push to Replicate
+  cog push r8.im/your-username/my-model
+
+  # Push to any OCI registry
+  cog push registry.example.com/your-username/model-name
+
+  # Push with model weights in a separate layer (Replicate only)
+  cog push r8.im/your-username/my-model --separate-weights
+```
+
+**Options**
+
+```
+  -f, --file string                  The name of the config file. (default "cog.yaml")
+  -h, --help                         help for push
+      --no-cache                     Do not use cache when building the image
+      --openapi-schema string        Load OpenAPI schema from a file
+      --progress string              Set type of build progress output, 'auto' (default), 'tty', 'plain', or 'quiet' (default "auto")
+      --secret stringArray           Secrets to pass to the build environment in the form 'id=foo,src=/path/to/file'
+      --separate-weights             Separate model weights from code in image layers
+      --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
+      --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
+```
+## `cog run`
+
+Run a command inside a Docker environment defined by cog.yaml.
+
+Cog builds a temporary image from your cog.yaml configuration and runs the
+given command inside it. This is useful for debugging, running scripts, or
+exploring the environment your model will run in.
+
+```
+cog run <command> [arg...] [flags]
+```
+
+**Examples**
+
+```
+  # Open a Python interpreter inside the model environment
+  cog run python
+
+  # Run a script
+  cog run python train.py
+
+  # Run with environment variables
+  cog run -e HUGGING_FACE_HUB_TOKEN=abc123 python download.py
+
+  # Expose a port (e.g. for Jupyter)
+  cog run -p 8888 jupyter notebook
+```
+
+**Options**
+
+```
+  -e, --env stringArray              Environment variables, in the form name=value
+  -f, --file string                  The name of the config file. (default "cog.yaml")
+      --gpus docker run --gpus       GPU devices to add to the container, in the same format as docker run --gpus.
+  -h, --help                         help for run
+      --progress string              Set type of build progress output, 'auto' (default), 'tty', 'plain', or 'quiet' (default "auto")
+  -p, --publish stringArray          Publish a container's port to the host, e.g. -p 8000
+      --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
+      --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
+```
+## `cog serve`
+
+Run a prediction HTTP server.
+
+Builds the model and starts an HTTP server that exposes the model's inputs
+and outputs as a REST API. Compatible with the Cog HTTP protocol.
+
+```
+cog serve [flags]
+```
+
+**Examples**
+
+```
+  # Start the server on the default port (8393)
+  cog serve
+
+  # Start on a custom port
+  cog serve -p 5000
+
+  # Test the server
+  curl http://localhost:8393/predictions \
+    -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"input": {"prompt": "a cat"}}'
+```
+
+**Options**
+
+```
+  -f, --file string                  The name of the config file. (default "cog.yaml")
+      --gpus docker run --gpus       GPU devices to add to the container, in the same format as docker run --gpus.
+  -h, --help                         help for serve
+  -p, --port int                     Port on which to listen (default 8393)
+      --progress string              Set type of build progress output, 'auto' (default), 'tty', 'plain', or 'quiet' (default "auto")
+      --upload-url string            Upload URL for file outputs (e.g. https://example.com/upload/)
+      --use-cog-base-image           Use pre-built Cog base image for faster cold boots (default true)
+      --use-cuda-base-image string   Use Nvidia CUDA base image, 'true' (default) or 'false' (use python base image). False results in a smaller image but may cause problems for non-torch projects (default "auto")
+```

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -1,0 +1,115 @@
+# Environment variables
+
+This reference lists the environment variables that change how Cog functions.
+
+## Build-time variables
+
+### `COG_SDK_WHEEL`
+
+Controls which cog Python SDK wheel is installed in the Docker image during `cog build`. Takes precedence over `build.sdk_version` in `cog.yaml`.
+
+**Supported values:**
+
+| Value                | Description                                          |
+| -------------------- | ---------------------------------------------------- |
+| `pypi`               | Install latest version from PyPI                     |
+| `pypi:0.12.0`        | Install specific version from PyPI                   |
+| `dist`               | Use wheel from `dist/` directory (requires git repo) |
+| `https://...`        | Install from URL                                     |
+| `/path/to/wheel.whl` | Install from local file path                         |
+
+**Default behavior:**
+
+- **Release builds**: Installs latest cog from PyPI
+- **Development builds**: Auto-detects wheel in `dist/` directory, falls back to latest PyPI
+
+**Examples:**
+
+```console
+# Use specific PyPI version
+$ COG_SDK_WHEEL=pypi:0.11.0 cog build
+
+# Use local development wheel
+$ COG_SDK_WHEEL=dist cog build
+
+# Use wheel from URL
+$ COG_SDK_WHEEL=https://example.com/cog-0.12.0-py3-none-any.whl cog build
+```
+
+The `dist` option searches for wheels in:
+
+1. `./dist/` (current directory)
+2. `$REPO_ROOT/dist/` (if REPO_ROOT is set)
+3. `<git-repo-root>/dist/` (via `git rev-parse`, useful when running from subdirectories)
+
+### `COGLET_WHEEL`
+
+Controls which coglet wheel is installed in the Docker image. Coglet is the Rust-based prediction server.
+
+**Supported values:** Same as `COG_SDK_WHEEL`
+
+**Default behavior:** For development builds, auto-detects a wheel in `dist/`. For release builds, installs the latest version from PyPI. Can be overridden with an explicit value.
+
+**Examples:**
+
+```console
+# Use local development wheel
+$ COGLET_WHEEL=dist cog build
+
+# Use specific version from PyPI
+$ COGLET_WHEEL=pypi:0.1.0 cog build
+```
+
+## Runtime variables
+
+### `COG_NO_UPDATE_CHECK`
+
+By default, Cog automatically checks for updates
+and notifies you if there is a new version available.
+
+To disable this behavior,
+set the `COG_NO_UPDATE_CHECK` environment variable to any value.
+
+```console
+$ COG_NO_UPDATE_CHECK=1 cog build  # runs without automatic update check
+```
+
+### `COG_SETUP_TIMEOUT`
+
+Controls the maximum time (in seconds) allowed for the model's `setup()` method to complete. If setup exceeds this timeout, the server will report a setup failure.
+
+By default, there is no timeout -- setup runs indefinitely.
+
+Set to `0` to disable the timeout (same as default). Invalid values are ignored with a warning.
+
+```console
+$ COG_SETUP_TIMEOUT=300 docker run -p 5000:5000 my-model  # 5-minute setup timeout
+```
+
+### `COG_CA_CERT`
+
+Injects a custom CA certificate into the Docker image during `cog build`. This is useful when building behind a corporate proxy or VPN that uses custom certificate authorities (e.g. Cloudflare WARP).
+
+**Supported values:**
+
+| Value                            | Description                                                 |
+| -------------------------------- | ----------------------------------------------------------- |
+| `/path/to/cert.crt`              | Path to a single PEM certificate file                       |
+| `/path/to/certs/`                | Directory of `.crt` and `.pem` files (all are concatenated) |
+| `-----BEGIN CERTIFICATE-----...` | Inline PEM certificate                                      |
+| `LS0tLS1CRUdJTi...`              | Base64-encoded PEM certificate                              |
+
+The certificate is installed into the system CA store and the `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` environment variables are set automatically in the built image.
+
+**Examples:**
+
+```console
+# From a file
+$ COG_CA_CERT=/usr/local/share/ca-certificates/corporate-ca.crt cog build
+
+# From a directory of certs
+$ COG_CA_CERT=/etc/custom-certs/ cog build
+
+# Inline (e.g. from a CI secret)
+$ COG_CA_CERT="$(cat /path/to/cert.pem)" cog build
+```

--- a/docs/reference/http.md
+++ b/docs/reference/http.md
@@ -1,0 +1,440 @@
+# HTTP API
+
+When you run a Docker image built by Cog,
+it serves an HTTP API for making predictions.
+
+The server supports both synchronous and asynchronous prediction creation:
+
+- **Synchronous**:
+  The server waits until the prediction is completed
+  and responds with the result.
+- **Asynchronous**:
+  The server immediately returns a response
+  and processes the prediction in the background.
+
+The client can create a prediction asynchronously
+by setting the `Prefer: respond-async` header in their request.
+When provided, the server responds immediately after starting the prediction
+with `202 Accepted` status and a prediction object in status `processing`.
+
+> [!NOTE]
+> The only supported way to receive updates on the status of predictions
+> started asynchronously is using [webhooks](#webhooks).
+> Polling for prediction status is not currently supported.
+
+You can also use certain server endpoints to create predictions idempotently,
+such that if a client calls this endpoint more than once with the same ID
+(for example, due to a network interruption)
+while the prediction is still running,
+no new prediction is created.
+Instead, the client receives a `202 Accepted` response
+with the initial state of the prediction.
+
+---
+
+Here's a summary of the prediction creation endpoints:
+
+| Endpoint                           | Header                  | Behavior                     |
+| ---------------------------------- | ----------------------- | ---------------------------- |
+| `POST /predictions`                | -                       | Synchronous, non-idempotent  |
+| `POST /predictions`                | `Prefer: respond-async` | Asynchronous, non-idempotent |
+| `PUT /predictions/<prediction_id>` | -                       | Synchronous, idempotent      |
+| `PUT /predictions/<prediction_id>` | `Prefer: respond-async` | Asynchronous, idempotent     |
+
+## Webhooks
+
+You can provide a `webhook` parameter in the client request body
+when creating a prediction.
+
+```http
+POST /predictions HTTP/1.1
+Content-Type: application/json; charset=utf-8
+Prefer: respond-async
+
+{
+    "input": {"prompt": "A picture of an onion with sunglasses"},
+    "webhook": "https://example.com/webhook/prediction"
+}
+```
+
+The server makes requests to the provided URL
+with the current state of the prediction object in the request body
+at the following times.
+
+- `start`:
+  Once, when the prediction starts
+  (`status` is `starting`).
+- `output`:
+  Each time a predict function generates an output
+  (either once using `return` or multiple times using `yield`)
+- `logs`:
+  Each time the predict function writes to `stdout`
+- `completed`:
+  Once, when the prediction reaches a terminal state
+  (`status` is `succeeded`, `canceled`, or `failed`)
+
+Webhook requests for `start` and `completed` event types
+are sent immediately.
+Webhook requests for `output` and `logs` event types
+are sent at most once every 500ms.
+This interval is not configurable.
+
+By default, the server sends requests for all event types.
+Clients can specify which events trigger webhook requests
+with the `webhook_events_filter` parameter in the prediction request body.
+For example,
+the following request specifies that webhooks are sent by the server
+only at the start and end of the prediction:
+
+```http
+POST /predictions HTTP/1.1
+Content-Type: application/json; charset=utf-8
+Prefer: respond-async
+
+{
+    "input": {"prompt": "A picture of an onion with sunglasses"},
+    "webhook": "https://example.com/webhook/prediction",
+    "webhook_events_filter": ["start", "completed"]
+}
+```
+
+For a practical guide to deploying models with webhooks, see [How to deploy models](../how-to/deploy.md).
+
+## Generating unique prediction IDs
+
+Endpoints for creating and canceling a prediction idempotently
+accept a `prediction_id` parameter in their path.
+By default, the server runs one prediction at a time,
+but this can be increased with the [`concurrency.max`](yaml.md#concurrency) setting.
+When all prediction slots are in use, the server returns `409 Conflict`.
+The client should ensure prediction slots are available
+before creating a new prediction with a different ID.
+
+Clients are responsible for providing unique prediction IDs.
+We recommend generating a UUIDv4 or [UUIDv7](https://uuid7.com),
+base32-encoding that value,
+and removing padding characters (`==`).
+This produces a random identifier that is 26 ASCII characters long.
+
+```python
+>> from uuid import uuid4
+>> from base64 import b32encode
+>> b32encode(uuid4().bytes).decode('utf-8').lower().rstrip('=')
+'wjx3whax6rf4vphkegkhcvpv6a'
+```
+
+## File uploads
+
+A model's `predict` function can produce file output by yielding or returning
+a `cog.Path` or `cog.File` value.
+
+By default,
+files are returned as a base64-encoded
+[data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
+
+```http
+POST /predictions HTTP/1.1
+Content-Type: application/json; charset=utf-8
+
+{
+    "input": {"prompt": "A picture of an onion with sunglasses"},
+}
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "status": "succeeded",
+    "output": "data:image/png;base64,..."
+}
+```
+
+When creating a prediction synchronously,
+the client can configure a base URL to upload output files to instead
+by setting the `output_file_prefix` parameter in the request body:
+
+```http
+POST /predictions HTTP/1.1
+Content-Type: application/json; charset=utf-8
+
+{
+    "input": {"prompt": "A picture of an onion with sunglasses"},
+    "output_file_prefix": "https://example.com/upload",
+}
+```
+
+When the model produces a file output,
+the server sends the following request to upload the file to the configured URL:
+
+```http
+PUT /upload HTTP/1.1
+Host: example.com
+Content-Type: multipart/form-data
+
+--boundary
+Content-Disposition: form-data; name="file"; filename="image.png"
+Content-Type: image/png
+
+<binary data>
+--boundary--
+```
+
+If the upload succeeds, the server responds with output:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "status": "succeeded",
+    "output": "http://example.com/upload/image.png"
+}
+```
+
+If the upload fails, the server responds with an error.
+
+> [!IMPORTANT]
+> File uploads for predictions created asynchronously
+> require `--upload-url` to be specified when starting the HTTP server.
+
+For a practical guide to working with file inputs and outputs, see [How to handle file I/O](../how-to/file-io.md).
+
+<a id="api"></a>
+
+## Endpoints
+
+### `GET /`
+
+Returns a discovery document listing available API endpoints, the OpenAPI schema URL, and version information.
+
+```http
+GET / HTTP/1.1
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "cog_version": "0.17.0",
+    "docs_url": "/openapi.json",
+    "openapi_url": "/openapi.json",
+    "predictions_url": "/predictions",
+    "health_check_url": "/health-check"
+}
+```
+
+If training is configured, the response also includes a `trainings_url` field.
+
+### `GET /health-check`
+
+Returns the current health status of the model container.
+This endpoint always responds with `200 OK` --
+check the `status` field in the response body to determine readiness.
+
+The response body is a JSON object with the following fields:
+
+- `status`: One of the following values:
+  - `STARTING`: The model's `setup()` method is still running.
+  - `READY`: The model is ready to accept predictions.
+  - `BUSY`: The model is ready but all prediction slots are in use.
+  - `SETUP_FAILED`: The model's `setup()` method raised an exception.
+  - `DEFUNCT`: The model encountered an unrecoverable error.
+  - `UNHEALTHY`: The model is ready
+    but a user-defined `healthcheck()` method returned `False`.
+- `setup`: Setup phase details (included once setup has started):
+  - `started_at`: ISO 8601 timestamp of when setup began.
+  - `completed_at`: ISO 8601 timestamp of when setup finished (if complete).
+  - `status`: One of `starting`, `succeeded`, or `failed`.
+  - `logs`: Output captured during setup.
+- `version`: Runtime version information:
+  - `coglet`: Coglet version.
+  - `cog`: Cog Python SDK version (if available).
+  - `python`: Python version (if available).
+- `user_healthcheck_error`:
+  Error message from a user-defined `healthcheck()` method (if applicable).
+
+```http
+GET /health-check HTTP/1.1
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "status": "READY",
+    "setup": {
+        "started_at": "2025-01-01T00:00:00.000000+00:00",
+        "completed_at": "2025-01-01T00:00:05.000000+00:00",
+        "status": "succeeded",
+        "logs": ""
+    },
+    "version": {
+        "coglet": "0.17.0",
+        "cog": "0.14.0",
+        "python": "3.13.0"
+    }
+}
+```
+
+### `GET /openapi.json`
+
+The [OpenAPI](https://swagger.io/specification/) specification of the API,
+which is derived from the input and output types specified in your model's
+[Predictor](python.md) and [Training](training.md) objects.
+
+### `POST /predictions`
+
+Makes a single prediction.
+
+The request body is a JSON object with the following fields:
+
+- `input`:
+  A JSON object with the same keys as the
+  [arguments to the `predict()` function](python.md).
+  Any `File` or `Path` inputs are passed as URLs.
+
+The response body is a JSON object with the following fields:
+
+- `status`: Either `succeeded` or `failed`.
+- `output`: The return value of the `predict()` function.
+- `error`: If `status` is `failed`, the error message.
+- `metrics`: An object containing prediction metrics.
+  Always includes `predict_time` (elapsed seconds).
+  May also include custom metrics recorded by the model
+  using [`self.record_metric()`](python.md#metrics).
+
+```http
+POST /predictions HTTP/1.1
+Content-Type: application/json; charset=utf-8
+
+{
+    "input": {
+        "image": "https://example.com/image.jpg",
+        "text": "Hello world!"
+    }
+}
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "status": "succeeded",
+    "output": "data:image/png;base64,...",
+    "metrics": {
+        "predict_time": 4.52
+    }
+}
+```
+
+If the client sets the `Prefer: respond-async` header in their request,
+the server responds immediately after starting the prediction
+with `202 Accepted` status and a prediction object in status `processing`.
+
+```http
+POST /predictions HTTP/1.1
+Content-Type: application/json; charset=utf-8
+Prefer: respond-async
+
+{
+    "input": {"prompt": "A picture of an onion with sunglasses"}
+}
+```
+
+```http
+HTTP/1.1 202 Accepted
+Content-Type: application/json
+
+{
+    "status": "starting",
+}
+```
+
+### `PUT /predictions/<prediction_id>`
+
+Make a single prediction.
+This is the idempotent version of the `POST /predictions` endpoint.
+
+```http
+PUT /predictions/wjx3whax6rf4vphkegkhcvpv6a HTTP/1.1
+Content-Type: application/json; charset=utf-8
+
+{
+    "input": {"prompt": "A picture of an onion with sunglasses"}
+}
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "status": "succeeded",
+    "output": "data:image/png;base64,..."
+}
+```
+
+If the client sets the `Prefer: respond-async` header in their request,
+the server responds immediately after starting the prediction
+with `202 Accepted` status and a prediction object in status `processing`.
+
+```http
+PUT /predictions/wjx3whax6rf4vphkegkhcvpv6a HTTP/1.1
+Content-Type: application/json; charset=utf-8
+Prefer: respond-async
+
+{
+    "input": {"prompt": "A picture of an onion with sunglasses"}
+}
+```
+
+```http
+HTTP/1.1 202 Accepted
+Content-Type: application/json
+
+{
+    "id": "wjx3whax6rf4vphkegkhcvpv6a",
+    "status": "starting"
+}
+```
+
+### `POST /predictions/<prediction_id>/cancel`
+
+Cancels an asynchronous prediction by prediction ID.
+
+If a prediction exists with the provided `id`,
+the server responds with status `200 OK`.
+Otherwise, the server responds with status `404 Not Found`.
+
+A prediction cannot be canceled if it was
+created synchronously (without the `Prefer: respond-async` header)
+or created without a provided `id`.
+
+```http
+POST /predictions/abcd1234/cancel HTTP/1.1
+```
+
+When a prediction is canceled,
+Cog raises [`CancelationException`](python.md#cancelationexception)
+in sync predictors (or `asyncio.CancelledError` in async predictors).
+This exception may be caught by the model to perform necessary cleanup.
+The cleanup should be brief, ideally completing within a few seconds.
+After cleanup, the exception must be re-raised using a bare `raise` statement.
+Failure to re-raise the exception may result in the termination of the container.
+
+```python
+from cog import BasePredictor, CancelationException, Input, Path
+
+class Predictor(BasePredictor):
+    def predict(self, image: Path = Input(description="Image to process")) -> Path:
+        try:
+            return self.process(image)
+        except CancelationException:
+            self.cleanup()
+            raise  # always re-raise
+```

--- a/docs/reference/python.md
+++ b/docs/reference/python.md
@@ -1,0 +1,500 @@
+# Prediction interface reference
+
+This document defines the API of the `cog` Python module, which is used to define the interface for running predictions on your model.
+
+## Contents
+
+- [Contents](#contents)
+- [`BasePredictor`](#basepredictor)
+  - [`Predictor.setup()`](#predictorsetup)
+  - [`Predictor.predict(**kwargs)`](#predictorpredictkwargs)
+- [`async` predictors and concurrency](#async-predictors-and-concurrency)
+- [`Input(**kwargs)`](#inputkwargs)
+  - [Deprecating inputs](#deprecating-inputs)
+- [Output](#output)
+  - [Returning an object](#returning-an-object)
+  - [Returning a list](#returning-a-list)
+  - [Optional properties](#optional-properties)
+  - [Streaming output](#streaming-output)
+- [Metrics](#metrics)
+  - [Recording metrics](#recording-metrics)
+  - [Accumulation modes](#accumulation-modes)
+  - [Dot-path keys](#dot-path-keys)
+  - [Type safety](#type-safety)
+- [Cancellation](#cancellation)
+  - [`CancelationException`](#cancelationexception)
+- [Input and output types](#input-and-output-types)
+- [`File()`](#file)
+- [`Path()`](#path)
+- [`Secret`](#secret)
+- [`Optional`](#optional)
+- [`List`](#list)
+
+## `BasePredictor`
+
+A class that defines how Cog runs predictions on your model. Subclass `BasePredictor` and implement `setup()` and `predict()`:
+
+```python
+from cog import BasePredictor, Path, Input
+import torch
+
+class Predictor(BasePredictor):
+    def setup(self):
+        """Load the model into memory to make running multiple predictions efficient"""
+        self.model = torch.load("weights.pth")
+
+    def predict(self,
+            image: Path = Input(description="Image to enlarge"),
+            scale: float = Input(description="Factor to scale image by", default=1.5)
+    ) -> Path:
+        """Run a single prediction on the model"""
+        # ... pre-processing ...
+        output = self.model(image)
+        # ... post-processing ...
+        return output
+```
+
+### `Predictor.setup()`
+
+Optional method. Runs once when the model container starts. Use it for expensive one-off operations such as loading trained models or instantiating data transformations.
+
+Models may download weights in `setup()` (e.g. using [`pget`](https://github.com/replicate/pget)) or store weights directly in the image. See [cog.yaml `build` reference](yaml.md#build) for image configuration options.
+
+### `Predictor.predict(**kwargs)`
+
+Required method. Runs a single prediction.
+
+Takes an arbitrary list of named arguments, where each argument name must correspond to an [`Input()`](#inputkwargs) annotation.
+
+Returns strings, numbers, [`cog.Path`](#path) objects representing files on disk, or lists or dicts of those types. You can also define a custom [`Output()`](#output) for complex return types.
+
+## `async` predictors and concurrency
+
+> Added in cog 0.14.0.
+
+The `predict()` method may be declared as `async def predict(...)`. When async, `setup()` may also be async:
+
+```py
+class Predictor(BasePredictor):
+    async def setup(self) -> None:
+        ...
+
+    async def predict(self) -> str:
+        return "hello world"
+```
+
+Models with an async `predict()` function can run predictions concurrently, up to the limit specified by [`concurrency.max`](yaml.md#max) in `cog.yaml`. Exceeding this limit returns a `409 Conflict` response.
+
+For a practical guide to concurrency, see [How to configure concurrency](../how-to/concurrency.md).
+
+## `Input(**kwargs)`
+
+Defines a parameter for the `predict()` method:
+
+```py
+class Predictor(BasePredictor):
+    def predict(self,
+            image: Path = Input(description="Image to enlarge"),
+            scale: float = Input(description="Factor to scale image by", default=1.5, ge=1.0, le=10.0)
+    ) -> Path:
+```
+
+The `Input()` function takes these keyword arguments:
+
+- `description`: A description of what to pass to this input for users of the model.
+- `default`: A default value to set the input to. If this argument is not passed, the input is required. If it is explicitly set to `None`, the input is optional.
+- `ge`: For `int` or `float` types, the value must be greater than or equal to this number.
+- `le`: For `int` or `float` types, the value must be less than or equal to this number.
+- `min_length`: For `str` types, the minimum length of the string.
+- `max_length`: For `str` types, the maximum length of the string.
+- `regex`: For `str` types, the string must match this regular expression.
+- `choices`: For `str` or `int` types, a list of possible values for this input.
+- `deprecated`: (optional) If set to `True`, marks this input as deprecated. Deprecated inputs will still be accepted, but tools and UIs may warn users that the input is deprecated and may be removed in the future. See [Deprecating inputs](#deprecating-inputs).
+
+Each parameter of the `predict()` method must be annotated with a type like `str`, `int`, `float`, `bool`, etc. See [Input and output types](#input-and-output-types) for the full list of supported types.
+
+Using the `Input` function provides better documentation and validation constraints to the users of your model, but it is not strictly required. Default values may be specified using plain Python:
+
+```py
+class Predictor(BasePredictor):
+    def predict(self,
+        prompt: str = "default prompt", # this is valid
+        iterations: int                 # also valid
+    ) -> str:
+        # ...
+```
+
+## Deprecating inputs
+
+Mark an input as deprecated by passing `deprecated=True` to the `Input()` function. Deprecated inputs are still accepted, but tools and UIs may warn users that the input may be removed in a future version.
+
+```py
+from cog import BasePredictor, Input
+
+class Predictor(BasePredictor):
+    def predict(self,
+        text: str = Input(description="Some deprecated text", deprecated=True),
+        prompt: str = Input(description="Prompt for the model")
+    ) -> str:
+        return prompt
+```
+
+## Output
+
+Cog predictors can return a simple data type like a string, number, float, or boolean. Use Python's `-> <type>` syntax to annotate the return type.
+
+```py
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self) -> str:
+        return "hello"
+```
+
+### Returning an object
+
+To return a complex object with multiple values, define an `Output` object with multiple fields:
+
+```py
+from cog import BasePredictor, BaseModel, File
+
+class Output(BaseModel):
+    file: File
+    text: str
+
+class Predictor(BasePredictor):
+    def predict(self) -> Output:
+        return Output(text="hello", file=io.StringIO("hello"))
+```
+
+Each of the output object's properties must be one of the supported output types. See [Input and output types](#input-and-output-types). The output class must be named `Output`.
+
+### Returning a list
+
+The `predict()` method can return a list of any supported output type:
+
+```py
+from cog import BasePredictor, Path
+
+class Predictor(BasePredictor):
+    def predict(self) -> list[Path]:
+        predictions = ["foo", "bar", "baz"]
+        output = []
+        for i, prediction in enumerate(predictions):
+            out_path = Path(f"/tmp/out-{i}.txt")
+            with out_path.open("w") as f:
+                f.write(prediction)
+            output.append(out_path)
+        return output
+```
+
+Files are named in the format `output.<index>.<extension>`, e.g. `output.0.txt`, `output.1.txt`, `output.2.txt`.
+
+### Optional properties
+
+To conditionally omit properties from the Output object, define them using `typing.Optional`:
+
+```py
+from cog import BaseModel, BasePredictor, Path
+from typing import Optional
+
+class Output(BaseModel):
+    score: Optional[float]
+    file: Optional[Path]
+
+class Predictor(BasePredictor):
+    def predict(self) -> Output:
+        if condition:
+            return Output(score=1.5)
+        else:
+            return Output(file=io.StringIO("hello"))
+```
+
+### Streaming output
+
+Cog models can stream output as `predict()` runs. The return type annotation takes the form `-> Iterator[<type>]` where `<type>` can be `str`, `int`, `float`, `bool`, or `cog.Path`. Use `yield` to emit each chunk.
+
+| Predictor type | Return type | Iterator type |
+|----------------|-------------|---------------|
+| Sync | `Iterator[T]` | `typing.Iterator` |
+| Async | `AsyncIterator[T]` | `cog.AsyncIterator` |
+| Sync (concatenated text) | `ConcatenateIterator[str]` | `cog.ConcatenateIterator` |
+| Async (concatenated text) | `AsyncConcatenateIterator[str]` | `cog.AsyncConcatenateIterator` |
+
+`ConcatenateIterator` and `AsyncConcatenateIterator` hint that output chunks should be concatenated into a single string.
+
+```py
+from cog import BasePredictor, ConcatenateIterator
+
+class Predictor(BasePredictor):
+    def predict(self) -> ConcatenateIterator[str]:
+        for token in ["The", "quick", "brown", "fox"]:
+            yield token + " "
+```
+
+For a practical guide to streaming, see [How to stream output](../how-to/streaming.md).
+
+## Metrics
+
+Custom metrics can be recorded from `predict()` to track model-specific data like token counts, timing breakdowns, or confidence scores. Metrics are included in the prediction response.
+
+### Recording metrics
+
+Use `self.record_metric()` inside `predict()`:
+
+```python
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, prompt: str) -> str:
+        self.record_metric("temperature", 0.7)
+        self.record_metric("token_count", 42)
+
+        result = self.model.generate(prompt)
+        return result
+```
+
+For dict-style access, use `self.scope`:
+
+```python
+self.scope.metrics["token_count"] = 42
+del self.scope.metrics["token_count"]
+```
+
+Metrics appear in the prediction response `metrics` field:
+
+```json
+{
+  "status": "succeeded",
+  "output": "...",
+  "metrics": {
+    "temperature": 0.7,
+    "token_count": 42,
+    "predict_time": 1.23
+  }
+}
+```
+
+The `predict_time` metric is always added automatically by the runtime. If you set `predict_time` yourself, the runtime value takes precedence.
+
+Supported value types are `bool`, `int`, `float`, `str`, `list`, and `dict`. Setting a metric to `None` deletes it.
+
+### Accumulation modes
+
+By default, recording a metric replaces any previous value for that key. The `mode` parameter accepts `"replace"` (default), `"incr"`, or `"append"`:
+
+```python
+# Increment a counter (adds to existing numeric value)
+self.record_metric("token_count", 1, mode="incr")
+self.record_metric("token_count", 1, mode="incr")
+# Result: {"token_count": 2}
+
+# Append to an array
+self.record_metric("steps", "preprocessing", mode="append")
+self.record_metric("steps", "inference", mode="append")
+# Result: {"steps": ["preprocessing", "inference"]}
+
+# Replace (default)
+self.record_metric("status", "running", mode="replace")
+self.record_metric("status", "done", mode="replace")
+# Result: {"status": "done"}
+```
+
+### Dot-path keys
+
+Use dot-separated keys to create nested objects in the metrics output:
+
+```python
+self.record_metric("timing.preprocess", 0.12)
+self.record_metric("timing.inference", 0.85)
+```
+
+Produces:
+
+```json
+{
+  "metrics": {
+    "timing": {
+      "preprocess": 0.12,
+      "inference": 0.85
+    },
+    "predict_time": 1.23
+  }
+}
+```
+
+### Type safety
+
+Once a metric key has been assigned a value of a certain type, it cannot be changed to a different type without deleting it first:
+
+```python
+self.record_metric("count", 1)
+
+# This would raise an error -- "count" is an int, not a string:
+# self.record_metric("count", "oops")
+
+# Delete first, then set with new type:
+del self.scope.metrics["count"]
+self.record_metric("count", "now a string")
+```
+
+Outside an active prediction, `self.record_metric()` and `self.scope` are silent no-ops.
+
+## Cancellation
+
+When a prediction is canceled (via the [cancel HTTP endpoint](http.md#post-predictionsprediction_idcancel) or a dropped connection), the Cog runtime interrupts the running `predict()` function. The exception raised depends on the predictor type:
+
+| Predictor type              | Exception raised         |
+| --------------------------- | ------------------------ |
+| Sync (`def predict`)        | `CancelationException`   |
+| Async (`async def predict`) | `asyncio.CancelledError` |
+
+### `CancelationException`
+
+```python
+from cog import CancelationException
+```
+
+`CancelationException` is raised in **sync** predictors when a prediction is cancelled. It is a `BaseException` subclass (not an `Exception` subclass), meaning bare `except Exception` blocks will not catch it -- matching the behavior of `KeyboardInterrupt` and `asyncio.CancelledError`.
+
+The runtime manages cancellation automatically. If cleanup logic is needed on cancellation, catch and re-raise:
+
+```python
+from cog import BasePredictor, CancelationException, Path
+
+class Predictor(BasePredictor):
+    def predict(self, image: Path) -> Path:
+        try:
+            return self.process(image)
+        except CancelationException:
+            self.cleanup()
+            raise  # always re-raise
+```
+
+> [!WARNING]
+> You **must** re-raise `CancelationException` after cleanup. Swallowing it will prevent the runtime from marking the prediction as canceled, and may result in the termination of the container.
+
+`CancelationException` is available as:
+
+- `cog.CancelationException` (recommended)
+- `cog.exceptions.CancelationException`
+
+For **async** predictors, cancellation follows standard Python async conventions and raises `asyncio.CancelledError` instead.
+
+## Input and output types
+
+Each parameter of the `predict()` method must be annotated with a type. The method's return type must also be annotated. The supported types are:
+
+- `str`: a string
+- `int`: an integer
+- `float`: a floating point number
+- `bool`: a boolean
+- [`cog.File`](#file): a file-like object representing a file
+- [`cog.Path`](#path): a path to a file on disk
+- [`cog.Secret`](#secret): a string containing sensitive information
+
+## `File()`
+
+> [!WARNING]
+> `cog.File` is deprecated and will be removed in a future version of Cog. Use [`cog.Path`](#path) instead.
+
+The `cog.File` object is used to get files in and out of models. It represents a _file handle_.
+
+For models that return a `cog.File` object, the prediction output returned by Cog's built-in HTTP server will be a URL.
+
+```python
+from cog import BasePredictor, File, Input, Path
+from PIL import Image
+
+class Predictor(BasePredictor):
+    def predict(self, source_image: File = Input(description="Image to enlarge")) -> File:
+        pillow_img = Image.open(source_image)
+        upscaled_image = do_some_processing(pillow_img)
+        return File(upscaled_image)
+```
+
+## `Path()`
+
+The `cog.Path` object is used to get files in and out of models. It represents a _path to a file on disk_.
+
+`cog.Path` is a subclass of Python's [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#basic-use) and can be used as a drop-in replacement.
+
+For models that return a `cog.Path` object, the prediction output returned by Cog's built-in HTTP server will be a URL.
+
+```python
+import tempfile
+from cog import BasePredictor, Input, Path
+
+class Predictor(BasePredictor):
+    def predict(self, image: Path = Input(description="Image to enlarge")) -> Path:
+        upscaled_image = do_some_processing(image)
+        output_path = Path(tempfile.mkdtemp()) / "upscaled.png"
+        upscaled_image.save(output_path)
+        return Path(output_path)
+```
+
+## `Secret`
+
+The `cog.Secret` type signifies that an input holds sensitive information, like a password or API token.
+
+`cog.Secret` redacts its contents in string representations to prevent accidental disclosure. Access the value with `get_secret_value()`.
+
+```python
+from cog import BasePredictor, Secret
+
+class Predictor(BasePredictor):
+    def predict(self, api_token: Secret) -> None:
+        print(api_token)                    # Prints '**********'
+        print(api_token.get_secret_value()) # Prints the actual value
+```
+
+OpenAPI schema representation:
+
+```json
+{
+  "type": "string",
+  "format": "password",
+  "x-cog-secret": true
+}
+```
+
+Models uploaded to Replicate treat secret inputs differently: any value passed to a `Secret` input is redacted after being sent to the model.
+
+> [!WARNING]
+> Passing secret values to untrusted models can result in
+> unintended disclosure, exfiltration, or misuse of sensitive data.
+
+## `Optional`
+
+Optional inputs should be explicitly defined as `Optional[T]` so that type checkers can warn about error-prone `None` values.
+
+```python
+class Predictor(BasePredictor):
+    def predict(self, prompt: Optional[str]=Input(description="prompt")) -> str:
+        if prompt is None:
+            return "hello"
+        else:
+            return "hello" + prompt
+```
+
+Note: `default=None` is redundant when using `Optional`, as `Optional` implies it. The error-prone usage of `prompt: str=Input(default=None)` may raise an error in a future release of Cog.
+
+## `List`
+
+The List type is supported in inputs. It can hold any supported type.
+
+```py
+class Predictor(BasePredictor):
+   def predict(self, paths: list[Path]) -> str:
+       output_parts = []
+       for path in paths:
+           with open(path) as f:
+             output_parts.append(f.read())
+       return "".join(output_parts)
+```
+
+Multiple values for a list input are passed by repeating the input name:
+
+```bash
+$ cog predict -i paths=@1.txt -i paths=@2.txt
+```

--- a/docs/reference/training.md
+++ b/docs/reference/training.md
@@ -1,0 +1,121 @@
+# Training API reference
+
+> [!WARNING]
+> The `cog train` command is deprecated and will be removed in the next version of Cog. The training API described below may still be used with the HTTP API's `/trainings` endpoint, but the CLI command is no longer recommended for new projects.
+
+Cog's training API defines a fine-tuning interface for an existing Cog model. Users of the model can bring their own training data to create derivative fine-tuned models.
+
+For a practical guide to fine-tuning, see [How to fine-tune with the training API](../how-to/training.md).
+
+## `cog.yaml` configuration
+
+The `train` key in `cog.yaml` points to the training entry point:
+
+```yaml
+build:
+  python_version: "3.13"
+train: "train.py:train"
+```
+
+The value follows the same `module:object` format as the [`predict`](yaml.md#predict) key. It can point to either a [function](#train-function) or a [class](#trainer-class).
+
+## `train()` function
+
+A standalone function that accepts typed inputs and returns a training output.
+
+```python
+from cog import File
+import io
+
+def train(param: str) -> File:
+    return io.StringIO("hello " + param)
+```
+
+**Signature:** `def train(**kwargs) -> <output_type>`
+
+Each parameter must be annotated with a type and may use [`Input()`](#inputkwargs) for validation. The return type must be annotated. See [Training output](#training-output) for supported return types.
+
+## `Trainer` class
+
+A class-based entry point that separates one-off setup from the training function. This is useful when running many training jobs that share expensive initialization.
+
+```python
+from cog import File
+
+class Trainer:
+    def setup(self) -> None:
+        self.base_model = ...  # Load a big base model
+
+    def train(self, param: str) -> File:
+        return self.base_model.train(param)
+```
+
+**Methods:**
+
+- `setup(self) -> None` -- Optional. Runs once when the container starts. Use for expensive one-off operations such as loading base models.
+- `train(self, **kwargs) -> <output_type>` -- Required. Runs a single training job. Parameters and return type follow the same rules as the [standalone `train()` function](#train-function).
+
+## `Input(**kwargs)`
+
+Defines a parameter for the `train()` function. The interface is identical to the [prediction `Input()`](python.md#inputkwargs).
+
+```py
+from cog import Input, Path
+
+def train(
+    train_data: Path = Input(description="HTTPS URL of a file containing training data"),
+    learning_rate: float = Input(description="learning rate", default=1e-4, ge=0),
+    seed: int = Input(description="random seed to use for training", default=None)
+) -> str:
+    return "hello, weights"
+```
+
+**Keyword arguments:**
+
+- `description`: A description of what to pass to this input.
+- `default`: A default value. If not passed, the input is required. If explicitly `None`, the input is optional.
+- `ge`: For `int` or `float` types, minimum value (inclusive).
+- `le`: For `int` or `float` types, maximum value (inclusive).
+- `min_length`: For `str` types, the minimum length.
+- `max_length`: For `str` types, the maximum length.
+- `regex`: For `str` types, a regular expression the value must match.
+- `choices`: For `str` or `int` types, a list of allowed values.
+
+Each parameter must be annotated with a type. See [Input and output types](python.md#input-and-output-types) for the full list of supported types.
+
+Default values may also be specified using plain Python without `Input()`.
+
+## Training output
+
+The `train()` function's return type defines the training output.
+
+**Simple return types:** The function may return any supported type directly (`str`, `int`, `float`, `bool`, `cog.Path`, `cog.File`).
+
+**Structured output:** For complex outputs (e.g. weights plus metadata), define a `TrainingOutput` class:
+
+```python
+from cog import BaseModel, Input, Path
+
+class TrainingOutput(BaseModel):
+    weights: Path
+
+def train(
+    train_data: Path = Input(description="HTTPS URL of a file containing training data"),
+    learning_rate: float = Input(description="learning rate", default=1e-4, ge=0),
+    seed: int = Input(description="random seed to use for training", default=42)
+) -> TrainingOutput:
+    weights_file = generate_weights("...")
+    return TrainingOutput(weights=Path(weights_file))
+```
+
+## HTTP endpoint
+
+Training is exposed via the `/trainings` endpoint on the HTTP API. The request and response format mirrors the [prediction endpoints](http.md#post-predictions), with `input` containing the training parameters and `output` containing the training result.
+
+## Testing
+
+To test a fine-tuned code path during development, specify a `COG_WEIGHTS` environment variable when running `predict`:
+
+```console
+cog predict -e COG_WEIGHTS=https://replicate.delivery/pbxt/xyz/weights.tar -i prompt="a photo of TOK"
+```

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -1,0 +1,238 @@
+# `cog.yaml` reference
+
+`cog.yaml` defines how to build a Docker image and how to run predictions on your model inside that image.
+
+It has three keys: [`build`](#build), [`image`](#image), and [`predict`](#predict). It looks a bit like this:
+
+```yaml
+build:
+  python_version: "3.13"
+  python_requirements: requirements.txt
+  system_packages:
+    - "ffmpeg"
+    - "git"
+predict: "predict.py:Predictor"
+```
+
+Tip: Run [`cog init`](../getting-started-own-model.md#initialization) to generate an annotated `cog.yaml` file that can be used as a starting point for setting up your model.
+
+## `build`
+
+This stanza describes how to build the Docker image your model runs in. It contains various options within it:
+
+<!-- Alphabetical order, please! -->
+
+### `cuda`
+
+Cog automatically picks the correct version of CUDA to install, but this lets you override it for whatever reason by specifying the minor (`11.8`) or patch (`11.8.0`) version of CUDA to use.
+
+For example:
+
+```yaml
+build:
+  cuda: "11.8"
+```
+
+### `gpu`
+
+Enable GPUs for this model. When enabled, the [nvidia-docker](https://github.com/NVIDIA/nvidia-docker) base image will be used, and Cog will automatically figure out what versions of CUDA and cuDNN to use based on the version of Python, PyTorch, and Tensorflow that you are using.
+
+For example:
+
+```yaml
+build:
+  gpu: true
+```
+
+When you use `cog run` or `cog predict`, Cog will automatically pass the `--gpus=all` flag to Docker. When you run a Docker image built with Cog, you'll need to pass this option to `docker run`.
+
+For a practical guide to GPU configuration, see [How to use GPUs](../how-to/gpu.md).
+
+### `python_requirements`
+
+A pip requirements file specifying the Python packages to install. For example:
+
+```yaml
+build:
+  python_requirements: requirements.txt
+```
+
+Your `cog.yaml` file can set either `python_packages` or `python_requirements`, but not both. Use `python_requirements` when you need to configure options like `--extra-index-url` or `--trusted-host` to fetch Python package dependencies.
+
+This follows the standard [requirements.txt](https://pip.pypa.io/en/stable/reference/requirements-file-format/) format.
+
+To install Git-hosted Python packages, add `git` to the `system_packages` list, then use the `git+https://` syntax to specify the package name. For example:
+
+`cog.yaml`:
+
+```yaml
+build:
+  system_packages:
+    - "git"
+  python_requirements: requirements.txt
+```
+
+`requirements.txt`:
+
+```
+git+https://github.com/huggingface/transformers
+```
+
+You can also pin Python package installations to a specific git commit:
+
+`cog.yaml`:
+
+```yaml
+build:
+  system_packages:
+    - "git"
+  python_requirements: requirements.txt
+```
+
+`requirements.txt`:
+
+```
+git+https://github.com/huggingface/transformers@2d1602a
+```
+
+Note that you can use a shortened prefix of the 40-character git commit SHA, but you must use at least six characters, like `2d1602a` above.
+
+### `python_packages`
+
+**DEPRECATED**: This will be removed in future versions, please use [python_requirements](#python_requirements) instead.
+
+A list of Python packages to install from the PyPi package index, in the format `package==version`. For example:
+
+```yaml
+build:
+  python_packages:
+    - pillow==8.3.1
+    - tensorflow==2.5.0
+```
+
+Your `cog.yaml` file can set either `python_packages` or `python_requirements`, but not both.
+
+### `python_version`
+
+The minor (`3.13`) or patch (`3.13.1`) version of Python to use. For example:
+
+```yaml
+build:
+  python_version: "3.13.1"
+```
+
+Cog supports Python 3.10, 3.11, 3.12, and 3.13. If you don't define a version, Cog will use the latest version of Python 3.13 or a version of Python that is compatible with the versions of PyTorch or TensorFlow you specify.
+
+Note that these are the versions supported **in the Docker container**, not your host machine. You can run any version(s) of Python you wish on your host machine.
+
+### `run`
+
+A list of setup commands to run in the environment after your system packages and Python packages have been installed. If you're familiar with Docker, it's like a `RUN` instruction in your `Dockerfile`.
+
+For example:
+
+```yaml
+build:
+  run:
+    - curl -L https://github.com/cowsay-org/cowsay/archive/refs/tags/v3.7.0.tar.gz | tar -xzf -
+    - cd cowsay-3.7.0 && make install
+```
+
+Your code is _not_ available to commands in `run`. This is so we can build your image efficiently when running locally.
+
+Each command in `run` can be either a string or a dictionary in the following format:
+
+```yaml
+build:
+  run:
+    - command: pip install
+      mounts:
+        - type: secret
+          id: pip
+          target: /etc/pip.conf
+```
+
+You can use secret mounts to securely pass credentials to setup commands, without baking them into the image. For more information, see [Dockerfile reference](https://docs.docker.com/engine/reference/builder/#run---mounttypesecret). For a practical guide to using secret mounts with private registries, see [How to use private registries](../how-to/private-registry.md).
+
+### `sdk_version`
+
+Pin the version of the cog Python SDK installed in the container. Accepts a [PEP 440](https://peps.python.org/pep-0440/) version string. When omitted, the latest release is installed.
+
+```yaml
+build:
+  python_version: "3.13"
+  sdk_version: "0.18.0"
+```
+
+Pre-release versions are also supported:
+
+```yaml
+build:
+  sdk_version: "0.18.0a1"
+```
+
+When a pre-release `sdk_version` is set, `--pre` is automatically passed to the pip install commands for both `cog` and `coglet`, so pip will resolve matching pre-release packages.
+
+The minimum supported version is `0.16.0`. Specifying an older version will cause `cog build` to fail with an error.
+
+The `COG_SDK_WHEEL` environment variable takes precedence over `sdk_version`. See [Environment variables](./environment.md) for details.
+
+### `system_packages`
+
+A list of Ubuntu APT packages to install. For example:
+
+```yaml
+build:
+  system_packages:
+    - "ffmpeg"
+    - "libavcodec-dev"
+```
+
+## `concurrency`
+
+> Added in cog 0.14.0.
+
+This stanza describes the concurrency capabilities of the model. It has one option:
+
+### `max`
+
+The maximum number of concurrent predictions the model can process. If this is set, the model must specify an [async `predict()` method](python.md#async-predictors-and-concurrency).
+
+For example:
+
+```yaml
+concurrency:
+  max: 10
+```
+
+For a practical guide to configuring concurrency, see [How to configure concurrency](../how-to/concurrency.md).
+
+## `image`
+
+The name given to built Docker images. If you want to push to a registry, this should also include the registry name.
+
+For example:
+
+```yaml
+image: "r8.im/your-username/your-model"
+```
+
+r8.im is Replicate's registry, but this can be any Docker registry.
+
+If you don't set this, then a name will be generated from the directory name.
+
+If you set this, then you can run `cog push` without specifying the model name.
+
+If you specify an image name argument when pushing (like `cog push your-username/custom-model-name`), the argument will be used and the value of `image` in cog.yaml will be ignored.
+
+## `predict`
+
+The pointer to the `Predictor` object in your code, which defines how predictions are run on your model.
+
+For example:
+
+```yaml
+predict: "predict.py:Predictor"
+```
+
+See [the Python API documentation for more information](python.md).

--- a/docs/training.md
+++ b/docs/training.md
@@ -1,7 +1,7 @@
 # Training interface reference
 
 > [!WARNING]  
-> The `cog train` command is deprecated and will be removed in a future version of Cog. The training API described below may still be used with the HTTP API's `/trainings` endpoint, but the CLI command is no longer recommended for new projects.
+> The `cog train` command is deprecated and will be removed in the next version of Cog. The training API described below may still be used with the HTTP API's `/trainings` endpoint, but the CLI command is no longer recommended for new projects.
 
 Cog's training API allows you to define a fine-tuning interface for an existing Cog model, so users of the model can bring their own training data to create derivative fine-tuned models. Real-world examples of this API in use include [fine-tuning SDXL with images](https://replicate.com/blog/fine-tune-sdxl) or [fine-tuning Llama 2 with structured text](https://replicate.com/blog/fine-tune-llama-2).
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -1,7 +1,7 @@
 # Training interface reference
 
-> [!NOTE]  
-> The training API is still experimental, and is subject to change.
+> [!WARNING]  
+> The `cog train` command is deprecated and will be removed in a future version of Cog. The training API described below may still be used with the HTTP API's `/trainings` endpoint, but the CLI command is no longer recommended for new projects.
 
 Cog's training API allows you to define a fine-tuning interface for an existing Cog model, so users of the model can bring their own training data to create derivative fine-tuned models. Real-world examples of this API in use include [fine-tuning SDXL with images](https://replicate.com/blog/fine-tune-sdxl) or [fine-tuning Llama 2 with structured text](https://replicate.com/blog/fine-tune-llama-2).
 
@@ -92,7 +92,7 @@ Each parameter of the `train()` function must be annotated with a type like `str
 Using the `Input` function provides better documentation and validation constraints to the users of your model, but it is not strictly required. You can also specify default values for your parameters using plain Python, or omit default assignment entirely:
 
 ```py
-def predict(self,
+def train(self,
   training_data: str = "foo bar", # this is valid
   iterations: int                 # also valid
 ) -> str:

--- a/docs/tutorials/deploy-local.md
+++ b/docs/tutorials/deploy-local.md
@@ -1,0 +1,288 @@
+# Build and deploy locally
+
+In this tutorial, we will take the model from [Package your first model](first-model.md), build it into a Docker image, run it as an HTTP server, and make predictions using curl. By the end, you will have a running prediction server that you can send requests to from any HTTP client.
+
+## Prerequisites
+
+Before starting, you should have:
+
+- Completed the [Package your first model](first-model.md) tutorial
+- The `cog-first-model` project directory with `cog.yaml` and `predict.py`
+- **Docker** running
+
+If you no longer have the project, create it now. Make a directory called `cog-first-model` and add these two files:
+
+`cog.yaml`:
+
+```yaml
+build:
+  python_version: "3.13"
+predict: "predict.py:Predictor"
+```
+
+`predict.py`:
+
+```python
+import tempfile
+from typing import Optional
+
+from cog import BasePredictor, Input, Path
+
+
+class Predictor(BasePredictor):
+    def setup(self):
+        """Load resources needed for predictions"""
+        self.substitutions = {
+            "hello": "greetings",
+            "world": "planet",
+            "goodbye": "farewell",
+            "friend": "companion",
+        }
+
+    def predict(
+        self,
+        text: str = Input(description="Text to transform", default=""),
+        text_file: Optional[Path] = Input(description="Text file to transform (used instead of text)", default=None),
+        repeat: int = Input(description="Number of times to repeat the output", default=1, ge=1, le=5),
+        uppercase: bool = Input(description="Convert output to uppercase", default=False),
+    ) -> Path:
+        if text_file is not None:
+            with open(text_file, "r") as f:
+                source_text = f.read().strip()
+        else:
+            source_text = text
+
+        words = source_text.lower().split()
+        result = " ".join(self.substitutions.get(word, word) for word in words)
+
+        if uppercase:
+            result = result.upper()
+
+        lines = [result] * repeat
+        output_text = "\n".join(lines)
+
+        output_path = Path(tempfile.mkdtemp()) / "output.txt"
+        with open(output_path, "w") as f:
+            f.write(output_text)
+
+        return output_path
+```
+
+## Build the Docker image
+
+From the `cog-first-model` directory, build the image:
+
+```bash
+cog build -t my-model
+```
+
+You will see build progress as Cog creates a Docker image with Python, the Cog runtime, and your model code. It ends with:
+
+```
+Built my-model:latest
+```
+
+Verify the image was created:
+
+```bash
+docker images my-model
+```
+
+You will see output like:
+
+```
+REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
+my-model     latest    abc123def456   5 seconds ago    1.2GB
+```
+
+## Start the prediction server
+
+Run the Docker image. It starts an HTTP server on port 5000:
+
+```bash
+docker run -d --rm -p 5000:5000 --name my-model my-model
+```
+
+The flags mean:
+
+- `-d` runs the container in the background
+- `--rm` removes the container when it stops
+- `-p 5000:5000` maps port 5000 on your machine to port 5000 in the container
+- `--name my-model` gives the container a name so we can refer to it later
+
+## Check the health endpoint
+
+Before sending predictions, verify the server is ready. The server exposes a health check endpoint:
+
+```bash
+curl http://localhost:5000/health-check
+```
+
+If the model is still loading, you will see:
+
+```json
+{
+  "status": "STARTING",
+  "setup": {
+    "started_at": "2025-01-15T10:00:00.000000+00:00",
+    "status": "starting",
+    "logs": ""
+  }
+}
+```
+
+Wait a moment and try again. When the model is ready, you will see:
+
+```json
+{
+  "status": "READY",
+  "setup": {
+    "started_at": "2025-01-15T10:00:00.000000+00:00",
+    "completed_at": "2025-01-15T10:00:01.000000+00:00",
+    "status": "succeeded",
+    "logs": ""
+  }
+}
+```
+
+Notice the `"status": "READY"` at the top. This means the `setup()` method has completed and the model is accepting predictions.
+
+## Make a prediction with curl
+
+Send a prediction request:
+
+```bash
+curl -s http://localhost:5000/predictions \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"input": {"text": "hello world"}}'
+```
+
+You will see a response like:
+
+```json
+{
+  "status": "succeeded",
+  "output": "data:text/plain;base64,Z3JlZXRpbmdzIHBsYW5ldA==",
+  "metrics": {
+    "predict_time": 0.001
+  }
+}
+```
+
+The response has three fields:
+
+- `status` tells you the prediction succeeded.
+- `output` contains the result. Because our model returns a file (via `cog.Path`), the output is a base64-encoded data URL. We will decode it in a moment.
+- `metrics` includes timing information. The `predict_time` value is how long the `predict()` method took in seconds.
+
+## Decode the file output
+
+The output is base64-encoded because our model returns a `cog.Path` (a file). To see the actual text, decode it:
+
+```bash
+curl -s http://localhost:5000/predictions \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"input": {"text": "hello world"}}' \
+  | python3 -c "
+import sys, json, base64
+resp = json.load(sys.stdin)
+data_url = resp['output']
+encoded = data_url.split(',', 1)[1]
+print(base64.b64decode(encoded).decode())
+"
+```
+
+You will see:
+
+```
+greetings planet
+```
+
+## Pass multiple inputs
+
+Send a request with all the input options:
+
+```bash
+curl -s http://localhost:5000/predictions \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"input": {"text": "hello world goodbye friend", "repeat": 3, "uppercase": true}}'
+```
+
+You will see a response with `"status": "succeeded"` and a base64-encoded output. The decoded content would be:
+
+```
+GREETINGS PLANET FAREWELL COMPANION
+GREETINGS PLANET FAREWELL COMPANION
+GREETINGS PLANET FAREWELL COMPANION
+```
+
+Notice that the input keys in the JSON (`text`, `repeat`, `uppercase`) match the parameter names in the `predict()` method exactly.
+
+## Explore the API schema
+
+The server generates an OpenAPI specification from your model's type annotations. Fetch it:
+
+```bash
+curl -s http://localhost:5000/openapi.json | python3 -m json.tool | head -20
+```
+
+You will see the beginning of the OpenAPI schema, which includes input descriptions, types, defaults, and constraints -- all generated from the `Input()` definitions in your `predict.py`. This schema can be used to auto-generate client libraries or documentation.
+
+You can also check the root endpoint to see available URLs:
+
+```bash
+curl -s http://localhost:5000/
+```
+
+You will see:
+
+```json
+{
+  "docs_url": "/openapi.json",
+  "openapi_url": "/openapi.json",
+  "predictions_url": "/predictions",
+  "health_check_url": "/health-check"
+}
+```
+
+## View the server logs
+
+To see what the server is doing, check the container logs:
+
+```bash
+docker logs my-model
+```
+
+You will see setup output, incoming request logs, and any output your model prints to stdout.
+
+## Stop the server
+
+When you are done, stop the container:
+
+```bash
+docker stop my-model
+```
+
+The container stops and is automatically removed (because of the `--rm` flag we used when starting it).
+
+## What you have built
+
+You have:
+
+1. Built a production Docker image with `cog build`
+2. Run the image as an HTTP prediction server with Docker
+3. Checked server readiness with the `/health-check` endpoint
+4. Made predictions using curl and the `/predictions` endpoint
+5. Inspected the auto-generated OpenAPI schema
+
+This is the same pattern used to deploy Cog models in production. The Docker image runs anywhere Docker does -- cloud VMs, Kubernetes clusters, or serverless platforms.
+
+## Next steps
+
+- [Deploying models](../deploy.md) -- deploy your model to Replicate or other platforms
+- [HTTP API reference](../http.md) -- full reference for the prediction server endpoints
+- [cog.yaml reference](../yaml.md) -- all environment configuration options
+- [Python SDK reference](../python.md) -- input types, output types, streaming, and more

--- a/docs/tutorials/first-model.md
+++ b/docs/tutorials/first-model.md
@@ -1,0 +1,388 @@
+# Package your first model
+
+In this tutorial, we will build a Cog model from scratch. Instead of using a pre-trained neural network, we will create a simple text processing model that takes text and transforms it. This keeps the focus on learning Cog's patterns -- `setup()`, `predict()`, typed inputs, and file outputs -- without waiting for large downloads.
+
+By the end, you will have a working Cog model that accepts text and configuration options, processes them, and returns results as files.
+
+## Prerequisites
+
+Before starting, you should have:
+
+- Completed the [quick start tutorial](quick-start.md)
+- **Cog** and **Docker** installed and working
+
+## Create the project
+
+Create a new directory for this tutorial:
+
+```bash
+mkdir cog-first-model
+cd cog-first-model
+```
+
+## Start with the simplest possible model
+
+We will build up the model step by step, running predictions at each stage so you can see the results.
+
+Create `cog.yaml`:
+
+```yaml
+build:
+  python_version: "3.13"
+predict: "predict.py:Predictor"
+```
+
+Notice there is no `python_requirements` line. This model has no external dependencies -- it uses only Python's standard library.
+
+Create `predict.py`:
+
+```python
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def predict(self, text: str) -> str:
+        return text.upper()
+```
+
+This is the simplest possible Cog model. It takes a string and returns it in uppercase. Run it:
+
+```bash
+cog predict -i text="hello world"
+```
+
+After the build completes, you will see:
+
+```
+HELLO WORLD
+```
+
+You have a working model. Now we will add structure to it, one piece at a time.
+
+## Add the setup method
+
+The `setup()` method runs once when the model loads. It is the right place for expensive one-time work like loading weights, initialising data structures, or reading configuration files.
+
+Update `predict.py`:
+
+```python
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def setup(self):
+        """Load resources needed for predictions"""
+        self.substitutions = {
+            "hello": "greetings",
+            "world": "planet",
+            "goodbye": "farewell",
+            "friend": "companion",
+        }
+
+    def predict(self, text: str) -> str:
+        words = text.lower().split()
+        result = [self.substitutions.get(word, word) for word in words]
+        return " ".join(result)
+```
+
+The `setup()` method builds a dictionary of word substitutions. The `predict()` method uses that dictionary to transform input text.
+
+Run it:
+
+```bash
+cog predict -i text="hello world"
+```
+
+You will see:
+
+```
+greetings planet
+```
+
+Try another input:
+
+```bash
+cog predict -i text="goodbye friend"
+```
+
+You will see:
+
+```
+farewell companion
+```
+
+Notice the pattern: `setup()` prepares resources, `predict()` uses them. In a real model, `setup()` would load model weights from disk and `predict()` would run inference. The structure is the same regardless of what the model does.
+
+## Add typed inputs with Input()
+
+So far, `predict()` takes a bare `text: str` argument. Cog's `Input()` function lets you add descriptions, defaults, and validation to each parameter. This makes your model self-documenting and generates better API schemas.
+
+Update `predict.py`:
+
+```python
+from cog import BasePredictor, Input
+
+
+class Predictor(BasePredictor):
+    def setup(self):
+        """Load resources needed for predictions"""
+        self.substitutions = {
+            "hello": "greetings",
+            "world": "planet",
+            "goodbye": "farewell",
+            "friend": "companion",
+        }
+
+    def predict(
+        self,
+        text: str = Input(description="Text to transform"),
+        repeat: int = Input(description="Number of times to repeat the output", default=1, ge=1, le=5),
+        uppercase: bool = Input(description="Convert output to uppercase", default=False),
+    ) -> str:
+        words = text.lower().split()
+        result = " ".join(self.substitutions.get(word, word) for word in words)
+
+        if uppercase:
+            result = result.upper()
+
+        lines = [result] * repeat
+        return "\n".join(lines)
+```
+
+We added two new inputs:
+
+- `repeat` is an integer with a default of `1`, constrained between 1 and 5 using `ge` (greater than or equal) and `le` (less than or equal).
+- `uppercase` is a boolean that defaults to `False`.
+
+Run a prediction with the defaults:
+
+```bash
+cog predict -i text="hello world"
+```
+
+You will see:
+
+```
+greetings planet
+```
+
+Now use the new inputs:
+
+```bash
+cog predict -i text="hello world" -i repeat=3 -i uppercase=true
+```
+
+You will see:
+
+```
+GREETINGS PLANET
+GREETINGS PLANET
+GREETINGS PLANET
+```
+
+Notice that `text` has no default, so it is required. The `repeat` and `uppercase` inputs have defaults, so they are optional.
+
+## Return a file with cog.Path
+
+Models often produce files as output -- images, audio, documents. Cog handles this with `cog.Path`. When your `predict()` method returns a `cog.Path`, Cog knows it is a file and handles it appropriately.
+
+Update `predict.py`:
+
+```python
+import tempfile
+
+from cog import BasePredictor, Input, Path
+
+
+class Predictor(BasePredictor):
+    def setup(self):
+        """Load resources needed for predictions"""
+        self.substitutions = {
+            "hello": "greetings",
+            "world": "planet",
+            "goodbye": "farewell",
+            "friend": "companion",
+        }
+
+    def predict(
+        self,
+        text: str = Input(description="Text to transform"),
+        repeat: int = Input(description="Number of times to repeat the output", default=1, ge=1, le=5),
+        uppercase: bool = Input(description="Convert output to uppercase", default=False),
+    ) -> Path:
+        words = text.lower().split()
+        result = " ".join(self.substitutions.get(word, word) for word in words)
+
+        if uppercase:
+            result = result.upper()
+
+        lines = [result] * repeat
+        output_text = "\n".join(lines)
+
+        output_path = Path(tempfile.mkdtemp()) / "output.txt"
+        with open(output_path, "w") as f:
+            f.write(output_text)
+
+        return output_path
+```
+
+Notice three changes:
+
+1. We import `Path` from `cog` (not `pathlib`).
+2. The return type changed from `-> str` to `-> Path`.
+3. We write the result to a temporary file and return the path.
+
+Run it:
+
+```bash
+cog predict -i text="hello world" -i repeat=2
+```
+
+You will see:
+
+```
+Written output to output.txt
+```
+
+Cog created the file `output.txt` in your current directory. Check its contents:
+
+```bash
+cat output.txt
+```
+
+You will see:
+
+```
+greetings planet
+greetings planet
+```
+
+When a model returns a `cog.Path`, Cog copies the file out of the container and saves it locally. When running as an HTTP server, the file is returned as a URL instead.
+
+## Accept a file as input
+
+Models that process files -- images, audio, documents -- accept `cog.Path` as an input type. Let us add a mode where the model reads text from a file instead of a string argument.
+
+Update `predict.py`:
+
+```python
+import tempfile
+from typing import Optional
+
+from cog import BasePredictor, Input, Path
+
+
+class Predictor(BasePredictor):
+    def setup(self):
+        """Load resources needed for predictions"""
+        self.substitutions = {
+            "hello": "greetings",
+            "world": "planet",
+            "goodbye": "farewell",
+            "friend": "companion",
+        }
+
+    def predict(
+        self,
+        text: str = Input(description="Text to transform", default=""),
+        text_file: Optional[Path] = Input(description="Text file to transform (used instead of text)", default=None),
+        repeat: int = Input(description="Number of times to repeat the output", default=1, ge=1, le=5),
+        uppercase: bool = Input(description="Convert output to uppercase", default=False),
+    ) -> Path:
+        if text_file is not None:
+            with open(text_file, "r") as f:
+                source_text = f.read().strip()
+        else:
+            source_text = text
+
+        words = source_text.lower().split()
+        result = " ".join(self.substitutions.get(word, word) for word in words)
+
+        if uppercase:
+            result = result.upper()
+
+        lines = [result] * repeat
+        output_text = "\n".join(lines)
+
+        output_path = Path(tempfile.mkdtemp()) / "output.txt"
+        with open(output_path, "w") as f:
+            f.write(output_text)
+
+        return output_path
+```
+
+Create a test input file:
+
+```bash
+echo "hello world goodbye friend" > input.txt
+```
+
+Run the model with the file:
+
+```bash
+cog predict -i text_file=@input.txt -i uppercase=true
+```
+
+You will see:
+
+```
+Written output to output.txt
+```
+
+Check the result:
+
+```bash
+cat output.txt
+```
+
+You will see:
+
+```
+GREETINGS PLANET FAREWELL COMPANION
+```
+
+Notice the `@` prefix on `text_file=@input.txt`. This tells Cog to pass the file contents, not the literal string "input.txt". You saw this same pattern in the quick start tutorial when passing an image file.
+
+## Review the final project
+
+Your project now contains:
+
+```
+cog-first-model/
+  cog.yaml
+  predict.py
+  input.txt
+```
+
+The `cog.yaml` is minimal:
+
+```yaml
+build:
+  python_version: "3.13"
+predict: "predict.py:Predictor"
+```
+
+The `predict.py` demonstrates all the core Cog patterns:
+
+- **`setup()`** for one-time initialisation
+- **`predict()`** for per-request processing
+- **`Input()`** for typed, documented, validated inputs
+- **`cog.Path`** for file inputs and outputs
+- **Type annotations** (`str`, `int`, `bool`, `Optional[Path]`) for the prediction interface
+
+## What you have built
+
+You have created a Cog model from scratch that:
+
+1. Loads resources in `setup()`
+2. Accepts multiple typed inputs with defaults and validation
+3. Processes both string and file inputs
+4. Returns file output using `cog.Path`
+
+These are the same patterns used by real machine learning models -- the only difference is what happens inside `setup()` and `predict()`.
+
+## Next steps
+
+- [Build and deploy locally](deploy-local.md) -- build a Docker image and serve predictions over HTTP
+- [cog.yaml reference](../yaml.md) -- full reference for environment configuration
+- [Python SDK reference](../python.md) -- all input types, output types, and advanced features

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -1,0 +1,195 @@
+# Quick start: classify an image with ResNet
+
+In this tutorial, we will package a ResNet image classifier using Cog, run a prediction on it, and build a Docker image. By the end, you will have a working model that classifies images and a Docker image ready to deploy.
+
+## What we will build
+
+We will take a pre-trained ResNet50 model (an image classifier trained on ImageNet) and package it with Cog. We will give it a photo and it will tell us what is in it.
+
+## Prerequisites
+
+Before starting, make sure you have:
+
+- **macOS or Linux** (Cog does not support Windows)
+- **Docker** installed and running ([install Docker](https://docs.docker.com/get-docker/))
+- **Cog** installed ([install instructions](https://github.com/replicate/cog#install))
+
+Verify both are working:
+
+```bash
+docker version
+cog --version
+```
+
+You should see version numbers for both. If either command fails, revisit the installation links above before continuing.
+
+## Create a project directory
+
+First, create a new directory and move into it:
+
+```bash
+mkdir cog-quickstart
+cd cog-quickstart
+```
+
+Every Cog project needs two things: a `cog.yaml` file that defines the environment, and a `predict.py` file that defines how predictions work. We will create both.
+
+## Define the environment
+
+Create a file called `cog.yaml` with the following content:
+
+```yaml
+build:
+  python_version: "3.13"
+  python_requirements: requirements.txt
+predict: "predict.py:Predictor"
+```
+
+This tells Cog three things: use Python 3.13, install Python packages from `requirements.txt`, and find the prediction code in `predict.py` in a class called `Predictor`.
+
+Now create the `requirements.txt` file:
+
+```
+pillow==11.1.0
+torch==2.6.0
+torchvision==0.21.0
+```
+
+## Write the prediction code
+
+Create a file called `predict.py`:
+
+```python
+import os
+os.environ["TORCH_HOME"] = "."
+
+import torch
+from cog import BasePredictor, Input, Path
+from PIL import Image
+from torchvision import models
+
+WEIGHTS = models.ResNet50_Weights.IMAGENET1K_V1
+
+
+class Predictor(BasePredictor):
+    def setup(self):
+        """Load the model into memory to make running multiple predictions efficient"""
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = models.resnet50(weights=WEIGHTS).to(self.device)
+        self.model.eval()
+
+    def predict(self, image: Path = Input(description="Image to classify")) -> dict:
+        """Run a single prediction on the model"""
+        img = Image.open(image).convert("RGB")
+        preds = self.model(WEIGHTS.transforms()(img).unsqueeze(0).to(self.device))
+        top3 = preds[0].softmax(0).topk(3)
+        categories = WEIGHTS.meta["categories"]
+        return {categories[i]: p.detach().item() for p, i in zip(*top3)}
+```
+
+Notice the two methods in the `Predictor` class:
+
+- `setup()` loads the model once when the container starts. This means predictions run fast because the model is already in memory.
+- `predict()` takes an image path as input and returns a dictionary of the top 3 classifications with their confidence scores.
+
+Your project directory now contains three files:
+
+```
+cog-quickstart/
+  cog.yaml
+  predict.py
+  requirements.txt
+```
+
+## Run a prediction
+
+We need a test image. Download one:
+
+```bash
+curl -o input.jpg https://gist.githubusercontent.com/bfirsh/3c2115692682ae260932a67d93fd94a8/raw/56b19f53f7643bb6c0b822c410c366c3a6244de2/mystery.jpg
+```
+
+Now run a prediction:
+
+```bash
+cog predict -i image=@input.jpg
+```
+
+The first time you run this, Cog builds a Docker image with all the dependencies. This takes a few minutes. You will see build progress in the terminal.
+
+Once the build completes and the model runs, you will see output like this:
+
+```json
+{
+  "tiger_cat": 0.4874822497367859,
+  "tabby": 0.23169134557247162,
+  "Egyptian_cat": 0.09728282690048218
+}
+```
+
+The model classified the image as a cat. Notice the `@` prefix on `image=@input.jpg` -- this tells Cog the value is a file path, not a string.
+
+Run the same prediction again:
+
+```bash
+cog predict -i image=@input.jpg
+```
+
+Notice it runs much faster this time. Cog reuses the Docker image it already built.
+
+## Build a Docker image
+
+Now we will build a standalone Docker image that you can run anywhere Docker runs:
+
+```bash
+cog build -t resnet
+```
+
+You will see build output ending with:
+
+```
+Built resnet:latest
+```
+
+Verify the image exists:
+
+```bash
+docker images resnet
+```
+
+You will see something like:
+
+```
+REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
+resnet       latest    abc123def456   10 seconds ago   5.2GB
+```
+
+You now have a self-contained Docker image with the model, its weights, all dependencies, and an HTTP prediction server.
+
+## Test the Docker image
+
+Run a prediction using the built image:
+
+```bash
+cog predict resnet -i image=@input.jpg
+```
+
+You will see the same classification output as before. The difference is this time it ran from the standalone Docker image, not from your source files.
+
+## What you have built
+
+You have:
+
+1. Defined a model environment in `cog.yaml`
+2. Written a prediction interface in `predict.py`
+3. Run a prediction with `cog predict`
+4. Built a production Docker image with `cog build`
+
+The Docker image `resnet:latest` includes an HTTP server for serving predictions. In the [deploy locally](deploy-local.md) tutorial, you will learn how to run this server and make requests to it with curl.
+
+## Next steps
+
+- [Package your first model](first-model.md) -- learn the Cog patterns by building a model from scratch
+- [Build and deploy locally](deploy-local.md) -- run your model as an HTTP server and make requests with curl
+- [cog.yaml reference](../yaml.md) -- full reference for the configuration file
+- [Python SDK reference](../python.md) -- full reference for the prediction interface

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -62,6 +62,7 @@ This follows the standard [requirements.txt](https://pip.pypa.io/en/stable/refer
 To install Git-hosted Python packages, add `git` to the `system_packages` list, then use the `git+https://` syntax to specify the package name. For example:
 
 `cog.yaml`:
+
 ```yaml
 build:
   system_packages:
@@ -70,6 +71,7 @@ build:
 ```
 
 `requirements.txt`:
+
 ```
 git+https://github.com/huggingface/transformers
 ```
@@ -77,6 +79,7 @@ git+https://github.com/huggingface/transformers
 You can also pin Python package installations to a specific git commit:
 
 `cog.yaml`:
+
 ```yaml
 build:
   system_packages:
@@ -85,6 +88,7 @@ build:
 ```
 
 `requirements.txt`:
+
 ```
 git+https://github.com/huggingface/transformers@2d1602a
 ```
@@ -190,7 +194,7 @@ This stanza describes the concurrency capabilities of the model. It has one opti
 
 ### `max`
 
-The maximum number of concurrent predictions the model can process.  If this is set, the model must specify an [async `predict()` method](python.md#async-predictors-and-concurrency).
+The maximum number of concurrent predictions the model can process. If this is set, the model must specify an [async `predict()` method](python.md#async-predictors-and-concurrency).
 
 For example:
 
@@ -213,7 +217,7 @@ r8.im is Replicate's registry, but this can be any Docker registry.
 
 If you don't set this, then a name will be generated from the directory name.
 
-If you set this, then you can run `cog push` without specifying the model name. 
+If you set this, then you can run `cog push` without specifying the model name.
 
 If you specify an image name argument when pushing (like `cog push your-username/custom-model-name`), the argument will be used and the value of `image` in cog.yaml will be ignored.
 

--- a/mise.toml
+++ b/mise.toml
@@ -338,14 +338,14 @@ fi
 alias = ["format", "fmt:check", "format:check"]
 description = "Check formatting for all languages (non-destructive)"
 run = [
-  { tasks = ["fmt:go", "fmt:rust", "fmt:python"] },
+  { tasks = ["fmt:go", "fmt:rust", "fmt:python", "fmt:docs"] },
 ]
 
 [tasks."fmt:fix"]
 alias = "format:fix"
 description = "Fix formatting for all languages"
 run = [
-  { tasks = ["fmt:go:fix", "fmt:rust:fix", "fmt:python:fix"] },
+  { tasks = ["fmt:go:fix", "fmt:rust:fix", "fmt:python:fix", "fmt:docs:fix"] },
 ]
 
 # Go formatting
@@ -382,6 +382,16 @@ run = "ruff format --check ."
 [tasks."fmt:python:fix"]
 description = "Fix Python formatting"
 run = "ruff format ."
+
+# Docs formatting
+[tasks."fmt:docs"]
+alias = "fmt:docs:check"
+description = "Check docs formatting"
+run = "npx prettier --check 'docs/**/*.md' README.md"
+
+[tasks."fmt:docs:fix"]
+description = "Fix docs formatting"
+run = "npx prettier -w 'docs/**/*.md' README.md"
 
 # =============================================================================
 # Lint tasks

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,19 +2,44 @@ site_name: Cog
 repo_url: https://github.com/replicate/cog
 docs_dir: docs/
 nav:
-  - README: README.md
-  - Getting Started: getting-started.md
-  - Using your own model: getting-started-own-model.md
-  - Deploy your model: deploy.md
-  - YAML spec: yaml.md
-  - Prediction API: python.md
-  - Training API: training.md
-  - HTTP API: http.md
-  - CLI: cli.md
-  - Environment variables: environment.md
-  - Private registry: private-package-registry.md
-  - Notebooks: notebooks.md
-  - Windows: wsl2/wsl2.md
+  - Home: README.md
+
+  - Tutorials:
+    - Quick start: tutorials/quick-start.md
+    - Package your first model: tutorials/first-model.md
+    - Build and deploy locally: tutorials/deploy-local.md
+
+  - How-to guides:
+    - Set up your own model: how-to/setup-own-model.md
+    - Use GPUs: how-to/gpu.md
+    - Manage model weights: how-to/model-weights.md
+    - Stream output: how-to/streaming.md
+    - Handle file inputs and outputs: how-to/file-io.md
+    - Run concurrent predictions: how-to/concurrency.md
+    - Use private package registries: how-to/private-registry.md
+    - Deploy to production: how-to/deploy.md
+    - Set up CI/CD: how-to/ci-cd.md
+    - Optimise image size: how-to/image-size.md
+    - Debug build failures: how-to/debug-builds.md
+    - Use Jupyter notebooks: how-to/notebooks.md
+    - Set up on Windows (WSL 2): how-to/wsl2.md
+    - Fine-tune with the training API: how-to/training.md
+
+  - Reference:
+    - cog.yaml: reference/yaml.md
+    - Python API: reference/python.md
+    - HTTP API: reference/http.md
+    - CLI: reference/cli.md
+    - Training API: reference/training.md
+    - Environment variables: reference/environment.md
+
+  - Explanation:
+    - How Cog works: explanation/how-cog-works.md
+    - Why containers for ML?: explanation/why-containers.md
+    - The prediction lifecycle: explanation/prediction-lifecycle.md
+    - CUDA and GPU compatibility: explanation/cuda-compat.md
+    - Docker image layer strategy: explanation/image-layers.md
+
   - Contributing: CONTRIBUTING.md
   - License: https://github.com/replicate/cog/blob/main/LICENSE
   - llms.txt: llms.txt
@@ -29,6 +54,7 @@ theme:
   # Display a link to edit pages right on GitHub
   features:
     - content.action.edit
+    - navigation.sections
 
   icon:
     logo: material/cog


### PR DESCRIPTION
## Summary

Restructures all documentation using the [Diataxis framework](https://diataxis.fr/), which organises docs into four categories based on user needs:

- **Tutorials** (learning by doing) -- guided lessons for new users
- **How-to guides** (working to achieve a goal) -- practical task-focused recipes
- **Reference** (facts while working) -- austere, complete technical descriptions
- **Explanation** (understanding concepts) -- discussion of why things work the way they do

## What changed

**28 new/reworked doc pages** organised into four sections:

| Section | Pages | Notes |
|---|---|---|
| **Tutorials** (3) | quick-start, first-model, deploy-local | 1 refined from existing, 2 new |
| **How-to guides** (14) | setup-own-model, gpu, model-weights, streaming, file-io, concurrency, private-registry, deploy, ci-cd, image-size, debug-builds, notebooks, wsl2, training | 4 reworked, 10 new |
| **Reference** (6) | yaml, python, http, cli, training, environment | Cleaned copies with instructional content extracted |
| **Explanation** (5) | how-cog-works, why-containers, prediction-lifecycle, cuda-compat, image-layers | All new |

Plus:
- `mkdocs.yml` updated with grouped section navigation
- `llms.txt` regenerated

**Old doc pages are preserved** at their original paths and can be removed in a follow-up once the new structure is validated.

## Why

The existing docs were heavily weighted toward reference material (5 of 12 pages). There was no explanation content at all, very few how-to guides, and the tutorials blurred the line between learning and working. The flat nav structure gave new users and experienced deployers the same undifferentiated list of links.

The Diataxis framework addresses this by ensuring each page serves exactly one user need, making it easier to find the right doc at the right time.