### PR TITLE
Support sdk_version: "prerelease" sentinel in cog.yaml

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -804,3 +804,15 @@ predict: predict.py:Predictor
 	// Parsing itself is fine; enforcement happens at Dockerfile generation time.
 	require.Equal(t, "0.15.0", conf.Build.SDKVersion)
 }
+
+func TestSDKVersionConfigPrereleaseSentinel(t *testing.T) {
+	// "prerelease" is accepted as a special sdk_version value
+	conf, err := FromYAML([]byte(`
+build:
+  python_version: "3.12"
+  sdk_version: "prerelease"
+predict: predict.py:Predictor
+`))
+	require.NoError(t, err)
+	require.Equal(t, "prerelease", conf.Build.SDKVersion)
+}

--- a/pkg/config/data/config_schema_v1.0.json
+++ b/pkg/config/data/config_schema_v1.0.json
@@ -94,7 +94,7 @@
         "sdk_version": {
           "$id": "#/properties/build/properties/sdk_version",
           "type": "string",
-          "description": "Pin the cog Python SDK version installed in the container (e.g. \"0.18.0\" or \"0.18.0a1\"). Defaults to latest. Overridden by the COG_SDK_WHEEL environment variable."
+          "description": "Pin the cog Python SDK version installed in the container (e.g. \"0.18.0\" or \"0.18.0a1\"). Use \"prerelease\" to always install the latest pre-release. Defaults to latest stable. Overridden by the COG_SDK_WHEEL environment variable."
         },
         "run": {
           "$id": "#/properties/build/properties/run",

--- a/pkg/dockerfile/standard_generator.go
+++ b/pkg/dockerfile/standard_generator.go
@@ -517,9 +517,16 @@ func (g *StandardGenerator) resolveCogWheelConfigs() error {
 			return err
 		}
 	} else if g.Config.Build != nil && g.Config.Build.SDKVersion != "" {
-		g.resolvedCogConfig = &wheels.WheelConfig{
-			Source:  wheels.WheelSourcePyPI,
-			Version: g.Config.Build.SDKVersion,
+		if g.Config.Build.SDKVersion == wheels.PreReleaseSentinel {
+			g.resolvedCogConfig = &wheels.WheelConfig{
+				Source:     wheels.WheelSourcePyPI,
+				PreRelease: true,
+			}
+		} else {
+			g.resolvedCogConfig = &wheels.WheelConfig{
+				Source:  wheels.WheelSourcePyPI,
+				Version: g.Config.Build.SDKVersion,
+			}
 		}
 	} else {
 		g.resolvedCogConfig, err = wheels.GetCogWheelConfig()
@@ -552,7 +559,8 @@ const cogletMinSDKVersion = "0.17.0"
 
 // isLegacySDKVersion returns true if the resolved cog SDK version is explicitly
 // pinned below the minimum version that supports coglet. Returns false for
-// unpinned, non-PyPI, or unparseable versions (assume modern).
+// unpinned versions (including the "prerelease" sentinel), non-PyPI sources,
+// or unparseable versions (assume modern).
 func (g *StandardGenerator) isLegacySDKVersion() bool {
 	cfg := g.resolvedCogConfig
 	if cfg == nil || cfg.Source != wheels.WheelSourcePyPI || cfg.Version == "" {
@@ -581,7 +589,12 @@ func (g *StandardGenerator) installCog() (string, error) {
 	wheelConfig := g.resolvedCogConfig
 
 	// Determine if we need --pre flag (pre-release SDK implies pre-release coglet too)
-	sdkIsPreRelease := wheelConfig.Source == wheels.WheelSourcePyPI && wheels.IsPreRelease(wheelConfig.Version)
+	sdkIsPreRelease := wheelConfig.Source == wheels.WheelSourcePyPI &&
+		(wheelConfig.PreRelease || wheels.IsPreRelease(wheelConfig.Version))
+
+	if wheelConfig.PreRelease {
+		console.Warn("sdk_version \"prerelease\" installs the latest pre-release SDK. Pin to a specific version for reproducible production builds.")
+	}
 
 	// Only install coglet explicitly when there's a specific source:
 	//   - COGLET_WHEEL env var (explicit override)
@@ -820,6 +833,9 @@ func (g *StandardGenerator) filterManagedPackages(reqContents string) string {
 		case wheels.WheelSourcePyPI:
 			if cfg.Version != "" {
 				return fmt.Sprintf("%s==%s from PyPI", pkg, cfg.Version)
+			}
+			if cfg.PreRelease {
+				return "latest pre-release " + pkg + " from PyPI"
 			}
 			return "latest " + pkg + " from PyPI"
 		case wheels.WheelSourceURL:

--- a/pkg/dockerfile/standard_generator_test.go
+++ b/pkg/dockerfile/standard_generator_test.go
@@ -1192,3 +1192,29 @@ predict: predict.py:Predictor
 	require.Contains(t, dockerfile, "uv pip install --no-cache cog==0.17.0")
 	require.NotContains(t, dockerfile, "cog==0.18.0")
 }
+
+func TestInstallCogWithPrereleaseSentinel(t *testing.T) {
+	// sdk_version: "prerelease" installs latest pre-release with --pre, no version pin
+	tmpDir := t.TempDir()
+	conf, err := config.FromYAML([]byte(`
+build:
+  python_version: "3.12"
+  sdk_version: "prerelease"
+predict: predict.py:Predictor
+`))
+	require.NoError(t, err)
+	require.NoError(t, conf.Complete(""))
+	command := dockertest.NewMockCommand()
+	client := registrytest.NewMockRegistryClient()
+	gen, err := NewStandardGenerator(conf, tmpDir, "", command, client, true)
+	require.NoError(t, err)
+	gen.cogletWheelConfig = &wheels.WheelConfig{Source: wheels.WheelSourcePyPI}
+	gen.SetUseCogBaseImage(false)
+
+	dockerfile, err := gen.GenerateInitialSteps(t.Context())
+	require.NoError(t, err)
+	// Should use --pre with no version pin
+	require.Contains(t, dockerfile, "uv pip install --pre --no-cache cog")
+	// Must NOT contain a version pin
+	require.NotContains(t, dockerfile, "cog==")
+}

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -483,6 +483,9 @@ func resolveSDKVersion(cfg *config.Config) string {
 		return ""
 	}
 	if cfg.Build != nil && cfg.Build.SDKVersion != "" {
+		if cfg.Build.SDKVersion == wheels.PreReleaseSentinel {
+			return "" // unpinned; latest pre-release resolved at build time
+		}
 		return cfg.Build.SDKVersion
 	}
 	if v := wheels.DetectLocalSDKVersion(); v != "" {

--- a/pkg/wheels/wheels.go
+++ b/pkg/wheels/wheels.go
@@ -79,6 +79,10 @@ func (s WheelSource) String() string {
 	}
 }
 
+// PreReleaseSentinel is the special sdk_version value that means
+// "install the latest pre-release from PyPI" without pinning a version.
+const PreReleaseSentinel = "prerelease"
+
 // WheelConfig represents the configuration for which wheel to install
 type WheelConfig struct {
 	// Source indicates where the wheel comes from
@@ -89,6 +93,9 @@ type WheelConfig struct {
 	Path string
 	// Version is set when Source is WheelSourcePyPI (optional, empty = latest)
 	Version string
+	// PreRelease indicates that pip should use --pre to resolve the latest
+	// pre-release, without pinning a specific version.
+	PreRelease bool
 }
 
 // CogSDKWheelEnvVar is the environment variable name for cog SDK wheel selection

--- a/pkg/wheels/wheels_test.go
+++ b/pkg/wheels/wheels_test.go
@@ -530,3 +530,15 @@ func TestPyPIPackageURLPreRelease(t *testing.T) {
 	cfg := &WheelConfig{Source: WheelSourcePyPI, Version: "0.17.0-alpha1"}
 	require.Equal(t, "cog==0.17.0a1", cfg.PyPIPackageURL("cog"))
 }
+
+func TestPreReleaseSentinelPyPIPackageURL(t *testing.T) {
+	// PreRelease flag with no version returns bare package name (no ==pin)
+	cfg := &WheelConfig{Source: WheelSourcePyPI, PreRelease: true}
+	require.Equal(t, "cog", cfg.PyPIPackageURL("cog"))
+}
+
+func TestValidateSDKVersionPreReleaseSentinel(t *testing.T) {
+	// PreRelease sentinel (empty version) passes validation
+	cfg := &WheelConfig{Source: WheelSourcePyPI, PreRelease: true}
+	require.NoError(t, ValidateSDKVersion(cfg, "cog"))
+}


### PR DESCRIPTION
Testers using RC builds have to hardcode `sdk_version: "0.17.0rc2"` in cog.yaml and bump it every time a new RC drops. That's friction for prerelease testing -- you end up pinging everyone to update their config.

This adds `sdk_version: "prerelease"` as a special value that generates `uv pip install --pre cog` with no version pin. Testers set it once, and each `cog build` picks up whatever the latest pre-release is. Once stable ships, builds transparently move to stable (pip prefers stable over RC of the same version). A build-time warning nudges folks to pin a specific version before going to production.

Related: #2832 (RC example project that currently hardcodes `0.17.0rc2`)