### PR TITLE
fix: docs deploy workflow uses Go 1.23, can't parse go.mod tool directive

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'


### PR DESCRIPTION
The docs deploy workflow hardcodes `go-version: '1.23'`, but `go.mod` uses the `tool` directive which requires Go 1.24+. The "Generate CLI docs" step fails immediately:

```
go: errors parsing go.mod:
go.mod:160: unknown block type: tool
```

Switch to `go-version-file: go.mod` -- consistent with every other workflow in the repo.