### PR TITLE
fix: support dict and list[dict] as predictor input types

### DIFF
--- a/integration-tests/tests/dict_input.txtar
+++ b/integration-tests/tests/dict_input.txtar
@@ -15,7 +15,7 @@ stdout '"output": ""'
 
 # Verify the schema has the correct type for dict input
 exec docker inspect $TEST_IMAGE --format '{{index .Config.Labels "run.cog.openapi_schema"}}'
-stdout '"data":{"x-order":0,"title":"Data","type":"object"}'
+stdout '"data":{"title":"Data","type":"object","x-order":0}'
 stdout '"required":\["data"\]'
 
 -- cog.yaml --

--- a/integration-tests/tests/dict_input.txtar
+++ b/integration-tests/tests/dict_input.txtar
@@ -1,0 +1,33 @@
+# Test bare dict as predict input type
+
+# Build the image
+cog build -t $TEST_IMAGE
+
+# Dict input works via JSON
+cog predict $TEST_IMAGE --json '{"data": {"greeting": "hello", "count": 3}}'
+stdout '"status": "succeeded"'
+stdout '"output": "count=3, greeting=hello"'
+
+# Empty dict also works
+cog predict $TEST_IMAGE --json '{"data": {}}'
+stdout '"status": "succeeded"'
+stdout '"output": ""'
+
+# Verify the schema has the correct type for dict input
+exec docker inspect $TEST_IMAGE --format '{{index .Config.Labels "run.cog.openapi_schema"}}'
+stdout '"data":{"x-order":0,"title":"Data","type":"object"}'
+stdout '"required":\["data"\]'
+
+-- cog.yaml --
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"
+
+-- predict.py --
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def predict(self, data: dict) -> str:
+        parts = [f"{k}={v}" for k, v in sorted(data.items())]
+        return ", ".join(parts)

--- a/integration-tests/tests/list_dict_input.txtar
+++ b/integration-tests/tests/list_dict_input.txtar
@@ -15,7 +15,7 @@ stdout '"output": ""'
 
 # Verify the schema has array-of-objects type for list[dict] input
 exec docker inspect $TEST_IMAGE --format '{{index .Config.Labels "run.cog.openapi_schema"}}'
-stdout '"messages":{"x-order":0,"title":"Messages","items":{"type":"object"},"type":"array"}'
+stdout '"messages":{"items":{"type":"object"},"title":"Messages","type":"array","x-order":0}'
 stdout '"required":\["messages"\]'
 
 -- cog.yaml --

--- a/integration-tests/tests/list_dict_input.txtar
+++ b/integration-tests/tests/list_dict_input.txtar
@@ -1,0 +1,33 @@
+# Test list[dict] as predict input type (common pattern for chat message arrays)
+
+# Build the image
+cog build -t $TEST_IMAGE
+
+# List of dicts works as input via JSON
+cog predict $TEST_IMAGE --json '{"messages": [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}]}'
+stdout '"status": "succeeded"'
+stdout '"output": "user: hello\\nassistant: hi"'
+
+# Empty list also works
+cog predict $TEST_IMAGE --json '{"messages": []}'
+stdout '"status": "succeeded"'
+stdout '"output": ""'
+
+# Verify the schema has array-of-objects type for list[dict] input
+exec docker inspect $TEST_IMAGE --format '{{index .Config.Labels "run.cog.openapi_schema"}}'
+stdout '"messages":{"x-order":0,"title":"Messages","items":{"type":"object"},"type":"array"}'
+stdout '"required":\["messages"\]'
+
+-- cog.yaml --
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"
+
+-- predict.py --
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def predict(self, messages: list[dict]) -> str:
+        parts = [f"{m['role']}: {m['content']}" for m in messages]
+        return "\n".join(parts)

--- a/integration-tests/tests/typing_dict_input.txtar
+++ b/integration-tests/tests/typing_dict_input.txtar
@@ -11,8 +11,8 @@ stdout '"output": "data=1 items=2"'
 
 # Verify the schema has correct types for both inputs
 exec docker inspect $TEST_IMAGE --format '{{index .Config.Labels "run.cog.openapi_schema"}}'
-stdout '"data":{"x-order":0,"title":"Data","type":"object"}'
-stdout '"items":{"x-order":1,"title":"Items","items":{"type":"object"},"type":"array"}'
+stdout '"data":{"title":"Data","type":"object","x-order":0}'
+stdout '"items":{"items":{"type":"object"},"title":"Items","type":"array","x-order":1}'
 
 -- cog.yaml --
 build:

--- a/integration-tests/tests/typing_dict_input.txtar
+++ b/integration-tests/tests/typing_dict_input.txtar
@@ -1,0 +1,34 @@
+# Test typing.Dict[str, Any] and List[Dict[str, Any]] as predict input types
+# Verifies the typing-module variants work (not just bare dict/list[dict])
+
+# Build the image
+cog build -t $TEST_IMAGE
+
+# Dict[str, Any] input works
+cog predict $TEST_IMAGE --json '{"data": {"name": "alice"}, "items": [{"id": 1}, {"id": 2}]}'
+stdout '"status": "succeeded"'
+stdout '"output": "data=1 items=2"'
+
+# Verify the schema has correct types for both inputs
+exec docker inspect $TEST_IMAGE --format '{{index .Config.Labels "run.cog.openapi_schema"}}'
+stdout '"data":{"x-order":0,"title":"Data","type":"object"}'
+stdout '"items":{"x-order":1,"title":"Items","items":{"type":"object"},"type":"array"}'
+
+-- cog.yaml --
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"
+
+-- predict.py --
+from typing import Any, Dict, List
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def predict(
+        self,
+        data: Dict[str, Any],
+        items: List[Dict[str, Any]],
+    ) -> str:
+        return f"data={len(data)} items={len(items)}"

--- a/pkg/schema/python/parser_test.go
+++ b/pkg/schema/python/parser_test.go
@@ -2598,3 +2598,206 @@ func indexOf(s, substr string) int {
 	}
 	return -1
 }
+
+// ---------------------------------------------------------------------------
+// dict input types
+// ---------------------------------------------------------------------------
+
+func TestBareDictInput(t *testing.T) {
+	source := `
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, data: dict) -> str:
+        return str(data)
+`
+	info := parse(t, source, "Predictor")
+	data, ok := info.Inputs.Get("data")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeAny, data.FieldType.Primitive)
+	require.Equal(t, schema.Required, data.FieldType.Repetition)
+}
+
+func TestDictStrAnyInput(t *testing.T) {
+	source := `
+from typing import Dict, Any
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, data: Dict[str, Any]) -> str:
+        return str(data)
+`
+	info := parse(t, source, "Predictor")
+	data, ok := info.Inputs.Get("data")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeAny, data.FieldType.Primitive)
+	require.Equal(t, schema.Required, data.FieldType.Repetition)
+}
+
+func TestListOfDictInput(t *testing.T) {
+	source := `
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, messages: list[dict]) -> str:
+        return str(messages)
+`
+	info := parse(t, source, "Predictor")
+	messages, ok := info.Inputs.Get("messages")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeAny, messages.FieldType.Primitive)
+	require.Equal(t, schema.Repeated, messages.FieldType.Repetition)
+}
+
+func TestListOfTypingDictInput(t *testing.T) {
+	source := `
+from typing import List, Dict, Any
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, messages: List[Dict[str, Any]]) -> str:
+        return str(messages)
+`
+	info := parse(t, source, "Predictor")
+	messages, ok := info.Inputs.Get("messages")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeAny, messages.FieldType.Primitive)
+	require.Equal(t, schema.Repeated, messages.FieldType.Repetition)
+}
+
+func TestOptionalDictInput(t *testing.T) {
+	source := `
+from typing import Optional
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, data: Optional[dict] = None) -> str:
+        return str(data)
+`
+	info := parse(t, source, "Predictor")
+	data, ok := info.Inputs.Get("data")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeAny, data.FieldType.Primitive)
+	require.Equal(t, schema.Optional, data.FieldType.Repetition)
+}
+
+func TestOptionalListOfDictInput(t *testing.T) {
+	source := `
+from typing import Optional
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, messages: Optional[list[dict]] = None) -> str:
+        return str(messages)
+`
+	info := parse(t, source, "Predictor")
+	messages, ok := info.Inputs.Get("messages")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeAny, messages.FieldType.Primitive)
+	require.Equal(t, schema.OptionalRepeated, messages.FieldType.Repetition)
+}
+
+func TestDictInputJSONSchema(t *testing.T) {
+	source := `
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, messages: list[dict]) -> str:
+        return str(messages)
+`
+	info := parse(t, source, "Predictor")
+	messages, ok := info.Inputs.Get("messages")
+	require.True(t, ok)
+
+	jt := messages.FieldType.JSONType()
+	require.Equal(t, "array", jt["type"])
+	items, ok := jt["items"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "object", items["type"])
+}
+
+func TestPEP604DictOrNoneInput(t *testing.T) {
+	source := `
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, data: dict | None = None) -> str:
+        return str(data)
+`
+	info := parse(t, source, "Predictor")
+	data, ok := info.Inputs.Get("data")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeAny, data.FieldType.Primitive)
+	require.Equal(t, schema.Optional, data.FieldType.Repetition)
+}
+
+func TestPEP604ListDictOrNoneInput(t *testing.T) {
+	source := `
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, messages: list[dict] | None = None) -> str:
+        return str(messages)
+`
+	info := parse(t, source, "Predictor")
+	messages, ok := info.Inputs.Get("messages")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeAny, messages.FieldType.Primitive)
+	require.Equal(t, schema.OptionalRepeated, messages.FieldType.Repetition)
+}
+
+func TestDictStrIntInputTypeErasure(t *testing.T) {
+	// dict[str, int] should be accepted as TypeAny — type parameters are
+	// intentionally discarded because FieldType is a flat model (no recursive
+	// structure). The output path uses SchemaType which can represent typed
+	// dicts precisely, but inputs are always opaque JSON objects.
+	source := `
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, data: dict[str, int]) -> str:
+        return str(data)
+`
+	info := parse(t, source, "Predictor")
+	data, ok := info.Inputs.Get("data")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeAny, data.FieldType.Primitive)
+	require.Equal(t, schema.Required, data.FieldType.Repetition)
+}
+
+func TestDictInputWithDefault(t *testing.T) {
+	source := `
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, data: dict = {}) -> str:
+        return str(data)
+`
+	info := parse(t, source, "Predictor")
+	data, ok := info.Inputs.Get("data")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeAny, data.FieldType.Primitive)
+	require.Equal(t, schema.Required, data.FieldType.Repetition)
+	require.NotNil(t, data.Default)
+	require.Equal(t, schema.DefaultDict, data.Default.Kind)
+	require.False(t, data.IsRequired())
+}
+
+func TestListDictInputWithDefault(t *testing.T) {
+	source := `
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, messages: list[dict] = []) -> str:
+        return str(messages)
+`
+	info := parse(t, source, "Predictor")
+	messages, ok := info.Inputs.Get("messages")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeAny, messages.FieldType.Primitive)
+	require.Equal(t, schema.Repeated, messages.FieldType.Repetition)
+	require.NotNil(t, messages.Default)
+	require.Equal(t, schema.DefaultList, messages.Default.Kind)
+	require.Empty(t, messages.Default.List)
+	require.False(t, messages.IsRequired())
+}

--- a/pkg/schema/types.go
+++ b/pkg/schema/types.go
@@ -271,6 +271,10 @@ func (ctx *ImportContext) IsBasePredictor(name string) bool {
 func ResolveFieldType(ann TypeAnnotation, ctx *ImportContext) (FieldType, error) {
 	switch ann.Kind {
 	case TypeAnnotSimple:
+		// Bare dict / Dict → opaque JSON object (TypeAny)
+		if ann.Name == "dict" || ann.Name == "Dict" {
+			return FieldType{Primitive: TypeAny, Repetition: Required}, nil
+		}
 		prim, ok := PrimitiveFromName(ann.Name)
 		if !ok {
 			return FieldType{}, errUnsupportedType(ann.Name)
@@ -279,6 +283,14 @@ func ResolveFieldType(ann TypeAnnotation, ctx *ImportContext) (FieldType, error)
 
 	case TypeAnnotGeneric:
 		outer := ann.Name
+		// dict[K, V] / Dict[K, V] → opaque JSON object (TypeAny).
+		// Type parameters are intentionally discarded because FieldType is flat
+		// (PrimitiveType + Repetition only). The output path uses the recursive
+		// SchemaType model which can represent typed dicts (e.g. dict[str, int])
+		// precisely; for inputs, all dicts are treated as opaque JSON objects.
+		if outer == "dict" || outer == "Dict" {
+			return FieldType{Primitive: TypeAny, Repetition: Required}, nil
+		}
 		if outer == "Optional" {
 			if len(ann.Args) != 1 {
 				return FieldType{}, errUnsupportedType(fmt.Sprintf("Optional expects exactly 1 type argument, got %d", len(ann.Args)))

--- a/python/cog/_adt.py
+++ b/python/cog/_adt.py
@@ -237,6 +237,13 @@ class FieldType:
                 if len(t_args) != 1:
                     raise ValueError("List must have one type argument")
                 elem_t = t_args[0]
+                # dict elements in lists → treat as ANY (opaque JSON objects)
+                if elem_t is dict or typing.get_origin(elem_t) is dict:
+                    return FieldType(
+                        primitive=PrimitiveType.ANY,
+                        repetition=Repetition.REPEATED,
+                        coder=None,
+                    )
                 nested_t = typing.get_origin(elem_t)
                 if nested_t is not None:
                     raise ValueError(
@@ -259,6 +266,13 @@ class FieldType:
                     if len(list_args) != 1:
                         raise ValueError("List must have one type argument")
                     elem_t = list_args[0]
+                    # dict elements in optional lists → ANY
+                    if elem_t is dict or typing.get_origin(elem_t) is dict:
+                        return FieldType(
+                            primitive=PrimitiveType.ANY,
+                            repetition=Repetition.OPTIONAL_REPEATED,
+                            coder=None,
+                        )
                     inner_origin = typing.get_origin(elem_t)
                     if inner_origin is not None:
                         raise ValueError(
@@ -267,6 +281,15 @@ class FieldType:
                 else:
                     elem_t = Any
                 repetition = Repetition.OPTIONAL_REPEATED
+            elif nested_t is dict or elem_t is dict:
+                # Optional[dict] or Optional[Dict[str, Any]] → optional ANY.
+                # nested_t is dict: elem_t is parameterized (e.g. Dict[str, Any]).
+                # elem_t is dict: elem_t is bare dict (nested_t is None).
+                return FieldType(
+                    primitive=PrimitiveType.ANY,
+                    repetition=Repetition.OPTIONAL,
+                    coder=None,
+                )
             elif nested_t is not None:
                 raise ValueError(
                     f"Optional cannot have nested type {_type_name(nested_t)}"

--- a/python/tests/test_adt.py
+++ b/python/tests/test_adt.py
@@ -1,0 +1,168 @@
+"""Tests for cog._adt module (FieldType, PrimitiveType)."""
+
+from typing import Any, Dict, List, Optional
+
+from cog._adt import FieldType, PrimitiveType, Repetition
+
+
+class TestDictInputTypes:
+    """Tests for FieldType.from_type() with dict types as inputs."""
+
+    def test_bare_dict_input(self) -> None:
+        """Bare dict should be accepted as an input type, mapped to ANY."""
+        ft = FieldType.from_type(dict)
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.REQUIRED
+        assert ft.coder is None
+
+    def test_dict_str_any_input(self) -> None:
+        """Dict[str, Any] should be accepted as an input type."""
+        ft = FieldType.from_type(Dict[str, Any])
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.REQUIRED
+
+    def test_list_of_dict_input(self) -> None:
+        """list[dict] should produce a repeated ANY field."""
+        ft = FieldType.from_type(list[dict])
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.REPEATED
+        assert ft.coder is None
+
+    def test_list_of_typing_dict_input(self) -> None:
+        """List[Dict[str, Any]] should produce a repeated ANY field."""
+        ft = FieldType.from_type(List[Dict[str, Any]])
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.REPEATED
+
+    def test_optional_dict_input(self) -> None:
+        """Optional[dict] should produce an optional ANY field."""
+        ft = FieldType.from_type(Optional[dict])
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.OPTIONAL
+        assert ft.coder is None
+
+    def test_optional_typing_dict_input(self) -> None:
+        """Optional[Dict[str, Any]] should produce an optional ANY field."""
+        ft = FieldType.from_type(Optional[Dict[str, Any]])
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.OPTIONAL
+        assert ft.coder is None
+
+    def test_optional_list_of_dict_input(self) -> None:
+        """Optional[list[dict]] should produce an optional repeated ANY field."""
+        ft = FieldType.from_type(Optional[list[dict]])
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.OPTIONAL_REPEATED
+
+    def test_optional_list_of_typing_dict_input(self) -> None:
+        """Optional[List[Dict[str, Any]]] should produce optional repeated ANY."""
+        ft = FieldType.from_type(Optional[List[Dict[str, Any]]])
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.OPTIONAL_REPEATED
+
+    def test_pep604_dict_or_none(self) -> None:
+        """dict | None (PEP 604) should produce optional ANY."""
+        ft = FieldType.from_type(dict | None)
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.OPTIONAL
+        assert ft.coder is None
+
+    def test_pep604_list_dict_or_none(self) -> None:
+        """list[dict] | None (PEP 604) should produce optional repeated ANY."""
+        ft = FieldType.from_type(list[dict] | None)
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.OPTIONAL_REPEATED
+
+    def test_dict_str_int_type_erasure(self) -> None:
+        """dict[str, int] should be accepted as ANY (type params discarded)."""
+        ft = FieldType.from_type(dict[str, int])
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.REQUIRED
+
+    def test_list_dict_str_int_type_erasure(self) -> None:
+        """list[dict[str, int]] should be accepted as repeated ANY."""
+        ft = FieldType.from_type(list[dict[str, int]])
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.REPEATED
+
+
+class TestDictJsonSchema:
+    """Tests for JSON schema generation with dict types."""
+
+    def test_dict_json_type(self) -> None:
+        """dict should generate {"type": "object"} schema."""
+        ft = FieldType.from_type(dict)
+        assert ft.json_type() == {"type": "object"}
+
+    def test_list_of_dict_json_type(self) -> None:
+        """list[dict] should generate array-of-objects schema."""
+        ft = FieldType.from_type(list[dict])
+        assert ft.json_type() == {"type": "array", "items": {"type": "object"}}
+
+
+class TestDictNormalization:
+    """Tests for normalize/encode/decode with dict types."""
+
+    def test_dict_normalize_passthrough(self) -> None:
+        """dict normalize should pass values through unchanged."""
+        ft = FieldType.from_type(dict)
+        data = {"key": "value", "nested": {"a": 1}}
+        assert ft.normalize(data) == data
+
+    def test_list_of_dict_normalize_passthrough(self) -> None:
+        """list[dict] normalize should pass list elements through unchanged."""
+        ft = FieldType.from_type(list[dict])
+        data = [{"key": "value"}, {"a": 1}]
+        assert ft.normalize(data) == data
+
+    def test_optional_dict_normalize_none(self) -> None:
+        """Optional[dict] should normalize None to None."""
+        ft = FieldType.from_type(Optional[dict])
+        assert ft.normalize(None) is None
+
+    def test_optional_list_dict_normalize_none(self) -> None:
+        """Optional[list[dict]] should normalize None to None."""
+        ft = FieldType.from_type(Optional[list[dict]])
+        assert ft.normalize(None) is None
+
+    def test_dict_json_encode_passthrough(self) -> None:
+        """dict json_encode should pass values through unchanged."""
+        ft = FieldType.from_type(dict)
+        data = {"key": "value", "nested": {"a": 1}}
+        assert ft.json_encode(data) == data
+
+    def test_list_of_dict_json_encode_passthrough(self) -> None:
+        """list[dict] json_encode should pass list elements through unchanged."""
+        ft = FieldType.from_type(list[dict])
+        data = [{"key": "value"}, {"a": 1}]
+        assert ft.json_encode(data) == data
+
+    def test_dict_json_decode_passthrough(self) -> None:
+        """dict json_decode should pass values through unchanged."""
+        ft = FieldType.from_type(dict)
+        data = {"key": "value"}
+        assert ft.json_decode(data) == data
+
+
+class TestFieldTypeExistingTypes:
+    """Regression tests: ensure existing types still work after dict changes."""
+
+    def test_bare_list(self) -> None:
+        ft = FieldType.from_type(list)
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.REPEATED
+
+    def test_list_str(self) -> None:
+        ft = FieldType.from_type(list[str])
+        assert ft.primitive is PrimitiveType.STRING
+        assert ft.repetition is Repetition.REPEATED
+
+    def test_list_int(self) -> None:
+        ft = FieldType.from_type(list[int])
+        assert ft.primitive is PrimitiveType.INTEGER
+        assert ft.repetition is Repetition.REPEATED
+
+    def test_optional_str(self) -> None:
+        ft = FieldType.from_type(Optional[str])
+        assert ft.primitive is PrimitiveType.STRING
+        assert ft.repetition is Repetition.OPTIONAL


### PR DESCRIPTION
dict, Dict[str, Any], list[dict], and List[Dict[str, Any]] were not supported as predictor input types, even though they worked as output types. This broke models using chat-style messages: list[dict] inputs.

The fix maps dict types to ANY (opaque JSON objects) in both the Go tree-sitter schema generator (ResolveFieldType) and the Python SDK runtime (FieldType.from_type), handling all variants: bare dict, parameterized Dict[K,V], list[dict], Optional[dict], and PEP 604 union syntax.