### PR TITLE
Detect pydantic.BaseModel in output types and error with migration gu…

### DIFF
--- a/integration-tests/tests/pydantic2_output.txtar
+++ b/integration-tests/tests/pydantic2_output.txtar
@@ -1,15 +1,10 @@
-# Test that Pydantic v2 BaseModel works as prediction output type.
-# Coglet's make_encodeable() must call model_dump() to serialize.
+# Test that Pydantic v2 BaseModel is detected and errors with migration guidance.
+# Cog 0.17+ uses cog.BaseModel for structured outputs.
 
-# Build the image
-cog build -t $TEST_IMAGE
-
-# Predict returns structured Pydantic output
-cog predict $TEST_IMAGE -i name=alice -i score=0.95
-stdout '"name": "alice"'
-stdout '"score": 0.95'
-stdout '"tags"'
-stdout 'default'
+# Build should fail with clear migration guidance
+! cog build -t $TEST_IMAGE
+stderr 'inherits from pydantic.BaseModel'
+stderr 'cog.BaseModel'
 
 -- cog.yaml --
 build:

--- a/python/cog/_inspector.py
+++ b/python/cog/_inspector.py
@@ -289,11 +289,11 @@ def _create_output_type(tpe: type) -> adt.OutputType:
         and inspect.isclass(tpe)
         and _check_parent(tpe, PydanticBaseModel)
     ):
-        fields = {}
-        for name, field_info in tpe.model_fields.items():
-            ft = adt.FieldType.from_type(field_info.annotation)
-            fields[name] = ft
-        return adt.OutputType(kind=adt.OutputKind.OBJECT, fields=fields)
+        raise ValueError(
+            f"{tpe.__name__} inherits from pydantic.BaseModel.\n"
+            "Cog 0.17+ uses cog.BaseModel for structured outputs.\n"
+            "Change: from cog import BaseModel"
+        )
 
     origin = typing.get_origin(tpe)
     concat_iters = {ConcatenateIterator, AsyncConcatenateIterator}

--- a/python/tests/test_inspector.py
+++ b/python/tests/test_inspector.py
@@ -1,0 +1,49 @@
+"""Tests for _inspector module."""
+
+import pytest
+
+from cog._inspector import _create_output_type
+
+try:
+    from pydantic import BaseModel as PydanticBaseModel
+
+    HAS_PYDANTIC = True
+except ImportError:
+    HAS_PYDANTIC = False
+
+
+@pytest.mark.skipif(not HAS_PYDANTIC, reason="pydantic not installed")
+def test_pydantic_basemodel_output_raises_error():
+    """Detect pydantic.BaseModel in output types and error with migration guidance (#2922)."""
+
+    class MyOutput(PydanticBaseModel):
+        text: str
+        score: float
+
+    with pytest.raises(ValueError, match="inherits from pydantic.BaseModel"):
+        _create_output_type(MyOutput)
+
+
+@pytest.mark.skipif(not HAS_PYDANTIC, reason="pydantic not installed")
+def test_pydantic_basemodel_error_message_includes_guidance():
+    """Error message should include migration guidance to cog.BaseModel."""
+
+    class Result(PydanticBaseModel):
+        name: str
+
+    with pytest.raises(ValueError, match="from cog import BaseModel"):
+        _create_output_type(Result)
+
+
+def test_cog_basemodel_output_works():
+    """cog.BaseModel should still work as output type."""
+    from cog.model import BaseModel
+
+    class Output(BaseModel):
+        text: str
+        score: float
+
+    result = _create_output_type(Output)
+    assert result.kind.name == "OBJECT"
+    assert "text" in result.fields
+    assert "score" in result.fields


### PR DESCRIPTION
## Summary

Fixes #2922

When a predictor uses `pydantic.BaseModel` as the output type, `cog push` fails with an opaque `PydanticSchemaGenerationError`. This PR detects `pydantic.BaseModel` subclasses early in `_create_output_type()` and raises a clear error with migration guidance to `cog.BaseModel`.

## Changes

- **`python/cog/_inspector.py`**: Replace silent acceptance of `pydantic.BaseModel` output types with a `ValueError` that includes the class name and migration instructions to `cog.BaseModel`.
- **`python/tests/test_inspector.py`** *(new)*: Add 3 unit tests — pydantic detection raises error, error message includes migration guidance, `cog.BaseModel` still works.
- **`integration-tests/tests/pydantic2_output.txtar`**: Update integration test to expect `cog build` to fail with the new error message.

## Error Message

```
MyOutput inherits from pydantic.BaseModel.
Cog 0.17+ uses cog.BaseModel for structured outputs.
Change: from cog import BaseModel
```

## Testing

- 3 new unit tests pass
- Integration test updated and passes
- Full Python test suite (64 tests) passes
