### PR TITLE
feat(test-harness): add --keep-outputs flag and refactor Runner to Options struct

### DIFF
--- a/tools/test-harness/README.md
+++ b/tools/test-harness/README.md
@@ -85,6 +85,7 @@ Common options:
   --cog-ref REF         Git ref to build cog from source
   --sdk-wheel PATH      Local SDK wheel path
   --keep-images         Keep Docker images after run
+  --keep-outputs        Preserve prediction outputs (images, files) in the work directory
 
 Run/schema-compare options:
   --output {console,json}   Output format

--- a/tools/test-harness/README.md
+++ b/tools/test-harness/README.md
@@ -84,7 +84,7 @@ Common options:
   --cog-binary PATH     Path to local cog binary
   --cog-ref REF         Git ref to build cog from source
   --sdk-wheel PATH      Local SDK wheel path
-  --keep-images         Keep Docker images after run
+  --clean-images        Remove Docker images after run (default: keep them)
   --keep-outputs        Preserve prediction outputs (images, files) in the work directory
 
 Run/schema-compare options:

--- a/tools/test-harness/README.md
+++ b/tools/test-harness/README.md
@@ -85,7 +85,7 @@ Common options:
   --cog-ref REF         Git ref to build cog from source
   --sdk-wheel PATH      Local SDK wheel path
   --clean-images        Remove Docker images after run (default: keep them)
-  --keep-outputs        Preserve prediction outputs (images, files) in the work directory
+  --keep-outputs        Preserve prediction outputs and print the work directory path
 
 Run/schema-compare options:
   --output {console,json}   Output format

--- a/tools/test-harness/cmd/build.go
+++ b/tools/test-harness/cmd/build.go
@@ -39,7 +39,7 @@ func runBuild(ctx context.Context) error {
 		CogBinary:   resolved.CogBinary,
 		SDKVersion:  resolved.SDKPatchVersion,
 		SDKWheel:    resolved.SDKWheel,
-		KeepImages:  keepImages,
+		CleanImages: cleanImages,
 		KeepOutputs: keepOutputs,
 	})
 	if err != nil {

--- a/tools/test-harness/cmd/build.go
+++ b/tools/test-harness/cmd/build.go
@@ -35,7 +35,13 @@ func runBuild(ctx context.Context) error {
 	fmt.Printf("Building %d model(s)\n\n", len(models))
 
 	// Create runner
-	r, err := runner.New(resolved.CogBinary, resolved.SDKPatchVersion, resolved.SDKWheel, "", keepImages)
+	r, err := runner.New(runner.Options{
+		CogBinary:   resolved.CogBinary,
+		SDKVersion:  resolved.SDKPatchVersion,
+		SDKWheel:    resolved.SDKWheel,
+		KeepImages:  keepImages,
+		KeepOutputs: keepOutputs,
+	})
 	if err != nil {
 		return fmt.Errorf("creating runner: %w", err)
 	}

--- a/tools/test-harness/cmd/root.go
+++ b/tools/test-harness/cmd/root.go
@@ -19,7 +19,7 @@ var (
 	cogBinary    string
 	cogRef       string
 	sdkWheel     string
-	keepImages   bool
+	cleanImages  bool
 	keepOutputs  bool
 )
 
@@ -44,7 +44,7 @@ It reads the same manifest.yaml format as the Python version.`,
 	rootCmd.PersistentFlags().StringVar(&cogBinary, "cog-binary", "cog", "Path to cog binary")
 	rootCmd.PersistentFlags().StringVar(&cogRef, "cog-ref", "", "Git ref to build cog from")
 	rootCmd.PersistentFlags().StringVar(&sdkWheel, "sdk-wheel", "", "Path to pre-built SDK wheel")
-	rootCmd.PersistentFlags().BoolVar(&keepImages, "keep-images", false, "Don't clean up Docker images")
+	rootCmd.PersistentFlags().BoolVar(&cleanImages, "clean-images", false, "Remove Docker images after run (default: keep them)")
 	rootCmd.PersistentFlags().BoolVar(&keepOutputs, "keep-outputs", false, "Preserve prediction outputs (images, files) in the work directory")
 
 	// Subcommands

--- a/tools/test-harness/cmd/root.go
+++ b/tools/test-harness/cmd/root.go
@@ -20,6 +20,7 @@ var (
 	cogRef       string
 	sdkWheel     string
 	keepImages   bool
+	keepOutputs  bool
 )
 
 // NewRootCommand creates the root command
@@ -44,6 +45,7 @@ It reads the same manifest.yaml format as the Python version.`,
 	rootCmd.PersistentFlags().StringVar(&cogRef, "cog-ref", "", "Git ref to build cog from")
 	rootCmd.PersistentFlags().StringVar(&sdkWheel, "sdk-wheel", "", "Path to pre-built SDK wheel")
 	rootCmd.PersistentFlags().BoolVar(&keepImages, "keep-images", false, "Don't clean up Docker images")
+	rootCmd.PersistentFlags().BoolVar(&keepOutputs, "keep-outputs", false, "Preserve prediction outputs (images, files) in the work directory")
 
 	// Subcommands
 	rootCmd.AddCommand(newRunCommand())

--- a/tools/test-harness/cmd/run.go
+++ b/tools/test-harness/cmd/run.go
@@ -54,7 +54,13 @@ func runRun(ctx context.Context, outputFormat, outputFile string) error {
 	fmt.Printf("Running %d model(s)\n\n", len(models))
 
 	// Create runner
-	r, err := runner.New(resolved.CogBinary, resolved.SDKPatchVersion, resolved.SDKWheel, "", keepImages)
+	r, err := runner.New(runner.Options{
+		CogBinary:   resolved.CogBinary,
+		SDKVersion:  resolved.SDKPatchVersion,
+		SDKWheel:    resolved.SDKWheel,
+		KeepImages:  keepImages,
+		KeepOutputs: keepOutputs,
+	})
 	if err != nil {
 		return fmt.Errorf("creating runner: %w", err)
 	}

--- a/tools/test-harness/cmd/run.go
+++ b/tools/test-harness/cmd/run.go
@@ -58,7 +58,7 @@ func runRun(ctx context.Context, outputFormat, outputFile string) error {
 		CogBinary:   resolved.CogBinary,
 		SDKVersion:  resolved.SDKPatchVersion,
 		SDKWheel:    resolved.SDKWheel,
-		KeepImages:  keepImages,
+		CleanImages: cleanImages,
 		KeepOutputs: keepOutputs,
 	})
 	if err != nil {

--- a/tools/test-harness/cmd/schema_compare.go
+++ b/tools/test-harness/cmd/schema_compare.go
@@ -52,7 +52,7 @@ func runSchemaCompare(ctx context.Context, outputFormat, outputFile string) erro
 		CogBinary:   resolved.CogBinary,
 		SDKVersion:  resolved.SDKPatchVersion,
 		SDKWheel:    resolved.SDKWheel,
-		KeepImages:  keepImages,
+		CleanImages: cleanImages,
 		KeepOutputs: keepOutputs,
 	})
 	if err != nil {

--- a/tools/test-harness/cmd/schema_compare.go
+++ b/tools/test-harness/cmd/schema_compare.go
@@ -48,7 +48,13 @@ func runSchemaCompare(ctx context.Context, outputFormat, outputFile string) erro
 	fmt.Printf("Comparing schemas for %d model(s)\n\n", len(models))
 
 	// Create runner
-	r, err := runner.New(resolved.CogBinary, resolved.SDKPatchVersion, resolved.SDKWheel, "", keepImages)
+	r, err := runner.New(runner.Options{
+		CogBinary:   resolved.CogBinary,
+		SDKVersion:  resolved.SDKPatchVersion,
+		SDKWheel:    resolved.SDKWheel,
+		KeepImages:  keepImages,
+		KeepOutputs: keepOutputs,
+	})
 	if err != nil {
 		return fmt.Errorf("creating runner: %w", err)
 	}

--- a/tools/test-harness/internal/patcher/patcher_test.go
+++ b/tools/test-harness/internal/patcher/patcher_test.go
@@ -4,47 +4,35 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPatch(t *testing.T) {
-	// Create temp directory
 	tmpDir := t.TempDir()
 
-	// Test case 1: Patch with SDK version
 	t.Run("patch sdk version", func(t *testing.T) {
 		cogYAML := filepath.Join(tmpDir, "cog1.yaml")
 		content := `build:
   python_version: "3.10"
 predict: predict.py
 `
-		if err := os.WriteFile(cogYAML, []byte(content), 0644); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := Patch(cogYAML, "0.16.12", nil); err != nil {
-			t.Fatalf("Patch failed: %v", err)
-		}
+		require.NoError(t, os.WriteFile(cogYAML, []byte(content), 0644))
+		require.NoError(t, Patch(cogYAML, "0.16.12", nil))
 
 		data, err := os.ReadFile(cogYAML)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if !contains(string(data), "sdk_version: 0.16.12") {
-			t.Errorf("Expected sdk_version in output, got:\n%s", string(data))
-		}
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "sdk_version: 0.16.12")
 	})
 
-	// Test case 2: Patch with overrides
 	t.Run("patch with overrides", func(t *testing.T) {
 		cogYAML := filepath.Join(tmpDir, "cog2.yaml")
 		content := `build:
   python_version: "3.10"
 predict: predict.py
 `
-		if err := os.WriteFile(cogYAML, []byte(content), 0644); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(cogYAML, []byte(content), 0644))
 
 		overrides := map[string]any{
 			"build": map[string]any{
@@ -52,51 +40,33 @@ predict: predict.py
 			},
 		}
 
-		if err := Patch(cogYAML, "", overrides); err != nil {
-			t.Fatalf("Patch failed: %v", err)
-		}
+		require.NoError(t, Patch(cogYAML, "", overrides))
 
 		data, err := os.ReadFile(cogYAML)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if !contains(string(data), "system_packages") {
-			t.Errorf("Expected system_packages in output, got:\n%s", string(data))
-		}
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "system_packages")
 	})
 
-	// Test case 3: Patch with both SDK version and overrides
 	t.Run("patch sdk and overrides", func(t *testing.T) {
 		cogYAML := filepath.Join(tmpDir, "cog3.yaml")
 		content := `build:
   python_version: "3.10"
 predict: predict.py
 `
-		if err := os.WriteFile(cogYAML, []byte(content), 0644); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(cogYAML, []byte(content), 0644))
 
 		overrides := map[string]any{
 			"predict": "new_predict.py",
 		}
 
-		if err := Patch(cogYAML, "0.16.12", overrides); err != nil {
-			t.Fatalf("Patch failed: %v", err)
-		}
+		require.NoError(t, Patch(cogYAML, "0.16.12", overrides))
 
 		data, err := os.ReadFile(cogYAML)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		result := string(data)
-		if !contains(result, "sdk_version: 0.16.12") {
-			t.Errorf("Expected sdk_version in output, got:\n%s", result)
-		}
-		if !contains(result, "new_predict.py") {
-			t.Errorf("Expected new_predict.py in output, got:\n%s", result)
-		}
+		assert.Contains(t, result, "sdk_version: 0.16.12")
+		assert.Contains(t, result, "new_predict.py")
 	})
 }
 
@@ -129,45 +99,7 @@ func TestDeepMerge(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := deepMerge(tt.base, tt.override)
-			if !mapsEqual(got, tt.want) {
-				t.Errorf("deepMerge() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, deepMerge(tt.base, tt.override))
 		})
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || containsAt(s, substr))
-}
-
-func containsAt(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}
-
-func mapsEqual(a, b map[string]any) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for k, v := range a {
-		bv, ok := b[k]
-		if !ok {
-			return false
-		}
-		vma, vmaOK := v.(map[string]any)
-		vmb, vmbOK := bv.(map[string]any)
-		if vmaOK && vmbOK {
-			if !mapsEqual(vma, vmb) {
-				return false
-			}
-		} else if v != bv {
-			return false
-		}
-	}
-	return true
 }

--- a/tools/test-harness/internal/runner/runner.go
+++ b/tools/test-harness/internal/runner/runner.go
@@ -32,7 +32,7 @@ type Options struct {
 	SDKVersion  string
 	SDKWheel    string
 	FixturesDir string
-	KeepImages  bool
+	CleanImages bool
 	KeepOutputs bool
 }
 
@@ -115,7 +115,7 @@ func resolveFixturesDir() (string, error) {
 // Cleanup removes temp directories and Docker images
 func (r *Runner) Cleanup() error {
 	var errs []error
-	if !r.opts.KeepImages {
+	if r.opts.CleanImages {
 		cmd := exec.Command("docker", "images", "--filter", "reference=cog-harness-*", "--format", "{{.Repository}}:{{.Tag}}")
 		output, err := cmd.Output()
 		if err == nil && len(output) > 0 {

--- a/tools/test-harness/internal/runner/runner.go
+++ b/tools/test-harness/internal/runner/runner.go
@@ -26,19 +26,27 @@ import (
 
 const openapiSchemaLabel = "run.cog.openapi_schema"
 
+// Options configures a Runner.
+type Options struct {
+	CogBinary   string
+	SDKVersion  string
+	SDKWheel    string
+	FixturesDir string
+	KeepImages  bool
+	KeepOutputs bool
+}
+
 // Runner orchestrates the test lifecycle
 type Runner struct {
-	cogBinary   string
-	sdkVersion  string
-	sdkWheel    string
+	opts        Options
 	fixturesDir string
 	workDir     string
-	keepImages  bool
 	clonedRepos map[string]string
 }
 
 // New creates a new Runner
-func New(cogBinary, sdkVersion, sdkWheel string, fixturesDir string, keepImages bool) (*Runner, error) {
+func New(opts Options) (*Runner, error) {
+	fixturesDir := opts.FixturesDir
 	if fixturesDir == "" {
 		var err error
 		fixturesDir, err = resolveFixturesDir()
@@ -66,12 +74,9 @@ func New(cogBinary, sdkVersion, sdkWheel string, fixturesDir string, keepImages 
 	}
 
 	return &Runner{
-		cogBinary:   cogBinary,
-		sdkVersion:  sdkVersion,
-		sdkWheel:    sdkWheel,
+		opts:        opts,
 		fixturesDir: fixturesDir,
 		workDir:     workDir,
-		keepImages:  keepImages,
 		clonedRepos: make(map[string]string),
 	}, nil
 }
@@ -110,7 +115,7 @@ func resolveFixturesDir() (string, error) {
 // Cleanup removes temp directories and Docker images
 func (r *Runner) Cleanup() error {
 	var errs []error
-	if !r.keepImages {
+	if !r.opts.KeepImages {
 		cmd := exec.Command("docker", "images", "--filter", "reference=cog-harness-*", "--format", "{{.Repository}}:{{.Tag}}")
 		output, err := cmd.Output()
 		if err == nil && len(output) > 0 {
@@ -125,8 +130,12 @@ func (r *Runner) Cleanup() error {
 	}
 
 	if r.workDir != "" {
-		if err := os.RemoveAll(r.workDir); err != nil {
-			errs = append(errs, fmt.Errorf("removing work dir: %w", err))
+		if r.opts.KeepOutputs {
+			fmt.Printf("Outputs preserved in: %s\n", r.workDir)
+		} else {
+			if err := os.RemoveAll(r.workDir); err != nil {
+				errs = append(errs, fmt.Errorf("removing work dir: %w", err))
+			}
 		}
 	}
 
@@ -388,7 +397,7 @@ func (r *Runner) prepareModel(ctx context.Context, model manifest.Model) (string
 	// Patch cog.yaml
 	sdkVersion := model.SDKVersion
 	if sdkVersion == "" {
-		sdkVersion = r.sdkVersion
+		sdkVersion = r.opts.SDKVersion
 	}
 	if err := patcher.Patch(filepath.Join(modelDir, "cog.yaml"), sdkVersion, model.CogYAMLOverrides); err != nil {
 		return "", fmt.Errorf("patching cog.yaml: %w", err)
@@ -454,11 +463,11 @@ func (r *Runner) buildModelWithEnv(ctx context.Context, modelDir string, model m
 
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, r.cogBinary, "build", "-t", imageTag)
+	cmd := exec.CommandContext(ctx, r.opts.CogBinary, "build", "-t", imageTag)
 	cmd.Dir = modelDir
 	cmd.Env = os.Environ()
-	if r.sdkWheel != "" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("COG_SDK_WHEEL=%s", r.sdkWheel))
+	if r.opts.SDKWheel != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("COG_SDK_WHEEL=%s", r.opts.SDKWheel))
 	}
 	envKeys := make([]string, 0, len(model.Env))
 	for k := range model.Env {
@@ -539,11 +548,11 @@ func (r *Runner) runCogTest(ctx context.Context, modelDir string, model manifest
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, r.cogBinary, args...)
+	cmd := exec.CommandContext(ctx, r.opts.CogBinary, args...)
 	cmd.Dir = modelDir
 	cmd.Env = os.Environ()
-	if r.sdkWheel != "" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("COG_SDK_WHEEL=%s", r.sdkWheel))
+	if r.opts.SDKWheel != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("COG_SDK_WHEEL=%s", r.opts.SDKWheel))
 	}
 	envKeys := make([]string, 0, len(model.Env))
 	for k := range model.Env {

--- a/tools/test-harness/internal/validator/validator.go
+++ b/tools/test-harness/internal/validator/validator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"mime"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -105,7 +106,7 @@ func validateFileExists(output string, expect manifest.Expectation) Result {
 
 	// Check MIME type if specified
 	if expect.Mime != "" {
-		guessed := mime.TypeByExtension(pathStr)
+		guessed := mime.TypeByExtension(filepath.Ext(pathStr))
 		if guessed != expect.Mime {
 			return Result{
 				Passed:  false,

--- a/tools/test-harness/internal/validator/validator_test.go
+++ b/tools/test-harness/internal/validator/validator_test.go
@@ -1,7 +1,11 @@
 package validator
 
 import (
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog/tools/test-harness/internal/manifest"
 )
@@ -36,9 +40,7 @@ func TestValidateExact(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := Validate(tt.output, tt.expect)
-			if result.Passed != tt.wantPass {
-				t.Errorf("Validate() passed = %v, want %v, message: %s", result.Passed, tt.wantPass, result.Message)
-			}
+			assert.Equal(t, tt.wantPass, result.Passed, "message: %s", result.Message)
 		})
 	}
 }
@@ -67,9 +69,7 @@ func TestValidateContains(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := Validate(tt.output, tt.expect)
-			if result.Passed != tt.wantPass {
-				t.Errorf("Validate() passed = %v, want %v", result.Passed, tt.wantPass)
-			}
+			assert.Equal(t, tt.wantPass, result.Passed, "message: %s", result.Message)
 		})
 	}
 }
@@ -104,9 +104,59 @@ func TestValidateRegex(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := Validate(tt.output, tt.expect)
-			if result.Passed != tt.wantPass {
-				t.Errorf("Validate() passed = %v, want %v", result.Passed, tt.wantPass)
-			}
+			assert.Equal(t, tt.wantPass, result.Passed, "message: %s", result.Message)
+		})
+	}
+}
+
+func TestValidateFileExists(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test-*.png")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	tests := []struct {
+		name     string
+		output   string
+		expect   manifest.Expectation
+		wantPass bool
+	}{
+		{
+			name:     "file exists no mime check",
+			output:   tmpFile.Name(),
+			expect:   manifest.Expectation{Type: "file_exists"},
+			wantPass: true,
+		},
+		{
+			name:     "file exists with correct mime",
+			output:   tmpFile.Name(),
+			expect:   manifest.Expectation{Type: "file_exists", Mime: "image/png"},
+			wantPass: true,
+		},
+		{
+			name:     "file exists with wrong mime",
+			output:   tmpFile.Name(),
+			expect:   manifest.Expectation{Type: "file_exists", Mime: "image/jpeg"},
+			wantPass: false,
+		},
+		{
+			name:     "file does not exist",
+			output:   "/nonexistent/path/file.png",
+			expect:   manifest.Expectation{Type: "file_exists"},
+			wantPass: false,
+		},
+		{
+			name:     "url passes",
+			output:   "https://example.com/image.png",
+			expect:   manifest.Expectation{Type: "file_exists"},
+			wantPass: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Validate(tt.output, tt.expect)
+			assert.Equal(t, tt.wantPass, result.Passed, "message: %s", result.Message)
 		})
 	}
 }
@@ -137,9 +187,7 @@ func TestValidateNotEmpty(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := Validate(tt.output, manifest.Expectation{Type: "not_empty"})
-			if result.Passed != tt.wantPass {
-				t.Errorf("Validate() passed = %v, want %v", result.Passed, tt.wantPass)
-			}
+			assert.Equal(t, tt.wantPass, result.Passed, "message: %s", result.Message)
 		})
 	}
 }
@@ -189,9 +237,7 @@ func TestValidateJSONMatch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := Validate(tt.output, tt.expect)
-			if result.Passed != tt.wantPass {
-				t.Errorf("Validate() passed = %v, want %v, message: %s", result.Passed, tt.wantPass, result.Message)
-			}
+			assert.Equal(t, tt.wantPass, result.Passed, "message: %s", result.Message)
 		})
 	}
 }
@@ -232,9 +278,7 @@ func TestValidateJSONKeys(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := Validate(tt.output, tt.expect)
-			if result.Passed != tt.wantPass {
-				t.Errorf("Validate() passed = %v, want %v", result.Passed, tt.wantPass)
-			}
+			assert.Equal(t, tt.wantPass, result.Passed, "message: %s", result.Message)
 		})
 	}
 }
@@ -274,10 +318,7 @@ func TestIsSubset(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isSubset(tt.subset, tt.superset)
-			if got != tt.want {
-				t.Errorf("isSubset() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, isSubset(tt.subset, tt.superset))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- **`--keep-outputs` flag**: Preserves the work directory (prediction output files like images) after a run, printing the path so they can be inspected instead of being automatically deleted.
- **Keep Docker images by default**: Replaces `--keep-images` with `--clean-images`. Images are now kept by default to avoid wasteful rebuilds during iterative local development.
- **Runner Options refactor**: Replaces the 6-argument `runner.New()` constructor with a `runner.Options` struct for clarity and extensibility.
- **MIME type detection fix**: `validateFileExists` was passing the full file path to `mime.TypeByExtension` instead of just the extension (e.g. `.png`), causing MIME checks to always return empty and fail.
- **Test convention cleanup**: Converts `patcher` and `validator` tests from raw `t.Fatal`/`t.Errorf` to testify `assert`/`require`, matching the project convention. Removes hand-rolled `contains`/`mapsEqual` helpers.

## Usage

```bash
# Keep outputs for inspection
go run . run --no-gpu --keep-outputs --model blur
# => Outputs preserved in: ~/.cache/cog-harness/run-XXXXXXX

# Explicitly clean up Docker images after run
go run . run --no-gpu --clean-images
```