### PR TITLE
ci: use mise-action as single tool installer across all workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -97,16 +97,15 @@ Runs CodeQL security scanning for Go, Python, and Rust.
 
 ## Caching Strategy
 
-### Rust Cache
+### Tool Cache (mise)
+- `jdx/mise-action@v4` with `cache: true` (default) caches all installed tools
+- Tool versions are defined in `mise.toml` — CI and local dev use the same versions
+- Cache key includes platform, mise version, and config file hashes
+
+### Rust Target Cache
 - **Save**: Only on `main` branch pushes (to avoid PR cache pollution)
 - **Restore**: On all runs (PRs restore from main's cache)
 - Uses `Swatinem/rust-cache@v2` with workspace path `crates -> target`
-
-### Go Cache
-- Built into `actions/setup-go` via `cache-dependency-path`
-
-### Python/uv Cache
-- Built into `jdx/mise-action` and `astral-sh/setup-uv`
 
 ## Artifacts
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,18 +39,13 @@ permissions: {}
 jobs:
   # Passthrough for SUPPORTED_PYTHONS — env context is unavailable in
   # strategy.matrix, so matrix jobs reference this job's output instead.
-  # Also warms the mise tool cache so downstream jobs get cache hits.
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     outputs:
       supported_pythons: ${{ env.SUPPORTED_PYTHONS }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
-        # This job warms the mise tool cache for all downstream jobs.
-        # All other jobs set cache_save: false to avoid save races.
       - run: echo "supported_pythons=$SUPPORTED_PYTHONS"
 
 # =============================================================================
@@ -127,8 +122,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Build SDK
         run: mise run ci:build:sdk
       - name: Upload SDK package
@@ -179,8 +172,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Get version from VERSION.txt
         id: version
         run: echo "version=$(tr -d '[:space:]' < VERSION.txt)" >> "$GITHUB_OUTPUT"
@@ -210,8 +201,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Check Go formatting
         run: mise run fmt:go
 
@@ -222,8 +211,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Check Rust formatting
         run: mise run fmt:rust
 
@@ -234,8 +221,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Check Python formatting
         run: mise run fmt:python
 
@@ -246,8 +231,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Check llms.txt is up to date
         run: mise run docs:llm:check
       - name: Check CLI docs are up to date
@@ -270,8 +253,6 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Check stubs are up to date
         run: |
           # stub_gen links libpython dynamically; tell the linker where to find it
@@ -289,8 +270,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Lint Go
         run: mise run lint:go
 
@@ -305,8 +284,6 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Lint Rust (clippy)
         run: mise run lint:rust
 
@@ -317,8 +294,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Check licenses and advisories
         run: mise run lint:rust:deny
 
@@ -341,8 +316,6 @@ jobs:
       - name: Extract source distribution
         run: tar xf dist/*.tar.gz --strip-components=1
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Lint Python
         run: mise run lint:python
 
@@ -353,8 +326,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Lint Markdown
         run: mise run lint:docs
 
@@ -373,9 +344,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
-        with:
-          # Save on macOS (only job on that platform); skip on Linux (setup job saves)
-          cache_save: ${{ matrix.platform == 'macos-latest' }}
       - name: Test Go
         shell: bash
         run: |
@@ -400,8 +368,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Fuzz schema type resolution
         run: go test ./pkg/schema/ -run='^$' -fuzz=FuzzResolveSchemaType -fuzztime=30s
       - name: Fuzz JSON schema generation
@@ -422,8 +388,6 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Test Rust
         run: mise run test:rust
 
@@ -445,8 +409,6 @@ jobs:
       - name: Extract source distribution
         run: tar xf dist/*.tar.gz --strip-components=1
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Remove src to ensure tests run against wheel
         run: rm -rf python/cog
       - name: Test Python
@@ -475,8 +437,6 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Test coglet-python bindings
         run: uvx nox -s coglet -p ${{ matrix.python-version }}
 
@@ -595,8 +555,6 @@ jobs:
           cp dist/cog ./cog
           chmod +x ./cog
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Set wheel environment
         run: |
           # Use locally-built wheels, not PyPI (version may not be published yet)
@@ -751,8 +709,6 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
-        with:
-          cache_save: false
       - name: Check coglet crates.io publish
         run: cargo publish --dry-run -p coglet --manifest-path crates/Cargo.toml
       - uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,6 +122,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Build SDK
         run: mise run ci:build:sdk
       - name: Upload SDK package
@@ -172,6 +174,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Get version from VERSION.txt
         id: version
         run: echo "version=$(tr -d '[:space:]' < VERSION.txt)" >> "$GITHUB_OUTPUT"
@@ -201,6 +205,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Check Go formatting
         run: mise run fmt:go
 
@@ -211,6 +217,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Check Rust formatting
         run: mise run fmt:rust
 
@@ -221,6 +229,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Check Python formatting
         run: mise run fmt:python
 
@@ -231,6 +241,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Check llms.txt is up to date
         run: mise run docs:llm:check
       - name: Check CLI docs are up to date
@@ -253,6 +265,8 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Check stubs are up to date
         run: |
           # stub_gen links libpython dynamically; tell the linker where to find it
@@ -270,6 +284,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Lint Go
         run: mise run lint:go
 
@@ -284,6 +300,8 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Lint Rust (clippy)
         run: mise run lint:rust
 
@@ -294,6 +312,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Check licenses and advisories
         run: mise run lint:rust:deny
 
@@ -316,6 +336,8 @@ jobs:
       - name: Extract source distribution
         run: tar xf dist/*.tar.gz --strip-components=1
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Lint Python
         run: mise run lint:python
 
@@ -326,6 +348,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Lint Markdown
         run: mise run lint:docs
 
@@ -344,6 +368,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Test Go
         shell: bash
         run: |
@@ -368,6 +394,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Fuzz schema type resolution
         run: go test ./pkg/schema/ -run='^$' -fuzz=FuzzResolveSchemaType -fuzztime=30s
       - name: Fuzz JSON schema generation
@@ -388,6 +416,8 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Test Rust
         run: mise run test:rust
 
@@ -409,6 +439,8 @@ jobs:
       - name: Extract source distribution
         run: tar xf dist/*.tar.gz --strip-components=1
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Remove src to ensure tests run against wheel
         run: rm -rf python/cog
       - name: Test Python
@@ -437,6 +469,8 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Test coglet-python bindings
         run: uvx nox -s coglet -p ${{ matrix.python-version }}
 
@@ -555,6 +589,8 @@ jobs:
           cp dist/cog ./cog
           chmod +x ./cog
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Set wheel environment
         run: |
           # Use locally-built wheels, not PyPI (version may not be published yet)
@@ -709,6 +745,8 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - name: Check coglet crates.io publish
         run: cargo publish --dry-run -p coglet --manifest-path crates/Cargo.toml
       - uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,8 +31,8 @@ env:
   CARGO_TERM_COLOR: always
   # CGo required for go-tree-sitter (static Python schema parser)
   CGO_ENABLED: "1"
-  # Disable tools that are only needed locally or are bundled by maturin-action
-  MISE_DISABLE_TOOLS: rustup,rustup-init
+  # Note: do NOT add rustup/rustup-init to MISE_DISABLE_TOOLS — mise needs
+  # them to install Rust components (rustfmt, clippy) specified in mise.toml.
 
 permissions: {}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,13 +39,18 @@ permissions: {}
 jobs:
   # Passthrough for SUPPORTED_PYTHONS — env context is unavailable in
   # strategy.matrix, so matrix jobs reference this job's output instead.
+  # Also warms the mise tool cache so downstream jobs get cache hits.
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     outputs:
       supported_pythons: ${{ env.SUPPORTED_PYTHONS }}
     steps:
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@v4
+        # This job warms the mise tool cache for all downstream jobs.
+        # All other jobs set cache_save: false to avoid save races.
       - run: echo "supported_pythons=$SUPPORTED_PYTHONS"
 
 # =============================================================================
@@ -122,6 +127,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Build SDK
         run: mise run ci:build:sdk
       - name: Upload SDK package
@@ -172,6 +179,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Get version from VERSION.txt
         id: version
         run: echo "version=$(tr -d '[:space:]' < VERSION.txt)" >> "$GITHUB_OUTPUT"
@@ -201,6 +210,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Check Go formatting
         run: mise run fmt:go
 
@@ -211,6 +222,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Check Rust formatting
         run: mise run fmt:rust
 
@@ -221,6 +234,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Check Python formatting
         run: mise run fmt:python
 
@@ -231,6 +246,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Check llms.txt is up to date
         run: mise run docs:llm:check
       - name: Check CLI docs are up to date
@@ -253,6 +270,8 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Check stubs are up to date
         run: |
           # stub_gen links libpython dynamically; tell the linker where to find it
@@ -270,6 +289,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Lint Go
         run: mise run lint:go
 
@@ -284,6 +305,8 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Lint Rust (clippy)
         run: mise run lint:rust
 
@@ -294,6 +317,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Check licenses and advisories
         run: mise run lint:rust:deny
 
@@ -316,6 +341,8 @@ jobs:
       - name: Extract source distribution
         run: tar xf dist/*.tar.gz --strip-components=1
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Lint Python
         run: mise run lint:python
 
@@ -326,6 +353,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Lint Markdown
         run: mise run lint:docs
 
@@ -344,6 +373,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          # Save on macOS (only job on that platform); skip on Linux (setup job saves)
+          cache_save: ${{ matrix.platform == 'macos-latest' }}
       - name: Test Go
         shell: bash
         run: |
@@ -368,6 +400,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Fuzz schema type resolution
         run: go test ./pkg/schema/ -run='^$' -fuzz=FuzzResolveSchemaType -fuzztime=30s
       - name: Fuzz JSON schema generation
@@ -388,6 +422,8 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Test Rust
         run: mise run test:rust
 
@@ -409,6 +445,8 @@ jobs:
       - name: Extract source distribution
         run: tar xf dist/*.tar.gz --strip-components=1
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Remove src to ensure tests run against wheel
         run: rm -rf python/cog
       - name: Test Python
@@ -437,6 +475,8 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Test coglet-python bindings
         run: uvx nox -s coglet -p ${{ matrix.python-version }}
 
@@ -555,6 +595,8 @@ jobs:
           cp dist/cog ./cog
           chmod +x ./cog
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Set wheel environment
         run: |
           # Use locally-built wheels, not PyPI (version may not be published yet)
@@ -709,6 +751,8 @@ jobs:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
+        with:
+          cache_save: false
       - name: Check coglet crates.io publish
         run: cargo publish --dry-run -p coglet --manifest-path crates/Cargo.toml
       - uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,17 +31,8 @@ env:
   CARGO_TERM_COLOR: always
   # CGo required for go-tree-sitter (static Python schema parser)
   CGO_ENABLED: "1"
-  # Disable tools in mise that CI installs via dedicated GitHub Actions for
-  # better reliability (avoids transient GitHub Releases 502s from aqua downloads),
-  # better caching, and guaranteed tool ordering.
-  # - Rust toolchain: dtolnay/rust-toolchain
-  # - cargo-binstall: taiki-e/install-action
-  # - Python: astral-sh/setup-uv
-  # - golangci-lint: golangci/golangci-lint-action
-  # - gotestsum: go install (uses Go module proxy, not GitHub Releases)
-  # - cargo-deny, cargo-nextest: taiki-e/install-action
-  # - zig, cargo-zigbuild, maturin, cargo-insta: not needed in CI (maturin-action bundles zig)
-  MISE_DISABLE_TOOLS: rust,rustup,rustup-init,cargo-binstall,python,golangci-lint,gotestsum,cargo-deny,cargo-insta,cargo-nextest,cargo:cargo-nextest,zig,cargo-zigbuild,maturin,cargo:maturin
+  # Disable tools that are only needed locally or are bundled by maturin-action
+  MISE_DISABLE_TOOLS: rustup,rustup-init
 
 permissions: {}
 
@@ -130,15 +121,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - uses: dtolnay/rust-toolchain@stable
-      - run: rustup default stable
-      - uses: taiki-e/install-action@cargo-binstall
       - uses: jdx/mise-action@v4
-        with:
-          cache: false
       - name: Build SDK
         run: mise run ci:build:sdk
       - name: Upload SDK package
@@ -155,19 +138,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      # No mise needed - maturin-action bundles maturin and zig
-      # Explicitly request MINIMUM_PYTHON inside the manylinux container so
-      # maturin produces an ABI3 wheel (cp310-abi3). Without this, maturin
-      # picks up the container's default Python (3.8), which doesn't support
-      # ABI3, producing a cp38-cp38 wheel that the upload glob won't match.
+      # maturin-action bundles maturin and zig inside a manylinux container.
+      # Explicitly request MINIMUM_PYTHON inside the container so maturin
+      # produces an ABI3 wheel (cp310-abi3). Without this, maturin picks up
+      # the container's default Python (3.8), which doesn't support ABI3.
       - name: Build coglet wheel (ABI3)
         uses: PyO3/maturin-action@v1
         with:
@@ -193,13 +171,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
+      - uses: jdx/mise-action@v4
       - name: Get version from VERSION.txt
         id: version
         run: echo "version=$(tr -d '[:space:]' < VERSION.txt)" >> "$GITHUB_OUTPUT"
@@ -228,12 +200,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - run: rustup default stable
-      - uses: taiki-e/install-action@cargo-binstall
       - uses: jdx/mise-action@v4
-        with:
-          cache: false
       - name: Check Go formatting
         run: mise run fmt:go
 
@@ -243,12 +210,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      # No mise needed - rustfmt comes with toolchain
+      - uses: jdx/mise-action@v4
       - name: Check Rust formatting
-        run: cargo fmt --manifest-path crates/Cargo.toml --all -- --check
+        run: mise run fmt:rust
 
   fmt-python:
     name: Format Python
@@ -256,15 +220,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - uses: dtolnay/rust-toolchain@stable
-      - run: rustup default stable
-      - uses: taiki-e/install-action@cargo-binstall
       - uses: jdx/mise-action@v4
-        with:
-          cache: false
       - name: Check Python formatting
         run: mise run fmt:python
 
@@ -274,12 +230,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - run: rustup default stable
-      - uses: taiki-e/install-action@cargo-binstall
       - uses: jdx/mise-action@v4
-        with:
-          cache: false
       - name: Check llms.txt is up to date
         run: mise run docs:llm:check
       - name: Check CLI docs are up to date
@@ -292,22 +243,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       # setup-python provides a shared-library Python (libpython3.x.so) needed
-      # by stub_gen at runtime (PyO3 auto-initialize). setup-uv's
+      # by stub_gen at runtime (PyO3 auto-initialize). mise's
       # python-build-standalone is statically linked and doesn't ship the .so.
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - uses: astral-sh/setup-uv@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - run: rustup default stable
-      - uses: taiki-e/install-action@cargo-binstall
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
-        with:
-          cache: false
       - name: Check stubs are up to date
         run: |
           # stub_gen links libpython dynamically; tell the linker where to find it
@@ -324,12 +269,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.10.1
+      - uses: jdx/mise-action@v4
+      - name: Lint Go
+        run: mise run lint:go
 
   lint-rust:
     name: Lint Rust
@@ -337,16 +279,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      # No mise needed - clippy comes with toolchain
+      - uses: jdx/mise-action@v4
       - name: Lint Rust (clippy)
-        run: cargo clippy --manifest-path crates/Cargo.toml --workspace -- -D warnings
+        run: mise run lint:rust
 
   lint-rust-deny:
     name: Lint Rust (deny)
@@ -354,13 +293,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-deny@0.19.0
-      # No mise needed - cargo-deny installed via taiki-e
+      - uses: jdx/mise-action@v4
       - name: Check licenses and advisories
-        run: cargo deny --manifest-path crates/Cargo.toml check
+        run: mise run lint:rust:deny
 
   lint-python:
     name: Lint Python
@@ -380,15 +315,7 @@ jobs:
           path: dist
       - name: Extract source distribution
         run: tar xf dist/*.tar.gz --strip-components=1
-      - uses: astral-sh/setup-uv@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - uses: dtolnay/rust-toolchain@stable
-      - run: rustup default stable
-      - uses: taiki-e/install-action@cargo-binstall
       - uses: jdx/mise-action@v4
-        with:
-          cache: false
       - name: Lint Python
         run: mise run lint:python
 
@@ -398,12 +325,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - run: rustup default stable
-      - uses: taiki-e/install-action@cargo-binstall
       - uses: jdx/mise-action@v4
-        with:
-          cache: false
       - name: Lint Markdown
         run: mise run lint:docs
 
@@ -421,12 +343,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-      # gotestsum via Go module proxy (not GitHub Releases) for reliability
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.13.0
+      - uses: jdx/mise-action@v4
       - name: Test Go
         shell: bash
         run: |
@@ -450,9 +367,7 @@ jobs:
       CGO_ENABLED: "1"
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
+      - uses: jdx/mise-action@v4
       - name: Fuzz schema type resolution
         run: go test ./pkg/schema/ -run='^$' -fuzz=FuzzResolveSchemaType -fuzztime=30s
       - name: Fuzz JSON schema generation
@@ -468,17 +383,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest@0.9.120
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      # No mise needed - cargo-nextest installed via taiki-e
+      - uses: jdx/mise-action@v4
       - name: Test Rust
-        run: cargo nextest run --manifest-path crates/Cargo.toml --workspace --exclude coglet-python --no-tests=pass
+        run: mise run test:rust
 
   test-python:
     name: "Test Python ${{ matrix.python-version }}"
@@ -497,12 +408,6 @@ jobs:
           merge-multiple: true
       - name: Extract source distribution
         run: tar xf dist/*.tar.gz --strip-components=1
-      - uses: astral-sh/setup-uv@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-      - uses: dtolnay/rust-toolchain@stable
-      - run: rustup default stable
-      - uses: taiki-e/install-action@cargo-binstall
       - uses: jdx/mise-action@v4
       - name: Remove src to ensure tests run against wheel
         run: rm -rf python/cog
@@ -527,16 +432,11 @@ jobs:
         with:
           name: CogletRustWheel
           path: dist
-      - uses: dtolnay/rust-toolchain@stable
-      - run: rustup default stable  # Required for cargo-binstall to find cargo
-      - uses: taiki-e/install-action@cargo-binstall
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: astral-sh/setup-uv@v6
-        with:
-          python-version: ${{ matrix.python-version }}
+      - uses: jdx/mise-action@v4
       - name: Test coglet-python bindings
         run: uvx nox -s coglet -p ${{ matrix.python-version }}
 
@@ -654,13 +554,7 @@ jobs:
         run: |
           cp dist/cog ./cog
           chmod +x ./cog
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
-      # gotestsum via Go module proxy (not GitHub Releases) for reliability
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.13.0
+      - uses: jdx/mise-action@v4
       - name: Set wheel environment
         run: |
           # Use locally-built wheels, not PyPI (version may not be published yet)
@@ -810,16 +704,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: jdx/mise-action@v4
       - name: Check coglet crates.io publish
         run: cargo publish --dry-run -p coglet --manifest-path crates/Cargo.toml
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
       - uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
 
       - name: Generate CLI docs
         run: go run ./tools/gendocs/main.go -o docs/cli.md

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,8 +8,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    env:
-      MISE_DISABLE_TOOLS: rustup,rustup-init
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,14 +8,11 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      MISE_DISABLE_TOOLS: rustup,rustup-init
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
+      - uses: jdx/mise-action@v4
 
       - name: Generate CLI docs
         run: go run ./tools/gendocs/main.go -o docs/cli.md

--- a/.github/workflows/mirror-cog-base-images.yaml
+++ b/.github/workflows/mirror-cog-base-images.yaml
@@ -21,10 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+      - uses: jdx/mise-action@v4
+        env:
+          MISE_DISABLE_TOOLS: rustup,rustup-init
 
       - name: Install crane
         run: go install github.com/google/go-containerregistry/cmd/crane@v0.21.1

--- a/.github/workflows/mirror-cog-base-images.yaml
+++ b/.github/workflows/mirror-cog-base-images.yaml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
 
       - name: Install crane
         run: go install github.com/google/go-containerregistry/cmd/crane@v0.21.1

--- a/.github/workflows/mirror-cog-base-images.yaml
+++ b/.github/workflows/mirror-cog-base-images.yaml
@@ -22,8 +22,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: jdx/mise-action@v4
-        env:
-          MISE_DISABLE_TOOLS: rustup,rustup-init
 
       - name: Install crane
         run: go install github.com/google/go-containerregistry/cmd/crane@v0.21.1

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -121,8 +121,6 @@ jobs:
     needs: verify-tag
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      MISE_DISABLE_TOOLS: rustup,rustup-init
     steps:
       - uses: actions/checkout@v6
         with:
@@ -211,7 +209,6 @@ jobs:
     timeout-minutes: 30
     env:
       CGO_ENABLED: "1"
-      MISE_DISABLE_TOOLS: rustup,rustup-init
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -121,14 +121,14 @@ jobs:
     needs: verify-tag
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      MISE_DISABLE_TOOLS: rustup,rustup-init
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v6
-        with:
-          python-version: "3.13"
+      - uses: jdx/mise-action@v4
 
       - name: Update coglet version constraint
         run: |
@@ -183,20 +183,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
           key: release-${{ matrix.target }}
 
-      - uses: astral-sh/setup-uv@v6
-        with:
-          python-version: "3.13"
-          enable-cache: false
-
+      # maturin-action bundles maturin, zig, and Rust inside a manylinux container
       - name: Build coglet wheel
         uses: PyO3/maturin-action@v1
         with:
@@ -219,18 +211,13 @@ jobs:
     timeout-minutes: 30
     env:
       CGO_ENABLED: "1"
+      MISE_DISABLE_TOOLS: rustup,rustup-init
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
+      - uses: jdx/mise-action@v4
 
       - name: Check for existing release
         run: |

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -127,6 +127,8 @@ jobs:
           fetch-depth: 0
 
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
 
       - name: Update coglet version constraint
         run: |
@@ -215,6 +217,8 @@ jobs:
           fetch-depth: 0
 
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
 
       - name: Check for existing release
         run: |

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -113,8 +113,6 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
 
       - uses: jdx/mise-action@v4
-        env:
-          MISE_DISABLE_TOOLS: rustup,rustup-init
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
 

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -113,6 +113,8 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
 
       - uses: jdx/mise-action@v4
+        with:
+          cache_key_prefix: mise-v2
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
 

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -112,8 +112,9 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - uses: dtolnay/rust-toolchain@stable
-
+      - uses: jdx/mise-action@v4
+        env:
+          MISE_DISABLE_TOOLS: rustup,rustup-init
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,27 +254,19 @@ For comprehensive architecture documentation, see [`architecture/`](./architectu
 
 ## CI Tool Dependencies
 
-Development tools are managed in **two places** that must be kept in sync:
+Development tools are managed in **one place**: **`mise.toml`**. CI workflows use
+`jdx/mise-action@v4` (with caching enabled) to install the same tool versions that
+developers use locally. This eliminates version drift between local dev and CI.
 
-1. **`mise.toml`** — Tool versions for local development (uses aqua backend for prebuilt binaries)
-2. **`.github/workflows/ci.yaml`** — Tool installation for CI (uses dedicated GitHub Actions)
+**Exceptions:**
 
-CI deliberately avoids aqua downloads from GitHub Releases to prevent transient 502 failures. Instead, it uses:
+| Tool | CI method | Why |
+|------|-----------|-----|
+| coglet wheel (maturin+zig) | `PyO3/maturin-action` | Builds inside a manylinux container with bundled maturin and zig |
+| Rust target cache | `Swatinem/rust-cache` | Caches `crates/target/` directory (separate from tool caching) |
+| `check-stubs` Python | `actions/setup-python` | Needs shared-library Python (libpython3.x.so) for PyO3 auto-initialize |
 
-| Tool | CI installation method | Why |
-|------|----------------------|-----|
-| gotestsum | `go install` | Uses Go module proxy, not GitHub Releases |
-| cargo-deny | `taiki-e/install-action` | Prebuilt with checksum verification |
-| cargo-nextest | `taiki-e/install-action` | Prebuilt with checksum verification |
-| coglet wheel (maturin+zig) | `PyO3/maturin-action` | Bundles maturin and zig |
-| golangci-lint | `golangci/golangci-lint-action` | Built-in caching |
-| Rust toolchain | `dtolnay/rust-toolchain` | Guaranteed ordering |
-
-Tools disabled in CI are listed in `MISE_DISABLE_TOOLS` in `ci.yaml`.
-
-**When updating a tool version**, update both:
-- The version in `mise.toml` (for local dev)
-- The corresponding version pin in `.github/workflows/ci.yaml` (for CI)
+**When updating a tool version**, update `mise.toml` only. CI picks it up automatically.
 
 ## Important Files
 - `VERSION.txt` - Canonical version (single source of truth)


### PR DESCRIPTION
## Summary

- Replace ~10 different GitHub Actions with `jdx/mise-action@v4` so tool versions are defined in **one place** (`mise.toml`) instead of two
- Remove the `MISE_DISABLE_TOOLS` env var entirely — mise manages all tools including rustup (needed for rustfmt/clippy components)
- Enable mise's built-in tool caching (`cache: true`, the default) with `cache_key_prefix: mise-v2`
- Update `AGENTS.md` and `.github/workflows/README.md` to reflect the new single-source-of-truth approach

## Actions removed

| Action | Jobs it was in |
|--------|---------------|
| `dtolnay/rust-toolchain@stable` | ~10 jobs |
| `taiki-e/install-action@cargo-binstall` | ~8 jobs |
| `astral-sh/setup-uv@v6` | ~7 jobs |
| `actions/setup-go@v6` | ~5 jobs |
| `golangci/golangci-lint-action@v9` | lint-go |
| `mlugg/setup-zig@v2` | build-cog, release-dry-run |
| `taiki-e/install-action` (cargo-deny, cargo-nextest) | test-rust, lint-rust-deny |
| `go install gotestsum` | test-go, test-integration |
| `actions/setup-python` | docs.yaml |

## Kept exceptions

| Tool | Why |
|------|-----|
| `PyO3/maturin-action@v1` | Builds inside a manylinux container with bundled maturin + zig |
| `Swatinem/rust-cache@v2` | Caches `crates/target/` compilation artifacts (not tools) |
| `actions/setup-python@v6` in check-stubs | Needs shared-library Python (libpython3.x.so) for PyO3 auto-initialize |

## Net result

- **-170 lines, +75 lines** across 7 files
- Tool version updates now only need to touch `mise.toml`
- `cache_key_prefix: mise-v2` busts stale caches from before this PR