### PR TITLE
ci: use per-job mise cache keys to prevent cache poisoning

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -98,9 +98,14 @@ Runs CodeQL security scanning for Go, Python, and Rust.
 ## Caching Strategy
 
 ### Tool Cache (mise)
-- `jdx/mise-action@v4` with `cache: true` (default) caches all installed tools
+- `jdx/mise-action@v4` with `cache: true` (default) caches `~/.local/share/mise`
 - Tool versions are defined in `mise.toml` — CI and local dev use the same versions
-- Cache key includes platform, mise version, and config file hashes
+- **Per-job cache keys**: Each job uses `cache_key_prefix: mise-{workflow}-${{ github.job }}`
+  to avoid parallel save races (GitHub Actions cache is first-writer-wins)
+- Full cache key: `{prefix}-{os}-{arch}-{hash_of_mise_toml}`
+- **Rust components caveat**: `~/.rustup` is NOT included in the mise cache. On cache
+  hit, mise sees rust as "installed" (symlink exists) but rustfmt/clippy are missing.
+  Rust jobs run `rustup component add rustfmt clippy` after mise-action to fix this.
 
 ### Rust Target Cache
 - **Save**: Only on `main` branch pushes (to avoid PR cache pollution)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,16 @@ env:
   CGO_ENABLED: "1"
   # Note: do NOT add rustup/rustup-init to MISE_DISABLE_TOOLS — mise needs
   # them to install Rust components (rustfmt, clippy) specified in mise.toml.
+  #
+  # mise cache & Rust components:
+  #   mise-action caches ~/.local/share/mise but NOT ~/.rustup. On cache hit,
+  #   mise sees rust as "installed" (symlink exists) and skips reinstall, but
+  #   the actual rustup toolchain + components (rustfmt, clippy) are missing.
+  #   Rust jobs must run `rustup component add` after mise-action to ensure
+  #   components are present regardless of cache state.
+  #
+  # mise cache keys: each job uses its own key (mise-ci-{job_id}) so parallel
+  # jobs don't race on a single shared cache entry.
 
 permissions: {}
 
@@ -123,7 +133,7 @@ jobs:
           fetch-depth: 0
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Build SDK
         run: mise run ci:build:sdk
       - name: Upload SDK package
@@ -175,7 +185,7 @@ jobs:
           fetch-depth: 0
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Get version from VERSION.txt
         id: version
         run: echo "version=$(tr -d '[:space:]' < VERSION.txt)" >> "$GITHUB_OUTPUT"
@@ -206,7 +216,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Check Go formatting
         run: mise run fmt:go
 
@@ -218,7 +228,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
+      - name: Ensure Rust components
+        run: rustup component add rustfmt clippy
       - name: Check Rust formatting
         run: mise run fmt:rust
 
@@ -230,7 +242,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Check Python formatting
         run: mise run fmt:python
 
@@ -242,7 +254,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Check llms.txt is up to date
         run: mise run docs:llm:check
       - name: Check CLI docs are up to date
@@ -266,7 +278,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Check stubs are up to date
         run: |
           # stub_gen links libpython dynamically; tell the linker where to find it
@@ -285,7 +297,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Lint Go
         run: mise run lint:go
 
@@ -301,7 +313,9 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
+      - name: Ensure Rust components
+        run: rustup component add rustfmt clippy
       - name: Lint Rust (clippy)
         run: mise run lint:rust
 
@@ -313,7 +327,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Check licenses and advisories
         run: mise run lint:rust:deny
 
@@ -337,7 +351,7 @@ jobs:
         run: tar xf dist/*.tar.gz --strip-components=1
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Lint Python
         run: mise run lint:python
 
@@ -349,7 +363,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Lint Markdown
         run: mise run lint:docs
 
@@ -369,7 +383,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Test Go
         shell: bash
         run: |
@@ -395,7 +409,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Fuzz schema type resolution
         run: go test ./pkg/schema/ -run='^$' -fuzz=FuzzResolveSchemaType -fuzztime=30s
       - name: Fuzz JSON schema generation
@@ -417,7 +431,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Test Rust
         run: mise run test:rust
 
@@ -440,7 +454,7 @@ jobs:
         run: tar xf dist/*.tar.gz --strip-components=1
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Remove src to ensure tests run against wheel
         run: rm -rf python/cog
       - name: Test Python
@@ -470,7 +484,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Test coglet-python bindings
         run: uvx nox -s coglet -p ${{ matrix.python-version }}
 
@@ -590,7 +604,7 @@ jobs:
           chmod +x ./cog
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Set wheel environment
         run: |
           # Use locally-built wheels, not PyPI (version may not be published yet)
@@ -746,7 +760,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-ci-${{ github.job }}
       - name: Check coglet crates.io publish
         run: cargo publish --dry-run -p coglet --manifest-path crates/Cargo.toml
       - uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-docs-${{ github.job }}
 
       - name: Generate CLI docs
         run: go run ./tools/gendocs/main.go -o docs/cli.md

--- a/.github/workflows/mirror-cog-base-images.yaml
+++ b/.github/workflows/mirror-cog-base-images.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-mirror-${{ github.job }}
 
       - name: Install crane
         run: go install github.com/google/go-containerregistry/cmd/crane@v0.21.1

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -128,7 +128,7 @@ jobs:
 
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-rel-${{ github.job }}
 
       - name: Update coglet version constraint
         run: |
@@ -218,7 +218,7 @@ jobs:
 
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-rel-${{ github.job }}
 
       - name: Check for existing release
         run: |

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -114,7 +114,7 @@ jobs:
 
       - uses: jdx/mise-action@v4
         with:
-          cache_key_prefix: mise-v2
+          cache_key_prefix: mise-pub-${{ github.job }}
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
 


### PR DESCRIPTION
## Summary

Fixes CI failures (`Format Rust`, `Lint Rust`, `Lint Python`) caused by mise-action cache issues after #2951.

## Root Cause

Two issues:

### 1. `~/.rustup` not included in mise cache (primary cause of Rust failures)

`mise-action` caches `~/.local/share/mise` but **not** `~/.rustup`. Mise installs Rust via a symlink:
```
~/.local/share/mise/installs/rust/1.93.0 → ~/.rustup/toolchains/1.93.0-x86_64-unknown-linux-gnu
```

On fresh install (cache miss): mise calls `rustup` → installs toolchain + components (rustfmt, clippy) → everything works.

On cache restore (cache hit): mise sees the symlink exists → skips reinstall → but `~/.rustup/` doesn't exist on the new runner → `rustup` bootstraps the base toolchain but doesn't install components → `cargo fmt` and `cargo clippy` fail.

### 2. Parallel cache save race (secondary issue)

All parallel jobs shared one cache key (`mise-v2-{os}-{arch}-{hash}`). GitHub Actions cache save is first-writer-wins — whichever job calls `reserveCache` first wins. This is non-deterministic and could cause other subtle issues.

## Fix

1. **`rustup component add rustfmt clippy`** in `fmt-rust` and `lint-rust` jobs after `mise-action`. Ensures components are present regardless of cache state. This is the direct fix for the Rust failures.

2. **Per-job mise cache keys** (`mise-ci-${{ github.job }}` instead of `mise-v2`). Each job saves/restores its own cache — no more cross-job race conditions.

3. **Deleted stale `mise-v2-*` caches** via `gh cache delete`.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yaml` | Per-job cache keys + `rustup component add` in Rust jobs |
| `.github/workflows/docs.yaml` | Per-job cache key |
| `.github/workflows/mirror-cog-base-images.yaml` | Per-job cache key |
| `.github/workflows/release-build.yaml` | Per-job cache key |
| `.github/workflows/release-publish.yaml` | Per-job cache key |
| `.github/workflows/README.md` | Document cache strategy and Rust caveat |