### PR TITLE
fix: separate-weights build with r8.im image names fails schema validation

### DIFF
--- a/integration-tests/tests/build_separate_weights_r8im.txtar
+++ b/integration-tests/tests/build_separate_weights_r8im.txtar
@@ -1,0 +1,33 @@
+# Test that --separate-weights works with r8.im image names.
+# Regression test for https://github.com/replicate/cog/issues/2953
+#
+# When the image name starts with "r8.im", cog uses a temporary tag
+# (cog-tmp:<hash>) for the intermediate build. The separate-weights code
+# path must tag its runner image with that temp tag so post-build schema
+# validation can find it.
+#
+# NOTE: Uses a hardcoded r8.im/... tag (not $TEST_IMAGE) to trigger the
+# cog-tmp code path. --use-cog-base-image=false avoids hitting the real
+# r8.im registry. Cleanup at the end won't run on build failure, but this
+# matches the pattern in build_image_option.txtar.
+
+cog build -t r8.im/test/separate-weights-r8im --separate-weights --use-cog-base-image=false
+
+# Verify schema label was set (proves post-build schema validation succeeded)
+exec docker inspect r8.im/test/separate-weights-r8im --format '{{index .Config.Labels "run.cog.openapi_schema"}}'
+stdout '"openapi":"3.0.2"'
+
+# Cleanup images created by this test
+exec sh -c 'docker rmi -f r8.im/test/separate-weights-r8im r8.im/test/separate-weights-r8im-weights 2>/dev/null; true'
+
+-- cog.yaml --
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"
+
+-- predict.py --
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, s: str) -> str:
+        return "hello " + s

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -225,7 +225,7 @@ func Build(
 				console.Info("Weights unchanged, skip rebuilding and use cached image...")
 			}
 
-			if err := buildRunnerImage(ctx, dockerCommand, dir, runnerDockerfile, dockerignore, imageName, secrets, noCache, progressOutput, contextDir, buildContexts); err != nil {
+			if err := buildRunnerImage(ctx, dockerCommand, dir, runnerDockerfile, dockerignore, tmpImageId, secrets, noCache, progressOutput, contextDir, buildContexts); err != nil {
 				return "", fmt.Errorf("Failed to build runner Docker image: %w", err)
 			}
 		} else {


### PR DESCRIPTION
Building with `--separate-weights` and an `r8.im/` image name fails at post-build schema validation with `No such image: cog-tmp:<hash>`.

The `cog-tmp` temporary tag was introduced in #2658 to avoid tagging intermediate builds with registry names. The non-separate-weights path uses it correctly, but the separate-weights path was missed -- it tagged the runner image with the final `imageName` instead of `tmpImageId`. Post-build steps (schema validation, pip freeze, label addition) then can't find the temp image.

One-line fix: `buildRunnerImage` in the separate-weights path now gets `tmpImageId` instead of `imageName`, consistent with the other build paths. The existing `BuildAddLabelsAndSchemaToImage` call already handles re-tagging from `tmpImageId` to `imageName` as the final step.

Integration test reproduces the exact failure. Uses `--use-cog-base-image=false` so it doesn't hit the real r8.im registry.

Fixes #2953