### PR TITLE
rename pkg/weights to pkg/weightslegacy

### DIFF
--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -3,7 +3,7 @@ package dockerfile
 import (
 	"context"
 
-	"github.com/replicate/cog/pkg/weights"
+	"github.com/replicate/cog/pkg/weightslegacy"
 )
 
 type Generator interface {
@@ -17,7 +17,7 @@ type Generator interface {
 	SetUseCudaBaseImage(string)
 	IsUsingCogBaseImage() bool
 	BaseImage(ctx context.Context) (string, error)
-	GenerateWeightsManifest(ctx context.Context) (*weights.Manifest, error)
+	GenerateWeightsManifest(ctx context.Context) (*weightslegacy.Manifest, error)
 	GenerateDockerfileWithoutSeparateWeights(ctx context.Context) (string, error)
 	GenerateModelBase(ctx context.Context) (string, error)
 	Name() string

--- a/pkg/dockerfile/standard_generator.go
+++ b/pkg/dockerfile/standard_generator.go
@@ -16,7 +16,7 @@ import (
 	"github.com/replicate/cog/pkg/requirements"
 	"github.com/replicate/cog/pkg/util/console"
 	"github.com/replicate/cog/pkg/util/version"
-	"github.com/replicate/cog/pkg/weights"
+	"github.com/replicate/cog/pkg/weightslegacy"
 	"github.com/replicate/cog/pkg/wheels"
 )
 
@@ -70,7 +70,7 @@ type StandardGenerator struct {
 	// tmpDir relative to Dir
 	relativeTmpDir string
 
-	fileWalker weights.FileWalker
+	fileWalker weightslegacy.FileWalker
 
 	modelDirs  []string
 	modelFiles []string
@@ -350,7 +350,7 @@ func (g *StandardGenerator) cpCogYaml() string {
 }
 
 func (g *StandardGenerator) generateForWeights() (string, []string, []string, error) {
-	modelDirs, modelFiles, err := weights.FindWeights(g.fileWalker)
+	modelDirs, modelFiles, err := weightslegacy.FindWeights(g.fileWalker)
 	if err != nil {
 		return "", nil, nil, err
 	}
@@ -1011,8 +1011,8 @@ func filterEmpty(list []string) []string {
 	return filtered
 }
 
-func (g *StandardGenerator) GenerateWeightsManifest(ctx context.Context) (*weights.Manifest, error) {
-	m := weights.NewManifest()
+func (g *StandardGenerator) GenerateWeightsManifest(ctx context.Context) (*weightslegacy.Manifest, error) {
+	m := weightslegacy.NewManifest()
 
 	for _, dir := range g.modelDirs {
 		err := g.fileWalker(dir, func(path string, info os.FileInfo, err error) error {

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -30,7 +30,7 @@ import (
 	"github.com/replicate/cog/pkg/schema/python"
 	"github.com/replicate/cog/pkg/util/console"
 	cogversion "github.com/replicate/cog/pkg/util/version"
-	"github.com/replicate/cog/pkg/weights"
+	"github.com/replicate/cog/pkg/weightslegacy"
 	"github.com/replicate/cog/pkg/wheels"
 )
 
@@ -211,7 +211,7 @@ func Build(
 			if err != nil {
 				return "", fmt.Errorf("Failed to generate weights manifest: %w", err)
 			}
-			cachedManifest, _ := weights.LoadManifest(weightsManifestPath)
+			cachedManifest, _ := weightslegacy.LoadManifest(weightsManifestPath)
 			changed := cachedManifest == nil || !weightsManifest.Equal(cachedManifest)
 			if changed {
 				if err := buildWeightsImage(ctx, dockerCommand, dir, weightsDockerfile, imageName+"-weights", secrets, noCache, progressOutput, contextDir, buildContexts); err != nil {

--- a/pkg/weightslegacy/manifest.go
+++ b/pkg/weightslegacy/manifest.go
@@ -1,4 +1,4 @@
-package weights
+package weightslegacy
 
 import (
 	"encoding/binary"

--- a/pkg/weightslegacy/weights.go
+++ b/pkg/weightslegacy/weights.go
@@ -1,4 +1,4 @@
-package weights
+package weightslegacy
 
 import (
 	"os"

--- a/pkg/weightslegacy/weights_test.go
+++ b/pkg/weightslegacy/weights_test.go
@@ -1,4 +1,4 @@
-package weights
+package weightslegacy
 
 import (
 	"os"


### PR DESCRIPTION
Free up the `pkg/weights` import path for the new managed weights implementation. The existing weight-discovery and manifest code still works -- it's just under `pkg/weightslegacy` now.

Pure rename, no behavior changes. Lint and tests pass.