### PR TITLE
chore(deps): bump rustls-webpki 0.103.12 -> 0.103.13 (RUSTSEC-2026-0104)

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2301,9 +2301,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
RUSTSEC-2026-0104 added a new advisory for rustls-webpki v0.103.12 -- a reachable panic when parsing certificate revocation lists. cargo-deny catches this and fails the "Lint Rust (deny)" CI job on every branch.

`cargo update -p rustls-webpki` bumps to 0.103.13 which has the fix. Lockfile-only change.