### PR TITLE
fix: run coglet wheel build after cog/sdk to avoid resource exhaustion

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -96,7 +96,8 @@ run = "rm -f dist/cog-*.whl dist/cog-*.tar.gz dist/coglet-*.whl"
 alias = "build:all"
 description = "Build all components"
 run = [
-  { tasks = ["build:cog", "build:coglet:wheel:linux-x64", "build:sdk"] },
+  { tasks = ["build:cog", "build:sdk"] },
+  { task = "build:coglet:wheel:linux-x64" },
   { task = "_build_summary" },
 ]
 


### PR DESCRIPTION
The `mise run build` task was running all three component builds in parallel -- cog CLI, SDK wheel, and coglet cross-compile (maturin+zig). The coglet build is heavy enough that running it alongside the others exhausts resources.

Now cog and SDK build in parallel, then coglet builds sequentially after they finish.