### PR TITLE
fix: support TypedDict schema generation

### DIFF
--- a/integration-tests/tests/typeddict_input.txtar
+++ b/integration-tests/tests/typeddict_input.txtar
@@ -1,0 +1,37 @@
+# Test TypedDict inputs through the default static schema path.
+#
+# This exercises the Go tree-sitter parser end-to-end for TypedDict inputs:
+# build-time extraction, embedded OpenAPI schema, and predict-time JSON input.
+
+# Build the image.
+cog build -t $TEST_IMAGE
+
+# TypedDict and optional list[TypedDict] inputs should be represented like dicts.
+exec docker inspect $TEST_IMAGE --format '{{index .Config.Labels "run.cog.openapi_schema"}}'
+stdout '"data":{"title":"Data","type":"object","x-order":0}'
+stdout '"items":{"items":{"type":"object"},"title":"Items","type":"array","x-order":1}'
+
+# Predict should accept TypedDict-shaped JSON payloads end-to-end.
+cog predict $TEST_IMAGE --json '{"data": {"name": "alice", "count": 2}, "items": [{"name": "first", "count": 1}, {"name": "second", "count": 3}]}'
+stdout '"status": "succeeded"'
+stdout '"output": "alice:2 items=2"'
+
+-- cog.yaml --
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"
+
+-- predict.py --
+from typing import TypedDict
+
+from cog import BasePredictor
+
+
+class Payload(TypedDict):
+    name: str
+    count: int
+
+
+class Predictor(BasePredictor):
+    def predict(self, data: Payload, items: list[Payload] | None = None) -> str:
+        return f"{data['name']}:{data['count']} items={len(items or [])}"

--- a/integration-tests/tests/typeddict_input.txtar
+++ b/integration-tests/tests/typeddict_input.txtar
@@ -9,7 +9,7 @@ cog build -t $TEST_IMAGE
 # TypedDict and optional list[TypedDict] inputs should be represented like dicts.
 exec docker inspect $TEST_IMAGE --format '{{index .Config.Labels "run.cog.openapi_schema"}}'
 stdout '"data":{"title":"Data","type":"object","x-order":0}'
-stdout '"items":{"items":{"type":"object"},"title":"Items","type":"array","x-order":1}'
+stdout '"items":{"default":null,"items":{"type":"object"},"nullable":true,"title":"Items","type":"array","x-order":1}'
 
 # Predict should accept TypedDict-shaped JSON payloads end-to-end.
 cog predict $TEST_IMAGE --json '{"data": {"name": "alice", "count": 2}, "items": [{"name": "first", "count": 1}, {"name": "second", "count": 3}]}'

--- a/integration-tests/tests/typeddict_input_legacy.txtar
+++ b/integration-tests/tests/typeddict_input_legacy.txtar
@@ -1,0 +1,41 @@
+# Test TypedDict inputs through the legacy runtime schema path.
+#
+# This exercises python/cog/_adt.py via in-container runtime schema generation,
+# proving TypedDict subclasses are treated like dict inputs when
+# COG_LEGACY_SCHEMA=1 forces the legacy path.
+
+env COG_LEGACY_SCHEMA=1
+
+# Build the image through the legacy runtime schema generator.
+cog build -t $TEST_IMAGE
+stderr 'Validating model schema'
+
+# TypedDict and list[TypedDict] inputs work via JSON.
+cog predict $TEST_IMAGE --json '{"data": {"name": "alice", "count": 2}, "items": [{"name": "first", "count": 1}, {"name": "second", "count": 3}]}'
+stdout '"status": "succeeded"'
+stdout '"output": "alice:2 items=2"'
+
+# The generated schema should still expose these as opaque JSON objects.
+exec docker inspect $TEST_IMAGE --format '{{index .Config.Labels "run.cog.openapi_schema"}}'
+stdout '"data":{"title":"Data","type":"object","x-order":0}'
+stdout '"items":{"items":{"type":"object"},"title":"Items","type":"array","x-order":1}'
+
+-- cog.yaml --
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"
+
+-- predict.py --
+from typing import TypedDict
+
+from cog import BasePredictor
+
+
+class Payload(TypedDict):
+    name: str
+    count: int
+
+
+class Predictor(BasePredictor):
+    def predict(self, data: Payload, items: list[Payload]) -> str:
+        return f"{data['name']}:{data['count']} items={len(items)}"

--- a/integration-tests/tests/typeddict_output.txtar
+++ b/integration-tests/tests/typeddict_output.txtar
@@ -1,0 +1,39 @@
+# Test TypedDict return types through the static schema path.
+#
+# This exercises the Go tree-sitter parser end-to-end: build-time extraction,
+# embedded OpenAPI schema, and prediction output for a TypedDict response.
+
+# Build the image.
+cog build -t $TEST_IMAGE
+
+# Verify the schema is embedded with object fields from the TypedDict.
+exec docker inspect $TEST_IMAGE --format '{{index .Config.Labels "run.cog.openapi_schema"}}'
+stdout '"type":"object"'
+stdout '"name":'
+stdout '"count":'
+stdout '"required":\["name"\]'
+
+# Predict should return a JSON object matching the TypedDict.
+cog predict $TEST_IMAGE
+stdout '"name": "alice"'
+stdout '"count": 3'
+
+-- cog.yaml --
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"
+
+-- predict.py --
+from typing import NotRequired, TypedDict
+
+from cog import BasePredictor
+
+
+class Output(TypedDict):
+    name: str
+    count: NotRequired[int]
+
+
+class Predictor(BasePredictor):
+    def predict(self) -> Output:
+        return {"name": "alice", "count": 3}

--- a/pkg/schema/python/parser.go
+++ b/pkg/schema/python/parser.go
@@ -45,9 +45,10 @@ func ParsePredictor(source []byte, predictRef string, mode schema.Mode, sourceDi
 
 	// 3. Collect schema object classes (BaseModel and TypedDict) locally first,
 	// then across local imports.
-	modelClasses, typedDicts := collectModelClasses(root, source, imports)
+	modelCtx := &modelParseContext{imports: imports, typedDicts: make(map[string]bool)}
+	modelClasses := collectModelClasses(root, source, modelCtx)
 	if sourceDir != "" {
-		resolveExternalModels(sourceDir, imports, modelClasses, typedDicts)
+		resolveExternalModels(sourceDir, modelClasses, modelCtx)
 	}
 
 	// 4. Collect Input() references from class attributes and static methods
@@ -72,7 +73,14 @@ func ParsePredictor(source []byte, predictRef string, mode schema.Mode, sourceDi
 	isMethod := firstParamIsSelf(paramsNode, source)
 
 	// 7. Extract parameters
-	inputs, err := extractInputs(paramsNode, source, methodName, isMethod, imports, inputRegistry, moduleScope, typedDicts)
+	paramCtx := &inputParseContext{
+		methodName: methodName,
+		imports:    imports,
+		registry:   inputRegistry,
+		scope:      moduleScope,
+		typedDicts: modelCtx.typedDicts,
+	}
+	inputs, err := extractInputs(paramsNode, source, isMethod, paramCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +220,7 @@ func parseImportFrom(node *sitter.Node, source []byte, ctx *schema.ImportContext
 func parseImport(node *sitter.Node, source []byte, ctx *schema.ImportContext) {
 	text := strings.TrimSpace(Content(node, source))
 	imports := strings.TrimSpace(strings.TrimPrefix(text, "import "))
-	for _, part := range strings.Split(imports, ",") {
+	for part := range strings.SplitSeq(imports, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue
@@ -403,9 +411,13 @@ func resolveChoicesCall(node *sitter.Node, source []byte, scope moduleScope) ([]
 // BaseModel subclass collection
 // ---------------------------------------------------------------------------
 
-func collectModelClasses(root *sitter.Node, source []byte, imports *schema.ImportContext) (schema.ModelClassMap, map[string]bool) {
+type modelParseContext struct {
+	imports    *schema.ImportContext
+	typedDicts map[string]bool
+}
+
+func collectModelClasses(root *sitter.Node, source []byte, ctx *modelParseContext) schema.ModelClassMap {
 	models := schema.NewOrderedMap[string, []schema.ModelField]()
-	typedDicts := make(map[string]bool)
 
 	for _, child := range NamedChildren(root) {
 		classNode := UnwrapClass(child)
@@ -419,22 +431,22 @@ func collectModelClasses(root *sitter.Node, source []byte, imports *schema.Impor
 		}
 		className := Content(nameNode, source)
 
-		isBaseModel := InheritsFromBaseModel(classNode, source, imports)
-		isTypedDict, requiredByDefault, parents := TypedDictClassInfo(classNode, source, imports, typedDicts)
+		isBaseModel := InheritsFromBaseModel(classNode, source, ctx.imports)
+		isTypedDict, requiredByDefault, parents := TypedDictClassInfo(classNode, source, ctx.imports, ctx.typedDicts)
 		if !isBaseModel && !isTypedDict {
 			continue
 		}
 
-		fields := extractClassAnnotations(classNode, source, imports, isTypedDict, requiredByDefault)
+		fields := extractClassAnnotations(classNode, source, ctx.imports, isTypedDict, requiredByDefault)
 		if isTypedDict {
 			fields = mergeModelFields(parentModelFields(models, parents), fields)
 		}
 		models.Set(className, fields)
 		if isTypedDict {
-			typedDicts[className] = true
+			ctx.typedDicts[className] = true
 		}
 	}
-	return models, typedDicts
+	return models
 }
 
 func parentModelFields(models schema.ModelClassMap, parents []string) [][]schema.ModelField {
@@ -483,11 +495,11 @@ func mergeModelFields(parents [][]schema.ModelField, own []schema.ModelField) []
 //
 // Non-local imports (stdlib, pip packages) are skipped because the file
 // won't exist on disk.
-func resolveExternalModels(sourceDir string, imports *schema.ImportContext, models schema.ModelClassMap, typedDicts map[string]bool) {
+func resolveExternalModels(sourceDir string, models schema.ModelClassMap, ctx *modelParseContext) {
 	// Track which modules we've already tried so we don't re-parse.
 	tried := make(map[string]bool)
 
-	imports.Names.Entries(func(localName string, entry schema.ImportEntry) {
+	ctx.imports.Names.Entries(func(localName string, entry schema.ImportEntry) {
 		// Already resolved locally — skip.
 		if _, ok := models.Get(localName); ok {
 			return
@@ -528,8 +540,8 @@ func resolveExternalModels(sourceDir string, imports *schema.ImportContext, mode
 				return
 			}
 
-			fileImports := CollectImports(tree.RootNode(), source)
-			fileModels, fileTypedDicts := collectModelClasses(tree.RootNode(), source, fileImports)
+			fileCtx := &modelParseContext{imports: CollectImports(tree.RootNode(), source), typedDicts: make(map[string]bool)}
+			fileModels := collectModelClasses(tree.RootNode(), source, fileCtx)
 
 			// Merge discovered models into the caller's map.
 			fileModels.Entries(func(name string, fields []schema.ModelField) {
@@ -537,8 +549,8 @@ func resolveExternalModels(sourceDir string, imports *schema.ImportContext, mode
 					models.Set(name, fields)
 				}
 			})
-			for name := range fileTypedDicts {
-				typedDicts[name] = true
+			for name := range fileCtx.typedDicts {
+				ctx.typedDicts[name] = true
 			}
 		}
 
@@ -551,8 +563,8 @@ func resolveExternalModels(sourceDir string, imports *schema.ImportContext, mode
 					models.Set(localName, fields)
 				}
 			}
-			if typedDicts[entry.Original] {
-				typedDicts[localName] = true
+			if ctx.typedDicts[entry.Original] {
+				ctx.typedDicts[localName] = true
 			}
 		}
 	})
@@ -1212,6 +1224,14 @@ func findMethodInClass(classNode *sitter.Node, source []byte, className, methodN
 // Parameter extraction
 // ---------------------------------------------------------------------------
 
+type inputParseContext struct {
+	methodName string
+	imports    *schema.ImportContext
+	registry   *inputRegistry
+	scope      moduleScope
+	typedDicts map[string]bool
+}
+
 func firstParamIsSelf(params *sitter.Node, source []byte) bool {
 	for _, child := range AllChildren(params) {
 		if child.Type() == "identifier" {
@@ -1224,12 +1244,8 @@ func firstParamIsSelf(params *sitter.Node, source []byte) bool {
 func extractInputs(
 	paramsNode *sitter.Node,
 	source []byte,
-	methodName string,
 	skipSelf bool,
-	imports *schema.ImportContext,
-	registry *inputRegistry,
-	scope moduleScope,
-	typedDicts map[string]bool,
+	ctx *inputParseContext,
 ) (*schema.OrderedMap[string, schema.InputField], error) {
 	inputs := schema.NewOrderedMap[string, schema.InputField]()
 	order := 0
@@ -1247,7 +1263,7 @@ func extractInputs(
 			}
 
 		case "typed_parameter":
-			input, err := parseTypedParameter(child, source, order, methodName, imports, typedDicts)
+			input, err := parseTypedParameter(child, source, order, ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -1255,7 +1271,7 @@ func extractInputs(
 			order++
 
 		case "typed_default_parameter":
-			input, err := parseTypedDefaultParameter(child, source, order, methodName, imports, registry, scope, typedDicts)
+			input, err := parseTypedDefaultParameter(child, source, order, ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -1268,14 +1284,14 @@ func extractInputs(
 			if nameNode != nil {
 				paramName = Content(nameNode, source)
 			}
-			return nil, schema.WrapError(schema.ErrMissingTypeAnnotation, fmt.Sprintf("parameter '%s' on %s has no type annotation", paramName, methodName), nil)
+			return nil, schema.WrapError(schema.ErrMissingTypeAnnotation, fmt.Sprintf("parameter '%s' on %s has no type annotation", paramName, ctx.methodName), nil)
 		}
 	}
 
 	return inputs, nil
 }
 
-func parseTypedParameter(node *sitter.Node, source []byte, order int, methodName string, imports *schema.ImportContext, typedDicts map[string]bool) (schema.InputField, error) {
+func parseTypedParameter(node *sitter.Node, source []byte, order int, ctx *inputParseContext) (schema.InputField, error) {
 	// typed_parameter has no "name" field in the Python grammar.
 	// Structure is: identifier ":" type
 	var name string
@@ -1295,14 +1311,14 @@ func parseTypedParameter(node *sitter.Node, source []byte, order int, methodName
 		return schema.InputField{}, schema.WrapError(schema.ErrParse, "typed_parameter has no identifier", nil)
 	}
 	if typeNode == nil {
-		return schema.InputField{}, schema.WrapError(schema.ErrMissingTypeAnnotation, fmt.Sprintf("parameter '%s' on %s has no type annotation", name, methodName), nil)
+		return schema.InputField{}, schema.WrapError(schema.ErrMissingTypeAnnotation, fmt.Sprintf("parameter '%s' on %s has no type annotation", name, ctx.methodName), nil)
 	}
 
 	typeAnn, err := parseTypeAnnotation(typeNode, source)
 	if err != nil {
 		return schema.InputField{}, err
 	}
-	fieldType, err := schema.ResolveFieldType(typeAnn, imports, typedDicts)
+	fieldType, err := schema.ResolveFieldType(typeAnn, ctx.imports, ctx.typedDicts)
 	if err != nil {
 		return schema.InputField{}, err
 	}
@@ -1314,16 +1330,7 @@ func parseTypedParameter(node *sitter.Node, source []byte, order int, methodName
 	}, nil
 }
 
-func parseTypedDefaultParameter(
-	node *sitter.Node,
-	source []byte,
-	order int,
-	methodName string,
-	imports *schema.ImportContext,
-	registry *inputRegistry,
-	scope moduleScope,
-	typedDicts map[string]bool,
-) (schema.InputField, error) {
+func parseTypedDefaultParameter(node *sitter.Node, source []byte, order int, ctx *inputParseContext) (schema.InputField, error) {
 	nameNode := node.ChildByFieldName("name")
 	if nameNode == nil {
 		return schema.InputField{}, schema.WrapError(schema.ErrParse, "typed_default_parameter has no name", nil)
@@ -1332,14 +1339,14 @@ func parseTypedDefaultParameter(
 
 	typeNode := node.ChildByFieldName("type")
 	if typeNode == nil {
-		return schema.InputField{}, schema.WrapError(schema.ErrMissingTypeAnnotation, fmt.Sprintf("parameter '%s' on %s has no type annotation", name, methodName), nil)
+		return schema.InputField{}, schema.WrapError(schema.ErrMissingTypeAnnotation, fmt.Sprintf("parameter '%s' on %s has no type annotation", name, ctx.methodName), nil)
 	}
 
 	typeAnn, err := parseTypeAnnotation(typeNode, source)
 	if err != nil {
 		return schema.InputField{}, err
 	}
-	fieldType, err := schema.ResolveFieldType(typeAnn, imports, typedDicts)
+	fieldType, err := schema.ResolveFieldType(typeAnn, ctx.imports, ctx.typedDicts)
 	if err != nil {
 		return schema.InputField{}, err
 	}
@@ -1348,8 +1355,8 @@ func parseTypedDefaultParameter(
 
 	if valNode != nil {
 		// 1. Direct Input() call
-		if isInputCall(valNode, source, imports) {
-			info, err := parseInputCall(valNode, source, name, scope)
+		if isInputCall(valNode, source, ctx.imports) {
+			info, err := parseInputCall(valNode, source, name, ctx.scope)
 			if err != nil {
 				return schema.InputField{}, err
 			}
@@ -1370,7 +1377,7 @@ func parseTypedDefaultParameter(
 		}
 
 		// 2. Reference to Input() via class attribute or static method
-		if info, ok := resolveInputReference(valNode, source, registry); ok {
+		if info, ok := resolveInputReference(valNode, source, ctx.registry); ok {
 			return schema.InputField{
 				Name:        name,
 				Order:       order,
@@ -1388,7 +1395,7 @@ func parseTypedDefaultParameter(
 		}
 
 		// 3. Plain default — must be statically resolvable
-		if def, ok := resolveDefaultExpr(valNode, source, scope); ok {
+		if def, ok := resolveDefaultExpr(valNode, source, ctx.scope); ok {
 			return schema.InputField{
 				Name:      name,
 				Order:     order,

--- a/pkg/schema/python/parser.go
+++ b/pkg/schema/python/parser.go
@@ -143,10 +143,10 @@ func CollectImports(root *sitter.Node, source []byte) *schema.ImportContext {
 	ctx := schema.NewImportContext()
 
 	for _, child := range NamedChildren(root) {
-		if child.Type() == "import_from_statement" {
+		switch child.Type() {
+		case "import_from_statement":
 			parseImportFrom(child, source, ctx)
-		}
-		if child.Type() == "import_statement" {
+		case "import_statement":
 			parseImport(child, source, ctx)
 		}
 	}
@@ -164,6 +164,35 @@ func CollectImports(root *sitter.Node, source []byte) *schema.ImportContext {
 	return ctx
 }
 
+func setImport(ctx *schema.ImportContext, localName, module, original string) {
+	ctx.Names.Set(localName, schema.ImportEntry{Module: module, Original: original})
+}
+
+func aliasedImportParts(node *sitter.Node, source []byte) (string, string, bool) {
+	origNode := node.ChildByFieldName("name")
+	if origNode == nil {
+		return "", "", false
+	}
+	original := Content(origNode, source)
+	alias := original
+	if aliasNode := node.ChildByFieldName("alias"); aliasNode != nil {
+		alias = Content(aliasNode, source)
+	}
+	return original, alias, true
+}
+
+func addImportFromNode(ctx *schema.ImportContext, module string, node *sitter.Node, source []byte) {
+	switch node.Type() {
+	case "dotted_name":
+		name := Content(node, source)
+		setImport(ctx, name, module, name)
+	case "aliased_import":
+		if original, alias, ok := aliasedImportParts(node, source); ok {
+			setImport(ctx, alias, module, original)
+		}
+	}
+}
+
 func parseImportFrom(node *sitter.Node, source []byte, ctx *schema.ImportContext) {
 	moduleNode := node.ChildByFieldName("module_name")
 	if moduleNode == nil {
@@ -177,41 +206,14 @@ func parseImportFrom(node *sitter.Node, source []byte, ctx *schema.ImportContext
 			// Single import: `from X import name`
 			// Skip if this is the module_name itself
 			if child.StartByte() != moduleNode.StartByte() {
-				name := Content(child, source)
-				ctx.Names.Set(name, schema.ImportEntry{Module: module, Original: name})
+				addImportFromNode(ctx, module, child, source)
 			}
 		case "aliased_import":
 			// Single aliased import: `from X import name as alias`
-			origNode := child.ChildByFieldName("name")
-			aliasNode := child.ChildByFieldName("alias")
-			orig := ""
-			if origNode != nil {
-				orig = Content(origNode, source)
-			}
-			alias := orig
-			if aliasNode != nil {
-				alias = Content(aliasNode, source)
-			}
-			ctx.Names.Set(alias, schema.ImportEntry{Module: module, Original: orig})
+			addImportFromNode(ctx, module, child, source)
 		case "import_list":
 			for _, importChild := range AllChildren(child) {
-				switch importChild.Type() {
-				case "dotted_name":
-					name := Content(importChild, source)
-					ctx.Names.Set(name, schema.ImportEntry{Module: module, Original: name})
-				case "aliased_import":
-					origNode := importChild.ChildByFieldName("name")
-					aliasNode := importChild.ChildByFieldName("alias")
-					orig := ""
-					if origNode != nil {
-						orig = Content(origNode, source)
-					}
-					alias := orig
-					if aliasNode != nil {
-						alias = Content(aliasNode, source)
-					}
-					ctx.Names.Set(alias, schema.ImportEntry{Module: module, Original: orig})
-				}
+				addImportFromNode(ctx, module, importChild, source)
 			}
 		}
 	}
@@ -231,7 +233,7 @@ func parseImport(node *sitter.Node, source []byte, ctx *schema.ImportContext) {
 			module = strings.TrimSpace(before)
 			alias = strings.TrimSpace(after)
 		}
-		ctx.Names.Set(alias, schema.ImportEntry{Module: module, Original: module})
+		setImport(ctx, alias, module, module)
 	}
 }
 
@@ -481,6 +483,67 @@ func mergeModelFields(parents [][]schema.ModelField, own []schema.ModelField) []
 	return merged
 }
 
+func mergeDiscoveredModels(dst, src schema.ModelClassMap) {
+	if src == nil {
+		return
+	}
+	src.Entries(func(name string, fields []schema.ModelField) {
+		if _, exists := dst.Get(name); !exists {
+			dst.Set(name, fields)
+		}
+	})
+}
+
+func (ctx *modelParseContext) loadModelsFromModule(sourceDir, module string) schema.ModelClassMap {
+	if isKnownExternalModule(module) {
+		return nil
+	}
+
+	pyPath := moduleToFilePath(module)
+	if pyPath == "" {
+		return nil
+	}
+
+	fullPath := filepath.Join(sourceDir, pyPath)
+	source, err := os.ReadFile(fullPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		fmt.Fprintf(os.Stderr, "cog: warning: failed to read %q: %v\n", fullPath, err)
+		return nil
+	}
+
+	parser := sitter.NewParser()
+	parser.SetLanguage(python.GetLanguage())
+	tree, err := parser.ParseCtx(context.Background(), nil, source)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cog: warning: failed to parse %q: %v\n", fullPath, err)
+		return nil
+	}
+
+	fileCtx := &modelParseContext{imports: CollectImports(tree.RootNode(), source), typedDicts: make(map[string]bool)}
+	fileModels := collectModelClasses(tree.RootNode(), source, fileCtx)
+	for name := range fileCtx.typedDicts {
+		ctx.typedDicts[name] = true
+	}
+	return fileModels
+}
+
+func propagateImportedAlias(localName string, entry schema.ImportEntry, models schema.ModelClassMap, typedDicts map[string]bool) {
+	if localName == entry.Original {
+		return
+	}
+	if fields, ok := models.Get(entry.Original); ok {
+		if _, exists := models.Get(localName); !exists {
+			models.Set(localName, fields)
+		}
+	}
+	if typedDicts[entry.Original] {
+		typedDicts[localName] = true
+	}
+}
+
 // resolveExternalModels looks at imports that brought in names not yet in
 // modelClasses, attempts to find the corresponding .py file on disk, parses
 // it, and merges any schema object classes into modelClasses.
@@ -508,65 +571,10 @@ func resolveExternalModels(sourceDir string, models schema.ModelClassMap, ctx *m
 		module := entry.Module
 		if !tried[module] {
 			tried[module] = true
-
-			// Skip known non-local modules.
-			if isKnownExternalModule(module) {
-				return
-			}
-
-			// Convert module path to filesystem path and try to find it.
-			pyPath := moduleToFilePath(module)
-			if pyPath == "" {
-				return
-			}
-
-			fullPath := filepath.Join(sourceDir, pyPath)
-			source, err := os.ReadFile(fullPath)
-			if err != nil {
-				if errors.Is(err, os.ErrNotExist) {
-					// File doesn't exist — it's an external package, not local.
-					return
-				}
-				fmt.Fprintf(os.Stderr, "cog: warning: failed to read %q: %v\n", fullPath, err)
-				return
-			}
-
-			// Parse the file and extract schema object classes.
-			parser := sitter.NewParser()
-			parser.SetLanguage(python.GetLanguage())
-			tree, err := parser.ParseCtx(context.Background(), nil, source)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "cog: warning: failed to parse %q: %v\n", fullPath, err)
-				return
-			}
-
-			fileCtx := &modelParseContext{imports: CollectImports(tree.RootNode(), source), typedDicts: make(map[string]bool)}
-			fileModels := collectModelClasses(tree.RootNode(), source, fileCtx)
-
-			// Merge discovered models into the caller's map.
-			fileModels.Entries(func(name string, fields []schema.ModelField) {
-				if _, exists := models.Get(name); !exists {
-					models.Set(name, fields)
-				}
-			})
-			for name := range fileCtx.typedDicts {
-				ctx.typedDicts[name] = true
-			}
+			mergeDiscoveredModels(models, ctx.loadModelsFromModule(sourceDir, module))
 		}
 
-		// Handle aliases: "from X import MyOutput as Output"
-		// localName is "Output", entry.Original is "MyOutput".
-		// If we resolved "MyOutput" from the file, also register it under "Output".
-		if localName != entry.Original {
-			if fields, ok := models.Get(entry.Original); ok {
-				if _, exists := models.Get(localName); !exists {
-					models.Set(localName, fields)
-				}
-			}
-			if ctx.typedDicts[entry.Original] {
-				ctx.typedDicts[localName] = true
-			}
-		}
+		propagateImportedAlias(localName, entry, models, ctx.typedDicts)
 	})
 }
 
@@ -1232,6 +1240,53 @@ type inputParseContext struct {
 	typedDicts map[string]bool
 }
 
+func resolveParameterFieldType(typeNode *sitter.Node, source []byte, ctx *inputParseContext) (schema.FieldType, error) {
+	typeAnn, err := parseTypeAnnotation(typeNode, source)
+	if err != nil {
+		return schema.FieldType{}, err
+	}
+	return schema.ResolveFieldType(typeAnn, ctx.imports, ctx.typedDicts)
+}
+
+func typedParameterParts(node *sitter.Node, source []byte) (string, *sitter.Node) {
+	var name string
+	var typeNode *sitter.Node
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		c := node.NamedChild(i)
+		switch c.Type() {
+		case "identifier":
+			if name == "" {
+				name = Content(c, source)
+			}
+		case "type":
+			typeNode = c
+		}
+	}
+	return name, typeNode
+}
+
+func inputField(name string, order int, fieldType schema.FieldType) schema.InputField {
+	return schema.InputField{
+		Name:      name,
+		Order:     order,
+		FieldType: fieldType,
+	}
+}
+
+func inputFieldWithInfo(name string, order int, fieldType schema.FieldType, info inputCallInfo) schema.InputField {
+	field := inputField(name, order, fieldType)
+	field.Default = info.Default
+	field.Description = info.Description
+	field.GE = info.GE
+	field.LE = info.LE
+	field.MinLength = info.MinLength
+	field.MaxLength = info.MaxLength
+	field.Regex = info.Regex
+	field.Choices = info.Choices
+	field.Deprecated = info.Deprecated
+	return field
+}
+
 func firstParamIsSelf(params *sitter.Node, source []byte) bool {
 	for _, child := range AllChildren(params) {
 		if child.Type() == "identifier" {
@@ -1294,19 +1349,7 @@ func extractInputs(
 func parseTypedParameter(node *sitter.Node, source []byte, order int, ctx *inputParseContext) (schema.InputField, error) {
 	// typed_parameter has no "name" field in the Python grammar.
 	// Structure is: identifier ":" type
-	var name string
-	var typeNode *sitter.Node
-	for i := 0; i < int(node.NamedChildCount()); i++ {
-		c := node.NamedChild(i)
-		switch c.Type() {
-		case "identifier":
-			if name == "" {
-				name = Content(c, source)
-			}
-		case "type":
-			typeNode = c
-		}
-	}
+	name, typeNode := typedParameterParts(node, source)
 	if name == "" {
 		return schema.InputField{}, schema.WrapError(schema.ErrParse, "typed_parameter has no identifier", nil)
 	}
@@ -1314,20 +1357,12 @@ func parseTypedParameter(node *sitter.Node, source []byte, order int, ctx *input
 		return schema.InputField{}, schema.WrapError(schema.ErrMissingTypeAnnotation, fmt.Sprintf("parameter '%s' on %s has no type annotation", name, ctx.methodName), nil)
 	}
 
-	typeAnn, err := parseTypeAnnotation(typeNode, source)
-	if err != nil {
-		return schema.InputField{}, err
-	}
-	fieldType, err := schema.ResolveFieldType(typeAnn, ctx.imports, ctx.typedDicts)
+	fieldType, err := resolveParameterFieldType(typeNode, source, ctx)
 	if err != nil {
 		return schema.InputField{}, err
 	}
 
-	return schema.InputField{
-		Name:      name,
-		Order:     order,
-		FieldType: fieldType,
-	}, nil
+	return inputField(name, order, fieldType), nil
 }
 
 func parseTypedDefaultParameter(node *sitter.Node, source []byte, order int, ctx *inputParseContext) (schema.InputField, error) {
@@ -1342,11 +1377,7 @@ func parseTypedDefaultParameter(node *sitter.Node, source []byte, order int, ctx
 		return schema.InputField{}, schema.WrapError(schema.ErrMissingTypeAnnotation, fmt.Sprintf("parameter '%s' on %s has no type annotation", name, ctx.methodName), nil)
 	}
 
-	typeAnn, err := parseTypeAnnotation(typeNode, source)
-	if err != nil {
-		return schema.InputField{}, err
-	}
-	fieldType, err := schema.ResolveFieldType(typeAnn, ctx.imports, ctx.typedDicts)
+	fieldType, err := resolveParameterFieldType(typeNode, source, ctx)
 	if err != nil {
 		return schema.InputField{}, err
 	}
@@ -1360,48 +1391,19 @@ func parseTypedDefaultParameter(node *sitter.Node, source []byte, order int, ctx
 			if err != nil {
 				return schema.InputField{}, err
 			}
-			return schema.InputField{
-				Name:        name,
-				Order:       order,
-				FieldType:   fieldType,
-				Default:     info.Default,
-				Description: info.Description,
-				GE:          info.GE,
-				LE:          info.LE,
-				MinLength:   info.MinLength,
-				MaxLength:   info.MaxLength,
-				Regex:       info.Regex,
-				Choices:     info.Choices,
-				Deprecated:  info.Deprecated,
-			}, nil
+			return inputFieldWithInfo(name, order, fieldType, info), nil
 		}
 
 		// 2. Reference to Input() via class attribute or static method
 		if info, ok := resolveInputReference(valNode, source, ctx.registry); ok {
-			return schema.InputField{
-				Name:        name,
-				Order:       order,
-				FieldType:   fieldType,
-				Default:     info.Default,
-				Description: info.Description,
-				GE:          info.GE,
-				LE:          info.LE,
-				MinLength:   info.MinLength,
-				MaxLength:   info.MaxLength,
-				Regex:       info.Regex,
-				Choices:     info.Choices,
-				Deprecated:  info.Deprecated,
-			}, nil
+			return inputFieldWithInfo(name, order, fieldType, info), nil
 		}
 
 		// 3. Plain default — must be statically resolvable
 		if def, ok := resolveDefaultExpr(valNode, source, ctx.scope); ok {
-			return schema.InputField{
-				Name:      name,
-				Order:     order,
-				FieldType: fieldType,
-				Default:   &def,
-			}, nil
+			field := inputField(name, order, fieldType)
+			field.Default = &def
+			return field, nil
 		}
 
 		// Can't resolve — hard error
@@ -1411,11 +1413,7 @@ func parseTypedDefaultParameter(node *sitter.Node, source []byte, order int, ctx
 	}
 
 	// No default — required parameter
-	return schema.InputField{
-		Name:      name,
-		Order:     order,
-		FieldType: fieldType,
-	}, nil
+	return inputField(name, order, fieldType), nil
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/schema/python/parser.go
+++ b/pkg/schema/python/parser.go
@@ -43,10 +43,11 @@ func ParsePredictor(source []byte, predictRef string, mode schema.Mode, sourceDi
 	// 2. Collect module-level variable assignments
 	moduleScope := collectModuleScope(root, source)
 
-	// 3. Collect BaseModel subclasses (local file first, then cross-file)
-	modelClasses := collectModelClasses(root, source, imports)
+	// 3. Collect schema object classes (BaseModel and TypedDict) locally first,
+	// then across local imports.
+	modelClasses, typedDicts := collectModelClasses(root, source, imports)
 	if sourceDir != "" {
-		resolveExternalModels(sourceDir, imports, modelClasses)
+		resolveExternalModels(sourceDir, imports, modelClasses, typedDicts)
 	}
 
 	// 4. Collect Input() references from class attributes and static methods
@@ -71,7 +72,7 @@ func ParsePredictor(source []byte, predictRef string, mode schema.Mode, sourceDi
 	isMethod := firstParamIsSelf(paramsNode, source)
 
 	// 7. Extract parameters
-	inputs, err := extractInputs(paramsNode, source, methodName, isMethod, imports, inputRegistry, moduleScope)
+	inputs, err := extractInputs(paramsNode, source, methodName, isMethod, imports, inputRegistry, moduleScope, typedDicts)
 	if err != nil {
 		return nil, err
 	}
@@ -136,6 +137,9 @@ func CollectImports(root *sitter.Node, source []byte) *schema.ImportContext {
 	for _, child := range NamedChildren(root) {
 		if child.Type() == "import_from_statement" {
 			parseImportFrom(child, source, ctx)
+		}
+		if child.Type() == "import_statement" {
+			parseImport(child, source, ctx)
 		}
 	}
 
@@ -202,6 +206,24 @@ func parseImportFrom(node *sitter.Node, source []byte, ctx *schema.ImportContext
 				}
 			}
 		}
+	}
+}
+
+func parseImport(node *sitter.Node, source []byte, ctx *schema.ImportContext) {
+	text := strings.TrimSpace(Content(node, source))
+	imports := strings.TrimSpace(strings.TrimPrefix(text, "import "))
+	for _, part := range strings.Split(imports, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		module := part
+		alias := part
+		if before, after, ok := strings.Cut(part, " as "); ok {
+			module = strings.TrimSpace(before)
+			alias = strings.TrimSpace(after)
+		}
+		ctx.Names.Set(alias, schema.ImportEntry{Module: module, Original: module})
 	}
 }
 
@@ -381,8 +403,9 @@ func resolveChoicesCall(node *sitter.Node, source []byte, scope moduleScope) ([]
 // BaseModel subclass collection
 // ---------------------------------------------------------------------------
 
-func collectModelClasses(root *sitter.Node, source []byte, imports *schema.ImportContext) schema.ModelClassMap {
+func collectModelClasses(root *sitter.Node, source []byte, imports *schema.ImportContext) (schema.ModelClassMap, map[string]bool) {
 	models := schema.NewOrderedMap[string, []schema.ModelField]()
+	typedDicts := make(map[string]bool)
 
 	for _, child := range NamedChildren(root) {
 		classNode := UnwrapClass(child)
@@ -396,19 +419,59 @@ func collectModelClasses(root *sitter.Node, source []byte, imports *schema.Impor
 		}
 		className := Content(nameNode, source)
 
-		if !InheritsFromBaseModel(classNode, source, imports) {
+		isBaseModel := InheritsFromBaseModel(classNode, source, imports)
+		isTypedDict, requiredByDefault, parents := TypedDictClassInfo(classNode, source, imports, typedDicts)
+		if !isBaseModel && !isTypedDict {
 			continue
 		}
 
-		fields := extractClassAnnotations(classNode, source)
+		fields := extractClassAnnotations(classNode, source, imports, isTypedDict, requiredByDefault)
+		if isTypedDict {
+			fields = mergeModelFields(parentModelFields(models, parents), fields)
+		}
 		models.Set(className, fields)
+		if isTypedDict {
+			typedDicts[className] = true
+		}
 	}
-	return models
+	return models, typedDicts
+}
+
+func parentModelFields(models schema.ModelClassMap, parents []string) [][]schema.ModelField {
+	merged := make([][]schema.ModelField, 0, len(parents))
+	for _, parent := range parents {
+		if fields, ok := models.Get(parent); ok {
+			merged = append(merged, fields)
+		}
+	}
+	return merged
+}
+
+func mergeModelFields(parents [][]schema.ModelField, own []schema.ModelField) []schema.ModelField {
+	merged := make([]schema.ModelField, 0)
+	index := make(map[string]int)
+	appendField := func(field schema.ModelField) {
+		if i, ok := index[field.Name]; ok {
+			merged[i] = field
+			return
+		}
+		index[field.Name] = len(merged)
+		merged = append(merged, field)
+	}
+	for _, parentFields := range parents {
+		for _, field := range parentFields {
+			appendField(field)
+		}
+	}
+	for _, field := range own {
+		appendField(field)
+	}
+	return merged
 }
 
 // resolveExternalModels looks at imports that brought in names not yet in
 // modelClasses, attempts to find the corresponding .py file on disk, parses
-// it, and merges any BaseModel subclasses into modelClasses.
+// it, and merges any schema object classes into modelClasses.
 //
 // This handles every local import permutation:
 //
@@ -420,7 +483,7 @@ func collectModelClasses(root *sitter.Node, source []byte, imports *schema.Impor
 //
 // Non-local imports (stdlib, pip packages) are skipped because the file
 // won't exist on disk.
-func resolveExternalModels(sourceDir string, imports *schema.ImportContext, models schema.ModelClassMap) {
+func resolveExternalModels(sourceDir string, imports *schema.ImportContext, models schema.ModelClassMap, typedDicts map[string]bool) {
 	// Track which modules we've already tried so we don't re-parse.
 	tried := make(map[string]bool)
 
@@ -456,7 +519,7 @@ func resolveExternalModels(sourceDir string, imports *schema.ImportContext, mode
 				return
 			}
 
-			// Parse the file and extract BaseModel subclasses.
+			// Parse the file and extract schema object classes.
 			parser := sitter.NewParser()
 			parser.SetLanguage(python.GetLanguage())
 			tree, err := parser.ParseCtx(context.Background(), nil, source)
@@ -466,7 +529,7 @@ func resolveExternalModels(sourceDir string, imports *schema.ImportContext, mode
 			}
 
 			fileImports := CollectImports(tree.RootNode(), source)
-			fileModels := collectModelClasses(tree.RootNode(), source, fileImports)
+			fileModels, fileTypedDicts := collectModelClasses(tree.RootNode(), source, fileImports)
 
 			// Merge discovered models into the caller's map.
 			fileModels.Entries(func(name string, fields []schema.ModelField) {
@@ -474,6 +537,9 @@ func resolveExternalModels(sourceDir string, imports *schema.ImportContext, mode
 					models.Set(name, fields)
 				}
 			})
+			for name := range fileTypedDicts {
+				typedDicts[name] = true
+			}
 		}
 
 		// Handle aliases: "from X import MyOutput as Output"
@@ -484,6 +550,9 @@ func resolveExternalModels(sourceDir string, imports *schema.ImportContext, mode
 				if _, exists := models.Get(localName); !exists {
 					models.Set(localName, fields)
 				}
+			}
+			if typedDicts[entry.Original] {
+				typedDicts[localName] = true
 			}
 		}
 	})
@@ -585,7 +654,53 @@ func InheritsFromBaseModel(classNode *sitter.Node, source []byte, imports *schem
 	return false
 }
 
-func extractClassAnnotations(classNode *sitter.Node, source []byte) []schema.ModelField {
+func TypedDictClassInfo(classNode *sitter.Node, source []byte, imports *schema.ImportContext, typedDicts map[string]bool) (bool, bool, []string) {
+	supers := classNode.ChildByFieldName("superclasses")
+	if supers == nil {
+		return false, true, nil
+	}
+
+	isTypedDict := false
+	requiredByDefault := true
+	parents := []string{}
+	for _, child := range NamedChildren(supers) {
+		switch child.Type() {
+		case "identifier":
+			name := Content(child, source)
+			if imports.IsTypedDict(name) || name == "TypedDict" {
+				isTypedDict = true
+				continue
+			}
+			if typedDicts[name] {
+				isTypedDict = true
+				parents = append(parents, name)
+			}
+		case "attribute":
+			text := Content(child, source)
+			if strings.HasSuffix(text, ".TypedDict") {
+				isTypedDict = true
+				continue
+			}
+			if resolved, _, ok := imports.ResolveQualifiedName(text); ok && typedDicts[resolved] {
+				isTypedDict = true
+				parents = append(parents, resolved)
+			}
+		case "keyword_argument":
+			nameNode := child.ChildByFieldName("name")
+			valueNode := child.ChildByFieldName("value")
+			if nameNode == nil || valueNode == nil {
+				continue
+			}
+			if Content(nameNode, source) == "total" && strings.TrimSpace(Content(valueNode, source)) == "False" {
+				requiredByDefault = false
+			}
+		}
+	}
+
+	return isTypedDict, requiredByDefault, parents
+}
+
+func extractClassAnnotations(classNode *sitter.Node, source []byte, imports *schema.ImportContext, isTypedDict bool, requiredByDefault bool) []schema.ModelField {
 	body := classNode.ChildByFieldName("body")
 	if body == nil {
 		return nil
@@ -600,11 +715,11 @@ func extractClassAnnotations(classNode *sitter.Node, source []byte) []schema.Mod
 
 		switch node.Type() {
 		case "assignment":
-			if f, ok := parseAnnotatedAssignment(node, source); ok {
+			if f, ok := parseAnnotatedAssignment(node, source, imports, isTypedDict, requiredByDefault); ok {
 				fields = append(fields, f)
 			}
 		case "type":
-			if f, ok := parseBareAnnotation(node, source); ok {
+			if f, ok := parseBareAnnotation(node, source, imports, isTypedDict, requiredByDefault); ok {
 				fields = append(fields, f)
 			}
 		}
@@ -612,7 +727,7 @@ func extractClassAnnotations(classNode *sitter.Node, source []byte) []schema.Mod
 	return fields
 }
 
-func parseAnnotatedAssignment(node *sitter.Node, source []byte) (schema.ModelField, bool) {
+func parseAnnotatedAssignment(node *sitter.Node, source []byte, imports *schema.ImportContext, isTypedDict bool, requiredByDefault bool) (schema.ModelField, bool) {
 	left := node.ChildByFieldName("left")
 	typeNode := node.ChildByFieldName("type")
 	if left == nil || typeNode == nil || left.Type() != "identifier" {
@@ -632,10 +747,12 @@ func parseAnnotatedAssignment(node *sitter.Node, source []byte) (schema.ModelFie
 		}
 	}
 
-	return schema.ModelField{Name: name, Type: typeAnn, Default: def}, true
+	typeAnn, keyRequired := typedDictFieldInfo(typeAnn, imports, isTypedDict, requiredByDefault)
+
+	return schema.ModelField{Name: name, Type: typeAnn, Default: def, KeyRequired: keyRequired}, true
 }
 
-func parseBareAnnotation(node *sitter.Node, source []byte) (schema.ModelField, bool) {
+func parseBareAnnotation(node *sitter.Node, source []byte, imports *schema.ImportContext, isTypedDict bool, requiredByDefault bool) (schema.ModelField, bool) {
 	text := strings.TrimSpace(Content(node, source))
 	parts := strings.SplitN(text, ":", 2)
 	if len(parts) != 2 {
@@ -653,7 +770,42 @@ func parseBareAnnotation(node *sitter.Node, source []byte) (schema.ModelField, b
 		return schema.ModelField{}, false
 	}
 
-	return schema.ModelField{Name: name, Type: typeAnn, Default: nil}, true
+	typeAnn, keyRequired := typedDictFieldInfo(typeAnn, imports, isTypedDict, requiredByDefault)
+
+	return schema.ModelField{Name: name, Type: typeAnn, Default: nil, KeyRequired: keyRequired}, true
+}
+
+func typedDictFieldInfo(typeAnn schema.TypeAnnotation, imports *schema.ImportContext, isTypedDict bool, requiredByDefault bool) (schema.TypeAnnotation, *bool) {
+	if !isTypedDict {
+		return typeAnn, nil
+	}
+	if typeAnn.Kind != schema.TypeAnnotGeneric || len(typeAnn.Args) != 1 {
+		return typeAnn, boolPtr(requiredByDefault)
+	}
+
+	name := typeAnn.Name
+	if name == "NotRequired" || strings.HasSuffix(name, ".NotRequired") {
+		return typeAnn.Args[0], boolPtr(false)
+	}
+	if name == "Required" || strings.HasSuffix(name, ".Required") {
+		return typeAnn.Args[0], boolPtr(true)
+	}
+	if imports.IsTypedDictFieldQualifier(name) {
+		if entry, ok := imports.Names.Get(name); ok {
+			switch entry.Original {
+			case "NotRequired":
+				return typeAnn.Args[0], boolPtr(false)
+			case "Required":
+				return typeAnn.Args[0], boolPtr(true)
+			}
+		}
+	}
+
+	return typeAnn, boolPtr(requiredByDefault)
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }
 
 func parseTypeFromString(s string) (schema.TypeAnnotation, bool) {
@@ -673,8 +825,7 @@ func parseTypeFromString(s string) (schema.TypeAnnotation, bool) {
 	}
 
 	// Union: X | Y
-	if strings.Contains(s, "|") {
-		parts := strings.Split(s, "|")
+	if parts, ok := splitTopLevelPipes(s); ok {
 		var members []schema.TypeAnnotation
 		for _, p := range parts {
 			m, ok := parseTypeFromString(strings.TrimSpace(p))
@@ -718,6 +869,32 @@ func parseTypeFromString(s string) (schema.TypeAnnotation, bool) {
 		}
 	}
 	return schema.TypeAnnotation{Kind: schema.TypeAnnotSimple, Name: s}, true
+}
+
+func splitTopLevelPipes(s string) ([]string, bool) {
+	depth := 0
+	start := 0
+	parts := []string{}
+	hasPipe := false
+	for i, c := range s {
+		switch c {
+		case '[':
+			depth++
+		case ']':
+			depth--
+		case '|':
+			if depth == 0 {
+				hasPipe = true
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	if !hasPipe {
+		return nil, false
+	}
+	parts = append(parts, s[start:])
+	return parts, true
 }
 
 // splitTopLevelCommas splits a string on commas that are not nested inside brackets.
@@ -1052,6 +1229,7 @@ func extractInputs(
 	imports *schema.ImportContext,
 	registry *inputRegistry,
 	scope moduleScope,
+	typedDicts map[string]bool,
 ) (*schema.OrderedMap[string, schema.InputField], error) {
 	inputs := schema.NewOrderedMap[string, schema.InputField]()
 	order := 0
@@ -1069,7 +1247,7 @@ func extractInputs(
 			}
 
 		case "typed_parameter":
-			input, err := parseTypedParameter(child, source, order, methodName, imports)
+			input, err := parseTypedParameter(child, source, order, methodName, imports, typedDicts)
 			if err != nil {
 				return nil, err
 			}
@@ -1077,7 +1255,7 @@ func extractInputs(
 			order++
 
 		case "typed_default_parameter":
-			input, err := parseTypedDefaultParameter(child, source, order, methodName, imports, registry, scope)
+			input, err := parseTypedDefaultParameter(child, source, order, methodName, imports, registry, scope, typedDicts)
 			if err != nil {
 				return nil, err
 			}
@@ -1097,7 +1275,7 @@ func extractInputs(
 	return inputs, nil
 }
 
-func parseTypedParameter(node *sitter.Node, source []byte, order int, methodName string, imports *schema.ImportContext) (schema.InputField, error) {
+func parseTypedParameter(node *sitter.Node, source []byte, order int, methodName string, imports *schema.ImportContext, typedDicts map[string]bool) (schema.InputField, error) {
 	// typed_parameter has no "name" field in the Python grammar.
 	// Structure is: identifier ":" type
 	var name string
@@ -1124,7 +1302,7 @@ func parseTypedParameter(node *sitter.Node, source []byte, order int, methodName
 	if err != nil {
 		return schema.InputField{}, err
 	}
-	fieldType, err := schema.ResolveFieldType(typeAnn, imports)
+	fieldType, err := schema.ResolveFieldType(typeAnn, imports, typedDicts)
 	if err != nil {
 		return schema.InputField{}, err
 	}
@@ -1144,6 +1322,7 @@ func parseTypedDefaultParameter(
 	imports *schema.ImportContext,
 	registry *inputRegistry,
 	scope moduleScope,
+	typedDicts map[string]bool,
 ) (schema.InputField, error) {
 	nameNode := node.ChildByFieldName("name")
 	if nameNode == nil {
@@ -1160,7 +1339,7 @@ func parseTypedDefaultParameter(
 	if err != nil {
 		return schema.InputField{}, err
 	}
-	fieldType, err := schema.ResolveFieldType(typeAnn, imports)
+	fieldType, err := schema.ResolveFieldType(typeAnn, imports, typedDicts)
 	if err != nil {
 		return schema.InputField{}, err
 	}

--- a/pkg/schema/python/parser_test.go
+++ b/pkg/schema/python/parser_test.go
@@ -2878,3 +2878,263 @@ class Predictor(BasePredictor):
 	require.Empty(t, messages.Default.List)
 	require.False(t, messages.IsRequired())
 }
+
+func TestTypedDictInput(t *testing.T) {
+	source := `
+from typing import TypedDict
+from cog import BasePredictor
+
+class Payload(TypedDict):
+    name: str
+    count: int
+
+class Predictor(BasePredictor):
+    def predict(self, data: Payload) -> str:
+        return data["name"]
+`
+	info := parse(t, source, "Predictor")
+	data, ok := info.Inputs.Get("data")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeAny, data.FieldType.Primitive)
+	require.Equal(t, schema.Required, data.FieldType.Repetition)
+}
+
+func TestOptionalListOfTypedDictInput(t *testing.T) {
+	source := `
+from typing import TypedDict
+from cog import BasePredictor
+
+class Payload(TypedDict):
+    name: str
+
+class Predictor(BasePredictor):
+    def predict(self, messages: list[Payload] | None = None) -> str:
+        return str(messages)
+`
+	info := parse(t, source, "Predictor")
+	messages, ok := info.Inputs.Get("messages")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeAny, messages.FieldType.Primitive)
+	require.Equal(t, schema.OptionalRepeated, messages.FieldType.Repetition)
+}
+
+func TestTypedDictOutput(t *testing.T) {
+	source := `
+from typing import TypedDict
+from cog import BasePredictor
+
+class Payload(TypedDict):
+    name: str
+    count: int
+
+class Predictor(BasePredictor):
+    def predict(self, x: str) -> Payload:
+        pass
+`
+	info := parse(t, source, "Predictor")
+	require.Equal(t, schema.SchemaObject, info.Output.Kind)
+	require.Equal(t, 2, info.Output.Fields.Len())
+
+	name, ok := info.Output.Fields.Get("name")
+	require.True(t, ok)
+	require.True(t, name.Required)
+	require.Equal(t, schema.TypeString, name.Type.Primitive)
+
+	count, ok := info.Output.Fields.Get("count")
+	require.True(t, ok)
+	require.True(t, count.Required)
+	require.Equal(t, schema.TypeInteger, count.Type.Primitive)
+}
+
+func TestTypedDictOutputTotalFalse(t *testing.T) {
+	source := `
+from typing import TypedDict
+from cog import BasePredictor
+
+class Payload(TypedDict, total=False):
+    name: str
+    count: int
+
+class Predictor(BasePredictor):
+    def predict(self, x: str) -> Payload:
+        pass
+`
+	info := parse(t, source, "Predictor")
+	require.Equal(t, schema.SchemaObject, info.Output.Kind)
+
+	name, ok := info.Output.Fields.Get("name")
+	require.True(t, ok)
+	require.False(t, name.Required)
+	require.False(t, name.Type.Nullable)
+
+	count, ok := info.Output.Fields.Get("count")
+	require.True(t, ok)
+	require.False(t, count.Required)
+	require.False(t, count.Type.Nullable)
+}
+
+func TestTypedDictOutputNotRequiredField(t *testing.T) {
+	source := `
+from typing import NotRequired, TypedDict
+from cog import BasePredictor
+
+class Payload(TypedDict):
+    name: str
+    count: NotRequired[int]
+
+class Predictor(BasePredictor):
+    def predict(self, x: str) -> Payload:
+        pass
+`
+	info := parse(t, source, "Predictor")
+	require.Equal(t, schema.SchemaObject, info.Output.Kind)
+
+	name, ok := info.Output.Fields.Get("name")
+	require.True(t, ok)
+	require.True(t, name.Required)
+	require.Equal(t, schema.TypeString, name.Type.Primitive)
+
+	count, ok := info.Output.Fields.Get("count")
+	require.True(t, ok)
+	require.False(t, count.Required)
+	require.False(t, count.Type.Nullable)
+	require.Equal(t, schema.TypeInteger, count.Type.Primitive)
+}
+
+func TestTypedDictOutputRequiredOptionalField(t *testing.T) {
+	source := `
+from typing import Required, TypedDict
+from cog import BasePredictor
+
+class Payload(TypedDict, total=False):
+    value: Required[int | None]
+
+class Predictor(BasePredictor):
+    def predict(self, x: str) -> Payload:
+        pass
+`
+	info := parse(t, source, "Predictor")
+	require.Equal(t, schema.SchemaObject, info.Output.Kind)
+
+	value, ok := info.Output.Fields.Get("value")
+	require.True(t, ok)
+	require.True(t, value.Required)
+	require.True(t, value.Type.Nullable)
+	require.Equal(t, schema.TypeInteger, value.Type.Primitive)
+}
+
+func TestCrossFileTypedDictImport(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "types.py", `
+from typing import TypedDict
+
+class Output(TypedDict):
+    text: str
+    score: float
+`)
+	writeFile(t, dir, "predict.py", `
+from cog import BasePredictor
+from types import Output
+
+class Predictor(BasePredictor):
+    def predict(self, x: str) -> Output:
+        pass
+`)
+	info := parseFile(t, dir, "predict.py", "Predictor")
+	require.Equal(t, schema.SchemaObject, info.Output.Kind)
+	require.Equal(t, 2, info.Output.Fields.Len())
+
+	text, ok := info.Output.Fields.Get("text")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeString, text.Type.Primitive)
+	require.True(t, text.Required)
+
+	score, ok := info.Output.Fields.Get("score")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeFloat, score.Type.Primitive)
+	require.True(t, score.Required)
+}
+
+func TestQualifiedTypedDictImportInputAndOutput(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "output_types.py", `
+from typing import TypedDict
+
+class Payload(TypedDict):
+    name: str
+    count: int
+
+class Output(TypedDict):
+    text: str
+`)
+	writeFile(t, dir, "predict.py", `
+import output_types as ot
+from cog import BasePredictor
+
+class Predictor(BasePredictor):
+    def predict(self, data: ot.Payload) -> ot.Output:
+        pass
+`)
+	info := parseFile(t, dir, "predict.py", "Predictor")
+
+	data, ok := info.Inputs.Get("data")
+	require.True(t, ok)
+	require.Equal(t, schema.TypeAny, data.FieldType.Primitive)
+	require.Equal(t, schema.Required, data.FieldType.Repetition)
+
+	require.Equal(t, schema.SchemaObject, info.Output.Kind)
+	text, ok := info.Output.Fields.Get("text")
+	require.True(t, ok)
+	require.True(t, text.Required)
+	require.Equal(t, schema.TypeString, text.Type.Primitive)
+}
+
+func TestInheritedTypedDictOutput(t *testing.T) {
+	source := `
+from typing import TypedDict
+from cog import BasePredictor
+
+class BasePayload(TypedDict):
+    name: str
+
+class Payload(BasePayload):
+    count: int
+
+class Predictor(BasePredictor):
+    def predict(self, x: str) -> Payload:
+        pass
+`
+	info := parse(t, source, "Predictor")
+	require.Equal(t, schema.SchemaObject, info.Output.Kind)
+	require.Equal(t, 2, info.Output.Fields.Len())
+
+	name, ok := info.Output.Fields.Get("name")
+	require.True(t, ok)
+	require.True(t, name.Required)
+	require.Equal(t, schema.TypeString, name.Type.Primitive)
+
+	count, ok := info.Output.Fields.Get("count")
+	require.True(t, ok)
+	require.True(t, count.Required)
+	require.Equal(t, schema.TypeInteger, count.Type.Primitive)
+}
+
+func TestNonTypedDictNotRequiredQualifierErrors(t *testing.T) {
+	source := `
+from typing import NotRequired
+from pydantic import BaseModel
+from cog import BasePredictor
+
+class Output(BaseModel):
+    count: NotRequired[int]
+
+class Predictor(BasePredictor):
+    def predict(self, x: str) -> Output:
+        pass
+`
+	se := parseErr(t, source, "Predictor", schema.ModePredict)
+	require.Equal(t, schema.ErrUnsupportedType, se.Kind)
+	require.Contains(t, se.Message, "NotRequired")
+}

--- a/pkg/schema/schema_type.go
+++ b/pkg/schema/schema_type.go
@@ -249,43 +249,56 @@ func resolveSchemaType(ann TypeAnnotation, ctx *ImportContext, models ModelClass
 }
 
 func resolveSimpleSchemaType(ann TypeAnnotation, ctx *ImportContext, models ModelClassMap, seen map[string]bool) (SchemaType, error) {
+	name := ann.Name
+	qualifiedEntry := ImportEntry{}
+	if resolved, entry, ok := ctx.ResolveQualifiedName(name); ok {
+		name = resolved
+		qualifiedEntry = entry
+	}
+
 	// Check for BaseModel subclass
-	if fields, ok := models.Get(ann.Name); ok {
+	if fields, ok := models.Get(name); ok {
 		// Cycle detection: if we're already resolving this model, emit opaque object.
-		if seen[ann.Name] {
+		if seen[name] {
 			return SchemaAnyType(), nil
 		}
 		if seen == nil {
 			seen = make(map[string]bool)
 		}
-		seen[ann.Name] = true
-		defer delete(seen, ann.Name)
+		seen[name] = true
+		defer delete(seen, name)
 		return resolveModelToSchemaType(fields, ctx, models, seen)
 	}
 
 	// Unparameterized dict → opaque JSON object
-	if ann.Name == "Any" || ann.Name == "dict" || ann.Name == "Dict" {
+	if name == "Any" || name == "dict" || name == "Dict" {
 		return SchemaAnyType(), nil
 	}
 
 	// Unparameterized list → array of opaque objects
-	if ann.Name == "list" || ann.Name == "List" {
+	if name == "list" || name == "List" {
 		return SchemaArrayOf(SchemaAnyType()), nil
 	}
 
-	prim, ok := PrimitiveFromName(ann.Name)
+	prim, ok := PrimitiveFromName(name)
 	if !ok {
 		// Check if this name was imported from an external package
-		if entry, imported := ctx.Names.Get(ann.Name); imported {
-			return SchemaType{}, errUnresolvableImportedType(ann.Name, entry.Module)
+		if qualifiedEntry.Module != "" {
+			return SchemaType{}, errUnresolvableImportedType(name, qualifiedEntry.Module)
 		}
-		return SchemaType{}, errUnresolvableType(ann.Name)
+		if entry, imported := ctx.Names.Get(name); imported {
+			return SchemaType{}, errUnresolvableImportedType(name, entry.Module)
+		}
+		return SchemaType{}, errUnresolvableType(name)
 	}
 	return SchemaPrim(prim), nil
 }
 
 func resolveGenericSchemaType(ann TypeAnnotation, ctx *ImportContext, models ModelClassMap, seen map[string]bool) (SchemaType, error) {
 	outer := ann.Name
+	if resolved, _, ok := ctx.ResolveQualifiedName(outer); ok {
+		outer = resolved
+	}
 
 	// dict[K, V] — recursively resolve value type
 	if outer == "dict" || outer == "Dict" {
@@ -376,6 +389,9 @@ func resolveModelToSchemaType(modelFields []ModelField, ctx *ImportContext, mode
 		st, required, err := resolveFieldSchemaType(f.Type, ctx, models, seen)
 		if err != nil {
 			return SchemaType{}, fmt.Errorf("field %q: %w", f.Name, err)
+		}
+		if f.KeyRequired != nil {
+			required = *f.KeyRequired
 		}
 		if f.Default != nil {
 			required = false

--- a/pkg/schema/types.go
+++ b/pkg/schema/types.go
@@ -317,7 +317,7 @@ func ResolveFieldType(ann TypeAnnotation, ctx *ImportContext, typedDicts map[str
 		prim, ok := PrimitiveFromName(name)
 		if !ok {
 			if qualifiedEntry.Module != "" {
-				return FieldType{}, errUnsupportedType(name)
+				return FieldType{}, errUnresolvableImportedType(name, qualifiedEntry.Module)
 			}
 			return FieldType{}, errUnsupportedType(name)
 		}

--- a/pkg/schema/types.go
+++ b/pkg/schema/types.go
@@ -259,6 +259,22 @@ func (ctx *ImportContext) IsBaseModel(name string) bool {
 	return false
 }
 
+// IsTypedDict returns true if name resolves to typing.TypedDict or typing_extensions.TypedDict.
+func (ctx *ImportContext) IsTypedDict(name string) bool {
+	if e, ok := ctx.Names.Get(name); ok {
+		return (e.Module == "typing" || e.Module == "typing_extensions") && e.Original == "TypedDict"
+	}
+	return false
+}
+
+// IsTypedDictFieldQualifier returns true if name resolves to Required or NotRequired.
+func (ctx *ImportContext) IsTypedDictFieldQualifier(name string) bool {
+	if e, ok := ctx.Names.Get(name); ok {
+		return (e.Module == "typing" || e.Module == "typing_extensions") && (e.Original == "Required" || e.Original == "NotRequired")
+	}
+	return false
+}
+
 // IsBasePredictor returns true if name resolves to cog.BasePredictor.
 func (ctx *ImportContext) IsBasePredictor(name string) bool {
 	if e, ok := ctx.Names.Get(name); ok {
@@ -267,22 +283,51 @@ func (ctx *ImportContext) IsBasePredictor(name string) bool {
 	return false
 }
 
+// ResolveQualifiedName unwraps module-qualified names like alias.Type to Type
+// when alias is known in the import context.
+func (ctx *ImportContext) ResolveQualifiedName(name string) (string, ImportEntry, bool) {
+	parts := strings.SplitN(name, ".", 2)
+	if len(parts) != 2 {
+		return name, ImportEntry{}, false
+	}
+	entry, ok := ctx.Names.Get(parts[0])
+	if !ok {
+		return parts[1], ImportEntry{}, true
+	}
+	return parts[1], entry, true
+}
+
 // ResolveFieldType resolves a TypeAnnotation into a FieldType.
-func ResolveFieldType(ann TypeAnnotation, ctx *ImportContext) (FieldType, error) {
+func ResolveFieldType(ann TypeAnnotation, ctx *ImportContext, typedDicts map[string]bool) (FieldType, error) {
 	switch ann.Kind {
 	case TypeAnnotSimple:
-		// Bare dict / Dict → opaque JSON object (TypeAny)
-		if ann.Name == "dict" || ann.Name == "Dict" {
+		name := ann.Name
+		qualifiedEntry := ImportEntry{}
+		if resolved, entry, ok := ctx.ResolveQualifiedName(name); ok {
+			name = resolved
+			qualifiedEntry = entry
+		}
+		if typedDicts[name] {
 			return FieldType{Primitive: TypeAny, Repetition: Required}, nil
 		}
-		prim, ok := PrimitiveFromName(ann.Name)
+		// Bare dict / Dict → opaque JSON object (TypeAny)
+		if name == "dict" || name == "Dict" {
+			return FieldType{Primitive: TypeAny, Repetition: Required}, nil
+		}
+		prim, ok := PrimitiveFromName(name)
 		if !ok {
-			return FieldType{}, errUnsupportedType(ann.Name)
+			if qualifiedEntry.Module != "" {
+				return FieldType{}, errUnsupportedType(name)
+			}
+			return FieldType{}, errUnsupportedType(name)
 		}
 		return FieldType{Primitive: prim, Repetition: Required}, nil
 
 	case TypeAnnotGeneric:
 		outer := ann.Name
+		if resolved, _, ok := ctx.ResolveQualifiedName(outer); ok {
+			outer = resolved
+		}
 		// dict[K, V] / Dict[K, V] → opaque JSON object (TypeAny).
 		// Type parameters are intentionally discarded because FieldType is flat
 		// (PrimitiveType + Repetition only). The output path uses the recursive
@@ -295,7 +340,7 @@ func ResolveFieldType(ann TypeAnnotation, ctx *ImportContext) (FieldType, error)
 			if len(ann.Args) != 1 {
 				return FieldType{}, errUnsupportedType(fmt.Sprintf("Optional expects exactly 1 type argument, got %d", len(ann.Args)))
 			}
-			inner, err := ResolveFieldType(ann.Args[0], ctx)
+			inner, err := ResolveFieldType(ann.Args[0], ctx, typedDicts)
 			if err != nil {
 				return FieldType{}, err
 			}
@@ -307,13 +352,13 @@ func ResolveFieldType(ann TypeAnnotation, ctx *ImportContext) (FieldType, error)
 		}
 		if outer == "Union" {
 			// typing.Union[X, Y] → treat as union type
-			return ResolveFieldType(TypeAnnotation{Kind: TypeAnnotUnion, Args: ann.Args}, ctx)
+			return ResolveFieldType(TypeAnnotation{Kind: TypeAnnotUnion, Args: ann.Args}, ctx, typedDicts)
 		}
 		if outer == "List" || outer == "list" {
 			if len(ann.Args) != 1 {
 				return FieldType{}, errUnsupportedType(fmt.Sprintf("List expects exactly 1 type argument, got %d", len(ann.Args)))
 			}
-			inner, err := ResolveFieldType(ann.Args[0], ctx)
+			inner, err := ResolveFieldType(ann.Args[0], ctx, typedDicts)
 			if err != nil {
 				return FieldType{}, err
 			}
@@ -326,7 +371,7 @@ func ResolveFieldType(ann TypeAnnotation, ctx *ImportContext) (FieldType, error)
 
 	case TypeAnnotUnion:
 		if inner, ok := UnwrapOptional(ann); ok {
-			ft, err := ResolveFieldType(inner, ctx)
+			ft, err := ResolveFieldType(inner, ctx, typedDicts)
 			if err != nil {
 				return FieldType{}, err
 			}
@@ -365,9 +410,10 @@ type ModelClassMap = *OrderedMap[string, []ModelField]
 
 // ModelField is a field extracted from a BaseModel subclass.
 type ModelField struct {
-	Name    string
-	Type    TypeAnnotation
-	Default *DefaultValue
+	Name        string
+	Type        TypeAnnotation
+	Default     *DefaultValue
+	KeyRequired *bool
 }
 
 // TitleCase converts snake_case to Title Case.

--- a/python/cog/_adt.py
+++ b/python/cog/_adt.py
@@ -37,6 +37,12 @@ def _is_union(tpe: type) -> bool:
     return False
 
 
+def _is_dict_like(tpe: Any) -> bool:
+    """Check if a type should be treated like a dict, including TypedDict."""
+    is_typeddict = getattr(typing, "is_typeddict", None)
+    return tpe is dict or (callable(is_typeddict) and is_typeddict(tpe))
+
+
 class PrimitiveType(Enum):
     """Primitive types supported by Cog."""
 
@@ -215,14 +221,14 @@ class FieldType:
         if tpe is list:
             tpe = List[Any]
             origin = typing.get_origin(tpe)
-        elif tpe is dict:
+        elif _is_dict_like(tpe):
             tpe = Dict[str, Any]
             origin = typing.get_origin(tpe)
         elif tpe is set:
             tpe = Set[Any]
             origin = typing.get_origin(tpe)
 
-        if origin is dict:
+        if origin is dict or _is_dict_like(tpe):
             # dict / Dict[K, V] → opaque JSON object, consistent with the
             # static Go schema generator's SchemaAnyType().
             return FieldType(
@@ -238,7 +244,7 @@ class FieldType:
                     raise ValueError("List must have one type argument")
                 elem_t = t_args[0]
                 # dict elements in lists → treat as ANY (opaque JSON objects)
-                if elem_t is dict or typing.get_origin(elem_t) is dict:
+                if _is_dict_like(elem_t) or typing.get_origin(elem_t) is dict:
                     return FieldType(
                         primitive=PrimitiveType.ANY,
                         repetition=Repetition.REPEATED,
@@ -267,7 +273,7 @@ class FieldType:
                         raise ValueError("List must have one type argument")
                     elem_t = list_args[0]
                     # dict elements in optional lists → ANY
-                    if elem_t is dict or typing.get_origin(elem_t) is dict:
+                    if _is_dict_like(elem_t) or typing.get_origin(elem_t) is dict:
                         return FieldType(
                             primitive=PrimitiveType.ANY,
                             repetition=Repetition.OPTIONAL_REPEATED,
@@ -281,7 +287,7 @@ class FieldType:
                 else:
                     elem_t = Any
                 repetition = Repetition.OPTIONAL_REPEATED
-            elif nested_t is dict or elem_t is dict:
+            elif nested_t is dict or _is_dict_like(elem_t):
                 # Optional[dict] or Optional[Dict[str, Any]] → optional ANY.
                 # nested_t is dict: elem_t is parameterized (e.g. Dict[str, Any]).
                 # elem_t is dict: elem_t is bare dict (nested_t is None).

--- a/python/tests/test_adt.py
+++ b/python/tests/test_adt.py
@@ -1,8 +1,17 @@
 """Tests for cog._adt module (FieldType, PrimitiveType)."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TypedDict
 
 from cog._adt import FieldType, PrimitiveType, Repetition
+
+
+class ExampleTypedDict(TypedDict):
+    name: str
+    count: int
+
+
+class ExampleDictSubclass(dict[str, int]):
+    pass
 
 
 class TestDictInputTypes:
@@ -78,6 +87,50 @@ class TestDictInputTypes:
         ft = FieldType.from_type(dict[str, int])
         assert ft.primitive is PrimitiveType.ANY
         assert ft.repetition is Repetition.REQUIRED
+
+    def test_typeddict_input(self) -> None:
+        """TypedDict subclasses should be accepted as dict-like inputs."""
+        ft = FieldType.from_type(ExampleTypedDict)
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.REQUIRED
+        assert ft.coder is None
+
+    def test_list_of_typeddict_input(self) -> None:
+        """list[TypedDict] should produce a repeated ANY field."""
+        ft = FieldType.from_type(list[ExampleTypedDict])
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.REPEATED
+        assert ft.coder is None
+
+    def test_optional_typeddict_input(self) -> None:
+        """Optional[TypedDict] should produce an optional ANY field."""
+        ft = FieldType.from_type(Optional[ExampleTypedDict])
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.OPTIONAL
+        assert ft.coder is None
+
+    def test_optional_list_of_typeddict_input(self) -> None:
+        """Optional[list[TypedDict]] should produce optional repeated ANY."""
+        ft = FieldType.from_type(Optional[list[ExampleTypedDict]])
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.OPTIONAL_REPEATED
+        assert ft.coder is None
+
+    def test_pep604_list_of_typeddict_or_none_input(self) -> None:
+        """list[TypedDict] | None should produce optional repeated ANY."""
+        ft = FieldType.from_type(list[ExampleTypedDict] | None)
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.OPTIONAL_REPEATED
+        assert ft.coder is None
+
+    def test_plain_dict_subclass_is_not_treated_as_dict(self) -> None:
+        """Plain dict subclasses should not be accepted as dict-like inputs."""
+        try:
+            FieldType.from_type(ExampleDictSubclass)
+        except ValueError as exc:
+            assert str(exc) == "unsupported Cog type ExampleDictSubclass"
+        else:
+            raise AssertionError("Expected ValueError for plain dict subclass")
 
     def test_list_dict_str_int_type_erasure(self) -> None:
         """list[dict[str, int]] should be accepted as repeated ANY."""


### PR DESCRIPTION
Fixes: #2973 

## Summary
- fix legacy runtime schema generation so `TypedDict` inputs are treated like dicts without accepting arbitrary dict subclasses
- add static schema support for `TypedDict` inputs and outputs, including qualified imports, inheritance, and `Required` / `NotRequired` key semantics
- add regression coverage in Python, Go parser tests, and integration txtar scripts for static and legacy TypedDict paths

## Notes
- added integration txtar coverage for `typeddict_input`, `typeddict_input_legacy`, and `typeddict_output`