### PR TITLE
fix: support typing_extensions TypedDict at runtime

### DIFF
--- a/integration-tests/tests/typeddict_input_legacy.txtar
+++ b/integration-tests/tests/typeddict_input_legacy.txtar
@@ -1,7 +1,7 @@
 # Test TypedDict inputs through the legacy runtime schema path.
 #
 # This exercises python/cog/_adt.py via in-container runtime schema generation,
-# proving TypedDict subclasses are treated like dict inputs when
+# proving typing_extensions.TypedDict subclasses are treated like dict inputs when
 # COG_LEGACY_SCHEMA=1 forces the legacy path.
 
 env COG_LEGACY_SCHEMA=1
@@ -10,7 +10,7 @@ env COG_LEGACY_SCHEMA=1
 cog build -t $TEST_IMAGE
 stderr 'Validating model schema'
 
-# TypedDict and list[TypedDict] inputs work via JSON.
+# typing_extensions.TypedDict and list[TypedDict] inputs work via JSON.
 cog predict $TEST_IMAGE --json '{"data": {"name": "alice", "count": 2}, "items": [{"name": "first", "count": 1}, {"name": "second", "count": 3}]}'
 stdout '"status": "succeeded"'
 stdout '"output": "alice:2 items=2"'
@@ -26,7 +26,7 @@ build:
 predict: "predict.py:Predictor"
 
 -- predict.py --
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 from cog import BasePredictor
 

--- a/integration-tests/tests/typeddict_input_typing_extensions_legacy.txtar
+++ b/integration-tests/tests/typeddict_input_typing_extensions_legacy.txtar
@@ -1,7 +1,7 @@
-# Test TypedDict inputs through the legacy runtime schema path.
+# Test typing_extensions.TypedDict inputs through the legacy runtime schema path.
 #
 # This exercises python/cog/_adt.py via in-container runtime schema generation,
-# proving TypedDict subclasses are treated like dict inputs when
+# proving typing_extensions.TypedDict subclasses are treated like dict inputs when
 # COG_LEGACY_SCHEMA=1 forces the legacy path.
 
 env COG_LEGACY_SCHEMA=1
@@ -10,7 +10,7 @@ env COG_LEGACY_SCHEMA=1
 cog build -t $TEST_IMAGE
 stderr 'Validating model schema'
 
-# TypedDict and list[TypedDict] inputs work via JSON.
+# typing_extensions.TypedDict and list[TypedDict] inputs work via JSON.
 cog predict $TEST_IMAGE --json '{"data": {"name": "alice", "count": 2}, "items": [{"name": "first", "count": 1}, {"name": "second", "count": 3}]}'
 stdout '"status": "succeeded"'
 stdout '"output": "alice:2 items=2"'
@@ -26,7 +26,7 @@ build:
 predict: "predict.py:Predictor"
 
 -- predict.py --
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 from cog import BasePredictor
 

--- a/python/cog/_adt.py
+++ b/python/cog/_adt.py
@@ -48,6 +48,7 @@ def _is_dict_like(tpe: Any) -> bool:
         if is_typeddict_ext(tpe):
             return True
     except ImportError:
+        # `typing_extensions` is optional; fall back to `typing.is_typeddict` below.
         pass
 
     is_typeddict = getattr(typing, "is_typeddict", None)

--- a/python/cog/_adt.py
+++ b/python/cog/_adt.py
@@ -39,8 +39,19 @@ def _is_union(tpe: type) -> bool:
 
 def _is_dict_like(tpe: Any) -> bool:
     """Check if a type should be treated like a dict, including TypedDict."""
+    if tpe is dict:
+        return True
+
+    try:
+        from typing_extensions import is_typeddict as is_typeddict_ext
+
+        if is_typeddict_ext(tpe):
+            return True
+    except ImportError:
+        pass
+
     is_typeddict = getattr(typing, "is_typeddict", None)
-    return tpe is dict or (callable(is_typeddict) and is_typeddict(tpe))
+    return callable(is_typeddict) and is_typeddict(tpe)
 
 
 class PrimitiveType(Enum):

--- a/python/tests/test_adt.py
+++ b/python/tests/test_adt.py
@@ -2,10 +2,17 @@
 
 from typing import Any, Dict, List, Optional, TypedDict
 
+from typing_extensions import TypedDict as ExtensionsTypedDict
+
 from cog._adt import FieldType, PrimitiveType, Repetition
 
 
 class ExampleTypedDict(TypedDict):
+    name: str
+    count: int
+
+
+class ExampleExtensionsTypedDict(ExtensionsTypedDict):
     name: str
     count: int
 
@@ -95,9 +102,23 @@ class TestDictInputTypes:
         assert ft.repetition is Repetition.REQUIRED
         assert ft.coder is None
 
+    def test_typing_extensions_typeddict_input(self) -> None:
+        """typing_extensions.TypedDict should be accepted as dict-like inputs."""
+        ft = FieldType.from_type(ExampleExtensionsTypedDict)
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.REQUIRED
+        assert ft.coder is None
+
     def test_list_of_typeddict_input(self) -> None:
         """list[TypedDict] should produce a repeated ANY field."""
         ft = FieldType.from_type(list[ExampleTypedDict])
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.REPEATED
+        assert ft.coder is None
+
+    def test_list_of_typing_extensions_typeddict_input(self) -> None:
+        """list[typing_extensions.TypedDict] should produce repeated ANY."""
+        ft = FieldType.from_type(list[ExampleExtensionsTypedDict])
         assert ft.primitive is PrimitiveType.ANY
         assert ft.repetition is Repetition.REPEATED
         assert ft.coder is None
@@ -109,6 +130,13 @@ class TestDictInputTypes:
         assert ft.repetition is Repetition.OPTIONAL
         assert ft.coder is None
 
+    def test_optional_typing_extensions_typeddict_input(self) -> None:
+        """Optional[typing_extensions.TypedDict] should produce optional ANY."""
+        ft = FieldType.from_type(Optional[ExampleExtensionsTypedDict])
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.OPTIONAL
+        assert ft.coder is None
+
     def test_optional_list_of_typeddict_input(self) -> None:
         """Optional[list[TypedDict]] should produce optional repeated ANY."""
         ft = FieldType.from_type(Optional[list[ExampleTypedDict]])
@@ -116,9 +144,23 @@ class TestDictInputTypes:
         assert ft.repetition is Repetition.OPTIONAL_REPEATED
         assert ft.coder is None
 
+    def test_optional_list_of_typing_extensions_typeddict_input(self) -> None:
+        """Optional[list[typing_extensions.TypedDict]] should be optional repeated ANY."""
+        ft = FieldType.from_type(Optional[list[ExampleExtensionsTypedDict]])
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.OPTIONAL_REPEATED
+        assert ft.coder is None
+
     def test_pep604_list_of_typeddict_or_none_input(self) -> None:
         """list[TypedDict] | None should produce optional repeated ANY."""
         ft = FieldType.from_type(list[ExampleTypedDict] | None)
+        assert ft.primitive is PrimitiveType.ANY
+        assert ft.repetition is Repetition.OPTIONAL_REPEATED
+        assert ft.coder is None
+
+    def test_pep604_list_of_typing_extensions_typeddict_or_none_input(self) -> None:
+        """list[typing_extensions.TypedDict] | None should be optional repeated ANY."""
+        ft = FieldType.from_type(list[ExampleExtensionsTypedDict] | None)
         assert ft.primitive is PrimitiveType.ANY
         assert ft.repetition is Repetition.OPTIONAL_REPEATED
         assert ft.coder is None


### PR DESCRIPTION
## Summary
- Prefer `typing_extensions.is_typeddict` when detecting dict-like annotations in the legacy runtime schema path.
- Add regression coverage for `typing_extensions.TypedDict` inputs, including list/optional forms.
- Update the legacy TypedDict integration fixture to exercise `typing_extensions.TypedDict`.

## Tests
- `.venv/bin/python -m pytest python/tests/test_adt.py -q`
- `mise run lint:python`

Fixes the runtime/legacy half of #2973 follow-up; third-party TypedDicts in the static Go parser remain a separate issue.