### PR TITLE
Allow uv-managed Python installs in generated Dockerfiles

### DIFF
--- a/pkg/cli/baseimage.go
+++ b/pkg/cli/baseimage.go
@@ -21,9 +21,10 @@ import (
 )
 
 var (
-	baseImageCUDAVersion   string
-	baseImagePythonVersion string
-	baseImageTorchVersion  string
+	baseImageCUDAVersion         string
+	baseImagePythonVersion       string
+	baseImageTorchVersion        string
+	baseImageBreakSystemPackages bool
 )
 
 func NewBaseImageRootCommand() (*cobra.Command, error) {
@@ -205,6 +206,8 @@ func addBaseImageFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&baseImageCUDAVersion, "cuda", "", "CUDA version")
 	cmd.Flags().StringVar(&baseImagePythonVersion, "python", "", "Python version")
 	cmd.Flags().StringVar(&baseImageTorchVersion, "torch", "", "Torch version")
+	cmd.Flags().BoolVar(&baseImageBreakSystemPackages, "break-system-packages", false, "Allow pip to modify uv-managed Python installs")
+	_ = cmd.Flags().MarkHidden("break-system-packages")
 	addBuildTimestampFlag(cmd)
 }
 
@@ -214,7 +217,7 @@ func baseImageGeneratorFromFlags(ctx context.Context) (*dockerfile.BaseImageGene
 		return nil, err
 	}
 	client := registry.NewRegistryClient()
-	return dockerfile.NewBaseImageGenerator(
+	generator, err := dockerfile.NewBaseImageGenerator(
 		ctx,
 		client,
 		baseImageCUDAVersion,
@@ -223,4 +226,9 @@ func baseImageGeneratorFromFlags(ctx context.Context) (*dockerfile.BaseImageGene
 		dockerClient,
 		true,
 	)
+	if err != nil {
+		return nil, err
+	}
+	generator.SetBreakSystemPackages(baseImageBreakSystemPackages)
+	return generator, nil
 }

--- a/pkg/dockerfile/base.go
+++ b/pkg/dockerfile/base.go
@@ -75,11 +75,12 @@ type BaseImageConfiguration struct {
 }
 
 type BaseImageGenerator struct {
-	cudaVersion   string
-	pythonVersion string
-	torchVersion  string
-	command       command.Command
-	client        registry.Client
+	cudaVersion         string
+	pythonVersion       string
+	torchVersion        string
+	command             command.Command
+	client              registry.Client
+	breakSystemPackages bool
 }
 
 func (b BaseImageConfiguration) MarshalJSON() ([]byte, error) {
@@ -170,7 +171,7 @@ func NewBaseImageGenerator(ctx context.Context, client registry.Client, cudaVers
 		return nil, err
 	}
 	if valid {
-		return &BaseImageGenerator{cudaVersion, pythonVersion, torchVersion, command, client}, nil
+		return &BaseImageGenerator{cudaVersion: cudaVersion, pythonVersion: pythonVersion, torchVersion: torchVersion, command: command, client: client}, nil
 	}
 	printNone := func(s string) string {
 		if s == "" {
@@ -193,6 +194,7 @@ func (g *BaseImageGenerator) GenerateDockerfile(ctx context.Context) (string, er
 	}
 	useCogBaseImage := false
 	generator.SetUseCogBaseImagePtr(&useCogBaseImage)
+	generator.SetBreakSystemPackages(g.breakSystemPackages)
 
 	dockerfile, err := generator.GenerateInitialSteps(ctx)
 	if err != nil {
@@ -200,6 +202,10 @@ func (g *BaseImageGenerator) GenerateDockerfile(ctx context.Context) (string, er
 	}
 
 	return dockerfile, nil
+}
+
+func (g *BaseImageGenerator) SetBreakSystemPackages(breakSystemPackages bool) {
+	g.breakSystemPackages = breakSystemPackages
 }
 
 func (g *BaseImageGenerator) makeConfig() (*config.Config, error) {

--- a/pkg/dockerfile/base_test.go
+++ b/pkg/dockerfile/base_test.go
@@ -54,6 +54,32 @@ func TestGenerateDockerfile(t *testing.T) {
 	dockerfile, err := generator.GenerateDockerfile(t.Context())
 	require.NoError(t, err)
 	require.True(t, strings.Contains(dockerfile, "FROM nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04"))
+	require.NotContains(t, dockerfile, "--break-system-packages")
+}
+
+func TestGenerateDockerfileWithBreakSystemPackages(t *testing.T) {
+	cudaVersion := "12.1"
+	pythonVersion := "3.10"
+	torchVersion := "2.1.0"
+	client := registrytest.NewMockRegistryClient()
+	client.AddMockImage(BaseImageName(cudaVersion, pythonVersion, torchVersion))
+	command := dockertest.NewMockCommand()
+	generator, err := NewBaseImageGenerator(
+		t.Context(),
+		client,
+		cudaVersion,
+		pythonVersion,
+		torchVersion,
+		command,
+		false,
+	)
+	require.NoError(t, err)
+	generator.SetBreakSystemPackages(true)
+
+	dockerfile, err := generator.GenerateDockerfile(t.Context())
+
+	require.NoError(t, err)
+	require.Contains(t, dockerfile, "uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt")
 }
 
 func TestBaseImageNameWithVersionModifier(t *testing.T) {

--- a/pkg/dockerfile/generator.go
+++ b/pkg/dockerfile/generator.go
@@ -10,6 +10,7 @@ type Generator interface {
 	GenerateInitialSteps(ctx context.Context) (string, error)
 	SetUseCogBaseImage(bool)
 	SetUseCogBaseImagePtr(*bool)
+	SetBreakSystemPackages(bool)
 	GenerateModelBaseWithSeparateWeights(ctx context.Context, imageName string) (string, string, string, error)
 	Cleanup() error
 	SetStrip(bool)

--- a/pkg/dockerfile/standard_generator.go
+++ b/pkg/dockerfile/standard_generator.go
@@ -80,6 +80,7 @@ type StandardGenerator struct {
 	command                    command.Command
 	client                     registry.Client
 	requiresCog                bool
+	breakSystemPackages        bool
 
 	// Optional overrides for wheel configs (used by tests for deterministic output).
 	// When nil, auto-detection is used (env var → dist/ → PyPI).
@@ -157,6 +158,17 @@ func (g *StandardGenerator) SetStrip(strip bool) {
 
 func (g *StandardGenerator) SetPrecompile(precompile bool) {
 	g.precompile = precompile
+}
+
+func (g *StandardGenerator) SetBreakSystemPackages(breakSystemPackages bool) {
+	g.breakSystemPackages = breakSystemPackages
+}
+
+func (g *StandardGenerator) uvPipInstallFlags(flags string) string {
+	if g.breakSystemPackages {
+		return uvBreakSystemPackages + " " + flags
+	}
+	return flags
 }
 
 func (g *StandardGenerator) GenerateInitialSteps(ctx context.Context) (string, error) {
@@ -678,7 +690,7 @@ func (g *StandardGenerator) installCogFromPyPI(config *wheels.WheelConfig, preRe
 	if preRelease {
 		flags = "--pre " + flags
 	}
-	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install " + uvBreakSystemPackages + " " + flags + " " + packageSpec
+	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install " + g.uvPipInstallFlags(flags) + " " + packageSpec
 	if g.strip {
 		pipInstallLine += " && " + StripDebugSymbolsCommand
 	}
@@ -705,9 +717,13 @@ func (g *StandardGenerator) installWheelFromURL(url string) (string, error) {
 	// with coglet's cog compatibility shim that provides the same module paths.
 	var pipPrefix string
 	if strings.Contains(url, "coglet") {
-		pipPrefix = uvPip + " uninstall " + uvBreakSystemPackages + " cog 2>/dev/null || true && "
+		uninstallFlags := ""
+		if g.breakSystemPackages {
+			uninstallFlags = " " + uvBreakSystemPackages
+		}
+		pipPrefix = uvPip + " uninstall" + uninstallFlags + " cog 2>/dev/null || true && "
 	}
-	pipInstallLine := "RUN " + uvCacheMount + " " + pipPrefix + uvPip + " install " + uvBreakSystemPackages + " --no-cache " + url
+	pipInstallLine := "RUN " + uvCacheMount + " " + pipPrefix + uvPip + " install " + g.uvPipInstallFlags("--no-cache") + " " + url
 	if g.strip {
 		pipInstallLine += " && " + StripDebugSymbolsCommand
 	}
@@ -743,10 +759,14 @@ func (g *StandardGenerator) installWheelFromFile(path string) (string, error) {
 		// Uninstall cog first to avoid conflicts with coglet's cog shim package.
 		// Some base images (e.g. r8.im/cog-base) have cog pre-installed, which conflicts
 		// with coglet's cog compatibility shim that provides the same module paths.
-		pipPrefix = uvPip + " uninstall " + uvBreakSystemPackages + " cog 2>/dev/null || true && "
+		uninstallFlags := ""
+		if g.breakSystemPackages {
+			uninstallFlags = " " + uvBreakSystemPackages
+		}
+		pipPrefix = uvPip + " uninstall" + uninstallFlags + " cog 2>/dev/null || true && "
 	}
 
-	pipInstallLine := "RUN " + uvCacheMount + " " + pipPrefix + uvPip + " install " + uvBreakSystemPackages + " --no-cache " + containerPath
+	pipInstallLine := "RUN " + uvCacheMount + " " + pipPrefix + uvPip + " install " + g.uvPipInstallFlags("--no-cache") + " " + containerPath
 	if g.strip {
 		pipInstallLine += " && " + StripDebugSymbolsCommand
 	}
@@ -777,7 +797,7 @@ func (g *StandardGenerator) installCogletFromPyPI(config *wheels.WheelConfig, pr
 	if preRelease {
 		flags = "--pre " + flags
 	}
-	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install " + uvBreakSystemPackages + " " + flags + " " + packageSpec
+	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install " + g.uvPipInstallFlags(flags) + " " + packageSpec
 	if g.strip {
 		pipInstallLine += " && " + StripDebugSymbolsCommand
 	}
@@ -787,7 +807,7 @@ func (g *StandardGenerator) installCogletFromPyPI(config *wheels.WheelConfig, pr
 
 // installCogletFromURL installs coglet from a URL
 func (g *StandardGenerator) installCogletFromURL(url string) (string, error) {
-	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install " + uvBreakSystemPackages + " --no-cache " + url
+	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install " + g.uvPipInstallFlags("--no-cache") + " " + url
 	if g.strip {
 		pipInstallLine += " && " + StripDebugSymbolsCommand
 	}
@@ -808,7 +828,7 @@ func (g *StandardGenerator) installCogletFromFile(path string) (string, error) {
 		return "", err
 	}
 
-	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install " + uvBreakSystemPackages + " --no-cache " + containerPath
+	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install " + g.uvPipInstallFlags("--no-cache") + " " + containerPath
 	if g.strip {
 		pipInstallLine += " && " + StripDebugSymbolsCommand
 	}
@@ -918,7 +938,7 @@ func (g *StandardGenerator) pipInstalls() (string, error) {
 		return "", err
 	}
 
-	pipInstallLine := "RUN --mount=type=cache,target=/root/.cache/pip uv run pip install " + uvBreakSystemPackages + " --cache-dir /root/.cache/pip -r " + containerPath
+	pipInstallLine := "RUN --mount=type=cache,target=/root/.cache/pip uv run pip install " + g.uvPipInstallFlags("--cache-dir /root/.cache/pip") + " -r " + containerPath
 	if g.strip {
 		pipInstallLine += " && " + StripDebugSymbolsCommand
 	}

--- a/pkg/dockerfile/standard_generator.go
+++ b/pkg/dockerfile/standard_generator.go
@@ -48,6 +48,7 @@ const CFlags = "ENV CFLAGS=\"-O3 -funroll-loops -fno-strict-aliasing -flto -S\""
 const UVVersion = "0.9.26"
 const uvCacheMount = "--mount=type=cache,target=/root/.cache/uv"
 const uvPip = "uv pip"
+const uvBreakSystemPackages = "--break-system-packages"
 const PrecompilePythonCommand = "RUN find / -type f -name \"*.py[co]\" -delete && find / -type f -name \"*.py\" -exec touch -t 197001010000 {} \\; && find / -type f -name \"*.py\" -printf \"%h\\n\" | sort -u | /usr/bin/python3 -m compileall --invalidation-mode timestamp -o 2 -j 0"
 const STANDARD_GENERATOR_NAME = "STANDARD_GENERATOR"
 
@@ -677,7 +678,7 @@ func (g *StandardGenerator) installCogFromPyPI(config *wheels.WheelConfig, preRe
 	if preRelease {
 		flags = "--pre " + flags
 	}
-	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install " + flags + " " + packageSpec
+	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install " + uvBreakSystemPackages + " " + flags + " " + packageSpec
 	if g.strip {
 		pipInstallLine += " && " + StripDebugSymbolsCommand
 	}
@@ -704,9 +705,9 @@ func (g *StandardGenerator) installWheelFromURL(url string) (string, error) {
 	// with coglet's cog compatibility shim that provides the same module paths.
 	var pipPrefix string
 	if strings.Contains(url, "coglet") {
-		pipPrefix = uvPip + " uninstall cog 2>/dev/null || true && "
+		pipPrefix = uvPip + " uninstall " + uvBreakSystemPackages + " cog 2>/dev/null || true && "
 	}
-	pipInstallLine := "RUN " + uvCacheMount + " " + pipPrefix + uvPip + " install --no-cache " + url
+	pipInstallLine := "RUN " + uvCacheMount + " " + pipPrefix + uvPip + " install " + uvBreakSystemPackages + " --no-cache " + url
 	if g.strip {
 		pipInstallLine += " && " + StripDebugSymbolsCommand
 	}
@@ -742,10 +743,10 @@ func (g *StandardGenerator) installWheelFromFile(path string) (string, error) {
 		// Uninstall cog first to avoid conflicts with coglet's cog shim package.
 		// Some base images (e.g. r8.im/cog-base) have cog pre-installed, which conflicts
 		// with coglet's cog compatibility shim that provides the same module paths.
-		pipPrefix = uvPip + " uninstall cog 2>/dev/null || true && "
+		pipPrefix = uvPip + " uninstall " + uvBreakSystemPackages + " cog 2>/dev/null || true && "
 	}
 
-	pipInstallLine := "RUN " + uvCacheMount + " " + pipPrefix + uvPip + " install --no-cache " + containerPath
+	pipInstallLine := "RUN " + uvCacheMount + " " + pipPrefix + uvPip + " install " + uvBreakSystemPackages + " --no-cache " + containerPath
 	if g.strip {
 		pipInstallLine += " && " + StripDebugSymbolsCommand
 	}
@@ -776,7 +777,7 @@ func (g *StandardGenerator) installCogletFromPyPI(config *wheels.WheelConfig, pr
 	if preRelease {
 		flags = "--pre " + flags
 	}
-	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install " + flags + " " + packageSpec
+	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install " + uvBreakSystemPackages + " " + flags + " " + packageSpec
 	if g.strip {
 		pipInstallLine += " && " + StripDebugSymbolsCommand
 	}
@@ -786,7 +787,7 @@ func (g *StandardGenerator) installCogletFromPyPI(config *wheels.WheelConfig, pr
 
 // installCogletFromURL installs coglet from a URL
 func (g *StandardGenerator) installCogletFromURL(url string) (string, error) {
-	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install --no-cache " + url
+	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install " + uvBreakSystemPackages + " --no-cache " + url
 	if g.strip {
 		pipInstallLine += " && " + StripDebugSymbolsCommand
 	}
@@ -807,7 +808,7 @@ func (g *StandardGenerator) installCogletFromFile(path string) (string, error) {
 		return "", err
 	}
 
-	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install --no-cache " + containerPath
+	pipInstallLine := "RUN " + uvCacheMount + " " + uvPip + " install " + uvBreakSystemPackages + " --no-cache " + containerPath
 	if g.strip {
 		pipInstallLine += " && " + StripDebugSymbolsCommand
 	}
@@ -917,7 +918,7 @@ func (g *StandardGenerator) pipInstalls() (string, error) {
 		return "", err
 	}
 
-	pipInstallLine := "RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r " + containerPath
+	pipInstallLine := "RUN --mount=type=cache,target=/root/.cache/pip uv run pip install " + uvBreakSystemPackages + " --cache-dir /root/.cache/pip -r " + containerPath
 	if g.strip {
 		pipInstallLine += " && " + StripDebugSymbolsCommand
 	}

--- a/pkg/dockerfile/standard_generator_test.go
+++ b/pkg/dockerfile/standard_generator_test.go
@@ -39,7 +39,7 @@ func testInstallCog(stripped bool) string {
 	// When coglet has no explicit version pin (empty version via pypiWheels()),
 	// the SDK's own dependency handles coglet installation — no explicit coglet line.
 	return fmt.Sprintf(`ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/uv uv pip install --break-system-packages --no-cache cog%s
+RUN --mount=type=cache,target=/root/.cache/uv uv pip install --no-cache cog%s
 ENV CFLAGS=`, strippedCall)
 }
 
@@ -182,7 +182,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 ` + testInstallUVLine + `
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt
 ENV CFLAGS=
 ` + testInstallCog(gen.strip) + `
 RUN find / -type f -name "*python*.so" -printf "%h\n" | sort -u > /etc/ld.so.conf.d/cog.conf && ldconfig
@@ -240,7 +240,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 ` + testTini() + `RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
 ` + testInstallPython("3.12") + `COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt
 ENV CFLAGS=
 ` + testInstallCog(gen.strip) + `
 RUN find / -type f -name "*python*.so" -printf "%h\n" | sort -u > /etc/ld.so.conf.d/cog.conf && ldconfig
@@ -323,7 +323,7 @@ build:
 	_, actual, _, err := gen.GenerateModelBaseWithSeparateWeights(t.Context(), "r8.im/replicate/cog-test")
 	require.NoError(t, err)
 	fmt.Println(actual)
-	require.Contains(t, actual, `uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt`)
+	require.Contains(t, actual, `uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt`)
 }
 
 // mockFileInfo is a test type to mock os.FileInfo
@@ -408,7 +408,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 ` + testTini() + `RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*` + `
 ` + testInstallPython("3.12") + `COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt
 ENV CFLAGS=
 ` + testInstallCog(gen.strip) + `
 RUN find / -type f -name "*python*.so" -printf "%h\n" | sort -u > /etc/ld.so.conf.d/cog.conf && ldconfig
@@ -566,7 +566,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq &
 ` + testInstallUVLine + `
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt
 ENV CFLAGS=
 ` + testInstallCog(gen.strip) + `
 RUN cowsay moo
@@ -626,7 +626,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq &
 `+testInstallUVLine+`
 COPY `+gen.relativeTmpDir+`/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt
 ENV CFLAGS=
 `+testInstallCog(gen.strip)+`
 RUN cowsay moo
@@ -685,7 +685,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq &
 ` + testInstallUVLine + `
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt
 ENV CFLAGS=
 ` + testInstallCog(gen.strip) + `
 RUN cowsay moo
@@ -743,7 +743,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq &
 ` + testInstallUVLine + `
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt && find / -type f -name "*python*.so" -not -name "*cpython*.so" -exec strip -S {} \;
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt && find / -type f -name "*python*.so" -not -name "*cpython*.so" -exec strip -S {} \;
 ENV CFLAGS=
 ` + testInstallCog(gen.strip) + `
 RUN cowsay moo
@@ -837,7 +837,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq &
 ` + testInstallUVLine + `
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt && find / -type f -name "*python*.so" -not -name "*cpython*.so" -exec strip -S {} \;
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt && find / -type f -name "*python*.so" -not -name "*cpython*.so" -exec strip -S {} \;
 ENV CFLAGS=
 ` + testInstallCog(gen.strip) + `
 RUN find / -type f -name "*.py[co]" -delete && find / -type f -name "*.py" -exec touch -t 197001010000 {} \; && find / -type f -name "*.py" -printf "%h\n" | sort -u | /usr/bin/python3 -m compileall --invalidation-mode timestamp -o 2 -j 0
@@ -899,7 +899,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq &
 ` + testInstallUVLine + `
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt && find / -type f -name "*python*.so" -not -name "*cpython*.so" -exec strip -S {} \;
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt && find / -type f -name "*python*.so" -not -name "*cpython*.so" -exec strip -S {} \;
 ENV CFLAGS=
 ` + testInstallCog(true) + `
 RUN find / -type f -name "*.py[co]" -delete && find / -type f -name "*.py" -exec touch -t 197001010000 {} \; && find / -type f -name "*.py" -printf "%h\n" | sort -u | /usr/bin/python3 -m compileall --invalidation-mode timestamp -o 2 -j 0
@@ -945,7 +945,7 @@ predict: predict.py:Predictor
 
 	// Should contain uv pip install cog from PyPI.
 	// Coglet is not explicitly installed when unpinned — the SDK dependency handles it.
-	require.Contains(t, actual, "uv pip install --break-system-packages --no-cache cog")
+	require.Contains(t, actual, "uv pip install --no-cache cog")
 }
 
 func TestCOGWheelEnvPyPI(t *testing.T) {
@@ -973,7 +973,7 @@ predict: predict.py:Predictor
 	require.NoError(t, err)
 
 	// Should contain uv pip install cog from PyPI
-	require.Contains(t, actual, "uv pip install --break-system-packages --no-cache cog")
+	require.Contains(t, actual, "uv pip install --no-cache cog")
 }
 
 func TestCOGWheelEnvPyPIWithVersion(t *testing.T) {
@@ -1001,7 +1001,7 @@ predict: predict.py:Predictor
 	require.NoError(t, err)
 
 	// Should contain uv pip install cog==0.17.0 from PyPI
-	require.Contains(t, actual, "uv pip install --break-system-packages --no-cache cog==0.17.0")
+	require.Contains(t, actual, "uv pip install --no-cache cog==0.17.0")
 }
 
 func TestCOGWheelEnvURL(t *testing.T) {
@@ -1030,7 +1030,7 @@ predict: predict.py:Predictor
 	require.NoError(t, err)
 
 	// Should contain uv pip install from custom URL
-	require.Contains(t, actual, "uv pip install --break-system-packages --no-cache "+customURL)
+	require.Contains(t, actual, "uv pip install --no-cache "+customURL)
 }
 
 func TestCOGWheelEnvFile(t *testing.T) {
@@ -1063,7 +1063,7 @@ predict: predict.py:Predictor
 	require.NoError(t, err)
 
 	// Should contain uv pip install from temp path (copied into container)
-	require.Contains(t, actual, "uv pip install --break-system-packages --no-cache /tmp/test-cog-0.1.0-py3-none-any.whl")
+	require.Contains(t, actual, "uv pip install --no-cache /tmp/test-cog-0.1.0-py3-none-any.whl")
 }
 
 func TestCogletStrippedFromRequirements(t *testing.T) {
@@ -1112,7 +1112,7 @@ predict: predict.py:Predictor
 
 	dockerfile, err := gen.GenerateInitialSteps(t.Context())
 	require.NoError(t, err)
-	require.Contains(t, dockerfile, "uv pip install --break-system-packages --no-cache cog==0.18.0")
+	require.Contains(t, dockerfile, "uv pip install --no-cache cog==0.18.0")
 	// No --pre flag for stable release
 	require.NotContains(t, dockerfile, "--pre")
 }
@@ -1138,7 +1138,7 @@ predict: predict.py:Predictor
 	dockerfile, err := gen.GenerateInitialSteps(t.Context())
 	require.NoError(t, err)
 	// cog install should have --pre and pinned version
-	require.Contains(t, dockerfile, "uv pip install --break-system-packages --pre --no-cache cog==0.18.0a1")
+	require.Contains(t, dockerfile, "uv pip install --pre --no-cache cog==0.18.0a1")
 	// coglet is NOT explicitly installed — SDK dependency pulls it in.
 	// No separate coglet install line expected.
 }
@@ -1189,7 +1189,7 @@ predict: predict.py:Predictor
 	dockerfile, err := gen.GenerateInitialSteps(t.Context())
 	require.NoError(t, err)
 	// env var wins: should install 0.17.0, not 0.18.0
-	require.Contains(t, dockerfile, "uv pip install --break-system-packages --no-cache cog==0.17.0")
+	require.Contains(t, dockerfile, "uv pip install --no-cache cog==0.17.0")
 	require.NotContains(t, dockerfile, "cog==0.18.0")
 }
 
@@ -1214,7 +1214,7 @@ predict: predict.py:Predictor
 	dockerfile, err := gen.GenerateInitialSteps(t.Context())
 	require.NoError(t, err)
 	// Should use --pre with no version pin
-	require.Contains(t, dockerfile, "uv pip install --break-system-packages --pre --no-cache cog")
+	require.Contains(t, dockerfile, "uv pip install --pre --no-cache cog")
 	// Must NOT contain a version pin
 	require.NotContains(t, dockerfile, "cog==")
 }

--- a/pkg/dockerfile/standard_generator_test.go
+++ b/pkg/dockerfile/standard_generator_test.go
@@ -39,7 +39,7 @@ func testInstallCog(stripped bool) string {
 	// When coglet has no explicit version pin (empty version via pypiWheels()),
 	// the SDK's own dependency handles coglet installation — no explicit coglet line.
 	return fmt.Sprintf(`ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/uv uv pip install --no-cache cog%s
+RUN --mount=type=cache,target=/root/.cache/uv uv pip install --break-system-packages --no-cache cog%s
 ENV CFLAGS=`, strippedCall)
 }
 
@@ -182,7 +182,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 ` + testInstallUVLine + `
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt
 ENV CFLAGS=
 ` + testInstallCog(gen.strip) + `
 RUN find / -type f -name "*python*.so" -printf "%h\n" | sort -u > /etc/ld.so.conf.d/cog.conf && ldconfig
@@ -240,7 +240,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 ` + testTini() + `RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*
 ` + testInstallPython("3.12") + `COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt
 ENV CFLAGS=
 ` + testInstallCog(gen.strip) + `
 RUN find / -type f -name "*python*.so" -printf "%h\n" | sort -u > /etc/ld.so.conf.d/cog.conf && ldconfig
@@ -323,7 +323,7 @@ build:
 	_, actual, _, err := gen.GenerateModelBaseWithSeparateWeights(t.Context(), "r8.im/replicate/cog-test")
 	require.NoError(t, err)
 	fmt.Println(actual)
-	require.Contains(t, actual, `uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt`)
+	require.Contains(t, actual, `uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt`)
 }
 
 // mockFileInfo is a test type to mock os.FileInfo
@@ -408,7 +408,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 ` + testTini() + `RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq && apt-get install -qqy ffmpeg cowsay && rm -rf /var/lib/apt/lists/*` + `
 ` + testInstallPython("3.12") + `COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt
 ENV CFLAGS=
 ` + testInstallCog(gen.strip) + `
 RUN find / -type f -name "*python*.so" -printf "%h\n" | sort -u > /etc/ld.so.conf.d/cog.conf && ldconfig
@@ -566,7 +566,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq &
 ` + testInstallUVLine + `
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt
 ENV CFLAGS=
 ` + testInstallCog(gen.strip) + `
 RUN cowsay moo
@@ -626,7 +626,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq &
 `+testInstallUVLine+`
 COPY `+gen.relativeTmpDir+`/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt
 ENV CFLAGS=
 `+testInstallCog(gen.strip)+`
 RUN cowsay moo
@@ -685,7 +685,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq &
 ` + testInstallUVLine + `
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt
 ENV CFLAGS=
 ` + testInstallCog(gen.strip) + `
 RUN cowsay moo
@@ -743,7 +743,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq &
 ` + testInstallUVLine + `
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt && find / -type f -name "*python*.so" -not -name "*cpython*.so" -exec strip -S {} \;
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt && find / -type f -name "*python*.so" -not -name "*cpython*.so" -exec strip -S {} \;
 ENV CFLAGS=
 ` + testInstallCog(gen.strip) + `
 RUN cowsay moo
@@ -837,7 +837,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq &
 ` + testInstallUVLine + `
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt && find / -type f -name "*python*.so" -not -name "*cpython*.so" -exec strip -S {} \;
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt && find / -type f -name "*python*.so" -not -name "*cpython*.so" -exec strip -S {} \;
 ENV CFLAGS=
 ` + testInstallCog(gen.strip) + `
 RUN find / -type f -name "*.py[co]" -delete && find / -type f -name "*.py" -exec touch -t 197001010000 {} \; && find / -type f -name "*.py" -printf "%h\n" | sort -u | /usr/bin/python3 -m compileall --invalidation-mode timestamp -o 2 -j 0
@@ -899,7 +899,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update -qq &
 ` + testInstallUVLine + `
 COPY ` + gen.relativeTmpDir + `/requirements.txt /tmp/requirements.txt
 ENV CFLAGS="-O3 -funroll-loops -fno-strict-aliasing -flto -S"
-RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt && find / -type f -name "*python*.so" -not -name "*cpython*.so" -exec strip -S {} \;
+RUN --mount=type=cache,target=/root/.cache/pip uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt && find / -type f -name "*python*.so" -not -name "*cpython*.so" -exec strip -S {} \;
 ENV CFLAGS=
 ` + testInstallCog(true) + `
 RUN find / -type f -name "*.py[co]" -delete && find / -type f -name "*.py" -exec touch -t 197001010000 {} \; && find / -type f -name "*.py" -printf "%h\n" | sort -u | /usr/bin/python3 -m compileall --invalidation-mode timestamp -o 2 -j 0
@@ -945,7 +945,7 @@ predict: predict.py:Predictor
 
 	// Should contain uv pip install cog from PyPI.
 	// Coglet is not explicitly installed when unpinned — the SDK dependency handles it.
-	require.Contains(t, actual, "uv pip install --no-cache cog")
+	require.Contains(t, actual, "uv pip install --break-system-packages --no-cache cog")
 }
 
 func TestCOGWheelEnvPyPI(t *testing.T) {
@@ -973,7 +973,7 @@ predict: predict.py:Predictor
 	require.NoError(t, err)
 
 	// Should contain uv pip install cog from PyPI
-	require.Contains(t, actual, "uv pip install --no-cache cog")
+	require.Contains(t, actual, "uv pip install --break-system-packages --no-cache cog")
 }
 
 func TestCOGWheelEnvPyPIWithVersion(t *testing.T) {
@@ -1001,7 +1001,7 @@ predict: predict.py:Predictor
 	require.NoError(t, err)
 
 	// Should contain uv pip install cog==0.17.0 from PyPI
-	require.Contains(t, actual, "uv pip install --no-cache cog==0.17.0")
+	require.Contains(t, actual, "uv pip install --break-system-packages --no-cache cog==0.17.0")
 }
 
 func TestCOGWheelEnvURL(t *testing.T) {
@@ -1030,7 +1030,7 @@ predict: predict.py:Predictor
 	require.NoError(t, err)
 
 	// Should contain uv pip install from custom URL
-	require.Contains(t, actual, "uv pip install --no-cache "+customURL)
+	require.Contains(t, actual, "uv pip install --break-system-packages --no-cache "+customURL)
 }
 
 func TestCOGWheelEnvFile(t *testing.T) {
@@ -1063,7 +1063,7 @@ predict: predict.py:Predictor
 	require.NoError(t, err)
 
 	// Should contain uv pip install from temp path (copied into container)
-	require.Contains(t, actual, "uv pip install --no-cache /tmp/test-cog-0.1.0-py3-none-any.whl")
+	require.Contains(t, actual, "uv pip install --break-system-packages --no-cache /tmp/test-cog-0.1.0-py3-none-any.whl")
 }
 
 func TestCogletStrippedFromRequirements(t *testing.T) {
@@ -1112,7 +1112,7 @@ predict: predict.py:Predictor
 
 	dockerfile, err := gen.GenerateInitialSteps(t.Context())
 	require.NoError(t, err)
-	require.Contains(t, dockerfile, "uv pip install --no-cache cog==0.18.0")
+	require.Contains(t, dockerfile, "uv pip install --break-system-packages --no-cache cog==0.18.0")
 	// No --pre flag for stable release
 	require.NotContains(t, dockerfile, "--pre")
 }
@@ -1138,7 +1138,7 @@ predict: predict.py:Predictor
 	dockerfile, err := gen.GenerateInitialSteps(t.Context())
 	require.NoError(t, err)
 	// cog install should have --pre and pinned version
-	require.Contains(t, dockerfile, "uv pip install --pre --no-cache cog==0.18.0a1")
+	require.Contains(t, dockerfile, "uv pip install --break-system-packages --pre --no-cache cog==0.18.0a1")
 	// coglet is NOT explicitly installed — SDK dependency pulls it in.
 	// No separate coglet install line expected.
 }
@@ -1189,7 +1189,7 @@ predict: predict.py:Predictor
 	dockerfile, err := gen.GenerateInitialSteps(t.Context())
 	require.NoError(t, err)
 	// env var wins: should install 0.17.0, not 0.18.0
-	require.Contains(t, dockerfile, "uv pip install --no-cache cog==0.17.0")
+	require.Contains(t, dockerfile, "uv pip install --break-system-packages --no-cache cog==0.17.0")
 	require.NotContains(t, dockerfile, "cog==0.18.0")
 }
 
@@ -1214,7 +1214,7 @@ predict: predict.py:Predictor
 	dockerfile, err := gen.GenerateInitialSteps(t.Context())
 	require.NoError(t, err)
 	// Should use --pre with no version pin
-	require.Contains(t, dockerfile, "uv pip install --pre --no-cache cog")
+	require.Contains(t, dockerfile, "uv pip install --break-system-packages --pre --no-cache cog")
 	// Must NOT contain a version pin
 	require.NotContains(t, dockerfile, "cog==")
 }


### PR DESCRIPTION
## Summary

- Add a hidden `base-image` flag, `--break-system-packages`, for the base image builder workflow.
- When the hidden flag is set, generated Dockerfiles add `--break-system-packages` to `uv pip install` and `uv run pip install` commands.
- Leave normal Cog-generated Dockerfiles unchanged by default.

## Root Cause

The `cog-base-images` build for Python 3.13 + CUDA 13 was failing while building Torch variants, for example:

```text
error: externally-managed-environment
× This environment is externally managed
╰─> This Python installation is managed by uv and should not be modified.
```

The base-image Dockerfile path installs Python with:

```dockerfile
RUN uv python install 3.13 && ln -sf $(uv python find 3.13) /usr/bin/python3
```

Then it installs requirements into that same runtime interpreter:

```dockerfile
RUN uv run pip install --cache-dir /root/.cache/pip -r /tmp/requirements.txt
```

Recent `uv` marks `uv python install` interpreters as externally managed. That makes pip reject modifications unless `--break-system-packages` is passed.

## Why this is hidden and opt-in

`--break-system-packages` disables PEP 668 protection, which would be risky to apply globally. It can mutate an externally managed interpreter and would be especially problematic for host or distro-managed Python installs.

For Cog base image builds, the interpreter is:

- installed by `uv` inside a disposable Docker build layer
- intentionally used as the image runtime Python
- not owned by apt/dpkg
- expected to receive model dependencies, Cog, and Coglet directly

Using a virtualenv would be a larger behavior change because generated Cog images expect packages in the runtime Python environment. This PR therefore keeps the behavior opt-in for the separate base image builder workflow and does not change normal Cog Dockerfile output.

## Verification

- `go test ./pkg/dockerfile ./pkg/cli -count=1`
- `go run ./cmd/base-image dockerfile --cuda 12.1 --python 3.10 --torch 2.1.0 --break-system-packages | grep -- '--break-system-packages'`
- `go run ./cmd/base-image dockerfile --cuda 12.1 --python 3.10 --torch 2.1.0` verified no `--break-system-packages` appears by default