### PR TITLE
Support durable base-image build context

### DIFF
--- a/pkg/cli/baseimage.go
+++ b/pkg/cli/baseimage.go
@@ -25,6 +25,7 @@ var (
 	baseImagePythonVersion       string
 	baseImageTorchVersion        string
 	baseImageBreakSystemPackages bool
+	baseImageBuildContextDir     string
 )
 
 func NewBaseImageRootCommand() (*cobra.Command, error) {
@@ -208,6 +209,8 @@ func addBaseImageFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&baseImageTorchVersion, "torch", "", "Torch version")
 	cmd.Flags().BoolVar(&baseImageBreakSystemPackages, "break-system-packages", false, "Allow pip to modify uv-managed Python installs")
 	_ = cmd.Flags().MarkHidden("break-system-packages")
+	cmd.Flags().StringVar(&baseImageBuildContextDir, "build-context-dir", "", "Directory for generated Docker build context artifacts")
+	_ = cmd.Flags().MarkHidden("build-context-dir")
 	addBuildTimestampFlag(cmd)
 }
 
@@ -230,5 +233,6 @@ func baseImageGeneratorFromFlags(ctx context.Context) (*dockerfile.BaseImageGene
 		return nil, err
 	}
 	generator.SetBreakSystemPackages(baseImageBreakSystemPackages)
+	generator.SetBuildContextDir(baseImageBuildContextDir)
 	return generator, nil
 }

--- a/pkg/dockerfile/base.go
+++ b/pkg/dockerfile/base.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/replicate/cog/pkg/config"
@@ -82,6 +83,7 @@ type BaseImageGenerator struct {
 	command             command.Command
 	client              registry.Client
 	breakSystemPackages bool
+	buildContextDir     string
 }
 
 func (b BaseImageConfiguration) MarshalJSON() ([]byte, error) {
@@ -189,16 +191,11 @@ func (g *BaseImageGenerator) GenerateDockerfile(ctx context.Context) (string, er
 		return "", err
 	}
 
-	dc, err := dotcog.OpenTemp()
+	buildDir, cleanup, err := g.buildDir()
 	if err != nil {
 		return "", err
 	}
-	defer dc.Close()
-
-	buildDir, err := dc.Path("build")
-	if err != nil {
-		return "", err
-	}
+	defer cleanup()
 
 	generator, err := NewStandardGenerator(conf, "", buildDir, "", g.command, g.client, false)
 	if err != nil {
@@ -218,6 +215,30 @@ func (g *BaseImageGenerator) GenerateDockerfile(ctx context.Context) (string, er
 
 func (g *BaseImageGenerator) SetBreakSystemPackages(breakSystemPackages bool) {
 	g.breakSystemPackages = breakSystemPackages
+}
+
+func (g *BaseImageGenerator) SetBuildContextDir(buildContextDir string) {
+	g.buildContextDir = buildContextDir
+}
+
+func (g *BaseImageGenerator) buildDir() (string, func(), error) {
+	if g.buildContextDir != "" {
+		if err := os.MkdirAll(g.buildContextDir, 0o755); err != nil {
+			return "", func() {}, fmt.Errorf("create build context dir: %w", err)
+		}
+		return g.buildContextDir, func() {}, nil
+	}
+
+	dc, err := dotcog.OpenTemp()
+	if err != nil {
+		return "", func() {}, err
+	}
+	buildDir, err := dc.Path("build")
+	if err != nil {
+		_ = dc.Close()
+		return "", func() {}, err
+	}
+	return buildDir, func() { _ = dc.Close() }, nil
 }
 
 func (g *BaseImageGenerator) makeConfig() (*config.Config, error) {

--- a/pkg/dockerfile/base_test.go
+++ b/pkg/dockerfile/base_test.go
@@ -1,6 +1,8 @@
 package dockerfile
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -80,6 +82,38 @@ func TestGenerateDockerfileWithBreakSystemPackages(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Contains(t, dockerfile, "uv run pip install --break-system-packages --cache-dir /root/.cache/pip -r /tmp/requirements.txt")
+}
+
+func TestGenerateDockerfileWritesDurableBuildContext(t *testing.T) {
+	cudaVersion := "12.1"
+	pythonVersion := "3.10"
+	torchVersion := "2.1.0"
+	client := registrytest.NewMockRegistryClient()
+	client.AddMockImage(BaseImageName(cudaVersion, pythonVersion, torchVersion))
+	command := dockertest.NewMockCommand()
+	generator, err := NewBaseImageGenerator(
+		t.Context(),
+		client,
+		cudaVersion,
+		pythonVersion,
+		torchVersion,
+		command,
+		false,
+	)
+	require.NoError(t, err)
+	buildContextDir := filepath.Join(t.TempDir(), "cog_build")
+	generator.SetBuildContextDir(buildContextDir)
+
+	dockerfile, err := generator.GenerateDockerfile(t.Context())
+
+	require.NoError(t, err)
+	require.Contains(t, dockerfile, "COPY --from=cog_build requirements.txt /tmp/requirements.txt")
+	contents, err := os.ReadFile(filepath.Join(buildContextDir, "requirements.txt"))
+	require.NoError(t, err)
+	require.Contains(t, string(contents), "torch==2.1.0")
+	require.Contains(t, string(contents), "torchvision==0.16.0")
+	require.Contains(t, string(contents), "torchaudio==2.1.0")
+	require.Contains(t, string(contents), "opencv-python==4.12.0.88")
 }
 
 func TestBaseImageNameWithVersionModifier(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add a hidden `base-image dockerfile --build-context-dir` flag for external base-image builders.
- Keep the default temporary build-context behavior unchanged.
- Persist generated `cog_build` artifacts, such as `requirements.txt`, when callers provide a durable context directory.

## Root Cause

`base-image dockerfile` can emit Dockerfiles that reference a named BuildKit context:

```dockerfile
COPY --from=cog_build requirements.txt /tmp/requirements.txt
```

That path is needed for Torch base images because the base-image generator writes Torch, torchvision, torchaudio, and OpenCV requirements into `requirements.txt`.

After the `.cog/build` refactor, `base-image dockerfile` stages those files in a temporary `.cog/build` directory created via `dotcog.OpenTemp()`. The temp directory is cleaned up before the command exits, so external builders like `cog-base-images` cannot provide the required `cog_build` context to Docker.

This PR lets external callers opt into a durable staging directory without changing the default cleanup behavior.

## Verification

- `go test ./pkg/dockerfile ./pkg/cli -count=1`
- Generated a Torch base-image Dockerfile with `--build-context-dir /tmp/cog-base-context-check` and verified:
  - Dockerfile contains `COPY --from=cog_build requirements.txt /tmp/requirements.txt`
  - `/tmp/cog-base-context-check/requirements.txt` exists after command exit
  - staged requirements include `torch==2.11.0`
- `git diff --check`