### PR TITLE
fix: sort compatibility matrices for deterministic output

### DIFF
--- a/tools/compatgen/internal/tensorflow.go
+++ b/tools/compatgen/internal/tensorflow.go
@@ -1,7 +1,9 @@
 package internal
 
 import (
+	"cmp"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -56,6 +58,15 @@ func FetchTensorFlowCompatibilityMatrix() ([]config.TFCompatibility, error) {
 	if len(compats) < 12 {
 		return nil, fmt.Errorf("Tensorflow compatibility matrix only had %d rows, has the html changed?", len(compats))
 	}
+
+	// stable sort for deterministic output
+	slices.SortFunc(compats, func(a, b config.TFCompatibility) int {
+		return cmp.Or(
+			cmp.Compare(a.TF, b.TF),
+			cmp.Compare(a.CUDA, b.CUDA),
+			cmp.Compare(a.CuDNN, b.CuDNN),
+		)
+	})
 
 	return compats, nil
 }

--- a/tools/compatgen/internal/tensorflow_test.go
+++ b/tools/compatgen/internal/tensorflow_test.go
@@ -1,0 +1,38 @@
+package internal
+
+import (
+	"cmp"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/replicate/cog/pkg/config"
+)
+
+func TestTensorFlowCompatibilitySortingIsDeterministic(t *testing.T) {
+	compats := []config.TFCompatibility{
+		{TF: "2.20.0", CUDA: "12.5", CuDNN: "9.3"},
+		{TF: "2.21.0", CUDA: "12.5", CuDNN: "9.3"},
+		{TF: "2.15.0", CUDA: "12.2", CuDNN: "8.9"},
+		{TF: "2.15.0", CUDA: "12.3", CuDNN: "8.9"},
+		{TF: "2.20.0", CUDA: "12.5", CuDNN: "9.2"},
+	}
+
+	// Apply the same sort logic used in FetchTensorFlowCompatibilityMatrix
+	slices.SortFunc(compats, func(a, b config.TFCompatibility) int {
+		return cmp.Or(
+			cmp.Compare(a.TF, b.TF),
+			cmp.Compare(a.CUDA, b.CUDA),
+			cmp.Compare(a.CuDNN, b.CuDNN),
+		)
+	})
+
+	require.Equal(t, []config.TFCompatibility{
+		{TF: "2.15.0", CUDA: "12.2", CuDNN: "8.9"},
+		{TF: "2.15.0", CUDA: "12.3", CuDNN: "8.9"},
+		{TF: "2.20.0", CUDA: "12.5", CuDNN: "9.2"},
+		{TF: "2.20.0", CUDA: "12.5", CuDNN: "9.3"},
+		{TF: "2.21.0", CUDA: "12.5", CuDNN: "9.3"},
+	}, compats)
+}

--- a/tools/compatgen/internal/torch.go
+++ b/tools/compatgen/internal/torch.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"net/url"
@@ -48,6 +49,26 @@ func FetchTorchCompatibilityMatrix() ([]config.TorchCompatibility, error) {
 	if len(compats) < 21 {
 		return nil, fmt.Errorf("PyTorch compatibility matrix only had %d rows, has the html changed?", len(compats))
 	}
+
+	// stable sort for deterministic output
+	slices.SortFunc(compats, func(a, b config.TorchCompatibility) int {
+		aCuda := ""
+		bCuda := ""
+		if a.CUDA != nil {
+			aCuda = *a.CUDA
+		}
+		if b.CUDA != nil {
+			bCuda = *b.CUDA
+		}
+		return cmp.Or(
+			cmp.Compare(a.Torch, b.Torch),
+			cmp.Compare(a.Torchvision, b.Torchvision),
+			cmp.Compare(a.Torchaudio, b.Torchaudio),
+			cmp.Compare(aCuda, bCuda),
+			cmp.Compare(a.ExtraIndexURL, b.ExtraIndexURL),
+			cmp.Compare(a.FindLinks, b.FindLinks),
+		)
+	})
 
 	return compats, nil
 }

--- a/tools/compatgen/internal/torch_test.go
+++ b/tools/compatgen/internal/torch_test.go
@@ -1,16 +1,19 @@
 package internal
 
 import (
+	"cmp"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/env"
 )
 
@@ -224,4 +227,48 @@ func TestPythonMVersion(t *testing.T) {
 	require.Equal(t, "", variant)
 	require.Equal(t, "36", pythonVersion)
 	require.Equal(t, "linux_x86_64", platform)
+}
+
+func TestTorchCompatibilitySortingIsDeterministic(t *testing.T) {
+	cuda126 := "12.6"
+	cuda128 := "12.8"
+	cpu := "cpu"
+
+	compats := []config.TorchCompatibility{
+		{Torch: "2.10.0+cu128", Torchvision: "0.25.0", Torchaudio: "2.10.0", CUDA: &cuda128, ExtraIndexURL: "https://download.pytorch.org/whl/cu128/"},
+		{Torch: "2.10.0+cpu", Torchvision: "0.25.0", Torchaudio: "2.10.0", CUDA: &cpu, ExtraIndexURL: "https://download.pytorch.org/whl/cpu/"},
+		{Torch: "2.11.0+cu126", Torchvision: "0.26.0", Torchaudio: "2.11.0", CUDA: &cuda126, ExtraIndexURL: "https://download.pytorch.org/whl/cu126/"},
+		{Torch: "2.10.0+cu126", Torchvision: "0.25.0", Torchaudio: "2.10.0", CUDA: &cuda126, ExtraIndexURL: "https://download.pytorch.org/whl/cu126/"},
+		{Torch: "2.11.0+cpu", Torchvision: "0.26.0", Torchaudio: "2.11.0", CUDA: nil, ExtraIndexURL: "https://download.pytorch.org/whl/cpu/"},
+		{Torch: "2.11.0+cu128", Torchvision: "0.26.0", Torchaudio: "2.11.0", CUDA: &cuda128, ExtraIndexURL: "https://download.pytorch.org/whl/cu128/"},
+	}
+
+	// Apply the same sort logic used in FetchTorchCompatibilityMatrix
+	slices.SortFunc(compats, func(a, b config.TorchCompatibility) int {
+		aCuda := ""
+		bCuda := ""
+		if a.CUDA != nil {
+			aCuda = *a.CUDA
+		}
+		if b.CUDA != nil {
+			bCuda = *b.CUDA
+		}
+		return cmp.Or(
+			cmp.Compare(a.Torch, b.Torch),
+			cmp.Compare(a.Torchvision, b.Torchvision),
+			cmp.Compare(a.Torchaudio, b.Torchaudio),
+			cmp.Compare(aCuda, bCuda),
+			cmp.Compare(a.ExtraIndexURL, b.ExtraIndexURL),
+			cmp.Compare(a.FindLinks, b.FindLinks),
+		)
+	})
+
+	require.Equal(t, []config.TorchCompatibility{
+		{Torch: "2.10.0+cpu", Torchvision: "0.25.0", Torchaudio: "2.10.0", CUDA: &cpu, ExtraIndexURL: "https://download.pytorch.org/whl/cpu/"},
+		{Torch: "2.10.0+cu126", Torchvision: "0.25.0", Torchaudio: "2.10.0", CUDA: &cuda126, ExtraIndexURL: "https://download.pytorch.org/whl/cu126/"},
+		{Torch: "2.10.0+cu128", Torchvision: "0.25.0", Torchaudio: "2.10.0", CUDA: &cuda128, ExtraIndexURL: "https://download.pytorch.org/whl/cu128/"},
+		{Torch: "2.11.0+cpu", Torchvision: "0.26.0", Torchaudio: "2.11.0", CUDA: nil, ExtraIndexURL: "https://download.pytorch.org/whl/cpu/"},
+		{Torch: "2.11.0+cu126", Torchvision: "0.26.0", Torchaudio: "2.11.0", CUDA: &cuda126, ExtraIndexURL: "https://download.pytorch.org/whl/cu126/"},
+		{Torch: "2.11.0+cu128", Torchvision: "0.26.0", Torchaudio: "2.11.0", CUDA: &cuda128, ExtraIndexURL: "https://download.pytorch.org/whl/cu128/"},
+	}, compats)
 }


### PR DESCRIPTION
Fixes the compatibility matrix update workflow opening PRs even when the underlying data has not changed.

## Problem

The scheduled update-compatibility-matrices workflow was creating PRs on days when no new CUDA/PyTorch/TensorFlow versions were released. This happened because the generated JSON was not deterministic.

## Root Cause

- CUDA: already sorted correctly
- PyTorch: non-deterministic because fetchCurrentTorchVersions iterates over a Go map with random iteration order
- TensorFlow: non-deterministic because it iterates over HTML table rows in document order

## Changes

- Added stable sorting to FetchTorchCompatibilityMatrix
- Added stable sorting to FetchTensorFlowCompatibilityMatrix
- Added tests verifying deterministic sorting for both generators

This should make the workflow idempotent: if the upstream data has not changed, the generated JSON will be byte-for-byte identical and no PR will be opened.