### PR TITLE
fix: prefer latest torch patch when resolving unpatched version

### DIFF
--- a/pkg/config/compatibility.go
+++ b/pkg/config/compatibility.go
@@ -318,12 +318,13 @@ func torchGPUPackage(ver string, cuda string) (name, cpuVersion, findLinks, extr
 		if latest == nil {
 			latest = &compat
 		} else {
-			greater, err := versionGreater(*compat.CUDA, *latest.CUDA)
+			cudaGreater, err := versionGreater(*compat.CUDA, *latest.CUDA)
 			if err != nil {
 				// should never happen
 				panic(fmt.Sprintf("Invalid CUDA version: %s", err))
 			}
-			if greater {
+			cudaEqual := *compat.CUDA == *latest.CUDA
+			if cudaGreater || (cudaEqual && version.Greater(compat.TorchVersion(), latest.TorchVersion())) {
 				latest = &compat
 			}
 		}


### PR DESCRIPTION
`torch==2.3` (no patch) started resolving to `2.3.0` instead of `2.3.1` after #3006 sorted the compatibility matrix ascending.

`torchGPUPackage` picks the best match by highest compatible CUDA version, but when two entries have equal CUDA (e.g. `2.3.0+cu118` and `2.3.1+cu118`), it kept whichever it found first -- which was previously `2.3.1` by accident of ordering, and is now `2.3.0`.

Break ties by preferring the higher torch patch version, consistent with `baseImageComponentNormalisation` which already does this.

Fixes the `TestGenerateFullGPUWithCogBaseImage` failure on main. The integration test failures in the same run were Docker infra flakes (`error reading from server: EOF`), not code bugs.