### PR TITLE
Add fuzz tests and fix config parsing panics

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -433,6 +433,11 @@ func validateCudaVersion(cudaVersion string) error {
 		return fmt.Errorf("invalid major version in CUDA version %q", cudaVersion)
 	}
 
+	_, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return fmt.Errorf("invalid minor version in CUDA version %q", cudaVersion)
+	}
+
 	if major < MinimumMajorCudaVersion {
 		return fmt.Errorf("minimum supported CUDA version is %d, requested %q", MinimumMajorCudaVersion, cudaVersion)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path"
 	"path/filepath"
@@ -48,6 +49,11 @@ func TestValidateCudaVersion(t *testing.T) {
 		{
 			name:        "LessThanMinimum",
 			input:       "9.1",
+			expectedErr: true,
+		},
+		{
+			name:        "InvalidMinorVersion",
+			input:       "11.A",
 			expectedErr: true,
 		},
 	}
@@ -962,4 +968,24 @@ predict: predict.py:Predictor
 `))
 	require.NoError(t, err)
 	require.Equal(t, "prerelease", conf.Build.SDKVersion)
+}
+
+// TestInvalidWeightsSourceDoesNotStackOverflow is a regression test for a
+// stack overflow caused by the yaml v4 library's LoadErrors.Is() method,
+// which has infinite recursion when errors.Is traverses the error chain.
+// When weights.source is an array of strings (not objects), yaml.Unmarshal
+// returns a LoadErrors. If we wrap it with %w, any caller doing errors.Is
+// on the returned error triggers the recursion. We use %v instead.
+func TestInvalidWeightsSourceDoesNotStackOverflow(t *testing.T) {
+	data := []byte(`weights:
+  - name: openai-privacy-filter
+    source:
+      - hf://openai/privacy-filter
+    target: /src/weights/openai-privacy-filter`)
+
+	_, err := FromYAML(data)
+	require.Error(t, err)
+
+	// This must not panic or stack overflow
+	require.False(t, errors.Is(err, errors.New("some error")))
 }

--- a/pkg/config/fuzz_test.go
+++ b/pkg/config/fuzz_test.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"testing"
+)
+
+// FuzzParseBytes fuzzes the YAML parsing layer to find inputs that cause
+// panics during unmarshaling.
+func FuzzParseBytes(f *testing.F) {
+	// Seed with valid and edge-case YAML inputs
+	f.Add([]byte(""))
+	f.Add([]byte("build:\n  python_version: \"3.13\"\n"))
+	f.Add([]byte("build:\n  run:\n    - \"echo hello\"\n"))
+	f.Add([]byte("weights:\n  - name: foo\n    target: /weights\n    source:\n      uri: hf://model\n"))
+	f.Add([]byte("build:\n  run:\n    - command: echo\n      mounts:\n        - type: bind\n          id: vol\n          target: /mnt\n"))
+	f.Add([]byte("{\"build\": {\"python_version\": \"3.13\"}}"))
+	f.Add([]byte("build:\n  gpu: true\n  cuda: \"12.4\"\n  python_version: \"3.13\"\n"))
+	f.Add([]byte("concurrency:\n  max: 5\n"))
+	f.Add([]byte("---\nnull\n"))
+	f.Add([]byte("build:\n  run:\n    - ~\n"))
+	f.Add([]byte("weights:\n  - name: a\n    target: /a\n    source: ~\n"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// The parser should never panic — it may return errors for invalid YAML,
+		// but it must not crash.
+		_, _ = parseBytes(data)
+	})
+}
+
+// FuzzFromYAML fuzzes the higher-level FromYAML function which parses YAML and
+// converts it into a Config struct. This exercises both the YAML layer and the
+// configFile-to-Config conversion.
+func FuzzFromYAML(f *testing.F) {
+	f.Add([]byte(""))
+	f.Add([]byte("build:\n  python_version: \"3.13\"\n"))
+	f.Add([]byte("build:\n  run:\n    - \"echo hello\"\n"))
+	f.Add([]byte("weights:\n  - name: foo\n    target: /weights\n    source:\n      uri: hf://model\n"))
+	f.Add([]byte("build:\n  run:\n    - command: echo\n      mounts:\n        - type: bind\n          id: vol\n          target: /mnt\n"))
+	f.Add([]byte("{\"build\": {\"python_version\": \"3.13\"}}"))
+	f.Add([]byte("build:\n  gpu: true\n  cuda: \"12.4\"\n  python_version: \"3.13\"\n"))
+	f.Add([]byte("concurrency:\n  max: 5\n"))
+	f.Add([]byte("---\nnull\n"))
+	f.Add([]byte("build:\n  run:\n    - ~\n"))
+	f.Add([]byte("weights:\n  - name: a\n    target: /a\n    source: ~\n"))
+	f.Add([]byte("predict: predict.py:Predictor\ntrain: train.py:Trainer\n"))
+	f.Add([]byte("environment:\n  - \"FOO=bar\"\n"))
+	f.Add([]byte("build:\n  python_packages:\n    - torch==2.0.1\n  python_version: \"3.13\"\n"))
+	f.Add([]byte("build:\n  python_requirements: requirements.txt\n  python_version: \"3.13\"\n"))
+	f.Add([]byte("image: \"registry.example.com/acme/my-model\"\n"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		cfg, err := FromYAML(data)
+		if err != nil {
+			// Errors are expected for invalid input; panics are not.
+			return
+		}
+		if cfg == nil {
+			t.Fatal("FromYAML returned nil config without error")
+		}
+	})
+}
+
+// FuzzConfigComplete fuzzes the Complete() method by generating random Config
+// structs from parsed YAML and calling Complete(). This catches panics in
+// CUDA resolution, requirements loading, and environment parsing.
+func FuzzConfigComplete(f *testing.F) {
+	f.Add([]byte("build:\n  python_version: \"3.13\"\n"))
+	f.Add([]byte("build:\n  gpu: true\n  python_version: \"3.13\"\n"))
+	f.Add([]byte("build:\n  gpu: true\n  python_version: \"3.13\"\n  cuda: \"12.4\"\n"))
+	f.Add([]byte("build:\n  python_version: \"3.13\"\n  python_packages:\n    - torch==2.0.1\n"))
+	f.Add([]byte("build:\n  gpu: true\n  python_version: \"3.13\"\n  python_packages:\n    - torch==2.0.1\n"))
+	f.Add([]byte("build:\n  python_version: \"3.13\"\n  python_requirements: reqs.txt\n"))
+	f.Add([]byte("build:\n  python_version: \"3.13\"\n  run:\n    - \"echo hello\"\n"))
+	f.Add([]byte("concurrency:\n  max: 3\n"))
+	f.Add([]byte("environment:\n  - \"FOO=bar\"\n"))
+	f.Add([]byte("weights:\n  - name: w\n    target: /weights\n    source:\n      uri: hf://model\n"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		cfg, err := FromYAML(data)
+		if err != nil {
+			return
+		}
+		if cfg == nil {
+			return
+		}
+		// Complete may error for invalid configs (e.g. missing requirements file),
+		// but it must never panic.
+		_ = cfg.Complete(t.TempDir())
+	})
+}

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -29,8 +29,13 @@ func parseBytes(contents []byte) (*configFile, error) {
 	}
 
 	if err := yaml.Unmarshal(contents, cfg); err != nil {
+		// NOTE: We intentionally use %v instead of %w here.
+		// The yaml v4 library's LoadErrors type has a buggy Is() method
+		// that causes infinite recursion when errors.Is traverses the
+		// error chain. By using %v we break the chain and prevent
+		// stack overflows when callers check the error.
 		return nil, &ParseError{
-			Err: fmt.Errorf("invalid YAML: %w", err),
+			Err: fmt.Errorf("invalid YAML: %v", err),
 		}
 	}
 

--- a/pkg/config/testdata/fuzz/FuzzConfigComplete/2886ff7212a9ca82
+++ b/pkg/config/testdata/fuzz/FuzzConfigComplete/2886ff7212a9ca82
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("build:\n  gpu: true\n  cuda: 11.A")

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -100,15 +100,39 @@ func (v *Version) PatchVersion() int {
 }
 
 func Equal(v1 string, v2 string) bool {
-	return MustVersion(v1).Equal(MustVersion(v2))
+	leftVersion, err := NewVersion(v1)
+	if err != nil {
+		return v1 == v2
+	}
+	rightVersion, err := NewVersion(v2)
+	if err != nil {
+		return v1 == v2
+	}
+	return leftVersion.Equal(rightVersion)
 }
 
 func EqualMinor(v1 string, v2 string) bool {
-	return MustVersion(v1).EqualMinor(MustVersion(v2))
+	leftVersion, err := NewVersion(v1)
+	if err != nil {
+		return false
+	}
+	rightVersion, err := NewVersion(v2)
+	if err != nil {
+		return false
+	}
+	return leftVersion.EqualMinor(rightVersion)
 }
 
 func Greater(v1 string, v2 string) bool {
-	return MustVersion(v1).Greater(MustVersion(v2))
+	leftVersion, err := NewVersion(v1)
+	if err != nil {
+		return false
+	}
+	rightVersion, err := NewVersion(v2)
+	if err != nil {
+		return false
+	}
+	return leftVersion.Greater(rightVersion)
 }
 
 func GreaterOrEqual(v1 string, v2 string) bool {
@@ -137,11 +161,22 @@ func (v *Version) Matches(other *Version) bool {
 }
 
 func Matches(v1 string, v2 string) bool {
-	return MustVersion(v1).Matches(MustVersion(v2))
+	leftVersion, err := NewVersion(v1)
+	if err != nil {
+		return false
+	}
+	rightVersion, err := NewVersion(v2)
+	if err != nil {
+		return false
+	}
+	return leftVersion.Matches(rightVersion)
 }
 
 func StripPatch(v string) string {
-	ver := MustVersion(v)
+	ver, err := NewVersion(v)
+	if err != nil {
+		return v
+	}
 	return fmt.Sprintf("%d.%d", ver.Major, ver.Minor)
 }
 

--- a/pkg/util/version/version_test.go
+++ b/pkg/util/version/version_test.go
@@ -85,3 +85,27 @@ func TestGreaterThanOrEqualToWithInvalidPatch(t *testing.T) {
 	rightVersion := "1.1.0b2"
 	require.True(t, GreaterOrEqual(leftVersion, rightVersion))
 }
+
+// TestInvalidVersionsDoNotPanic verifies that the version helper functions
+// handle invalid version strings gracefully instead of panicking.
+// This is important for config parsing where user-provided versions may
+// be malformed.
+func TestInvalidVersionsDoNotPanic(t *testing.T) {
+	invalid := "11.A"
+	valid := "11.8"
+
+	// None of these should panic
+	require.False(t, Equal(invalid, valid))
+	require.False(t, Equal(valid, invalid))
+	require.False(t, EqualMinor(invalid, valid))
+	require.False(t, EqualMinor(valid, invalid))
+	require.False(t, Greater(invalid, valid))
+	require.False(t, Greater(valid, invalid))
+	require.False(t, Matches(invalid, valid))
+	require.False(t, Matches(valid, invalid))
+	require.Equal(t, invalid, StripPatch(invalid))
+
+	// GreaterOrEqual falls back to string equality for invalid versions
+	require.True(t, GreaterOrEqual(invalid, invalid))
+	require.False(t, GreaterOrEqual(invalid, valid))
+}


### PR DESCRIPTION
This PR adds Go fuzz tests for config parsing and fixes two categories of crashes found during fuzzing.

## Changes

### Fuzz tests (pkg/config/fuzz_test.go)
- `FuzzParseBytes` — fuzzes raw YAML → configFile parsing
- `FuzzFromYAML` — fuzzes YAML → Config struct conversion  
- `FuzzConfigComplete` — fuzzes the full path including CUDA resolution, requirements loading, and environment parsing

### Bug fixes

**1. Panic on invalid CUDA version strings**
`version.Matches()`, `Equal()`, `Greater()`, and `StripPatch()` called `MustVersion()`, which panics on invalid input like `11.A`. Replaced with graceful `NewVersion` error handling.

Also added minor version validation to `validateCudaVersion()` so invalid versions are rejected early with a clean error.

**2. Stack overflow from yaml v4 error wrapping**
The yaml v4 library's `LoadErrors` type creates a self-referential error cycle when custom `UnmarshalYAML` implementations wrap the callback error with `%w`. Any subsequent `errors.Is` call triggers infinite recursion.

Fixed by using `%v` instead of `%w` when wrapping yaml parse errors, with an explanatory comment. Filed upstream: https://github.com/yaml/go-yaml/issues/345

## Regression tests
- `TestInvalidVersionsDoNotPanic` — verifies graceful handling of invalid version strings
- `TestInvalidWeightsSourceDoesNotStackOverflow` — verifies `errors.Is` doesn't crash on yaml parse errors
- Fuzz corpus entry for the `11.A` case