### PR TITLE
feat: model refs for cog push and weights commands

### DIFF
--- a/examples/managed-weights/README.md
+++ b/examples/managed-weights/README.md
@@ -103,4 +103,4 @@ crane ls localhost:5000/managed-weights
 ```
 
 Weight manifests are pushed under tags like
-`weights-<name>-<12-hex-digest>` (see `pkg/model/weight_pusher.go`).
+`cog-weight.<name>.<12-hex-digest>` (see `pkg/model/weight_pusher.go`).

--- a/integration-tests/tests/oci_bundle_push.txtar
+++ b/integration-tests/tests/oci_bundle_push.txtar
@@ -8,6 +8,13 @@
 
 registry-start
 
+# Drive both weight import and the final push to the same model ref.
+# COG_MODEL pins the full ref (registry + repo + tag) so the bundle
+# lands at $TEST_REGISTRY/test/bundle-model:v1 deterministically;
+# without an explicit tag, ResolveModelRef would append a fresh
+# timestamp and break registry-inspect below.
+env COG_MODEL=$TEST_REGISTRY/test/bundle-model:v1
+
 # Two weight directories. Each holds a single small file; the packer
 # emits a bundle layer for all the small files under the default
 # threshold so we end up with one layer per weight entry.
@@ -16,21 +23,23 @@ mkdir weights-beta
 exec sh -c 'printf AAAA > weights-alpha/data.bin'
 exec sh -c 'printf BBBB > weights-beta/data.bin'
 
-# image: is required in cog.yaml when weights are declared, and
-# cog weights import reads it from there.
-exec sh -c 'printf "image: %s/test/bundle-model\n" "$TEST_REGISTRY" >> cog.yaml'
-
 # Step 1: import generates weights.lock and pushes weight manifests.
 # cog push later requires the lockfile to already exist.
 cog weights import
 
 # Step 2: cog push assembles the OCI index (image + weight manifests)
-# and uploads it to the registry under the supplied tag.
-cog push $TEST_REGISTRY/test/bundle-model:v1
+# and uploads it to the same model ref. Positional [IMAGE] args are
+# rejected in model mode, so the ref comes entirely from COG_MODEL.
+cog push
 
-# Image push header — weights are pushed during `cog weights import`,
-# not during `cog push`.
-stderr 'Pushing image '
+# Push prints a structured ref tree on success: the bundle (model)
+# digest plus each contained artifact. Weights were already pushed
+# during `cog weights import`, so they only show up in the tree.
+stderr 'Pushing to localhost'
+stderr 'model   localhost'
+stderr 'image   localhost'
+stderr 'weight  alpha  localhost'
+stderr 'weight  beta   localhost'
 
 # Resolve the pushed ref and verify the top-level index shape.
 registry-inspect $TEST_REGISTRY/test/bundle-model:v1
@@ -41,13 +50,13 @@ stdout 'run.cog.weight.name.*beta'
 stdout 'run.cog.weight.set-digest'
 
 -- cog.yaml --
-# image: is appended by the test before `cog push` (the value depends
-# on $TEST_REGISTRY, which varies per run). cog push <ref> still
-# pushes to the supplied ref, but image: must be set when weights are
-# configured (validation requirement).
+# 'model:' satisfies the schema requirement that weight-bearing configs
+# declare a model ref. The full registry/repo:tag target is overridden
+# at runtime via COG_MODEL because $TEST_REGISTRY varies per run.
 build:
   python_version: "3.12"
 predict: "predict.py:Predictor"
+model: test/bundle-model
 weights:
   - name: alpha
     target: /src/weights-alpha

--- a/integration-tests/tests/weights_filter.txtar
+++ b/integration-tests/tests/weights_filter.txtar
@@ -9,6 +9,11 @@ env COG_CACHE_DIR=$WORK/cache
 
 registry-start
 
+# Point the model ref at the ephemeral test registry. cog.yaml carries
+# the bare repo via 'model:'; COG_MODEL_REGISTRY swaps in the host
+# now that registry-start has assigned a port.
+env COG_MODEL_REGISTRY=$TEST_REGISTRY
+
 # Build a weight directory with multiple file types.
 mkdir weights-src
 exec sh -c 'echo "safetensor-data" > weights-src/model.safetensors'
@@ -17,9 +22,6 @@ exec sh -c 'echo "tokenizer-data" > weights-src/tokenizer.json'
 exec sh -c 'echo "onnx-data" > weights-src/model.onnx'
 exec sh -c 'echo "pytorch-bin-data" > weights-src/pytorch_model.bin'
 exec sh -c 'echo "readme-text" > weights-src/README.md'
-
-# Patch image to use ephemeral test registry.
-exec sh -c 'printf "image: %s/test/filter-model\n" "$TEST_REGISTRY" >> cog.yaml'
 
 # Import with include/exclude filters.
 cog weights import
@@ -40,11 +42,13 @@ cog predict -i s=check
 stdout 'files=config.json,model.safetensors,tokenizer.json'
 
 -- cog.yaml --
-# image: is appended by the test before `cog weights import` (the
-# value depends on $TEST_REGISTRY, which varies per run).
+# 'model:' carries the bare repo. The registry host is set via
+# COG_MODEL_REGISTRY in the test body since $TEST_REGISTRY varies
+# per run.
 build:
   python_version: "3.12"
 predict: "predict.py:Predictor"
+model: test/filter-model
 weights:
   - name: filtered
     target: /src/weights/filtered

--- a/integration-tests/tests/weights_import_predict.txtar
+++ b/integration-tests/tests/weights_import_predict.txtar
@@ -12,12 +12,14 @@ env COG_CACHE_DIR=$WORK/cache
 
 registry-start
 
+# Point the model ref at the ephemeral test registry. cog.yaml carries
+# the bare repo via 'model:'; COG_MODEL_REGISTRY swaps in the host
+# now that registry-start has assigned a port.
+env COG_MODEL_REGISTRY=$TEST_REGISTRY
+
 # Build a deterministic weight directory.
 mkdir weights-src
 exec sh -c 'dd if=/dev/zero bs=1024 count=1 2>/dev/null | tr "\0" "X" > weights-src/greeting.txt'
-
-# Patch cog.yaml to set image: to the ephemeral test registry.
-exec sh -c 'printf "image: %s/test/import-predict-model\n" "$TEST_REGISTRY" >> cog.yaml'
 
 # Step 1: import. After this, the local content store under
 # $COG_CACHE_DIR/weights/files/sha256/ must contain greeting.txt's
@@ -35,11 +37,13 @@ stdout 'hello world \(weight-size=1024\)'
 exec sh -c 'test ! -d .cog/mounts || test -z "$(ls -A .cog/mounts)"'
 
 -- cog.yaml --
-# image: is appended by the test before `cog weights import` (the
-# value depends on $TEST_REGISTRY, which varies per run).
+# 'model:' carries the bare repo. The registry host is set via
+# COG_MODEL_REGISTRY in the test body since $TEST_REGISTRY varies
+# per run.
 build:
   python_version: "3.12"
 predict: "predict.py:Predictor"
+model: test/import-predict-model
 weights:
   - name: greeting
     target: /src/mounted-weights/greeting

--- a/integration-tests/tests/weights_pull.txtar
+++ b/integration-tests/tests/weights_pull.txtar
@@ -11,6 +11,11 @@ env COG_CACHE_DIR=$WORK/cache
 
 registry-start
 
+# Point the model ref at the ephemeral test registry. cog.yaml carries
+# the bare repo via 'model:'; COG_MODEL_REGISTRY swaps in the host
+# now that registry-start has assigned a port.
+env COG_MODEL_REGISTRY=$TEST_REGISTRY
+
 # Build deterministic weight directories (file:// sources must be directories).
 mkdir weights-alpha
 mkdir weights-beta
@@ -20,7 +25,7 @@ exec sh -c 'dd if=/dev/zero bs=1024 count=1 2>/dev/null | tr "\0" "B" > weights-
 # Step 1: import weights to the local registry. This populates
 # weights.lock, pushes the layers, and warms the local cache as a
 # side effect (cog-i12u: import == build + push + populate cache).
-cog weights import --image $TEST_REGISTRY/test/pull-model
+cog weights import
 stderr 'Pushing 2 weight'
 exists weights.lock
 
@@ -31,7 +36,7 @@ exec sh -c 'rm -rf $WORK/cache/weights/files'
 ! exists $WORK/cache/weights/files/sha256
 
 # Step 2: pull from a cold cache. Expect both weights to be fetched.
-cog weights pull --image $TEST_REGISTRY/test/pull-model
+cog weights pull
 stderr 'Pulling alpha'
 stderr 'Pulling beta'
 stderr 'done'
@@ -41,13 +46,13 @@ stderr 'Pulled'
 exists $WORK/cache/weights/files/sha256
 
 # Step 3: pull again — everything is cached, no registry I/O needed.
-cog weights pull --image $TEST_REGISTRY/test/pull-model
+cog weights pull
 stderr 'cached'
 stderr 'All 2 weight\(s\) already cached'
 
 # Step 4: verbose mode surfaces cache dir, manifest ref, and per-file
 # lines.
-cog weights pull --image $TEST_REGISTRY/test/pull-model --verbose
+cog weights pull --verbose
 stderr 'Cache:'
 stderr 'Lockfile:'
 # Everything is cached so we only see the per-weight "cached" lines
@@ -57,7 +62,7 @@ stderr 'cached \(1/1 files\)'
 # Step 5: delete one blob from the cache and verify pull restores just
 # it. We pick any file under the sha256 tree.
 exec sh -c 'find $WORK/cache/weights/files/sha256 -type f | head -1 | xargs rm'
-cog weights pull --image $TEST_REGISTRY/test/pull-model --verbose
+cog weights pull --verbose
 # The weight with the missing file reports 1 missing / 1 total; the
 # other reports as cached. Verbose mode also prints per-layer detail
 # (short digest + size).
@@ -66,14 +71,14 @@ stderr '  layer [0-9a-f]+'
 
 # Step 6: unknown weight name errors with every missing name listed,
 # and the cache is unchanged.
-! cog weights pull --image $TEST_REGISTRY/test/pull-model alpha nope typo
+! cog weights pull alpha nope typo
 stderr 'nope'
 stderr 'typo'
 
 # Step 7: named filter pulls only the requested weight. Delete both
 # cache trees and re-pull only alpha.
 exec sh -c 'rm -rf $WORK/cache/weights/files'
-cog weights pull --image $TEST_REGISTRY/test/pull-model alpha
+cog weights pull alpha
 stderr 'Pulling alpha'
 ! stderr 'Pulling beta'
 
@@ -81,7 +86,7 @@ stderr 'Pulling alpha'
 build:
   python_version: "3.12"
 predict: "predict.py:Predictor"
-image: test/pull-model
+model: test/pull-model
 weights:
   - name: alpha
     target: /src/weights/alpha

--- a/integration-tests/tests/weights_pull_predict.txtar
+++ b/integration-tests/tests/weights_pull_predict.txtar
@@ -9,14 +9,13 @@ env COG_CACHE_DIR=$WORK/cache
 
 registry-start
 
+# Point the model ref at the ephemeral test registry. cog predict
+# picks this up via newWeightManager → resolveWeightRepo → ResolveModelRef.
+env COG_MODEL_REGISTRY=$TEST_REGISTRY
+
 # Build a deterministic weight directory.
 mkdir weights-src
 exec sh -c 'dd if=/dev/zero bs=1024 count=1 2>/dev/null | tr "\0" "X" > weights-src/greeting.txt'
-
-# Patch cog.yaml to set image: to the ephemeral test registry. This
-# makes the `cog predict` path (which has no --image flag) resolve
-# the repo via src.Config.Image when constructing the WeightManager.
-exec sh -c 'printf "image: %s/test/pull-predict-model\n" "$TEST_REGISTRY" >> cog.yaml'
 
 # Step 1: import to the local registry. This also warms the local
 # cache as a side effect of import (cog-i12u guarantee).
@@ -44,11 +43,13 @@ stdout 'hello world \(weight-size=1024\)'
 exec sh -c 'test ! -d .cog/mounts || test -z "$(ls -A .cog/mounts)"'
 
 -- cog.yaml --
-# image: is appended by the test before `cog weights import` (the
-# value depends on $TEST_REGISTRY, which varies per run).
+# 'model:' carries the bare repo. The registry host is set via
+# COG_MODEL_REGISTRY in the test body since $TEST_REGISTRY varies
+# per run.
 build:
   python_version: "3.12"
 predict: "predict.py:Predictor"
+model: test/pull-predict-model
 weights:
   - name: greeting
     target: /src/mounted-weights/greeting

--- a/mise.lock
+++ b/mise.lock
@@ -216,6 +216,38 @@ url = "https://static.rust-lang.org/rustup/archive/1.28.2/x86_64-apple-darwin/ru
 checksum = "sha256:88d8258dcf6ae4f7a80c7d1088e1f36fa7025a1cfd1343731b4ee6f385121fc0"
 url = "https://static.rust-lang.org/rustup/archive/1.28.2/x86_64-pc-windows-msvc/rustup-init.exe"
 
+[[tools."aqua:vektra/mockery"]]
+version = "3.7.0"
+backend = "aqua:vektra/mockery"
+
+[tools."aqua:vektra/mockery"."platforms.linux-arm64"]
+checksum = "sha256:94dab8c6d8421630da51fe950b4f0f1180e5bef6022a3a5b3fe537acace94741"
+url = "https://github.com/vektra/mockery/releases/download/v3.7.0/mockery_3.7.0_Linux_arm64.tar.gz"
+
+[tools."aqua:vektra/mockery"."platforms.linux-arm64-musl"]
+checksum = "sha256:94dab8c6d8421630da51fe950b4f0f1180e5bef6022a3a5b3fe537acace94741"
+url = "https://github.com/vektra/mockery/releases/download/v3.7.0/mockery_3.7.0_Linux_arm64.tar.gz"
+
+[tools."aqua:vektra/mockery"."platforms.linux-x64"]
+checksum = "sha256:5e10597d9741d7b8cda699f044b24c9e8b51467dce413e79516d7cd9373c2896"
+url = "https://github.com/vektra/mockery/releases/download/v3.7.0/mockery_3.7.0_Linux_x86_64.tar.gz"
+
+[tools."aqua:vektra/mockery"."platforms.linux-x64-musl"]
+checksum = "sha256:5e10597d9741d7b8cda699f044b24c9e8b51467dce413e79516d7cd9373c2896"
+url = "https://github.com/vektra/mockery/releases/download/v3.7.0/mockery_3.7.0_Linux_x86_64.tar.gz"
+
+[tools."aqua:vektra/mockery"."platforms.macos-arm64"]
+checksum = "sha256:c0a8ea54d602c071775d1692321d385903ccc80bd2d1ae9f230539a195643d7d"
+url = "https://github.com/vektra/mockery/releases/download/v3.7.0/mockery_3.7.0_Darwin_arm64.tar.gz"
+
+[tools."aqua:vektra/mockery"."platforms.macos-x64"]
+checksum = "sha256:36e7357fd160689a9a8ae57726e099761159845e2749ba31091589853a5a894d"
+url = "https://github.com/vektra/mockery/releases/download/v3.7.0/mockery_3.7.0_Darwin_x86_64.tar.gz"
+
+[tools."aqua:vektra/mockery"."platforms.windows-x64"]
+checksum = "sha256:76d524ad1740cd02ed621d90015f538fdb53cf6cd4a1ad4d289db017fb69bd0e"
+url = "https://github.com/vektra/mockery/releases/download/v3.7.0/mockery_3.7.0_Windows_x86_64.tar.gz"
+
 [[tools."aqua:ziglang/zig"]]
 version = "0.15.2"
 backend = "aqua:ziglang/zig"

--- a/mise.toml
+++ b/mise.toml
@@ -48,6 +48,7 @@ cargo-binstall = "1.16.6"
 "aqua:rust-cross/cargo-zigbuild" = "0.20.1"
 "aqua:gotestyourself/gotestsum" = "1.13.0"
 "aqua:golangci/golangci-lint" = "2.10.1"
+"aqua:vektra/mockery" = "3.7.0"
 ruff = "0.14.13"
 ty = "0.0.10"
 "npm:prettier" = "3.6.2"
@@ -526,7 +527,19 @@ run = "nox -s typecheck"
 
 [tasks.generate]
 description = "Run all code generation"
-run = [{ tasks = ["generate:stubs"] }]
+run = [{ tasks = ["generate:stubs", "generate:mocks"] }]
+
+[tasks."generate:mocks"]
+description = "Regenerate Go mocks via mockery (config in .mockery.yml)"
+# Source list mirrors the interfaces mockery generates from (per
+# .mockery.yml). Add to this list when adding new interfaces to that
+# config so mise's source-change detection re-runs generation.
+sources = [
+  ".mockery.yml",
+  "pkg/docker/command/*.go",
+]
+outputs = ["pkg/docker/dockertest/command_mocks.go"]
+run = "mockery"
 
 [tasks."generate:stubs"]
 alias = "stub:generate"

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -94,6 +94,9 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	imageName := src.Config.Image
+	if imageName == "" {
+		imageName = src.Config.Model
+	}
 	if buildTag != "" {
 		imageName = buildTag
 	}

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -227,7 +227,7 @@ func cmdPredict(cmd *cobra.Command, args []string) error {
 			gpus = "all"
 		}
 
-		wm, err = newWeightManager(src, "")
+		wm, err = newWeightManager(src)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -74,6 +74,10 @@ func push(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := validatePushArgs(src.Config.Model, args); err != nil {
+		return err
+	}
+
 	imageName := src.Config.Image
 	if len(args) > 0 {
 		imageName = args[0]
@@ -104,13 +108,6 @@ func push(cmd *cobra.Command, args []string) error {
 
 	regClient := registry.NewRegistryClient()
 	resolver := model.NewResolver(dockerClient, regClient)
-
-	// Validate the model ref before kicking off a Docker build so
-	// COG_MODEL_TAG or cog.yaml mistakes surface in seconds, not
-	// minutes. Resolver.Build re-resolves and is authoritative.
-	if _, err := model.ResolveModelRef(src.Config.Model); err != nil && !errors.Is(err, model.ErrNoModelRef) {
-		return err
-	}
 
 	// Build the model
 	console.Infof("Building Docker image from environment in cog.yaml as %s...", console.Bold(imageName))
@@ -187,6 +184,27 @@ func push(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to push image: %w", pushErr)
 	}
 
+	return nil
+}
+
+// validatePushArgs runs the user-input checks `cog push` needs before
+// touching Docker: resolve the model ref so a malformed COG_MODEL_TAG
+// fails in seconds instead of after a multi-minute build, and reject
+// the legacy positional [IMAGE] arg in FormatBundle mode where its
+// meaning is ambiguous. The arg is still valid for FormatImage models,
+// so the rejection is conditional on a resolvable model ref.
+func validatePushArgs(configModel string, args []string) error {
+	ref, err := model.ResolveModelRef(configModel)
+	if err != nil && !errors.Is(err, model.ErrNoModelRef) {
+		return err
+	}
+	if ref != nil && len(args) > 0 {
+		return errors.New(
+			"positional image argument not supported with 'model' config\n" +
+				"  use COG_MODEL to override the full reference\n" +
+				"  use COG_MODEL_TAG to override just the tag",
+		)
+	}
 	return nil
 }
 

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -126,8 +128,12 @@ func push(cmd *cobra.Command, args []string) error {
 		console.Infof("\n%d managed weight(s)", len(m.Weights))
 	}
 
-	// Push the model (image + optional weights)
-	console.Infof("\nPushing image %s...", console.Bold(m.ImageRef()))
+	// Prefer the resolved bundle ref; fall back to the image ref for FormatImage.
+	pushTarget := m.ImageRef()
+	if m.Ref != nil {
+		pushTarget = m.Ref.String()
+	}
+	console.Infof("\nPushing to %s...", console.Bold(pushTarget))
 
 	// Set up progress display using Docker's jsonmessage rendering. This uses the
 	// same cursor movement and progress display as `docker push`, which handles
@@ -160,14 +166,17 @@ func push(cmd *cobra.Command, args []string) error {
 
 	pw.Close()
 
-	// pushed.Ref is set only when a model reference resolved during
-	// Build (i.e. FormatBundle); FormatImage pushes have no model-ref
-	// concept and rely on per-layer progress output alone.
-	if pushErr == nil && pushed != nil && pushed.Ref != nil {
-		console.Infof("Pushed %s", console.Bold(pushed.Ref.String()))
+	// Bypass console.InfoUnformatted: it wraps at terminal width and
+	// would hard-break the digest refs we want to be copy-pasteable.
+	if pushErr == nil && pushed != nil {
+		if tree := formatPushResult(pushed); tree != "" {
+			_, _ = fmt.Fprintln(os.Stderr)
+			_, _ = fmt.Fprintln(os.Stderr, tree)
+		}
 	}
 
-	// PostPush: the provider handles formatting errors and showing success messages
+	// PostPush: the provider handles formatting errors and any
+	// provider-specific success output (e.g. the Replicate model URL).
 	if err := p.PostPush(ctx, pushOpts, pushErr); err != nil {
 		return err
 	}
@@ -180,3 +189,66 @@ func push(cmd *cobra.Command, args []string) error {
 
 	return nil
 }
+
+// formatPushResult renders a tree of the digest-pinned refs published
+// by a successful push. Returns "" for nil models or FormatImage with
+// no image artifact.
+//
+// Output uses space-padded columns (survives copy-paste) and has no
+// leading or trailing newlines — callers add separators. Refs are
+// assumed digest-pinned per Resolver.Push's post-condition; the tests
+// assert this invariant.
+func formatPushResult(m *model.Model) string {
+	if m == nil {
+		return ""
+	}
+
+	img := m.GetImageArtifact()
+
+	if m.Format != model.FormatBundle {
+		if img == nil || img.Reference == "" {
+			return ""
+		}
+		return fmt.Sprintf("  image  %s", img.Reference)
+	}
+
+	// Count siblings so we know which row gets └─ vs ├─.
+	hasImage := img != nil && img.Reference != ""
+	totalChildren := len(m.Weights)
+	if hasImage {
+		totalChildren++
+	}
+
+	// "weight" is the longest kind label; align weight names so refs
+	// line up across rows.
+	const labelWidth = len("weight")
+	nameWidth := 0
+	for _, w := range m.Weights {
+		if len(w.Name) > nameWidth {
+			nameWidth = len(w.Name)
+		}
+	}
+
+	var b strings.Builder
+	if m.Ref != nil {
+		fmt.Fprintf(&b, "  %-*s  %s\n", labelWidth, "model", m.Ref.String())
+	}
+
+	i := 0
+	branch := func() string {
+		i++
+		if i == totalChildren {
+			return "└─"
+		}
+		return "├─"
+	}
+
+	if hasImage {
+		fmt.Fprintf(&b, "  %s %-*s  %s\n", branch(), labelWidth, "image", img.Reference)
+	}
+	for _, w := range m.Weights {
+		fmt.Fprintf(&b, "  %s %-*s  %-*s  %s\n", branch(), labelWidth, "weight", nameWidth, w.Name, w.Reference)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -102,6 +103,13 @@ func push(cmd *cobra.Command, args []string) error {
 	regClient := registry.NewRegistryClient()
 	resolver := model.NewResolver(dockerClient, regClient)
 
+	// Validate the model ref before kicking off a Docker build so
+	// COG_MODEL_TAG or cog.yaml mistakes surface in seconds, not
+	// minutes. Resolver.Build re-resolves and is authoritative.
+	if _, err := model.ResolveModelRef(src.Config.Model); err != nil && !errors.Is(err, model.ErrNoModelRef) {
+		return err
+	}
+
 	// Build the model
 	console.Infof("Building Docker image from environment in cog.yaml as %s...", console.Bold(imageName))
 	console.Info("")
@@ -128,7 +136,7 @@ func push(cmd *cobra.Command, args []string) error {
 	pw := docker.NewProgressWriter()
 	defer pw.Close()
 
-	pushErr := resolver.Push(ctx, m, model.PushOptions{
+	pushed, pushErr := resolver.Push(ctx, m, model.PushOptions{
 		ImageProgressFn: func(prog model.PushProgress) {
 			if prog.Phase != "" {
 				switch prog.Phase {
@@ -151,6 +159,13 @@ func push(cmd *cobra.Command, args []string) error {
 	})
 
 	pw.Close()
+
+	// pushed.Ref is set only when a model reference resolved during
+	// Build (i.e. FormatBundle); FormatImage pushes have no model-ref
+	// concept and rely on per-layer progress output alone.
+	if pushErr == nil && pushed != nil && pushed.Ref != nil {
+		console.Infof("Pushed %s", console.Bold(pushed.Ref.String()))
+	}
 
 	// PostPush: the provider handles formatting errors and showing success messages
 	if err := p.PostPush(ctx, pushOpts, pushErr); err != nil {

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -74,27 +74,37 @@ func push(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := validatePushArgs(src.Config.Model, args); err != nil {
+	// Resolve up front so user-input errors (malformed COG_MODEL_TAG,
+	// image:+env mode mix-up, bad positional arg) fail in seconds
+	// rather than after a multi-minute Docker build. We also need the
+	// resolved ref before Resolver.Build so the provider lookup below
+	// can drive credential selection from the correct host even when
+	// Build fails (the build-error path calls p.PostPush(...) for
+	// Replicate-specific guidance).
+	modelRef, err := validatePushArgs(src.Config.Image, src.Config.Model, args)
+	if err != nil {
 		return err
 	}
-
-	imageName := src.Config.Image
-	if len(args) > 0 {
-		imageName = args[0]
-	}
-
-	if imageName == "" {
-		return fmt.Errorf("To push images, you must either set the 'image' option in cog.yaml or pass an image name as an argument. For example, 'cog push registry.example.com/your-username/model-name'")
+	var pushTarget string
+	switch {
+	case modelRef != nil:
+		pushTarget = modelRef.String()
+	case len(args) > 0:
+		pushTarget = args[0]
+	case src.Config.Image != "":
+		pushTarget = src.Config.Image
+	default:
+		return errors.New("To push images, you must either set the 'image' option in cog.yaml or pass an image name as an argument. For example, 'cog push registry.example.com/your-username/model-name'")
 	}
 
 	// Look up the provider for the target registry
-	p := provider.DefaultRegistry().ForImage(imageName)
+	p := provider.DefaultRegistry().ForImage(pushTarget)
 	if p == nil {
-		return fmt.Errorf("no provider found for image '%s'", imageName)
+		return fmt.Errorf("no provider found for image '%s'", pushTarget)
 	}
 
 	pushOpts := provider.PushOptions{
-		Image:      imageName,
+		Image:      pushTarget,
 		Config:     src.Config,
 		ProjectDir: src.ProjectDir,
 	}
@@ -110,9 +120,9 @@ func push(cmd *cobra.Command, args []string) error {
 	resolver := model.NewResolver(dockerClient, regClient)
 
 	// Build the model
-	console.Infof("Building Docker image from environment in cog.yaml as %s...", console.Bold(imageName))
+	console.Infof("Building Docker image from environment in cog.yaml as %s...", console.Bold(pushTarget))
 	console.Info("")
-	buildOpts := buildOptionsFromFlags(cmd, imageName, annotations)
+	buildOpts := buildOptionsFromFlags(cmd, pushTarget, annotations)
 	m, err := resolver.Build(ctx, src, buildOpts)
 	if err != nil {
 		// Call PostPush to handle error logging/analytics
@@ -126,11 +136,11 @@ func push(cmd *cobra.Command, args []string) error {
 	}
 
 	// Prefer the resolved bundle ref; fall back to the image ref for FormatImage.
-	pushTarget := m.ImageRef()
+	announceTarget := m.ImageRef()
 	if m.Ref != nil {
-		pushTarget = m.Ref.String()
+		announceTarget = m.Ref.String()
 	}
-	console.Infof("\nPushing to %s...", console.Bold(pushTarget))
+	console.Infof("\nPushing to %s...", console.Bold(announceTarget))
 
 	// Set up progress display using Docker's jsonmessage rendering. This uses the
 	// same cursor movement and progress display as `docker push`, which handles
@@ -187,25 +197,28 @@ func push(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// validatePushArgs runs the user-input checks `cog push` needs before
-// touching Docker: resolve the model ref so a malformed COG_MODEL_TAG
-// fails in seconds instead of after a multi-minute build, and reject
-// the legacy positional [IMAGE] arg in FormatBundle mode where its
-// meaning is ambiguous. The arg is still valid for FormatImage models,
+// validatePushArgs resolves the model ref and runs the push-specific
+// user-input checks before any Docker work. Returns the resolved ref
+// (or nil for FormatImage paths) so the caller can drive the provider
+// lookup and push target from the same resolution — avoiding a second
+// call to ResolveModelRef that could disagree on the timestamp tag.
+//
+// The positional [IMAGE] arg is rejected in FormatBundle mode where
+// its meaning is ambiguous; it's still valid for FormatImage models,
 // so the rejection is conditional on a resolvable model ref.
-func validatePushArgs(configModel string, args []string) error {
-	ref, err := model.ResolveModelRef(configModel)
+func validatePushArgs(configImage, configModel string, args []string) (*model.ResolvedRef, error) {
+	ref, err := model.ResolveModelRef(configImage, configModel)
 	if err != nil && !errors.Is(err, model.ErrNoModelRef) {
-		return err
+		return nil, err
 	}
 	if ref != nil && len(args) > 0 {
-		return errors.New(
+		return nil, errors.New(
 			"positional image argument not supported with 'model' config\n" +
 				"  use COG_MODEL to override the full reference\n" +
 				"  use COG_MODEL_TAG to override just the tag",
 		)
 	}
-	return nil
+	return ref, nil
 }
 
 // formatPushResult renders a tree of the digest-pinned refs published
@@ -269,4 +282,3 @@ func formatPushResult(m *model.Model) string {
 	}
 	return strings.TrimRight(b.String(), "\n")
 }
-

--- a/pkg/cli/push_test.go
+++ b/pkg/cli/push_test.go
@@ -20,6 +20,94 @@ const (
 	testWeightRef2  = testRepo + "@sha256:e4f5a60000000000000000000000000000000000000000000000000000000000"
 )
 
+// clearModelEnv blanks out the COG_MODEL* env vars for the duration
+// of the test so a developer shell with custom overrides can't change
+// the resolver's behavior under test. Mirrors the unexported helper in
+// pkg/model/resolve_test.go.
+func clearModelEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(model.EnvModel, "")
+	t.Setenv(model.EnvModelRegistry, "")
+	t.Setenv(model.EnvModelRepo, "")
+	t.Setenv(model.EnvModelTag, "")
+}
+
+func TestValidatePushArgs(t *testing.T) {
+	const bundleModel = "registry.example.com/user/model"
+
+	tests := []struct {
+		name        string
+		configModel string
+		envRepo     string // COG_MODEL_REPO override
+		envTag      string // COG_MODEL_TAG override
+		args        []string
+		errContains []string // empty = expect no error
+	}{
+		{
+			// cog.yaml `model:` means FormatBundle. The legacy
+			// positional IMAGE arg is ambiguous here — error message
+			// must direct the user to the env var overrides instead.
+			name:        "FormatBundle with positional arg rejected with helpful message",
+			configModel: bundleModel,
+			args:        []string{"some/other:tag"},
+			errContains: []string{"positional image argument not supported", model.EnvModel, model.EnvModelTag},
+		},
+		{
+			name:        "FormatBundle with no args proceeds",
+			configModel: bundleModel,
+		},
+		{
+			// FormatImage path: positional arg is the legacy way to
+			// specify the image ref and must keep working.
+			name: "FormatImage with positional arg proceeds",
+			args: []string{"r8.im/user/model"},
+		},
+		{
+			// validatePushArgs is not responsible for the "no image:
+			// and no arg" error — that's the downstream caller's job.
+			name: "FormatImage with no args proceeds",
+		},
+		{
+			// COG_MODEL_REPO alone is enough to flip to FormatBundle —
+			// the CI override path. Same rejection applies.
+			name:        "env var promotion to FormatBundle rejects positional arg",
+			envRepo:     "user/model",
+			args:        []string{"r8.im/user/model"},
+			errContains: []string{"positional image argument not supported"},
+		},
+		{
+			// Validation errors surface fast, even with no positional
+			// arg — the whole point of the pre-flight check.
+			name:        "invalid env var surfaces before positional check",
+			configModel: bundleModel,
+			envTag:      "cog-reserved",
+			errContains: []string{"reserved prefix"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearModelEnv(t)
+			if tt.envRepo != "" {
+				t.Setenv(model.EnvModelRepo, tt.envRepo)
+			}
+			if tt.envTag != "" {
+				t.Setenv(model.EnvModelTag, tt.envTag)
+			}
+
+			err := validatePushArgs(tt.configModel, tt.args)
+			if len(tt.errContains) == 0 {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, s := range tt.errContains {
+				assert.Contains(t, err.Error(), s)
+			}
+		})
+	}
+}
+
 func TestFormatPushResult_FormatBundle_NoWeights(t *testing.T) {
 	img := &model.ImageArtifact{Reference: testImageRef}
 	m := &model.Model{

--- a/pkg/cli/push_test.go
+++ b/pkg/cli/push_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog/pkg/model"
+	"github.com/replicate/cog/pkg/model/modeltest"
 )
 
 // Refs are full 64-char digests so the assertions exercise the
@@ -19,18 +20,6 @@ const (
 	testWeightRef1  = testRepo + "@sha256:d2daaf0000000000000000000000000000000000000000000000000000000000"
 	testWeightRef2  = testRepo + "@sha256:e4f5a60000000000000000000000000000000000000000000000000000000000"
 )
-
-// clearModelEnv blanks out the COG_MODEL* env vars for the duration
-// of the test so a developer shell with custom overrides can't change
-// the resolver's behavior under test. Mirrors the unexported helper in
-// pkg/model/resolve_test.go.
-func clearModelEnv(t *testing.T) {
-	t.Helper()
-	t.Setenv(model.EnvModel, "")
-	t.Setenv(model.EnvModelRegistry, "")
-	t.Setenv(model.EnvModelRepo, "")
-	t.Setenv(model.EnvModelTag, "")
-}
 
 func TestValidatePushArgs(t *testing.T) {
 	const bundleModel = "registry.example.com/user/model"
@@ -99,7 +88,7 @@ func TestValidatePushArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			clearModelEnv(t)
+			modeltest.ClearEnv(t)
 			if tt.envRepo != "" {
 				t.Setenv(model.EnvModelRepo, tt.envRepo)
 			}

--- a/pkg/cli/push_test.go
+++ b/pkg/cli/push_test.go
@@ -1,0 +1,239 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/replicate/cog/pkg/model"
+)
+
+// Refs are full 64-char digests so the assertions exercise the
+// "copy-pasteable, never truncated" contract.
+const (
+	testRepo        = "registry.example.com/acct/resnet-50"
+	testImageRef    = testRepo + "@sha256:f3c67c0000000000000000000000000000000000000000000000000000000000"
+	testModelDigest = "sha256:abc1230000000000000000000000000000000000000000000000000000000000"
+	testWeightRef1  = testRepo + "@sha256:d2daaf0000000000000000000000000000000000000000000000000000000000"
+	testWeightRef2  = testRepo + "@sha256:e4f5a60000000000000000000000000000000000000000000000000000000000"
+)
+
+func TestFormatPushResult_FormatBundle_NoWeights(t *testing.T) {
+	img := &model.ImageArtifact{Reference: testImageRef}
+	m := &model.Model{
+		Format: model.FormatBundle,
+		Ref: &model.ResolvedRef{
+			Registry: "registry.example.com",
+			Repo:     "acct/resnet-50",
+			Digest:   testModelDigest,
+		},
+		Image:     img,
+		Artifacts: []model.Artifact{img},
+	}
+
+	out := formatPushResult(m)
+
+	assert.Contains(t, out, "model")
+	assert.Contains(t, out, testRepo+"@"+testModelDigest)
+	assert.Contains(t, out, "└─ image")
+	assert.Contains(t, out, testImageRef)
+	// Only one child — should be └─, never ├─.
+	assert.NotContains(t, out, "├─")
+	// Refs must always be full digests — no truncation.
+	assert.NotContains(t, out, "...")
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.Contains(line, "model") || strings.Contains(line, "image") {
+			assert.Contains(t, line, "@sha256:", "ref must be digest-pinned: %q", line)
+		}
+	}
+	// Caller adds separators; the formatter must not.
+	assert.False(t, strings.HasPrefix(out, "\n"), "output should not start with a blank line")
+	assert.False(t, strings.HasSuffix(out, "\n"), "output should not end with a trailing newline")
+}
+
+func TestFormatPushResult_FormatBundle_SingleWeight(t *testing.T) {
+	img := &model.ImageArtifact{Reference: testImageRef}
+	m := &model.Model{
+		Format: model.FormatBundle,
+		Ref: &model.ResolvedRef{
+			Registry: "registry.example.com",
+			Repo:     "acct/resnet-50",
+			Digest:   testModelDigest,
+		},
+		Image:     img,
+		Artifacts: []model.Artifact{img},
+		Weights: []model.Weight{
+			{Name: "resnet50", Reference: testWeightRef1},
+		},
+	}
+
+	out := formatPushResult(m)
+
+	assert.Contains(t, out, "model")
+	assert.Contains(t, out, "├─ image")
+	assert.Contains(t, out, "└─ weight")
+	assert.Contains(t, out, "resnet50")
+	assert.Contains(t, out, testWeightRef1)
+	// Image is the not-last child, so it should be ├─ not └─.
+	assert.NotContains(t, out, "└─ image")
+}
+
+func TestFormatPushResult_FormatBundle_MultipleWeights(t *testing.T) {
+	img := &model.ImageArtifact{Reference: testImageRef}
+	m := &model.Model{
+		Format: model.FormatBundle,
+		Ref: &model.ResolvedRef{
+			Registry: "registry.example.com",
+			Repo:     "flux",
+			Digest:   testModelDigest,
+		},
+		Image:     img,
+		Artifacts: []model.Artifact{img},
+		Weights: []model.Weight{
+			{Name: "transformer", Reference: testWeightRef1},
+			{Name: "text-encoder", Reference: testWeightRef2},
+		},
+	}
+
+	out := formatPushResult(m)
+
+	assert.Contains(t, out, "├─ image")
+	assert.Contains(t, out, "├─ weight")
+	assert.Contains(t, out, "└─ weight")
+	assert.Contains(t, out, "transformer")
+	assert.Contains(t, out, "text-encoder")
+	assert.Contains(t, out, testWeightRef1)
+	assert.Contains(t, out, testWeightRef2)
+
+	// Weight names should be column-aligned: find the two weight
+	// lines and assert their refs start at the same column.
+	var weightLines []string
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.Contains(line, "weight") && strings.Contains(line, "@sha256:") {
+			weightLines = append(weightLines, line)
+		}
+	}
+	require.Len(t, weightLines, 2, "expected two weight lines, got: %v", weightLines)
+	assert.Equal(t,
+		strings.Index(weightLines[0], "@sha256:"),
+		strings.Index(weightLines[1], "@sha256:"),
+		"weight refs should be column-aligned across rows; got:\n%s\n%s",
+		weightLines[0], weightLines[1],
+	)
+}
+
+// Full layout assertion: pin the exact rendering so a future
+// alignment/format change is caught loudly. Uses short fixed digests
+// so the golden output stays readable in the test file.
+func TestFormatPushResult_FormatBundle_GoldenLayout(t *testing.T) {
+	const (
+		repo    = "registry.example.com/acct/flux"
+		modelD  = "sha256:abc123"
+		imageD  = "sha256:f3c67c"
+		weightD = "sha256:d2daaf"
+	)
+
+	img := &model.ImageArtifact{Reference: repo + "@" + imageD}
+	m := &model.Model{
+		Format: model.FormatBundle,
+		Ref: &model.ResolvedRef{
+			Registry: "registry.example.com",
+			Repo:     "acct/flux",
+			Digest:   modelD,
+		},
+		Image:     img,
+		Artifacts: []model.Artifact{img},
+		Weights: []model.Weight{
+			{Name: "transformer", Reference: repo + "@" + weightD},
+		},
+	}
+
+	expected := strings.Join([]string{
+		"  model   " + repo + "@" + modelD,
+		"  ├─ image   " + repo + "@" + imageD,
+		"  └─ weight  transformer  " + repo + "@" + weightD,
+	}, "\n")
+
+	assert.Equal(t, expected, formatPushResult(m))
+}
+
+func TestFormatPushResult_FormatImage(t *testing.T) {
+	img := &model.ImageArtifact{Reference: testImageRef}
+	m := &model.Model{
+		Format:    model.FormatImage,
+		Image:     img,
+		Artifacts: []model.Artifact{img},
+	}
+
+	out := formatPushResult(m)
+
+	// FormatImage: no model/weight rows, no tree branches.
+	assert.NotContains(t, out, "  model ")
+	assert.NotContains(t, out, "├─")
+	assert.NotContains(t, out, "└─")
+	assert.NotContains(t, out, "weight")
+	assert.Equal(t, "  image  "+testImageRef, out)
+}
+
+func TestFormatPushResult_NilModel(t *testing.T) {
+	assert.Empty(t, formatPushResult(nil), "nil model should produce empty output")
+}
+
+// Defensive guards: these states should be unreachable post-push
+// (Resolver.Push enriches Image.Reference and Model.Ref), but the
+// function defends against them. Lock the contract so a future
+// refactor that drops the guards has to update these tests.
+func TestFormatPushResult_DefensiveGuards(t *testing.T) {
+	t.Run("FormatImage with no image artifact", func(t *testing.T) {
+		m := &model.Model{Format: model.FormatImage}
+		assert.Empty(t, formatPushResult(m))
+	})
+
+	t.Run("FormatImage with empty image reference", func(t *testing.T) {
+		img := &model.ImageArtifact{Reference: ""}
+		m := &model.Model{
+			Format:    model.FormatImage,
+			Image:     img,
+			Artifacts: []model.Artifact{img},
+		}
+		assert.Empty(t, formatPushResult(m))
+	})
+
+	t.Run("FormatBundle with nil Ref skips the model line but still shows children", func(t *testing.T) {
+		img := &model.ImageArtifact{Reference: testImageRef}
+		m := &model.Model{
+			Format:    model.FormatBundle,
+			Image:     img,
+			Artifacts: []model.Artifact{img},
+		}
+
+		out := formatPushResult(m)
+		assert.NotContains(t, out, "  model ", "nil Ref should suppress the model row")
+		assert.Contains(t, out, "└─ image", "image child should still render")
+	})
+
+	t.Run("FormatBundle with weights but no image artifact", func(t *testing.T) {
+		// Bundle without an image makes no sense in practice, but
+		// the function defends against it: the single weight
+		// becomes the last child.
+		m := &model.Model{
+			Format: model.FormatBundle,
+			Ref: &model.ResolvedRef{
+				Registry: "registry.example.com",
+				Repo:     "acct/flux",
+				Digest:   testModelDigest,
+			},
+			Weights: []model.Weight{
+				{Name: "w1", Reference: testWeightRef1},
+			},
+		}
+
+		out := formatPushResult(m)
+		assert.Contains(t, out, "model")
+		assert.Contains(t, out, "└─ weight")
+		assert.NotContains(t, out, "├─", "single child should use └─, not ├─")
+		assert.NotContains(t, out, "image")
+	})
+}

--- a/pkg/cli/push_test.go
+++ b/pkg/cli/push_test.go
@@ -37,11 +37,13 @@ func TestValidatePushArgs(t *testing.T) {
 
 	tests := []struct {
 		name        string
+		configImage string
 		configModel string
 		envRepo     string // COG_MODEL_REPO override
 		envTag      string // COG_MODEL_TAG override
 		args        []string
 		errContains []string // empty = expect no error
+		wantRef     bool     // expect a non-nil ResolvedRef (FormatBundle path)
 	}{
 		{
 			// cog.yaml `model:` means FormatBundle. The legacy
@@ -53,8 +55,9 @@ func TestValidatePushArgs(t *testing.T) {
 			errContains: []string{"positional image argument not supported", model.EnvModel, model.EnvModelTag},
 		},
 		{
-			name:        "FormatBundle with no args proceeds",
+			name:        "FormatBundle with no args proceeds and returns the ref",
 			configModel: bundleModel,
+			wantRef:     true,
 		},
 		{
 			// FormatImage path: positional arg is the legacy way to
@@ -83,6 +86,15 @@ func TestValidatePushArgs(t *testing.T) {
 			envTag:      "cog-reserved",
 			errContains: []string{"reserved prefix"},
 		},
+		{
+			// Smoke test that the image:+env mode-mix rejection
+			// propagates through the CLI boundary. The full matrix
+			// lives in TestResolveModelRef_ImageModelEnvConflict.
+			name:        "image: in cog.yaml + COG_MODEL_REPO is rejected",
+			configImage: "ghcr.io/owner/repo",
+			envRepo:     "acct/model",
+			errContains: []string{"'image' in cog.yaml cannot be combined with COG_MODEL"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -95,9 +107,14 @@ func TestValidatePushArgs(t *testing.T) {
 				t.Setenv(model.EnvModelTag, tt.envTag)
 			}
 
-			err := validatePushArgs(tt.configModel, tt.args)
+			ref, err := validatePushArgs(tt.configImage, tt.configModel, tt.args)
 			if len(tt.errContains) == 0 {
 				require.NoError(t, err)
+				if tt.wantRef {
+					require.NotNil(t, ref, "FormatBundle path should return a resolved ref")
+				} else {
+					require.Nil(t, ref, "FormatImage path should return nil ref")
+				}
 				return
 			}
 			require.Error(t, err)

--- a/pkg/cli/train.go
+++ b/pkg/cli/train.go
@@ -102,7 +102,7 @@ func cmdTrain(cmd *cobra.Command, args []string) error {
 			gpus = "all"
 		}
 
-		wm, err = newWeightManager(src, "")
+		wm, err = newWeightManager(src)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/weights.go
+++ b/pkg/cli/weights.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
@@ -53,9 +52,7 @@ a repo with a checked-in weights.lock but a cold local cache.
 If weight names are provided, only those weights are imported. Otherwise all weights
 defined in cog.yaml are imported.
 
-The registry is determined from the image name, which can be:
-- Set in cog.yaml as the 'image' field
-- Overridden with the --image flag
+` + weightRegistryResolutionHelp + `
 
 Use --dry-run to preview what would change without importing anything.
 Add --verbose to see per-file details including which files pass the filter.`,
@@ -66,7 +63,6 @@ Add --verbose to see per-file details including which files pass the filter.`,
 	}
 
 	addConfigFlag(cmd)
-	cmd.Flags().String("image", "", "Registry repository (overrides cog.yaml image field)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be imported without making changes")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show per-file details")
 	return cmd
@@ -83,15 +79,7 @@ func weightsImportCommand(cmd *cobra.Command, args []string, dryRun, verbose boo
 
 	cfg := src.Config
 
-	imageName, _ := cmd.Flags().GetString("image")
-	if imageName == "" {
-		imageName = cfg.Image
-	}
-	if imageName == "" {
-		return fmt.Errorf("To import weights, you must either set the 'image' option in cog.yaml or pass --image. For example, 'cog weights import --image registry.example.com/your-username/model-name'")
-	}
-
-	repo, err := parseRepoOnly(imageName)
+	repo, err := resolveWeightRepo(src, configFilename)
 	if err != nil {
 		return err
 	}
@@ -277,19 +265,6 @@ func collectWeightSpecs(src *model.Source, filterNames []string) ([]*model.Weigh
 		filtered = append(filtered, ws)
 	}
 	return filtered, nil
-}
-
-// parseRepoOnly parses an image string as a bare repository, rejecting
-// tags and digests (weight tags are auto-generated).
-func parseRepoOnly(imageName string) (string, error) {
-	parsedRepo, err := name.NewRepository(imageName, name.Insecure)
-	if err != nil {
-		if ref, refErr := name.ParseReference(imageName, name.Insecure); refErr == nil {
-			return "", fmt.Errorf("image reference %q includes a tag or digest — provide only the repository (e.g., %q)", imageName, ref.Context().Name())
-		}
-		return "", fmt.Errorf("invalid repository %q: %w", imageName, err)
-	}
-	return parsedRepo.Name(), nil
 }
 
 // pushWeightArtifacts pushes weight artifacts to the registry with

--- a/pkg/cli/weights_manager.go
+++ b/pkg/cli/weights_manager.go
@@ -1,28 +1,48 @@
 package cli
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/replicate/cog/pkg/model"
 	"github.com/replicate/cog/pkg/weights"
 )
 
-// newWeightManager resolves the repo (from imageOverride or
-// src.Config.Image) and delegates construction to weights.NewFromSource.
-// Repo resolution is CLI-input parsing, which is why it lives here and
-// not in pkg/weights.
-func newWeightManager(src *model.Source, imageOverride string) (*weights.Manager, error) {
-	repo := ""
-	if len(src.Config.Weights) > 0 {
-		imageName := imageOverride
-		if imageName == "" {
-			imageName = src.Config.Image
-		}
-		if imageName != "" {
-			parsed, err := parseRepoOnly(imageName)
-			if err != nil {
-				return nil, err
-			}
-			repo = parsed
-		}
+// weightRegistryResolutionHelp is shared help text for weight
+// subcommands so the docs can't drift between import/pull/status.
+const weightRegistryResolutionHelp = "The registry is determined from the resolved model ref ('model' in\n" +
+	"cog.yaml, optionally overridden by COG_MODEL or COG_MODEL_REPO)."
+
+func newWeightManager(src *model.Source) (*weights.Manager, error) {
+	repo, err := resolveWeightRepo(src, configFilename)
+	if err != nil {
+		return nil, err
 	}
 	return weights.NewFromSource(src, repo)
+}
+
+// resolveWeightRepo returns the bundle repository (registry/repo, no
+// tag) for weight operations. Returns ("", nil) for weight-less
+// projects — preserves the no-op Manager contract used by cog predict
+// and cog train. cfgPath is woven into user-facing errors so messages
+// reflect the actual --config flag value, not a hardcoded "cog.yaml".
+//
+// The image-in-cog.yaml branch is defense-in-depth: config validation
+// already rejects 'image:' + 'weights:'; this catches programmatic
+// callers that build a Source from a hand-rolled Config.
+func resolveWeightRepo(src *model.Source, cfgPath string) (string, error) {
+	if len(src.Config.Weights) == 0 {
+		return "", nil
+	}
+	if src.Config.Image != "" {
+		return "", fmt.Errorf("weight commands require 'model' in %s, not 'image' — rename 'image' to 'model'", cfgPath)
+	}
+	ref, err := model.ResolveModelRef("", src.Config.Model)
+	if err != nil {
+		if errors.Is(err, model.ErrNoModelRef) {
+			return "", fmt.Errorf("weight commands require a model ref: set 'model' in %s, or export COG_MODEL / COG_MODEL_REPO", cfgPath)
+		}
+		return "", fmt.Errorf("resolving model ref: %w", err)
+	}
+	return ref.Repository(), nil
 }

--- a/pkg/cli/weights_manager_test.go
+++ b/pkg/cli/weights_manager_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/model"
+	"github.com/replicate/cog/pkg/model/modeltest"
 )
 
 func TestResolveWeightRepo(t *testing.T) {
@@ -75,7 +76,7 @@ func TestResolveWeightRepo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			clearModelEnv(t)
+			modeltest.ClearEnv(t)
 			if tt.envModel != "" {
 				t.Setenv(model.EnvModel, tt.envModel)
 			}

--- a/pkg/cli/weights_manager_test.go
+++ b/pkg/cli/weights_manager_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/replicate/cog/pkg/config"
+	"github.com/replicate/cog/pkg/model"
+)
+
+func TestResolveWeightRepo(t *testing.T) {
+	const bundleModel = "registry.example.com/user/model"
+
+	tests := []struct {
+		name         string
+		configImage  string
+		configModel  string
+		hasWeights   bool
+		envModel     string // COG_MODEL full-ref override
+		envRepo      string // COG_MODEL_REPO override
+		wantRepo     string
+		wantErrMatch string
+	}{
+		{
+			name:       "no weights returns empty repo",
+			hasWeights: false,
+			wantRepo:   "",
+		},
+		{
+			name:        "model in config resolves to repository",
+			configModel: bundleModel,
+			hasWeights:  true,
+			wantRepo:    bundleModel,
+		},
+		{
+			name:        "COG_MODEL_REPO overrides config model",
+			configModel: bundleModel,
+			hasWeights:  true,
+			envRepo:     "user/other",
+			wantRepo:    "registry.example.com/user/other",
+		},
+		{
+			name:       "COG_MODEL full-ref wins with no config model",
+			hasWeights: true,
+			envModel:   "registry.example.com/team/other:v1",
+			wantRepo:   "registry.example.com/team/other",
+		},
+		{
+			name:         "image with weights is rejected and names the config file",
+			configImage:  bundleModel,
+			hasWeights:   true,
+			wantErrMatch: "weight commands require 'model' in test-cog.yaml, not 'image'",
+		},
+		{
+			name:         "no model ref names the config file",
+			hasWeights:   true,
+			wantErrMatch: "set 'model' in test-cog.yaml",
+		},
+		{
+			name:         "invalid COG_MODEL is wrapped, not swallowed",
+			hasWeights:   true,
+			envModel:     "::not a ref::",
+			wantErrMatch: "resolving model ref",
+		},
+		{
+			name:         "invalid COG_MODEL_REPO names the offending env var",
+			configModel:  bundleModel,
+			hasWeights:   true,
+			envRepo:      "user/model:v1", // colon is illegal in a bare repo
+			wantErrMatch: "COG_MODEL_REPO",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearModelEnv(t)
+			if tt.envModel != "" {
+				t.Setenv(model.EnvModel, tt.envModel)
+			}
+			if tt.envRepo != "" {
+				t.Setenv(model.EnvModelRepo, tt.envRepo)
+			}
+
+			cfg := &config.Config{
+				Image: tt.configImage,
+				Model: tt.configModel,
+			}
+			if tt.hasWeights {
+				// Single placeholder weight — content is irrelevant;
+				// resolveWeightRepo only checks len(Weights) > 0.
+				cfg.Weights = []config.WeightSource{{Name: "w", Target: "/w"}}
+			}
+			src := model.NewSourceFromConfig(cfg, t.TempDir())
+
+			got, err := resolveWeightRepo(src, "test-cog.yaml")
+			if tt.wantErrMatch != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMatch)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRepo, got)
+		})
+	}
+}

--- a/pkg/cli/weights_pull.go
+++ b/pkg/cli/weights_pull.go
@@ -14,10 +14,7 @@ import (
 )
 
 func newWeightsPullCommand() *cobra.Command {
-	var (
-		verbose       bool
-		imageOverride string
-	)
+	var verbose bool
 
 	cmd := &cobra.Command{
 		Use:   "pull [NAME...]",
@@ -38,20 +35,21 @@ cheap. The local cache defaults to $HOME/.cache/cog/weights; set
 COG_CACHE_DIR (or XDG_CACHE_HOME) to move it elsewhere — useful if your
 home directory is on a different filesystem than your project.
 
+` + weightRegistryResolutionHelp + `
+
 Use --verbose to show per-layer and per-file progress.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return weightsPullCommand(cmd, args, verbose, imageOverride)
+			return weightsPullCommand(cmd, args, verbose)
 		},
 	}
 
 	addConfigFlag(cmd)
-	cmd.Flags().StringVar(&imageOverride, "image", "", "Registry repository (overrides cog.yaml image field)")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show per-layer and per-file progress")
 	return cmd
 }
 
-func weightsPullCommand(cmd *cobra.Command, args []string, verbose bool, imageOverride string) error {
+func weightsPullCommand(cmd *cobra.Command, args []string, verbose bool) error {
 	ctx := cmd.Context()
 
 	src, err := model.NewSource(configFilename)
@@ -64,7 +62,7 @@ func weightsPullCommand(cmd *cobra.Command, args []string, verbose bool, imageOv
 		return fmt.Errorf("no weights defined in %s", configFilename)
 	}
 
-	mgr, err := newWeightManager(src, imageOverride)
+	mgr, err := newWeightManager(src)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/weights_status.go
+++ b/pkg/cli/weights_status.go
@@ -74,6 +74,8 @@ Status values:
 
 Every non-ready status is resolved by running 'cog weights import'.
 
+` + weightRegistryResolutionHelp + `
+
 Use --verbose to show per-layer status for each weight.
 
 Exit code is 0 when all weights are ready, 1 otherwise.`,
@@ -99,21 +101,21 @@ func weightsStatusCommand(cmd *cobra.Command, jsonOutput, verbose bool) error {
 	}
 	defer src.Close()
 
+	if len(src.Config.Weights) == 0 {
+		return fmt.Errorf("no weights defined in %s", configFilename)
+	}
+
+	repo, err := resolveWeightRepo(src, configFilename)
+	if err != nil {
+		return err
+	}
+
 	// Load lockfile — missing is fine (weights may not be built yet), but
 	// a present-but-corrupt file gets a warning so it doesn't fail silently.
 	lockPath := filepath.Join(src.ProjectDir, lockfile.WeightsLockFilename)
 	lock, lockErr := lockfile.LoadWeightsLock(lockPath)
 	if lockErr != nil && !errors.Is(lockErr, os.ErrNotExist) {
 		console.Warnf("Failed to load %s: %s", lockfile.WeightsLockFilename, lockErr)
-	}
-
-	// Resolve registry repo — required for status checks.
-	if src.Config.Image == "" {
-		return fmt.Errorf("no 'image' configured in %s — cannot check registry state", configFilename)
-	}
-	repo, err := parseRepoOnly(src.Config.Image)
-	if err != nil {
-		return fmt.Errorf("invalid image %q: %w", src.Config.Image, err)
 	}
 
 	reg := registry.NewRegistryClient()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,6 +99,7 @@ func WeightNames(ws []WeightSource) []string {
 type Config struct {
 	Build       *Build         `json:"build" yaml:"build"`
 	Image       string         `json:"image,omitempty" yaml:"image,omitempty"`
+	Model       string         `json:"model,omitempty" yaml:"model,omitempty"`
 	Predict     string         `json:"predict,omitempty" yaml:"predict"`
 	Train       string         `json:"train,omitempty" yaml:"train,omitempty"`
 	Concurrency *Concurrency   `json:"concurrency,omitempty" yaml:"concurrency,omitempty"`

--- a/pkg/config/config_file.go
+++ b/pkg/config/config_file.go
@@ -14,6 +14,7 @@ import (
 type configFile struct {
 	Build       *buildFile       `json:"build,omitempty" yaml:"build,omitempty"`
 	Image       *string          `json:"image,omitempty" yaml:"image,omitempty"`
+	Model       *string          `json:"model,omitempty" yaml:"model,omitempty"`
 	Predict     *string          `json:"predict,omitempty" yaml:"predict,omitempty"`
 	Train       *string          `json:"train,omitempty" yaml:"train,omitempty"`
 	Concurrency *concurrencyFile `json:"concurrency,omitempty" yaml:"concurrency,omitempty"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -682,7 +682,7 @@ func TestAbsolutePathInPythonRequirements(t *testing.T) {
 func TestWeightsWithSourceYAML(t *testing.T) {
 	yamlString := `build:
   python_version: "3.12"
-image: "registry.example.com/acme/my-model"
+model: "registry.example.com/acme/my-model"
 predict: "predict.py:Predictor"
 
 weights:
@@ -700,7 +700,7 @@ weights:
 	config, err := FromYAML([]byte(yamlString))
 	require.NoError(t, err)
 	require.Len(t, config.Weights, 2)
-	require.Equal(t, "registry.example.com/acme/my-model", config.Image)
+	require.Equal(t, "registry.example.com/acme/my-model", config.Model)
 
 	require.Equal(t, "model-v1", config.Weights[0].Name)
 	require.Equal(t, "/weights/model-v1", config.Weights[0].Target)
@@ -720,7 +720,7 @@ func TestWeightsWithoutSourceYAML(t *testing.T) {
 	// parses (Go doesn't enforce JSON schema) but fails validation.
 	yamlString := `build:
   python_version: "3.12"
-image: "registry.example.com/acme/my-model"
+model: "registry.example.com/acme/my-model"
 predict: "predict.py:Predictor"
 
 weights:
@@ -741,7 +741,7 @@ func TestWeightsWithSourceJSON(t *testing.T) {
 	"build": {
 		"python_version": "3.12"
 	},
-	"image": "registry.example.com/acme/my-model",
+	"model": "registry.example.com/acme/my-model",
 	"predict": "predict.py:Predictor",
 	"weights": [
 		{
@@ -766,7 +766,7 @@ func TestWeightsWithSourceJSON(t *testing.T) {
 	err := json.Unmarshal([]byte(jsonString), &config)
 	require.NoError(t, err)
 	require.Len(t, config.Weights, 2)
-	require.Equal(t, "registry.example.com/acme/my-model", config.Image)
+	require.Equal(t, "registry.example.com/acme/my-model", config.Model)
 
 	require.Equal(t, "model-v1", config.Weights[0].Name)
 	require.Equal(t, "/weights/model-v1", config.Weights[0].Target)
@@ -988,4 +988,41 @@ func TestInvalidWeightsSourceDoesNotStackOverflow(t *testing.T) {
 
 	// This must not panic or stack overflow
 	require.False(t, errors.Is(err, errors.New("some error")))
+}
+
+func TestModelFieldYAML(t *testing.T) {
+	// model is parsed into Config.Model.
+	conf, err := FromYAML([]byte(`
+build:
+  python_version: "3.12"
+model: "registry.example.com/acme/my-model"
+predict: predict.py:Predictor
+`))
+	require.NoError(t, err)
+	require.Equal(t, "registry.example.com/acme/my-model", conf.Model)
+	require.Empty(t, conf.Image)
+}
+
+func TestModelFieldPartialNoRegistry(t *testing.T) {
+	// A bare repo without a registry parses fine — the registry will be
+	// supplied later by env vars or defaults.
+	conf, err := FromYAML([]byte(`
+build:
+  python_version: "3.12"
+model: "user/project"
+predict: predict.py:Predictor
+`))
+	require.NoError(t, err)
+	require.Equal(t, "user/project", conf.Model)
+}
+
+func TestModelFieldOmittedLeavesEmpty(t *testing.T) {
+	// Omitting model leaves Config.Model as the zero value.
+	conf, err := FromYAML([]byte(`
+build:
+  python_version: "3.12"
+predict: predict.py:Predictor
+`))
+	require.NoError(t, err)
+	require.Empty(t, conf.Model)
 }

--- a/pkg/config/data/config_schema_v1.0.json
+++ b/pkg/config/data/config_schema_v1.0.json
@@ -160,6 +160,11 @@
       "type": "string",
       "description": "The name given to built Docker images. If you want to push to a registry, this should also include the registry name."
     },
+    "model": {
+      "$id": "#/properties/model",
+      "type": "string",
+      "description": "The repository where this model's image and weights are pushed. Must be a bare repository (no tag or digest)."
+    },
     "predict": {
       "$id": "#/properties/predict",
       "type": "string",
@@ -219,7 +224,7 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "A unique identifier for this weight entry. Maps to <image>/weights/<name> in the registry.",
+            "description": "A unique identifier for this weight entry.",
             "pattern": "^[a-z0-9]+([._-][a-z0-9]+)*$"
           },
           "target": {

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -114,6 +114,9 @@ func configFileToConfig(cfg *configFile) (*Config, error) {
 	if cfg.Image != nil {
 		config.Image = *cfg.Image
 	}
+	if cfg.Model != nil {
+		config.Model = *cfg.Model
+	}
 	if cfg.Predict != nil {
 		config.Predict = *cfg.Predict
 	}

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/replicate/cog/pkg/requirements"
@@ -59,6 +60,7 @@ func ValidateConfigFile(cfg *configFile, opts ...ValidateOption) *ValidationResu
 	validateBuild(cfg, options, result)
 	validateEnvironment(cfg, result)
 	validateConcurrency(cfg, result)
+	validateModel(cfg, result)
 	validateWeights(cfg, result)
 
 	// Check deprecated fields
@@ -443,9 +445,55 @@ func validateConcurrency(cfg *configFile, result *ValidationResult) {
 	}
 }
 
-// weightNameRegex matches OCI-safe path components: lowercase alphanumeric,
-// separated by hyphens, dots, or underscores. Weight names become registry
-// path components (<image>/weights/<name>), so they must follow OCI rules.
+// validateModel validates the model field. It enforces:
+//   - 'model' and 'image' are mutually exclusive.
+//   - 'model' must be a bare repository (no tag, no digest).
+//
+// The "model is required when weights are present" check is intentionally
+// not done here, because environment variables can supply the model ref at
+// command-time. That check belongs to the commands that actually need a
+// resolved ref (push, weights import).
+func validateModel(cfg *configFile, result *ValidationResult) {
+	modelSet := cfg.Model != nil && *cfg.Model != ""
+	imageSet := cfg.Image != nil && *cfg.Image != ""
+
+	if modelSet && imageSet {
+		result.AddError(&ValidationError{
+			Field:   "model",
+			Message: "'model' and 'image' cannot both be set",
+		})
+	}
+
+	if !modelSet {
+		return
+	}
+
+	model := *cfg.Model
+
+	// name.NewRepository accepts host:port repos (e.g. localhost:5000/foo).
+	// If it rejects the string, retry with ParseReference to disambiguate
+	// "looks like repo:tag or repo@digest" from "malformed" so we can give
+	// a more useful error.
+	if _, err := name.NewRepository(model); err != nil {
+		if _, refErr := name.ParseReference(model); refErr == nil {
+			result.AddError(&ValidationError{
+				Field:   "model",
+				Value:   model,
+				Message: "must be a bare repository — tags and digests are not allowed",
+			})
+			return
+		}
+		result.AddError(&ValidationError{
+			Field:   "model",
+			Value:   model,
+			Message: fmt.Sprintf("invalid repository: %v", err),
+		})
+	}
+}
+
+// weightNameRegex matches OCI-safe tag segments: lowercase alphanumeric,
+// separated by hyphens, dots, or underscores. Weight names appear in
+// registry tags (cog-weight.<name>.<digest>), so they must be OCI-safe.
 var weightNameRegex = regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*$`)
 
 // validateWeights validates the weights stanza.
@@ -454,11 +502,22 @@ func validateWeights(cfg *configFile, result *ValidationResult) {
 		return
 	}
 
-	// Weights require an image field.
-	if cfg.Image == nil || *cfg.Image == "" {
+	// Weights belong to the model's OCI bundle, so they require 'model'.
+	modelSet := cfg.Model != nil && *cfg.Model != ""
+	imageSet := cfg.Image != nil && *cfg.Image != ""
+
+	switch {
+	case imageSet && !modelSet:
+		// User is on the legacy image: path but tried to add weights.
+		// Point them at the rename.
 		result.AddError(&ValidationError{
 			Field:   "image",
-			Message: "image is required when weights are configured",
+			Message: "weights require 'model', not 'image' — rename 'image' to 'model'",
+		})
+	case !modelSet:
+		result.AddError(&ValidationError{
+			Field:   "model",
+			Message: "weights require 'model' in cog.yaml — rename 'image' to 'model'",
 		})
 	}
 

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -9,13 +9,13 @@ import (
 func TestValidateConfigFile(t *testing.T) {
 	cfg := &configFile{
 		Build: &buildFile{
-			GPU:           ptr(true),
-			PythonVersion: ptr("3.10"),
+			GPU:           new(true),
+			PythonVersion: new("3.10"),
 			PythonPackages: []string{
 				"tensorflow==2.12.0",
 				"foo==1.0.0",
 			},
-			CUDA: ptr("11.8"),
+			CUDA: new("11.8"),
 		},
 	}
 	result := ValidateConfigFile(cfg)
@@ -25,12 +25,12 @@ func TestValidateConfigFile(t *testing.T) {
 func TestValidateConfigFileSuccess(t *testing.T) {
 	cfg := &configFile{
 		Build: &buildFile{
-			GPU: ptr(true),
+			GPU: new(true),
 			SystemPackages: []string{
 				"libgl1",
 				"libglib2.0-0",
 			},
-			PythonVersion: ptr("3.10"),
+			PythonVersion: new("3.10"),
 			PythonPackages: []string{
 				"torch==1.8.1",
 			},
@@ -44,12 +44,12 @@ func TestValidateConfigFileSuccess(t *testing.T) {
 func TestValidateConfigFilePythonVersionNumerical(t *testing.T) {
 	cfg := &configFile{
 		Build: &buildFile{
-			GPU: ptr(true),
+			GPU: new(true),
 			SystemPackages: []string{
 				"libgl1",
 				"libglib2.0-0",
 			},
-			PythonVersion: ptr("3.10"),
+			PythonVersion: new("3.10"),
 			PythonPackages: []string{
 				"torch==1.8.1",
 			},
@@ -63,8 +63,8 @@ func TestValidateConfigFilePythonVersionNumerical(t *testing.T) {
 func TestValidateConfigFileNullListsAllowed(t *testing.T) {
 	cfg := &configFile{
 		Build: &buildFile{
-			GPU:            ptr(true),
-			PythonVersion:  ptr("3.10"),
+			GPU:            new(true),
+			PythonVersion:  new("3.10"),
 			SystemPackages: nil,
 			PythonPackages: nil,
 			Run:            nil,
@@ -79,16 +79,16 @@ func TestValidateConfigFilePredictFormat(t *testing.T) {
 	// Valid predict format
 	cfg := &configFile{
 		Build: &buildFile{
-			PythonVersion: ptr("3.10"),
+			PythonVersion: new("3.10"),
 		},
-		Predict: ptr("predict.py:Predictor"),
+		Predict: new("predict.py:Predictor"),
 	}
 
 	result := ValidateConfigFile(cfg)
 	require.False(t, result.HasErrors(), "expected no errors, got: %v", result.Errors)
 
 	// Invalid predict format
-	cfg.Predict = ptr("invalid_format")
+	cfg.Predict = new("invalid_format")
 	result = ValidateConfigFile(cfg)
 	require.True(t, result.HasErrors())
 	require.Contains(t, result.Err().Error(), "predict.py:Predictor")
@@ -97,16 +97,16 @@ func TestValidateConfigFilePredictFormat(t *testing.T) {
 func TestValidateConfigFileConcurrencyType(t *testing.T) {
 	cfg := &configFile{
 		Build: &buildFile{
-			GPU:           ptr(true),
-			CUDA:          ptr("11.8"),
-			PythonVersion: ptr("3.11"),
+			GPU:           new(true),
+			CUDA:          new("11.8"),
+			PythonVersion: new("3.11"),
 			PythonPackages: []string{
 				"torch==2.0.1",
 			},
 		},
-		Predict: ptr("predict.py:Predictor"),
+		Predict: new("predict.py:Predictor"),
 		Concurrency: &concurrencyFile{
-			Max: ptr(5),
+			Max: new(5),
 		},
 	}
 
@@ -117,7 +117,7 @@ func TestValidateConfigFileConcurrencyType(t *testing.T) {
 func TestValidateConfigFileDeprecatedPythonPackages(t *testing.T) {
 	cfg := &configFile{
 		Build: &buildFile{
-			PythonVersion: ptr("3.10"),
+			PythonVersion: new("3.10"),
 			PythonPackages: []string{
 				"torch==1.8.1",
 			},
@@ -133,7 +133,7 @@ func TestValidateConfigFileDeprecatedPythonPackages(t *testing.T) {
 func TestValidateConfigFileDeprecatedPreInstall(t *testing.T) {
 	cfg := &configFile{
 		Build: &buildFile{
-			PythonVersion: ptr("3.10"),
+			PythonVersion: new("3.10"),
 			PreInstall: []string{
 				"echo hello",
 			},
@@ -149,7 +149,7 @@ func TestValidateConfigFileDeprecatedPreInstall(t *testing.T) {
 func TestValidateConfigFileMissingPythonVersion(t *testing.T) {
 	cfg := &configFile{
 		Build: &buildFile{
-			GPU: ptr(true),
+			GPU: new(true),
 		},
 	}
 
@@ -177,17 +177,18 @@ func TestValidateConfigFileNilBuildSkipsPythonVersionCheck(t *testing.T) {
 }
 
 func TestValidateWeights(t *testing.T) {
-	image := ptr("registry.example.com/acme/my-model")
+	model := new("registry.example.com/acme/my-model")
 
 	tests := []struct {
 		name    string
 		image   *string
+		model   *string
 		weights []weightFile
 		wantErr string // empty means expect no error
 	}{
 		{
 			name:  "valid with two weights",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/base"}}}},
 				{Name: "lora", Target: "/src/lora", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/lora"}}}},
@@ -195,7 +196,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "valid with source",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model", Exclude: []string{"*.onnx"}}}}},
 			},
@@ -206,7 +207,7 @@ func TestValidateWeights(t *testing.T) {
 			// form must pass the same checks as the single-source
 			// case.
 			name:  "valid with multiple sources",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "merged", Target: "/src/weights/merged", Source: WeightSourceList{Items: []WeightSourceConfig{
 					{URI: "hf://acme/base", Include: []string{"*.safetensors"}},
@@ -218,7 +219,7 @@ func TestValidateWeights(t *testing.T) {
 			// A bad pattern in any source surfaces with that
 			// source's index, not the weight's.
 			name:  "invalid pattern in second source",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "merged", Target: "/src/w", Source: WeightSourceList{Items: []WeightSourceConfig{
 					{URI: "hf://acme/base"},
@@ -229,20 +230,28 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:    "missing source",
-			image:   image,
+			model:   model,
 			weights: []weightFile{{Name: "base", Target: "/src/weights"}},
 			wantErr: "source is required",
 		},
 		{
-			name: "weights without image",
+			name: "weights without model",
 			weights: []weightFile{
 				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model"}}}},
 			},
-			wantErr: "image is required when weights are configured",
+			wantErr: "weights require 'model' in cog.yaml",
+		},
+		{
+			name:  "weights with image instead of model",
+			image: new("registry.example.com/acme/my-model"),
+			weights: []weightFile{
+				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model"}}}},
+			},
+			wantErr: "weights require 'model', not 'image' — rename 'image' to 'model'",
 		},
 		{
 			name:  "missing name",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model"}}}},
 			},
@@ -250,7 +259,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "uppercase name",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "MyModel", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model"}}}},
 			},
@@ -258,7 +267,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "name with spaces",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "my model", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model"}}}},
 			},
@@ -266,7 +275,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "name starting with hyphen",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "-base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model"}}}},
 			},
@@ -274,14 +283,14 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "valid name with separators",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "z-image.turbo_v1", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model"}}}},
 			},
 		},
 		{
 			name:  "duplicate name",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model"}}}},
 				{Name: "base", Target: "/src/other", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model"}}}},
@@ -290,7 +299,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "missing target",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "base", Target: "", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model"}}}},
 			},
@@ -298,7 +307,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "relative target",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "base", Target: "src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model"}}}},
 			},
@@ -306,7 +315,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "duplicate target",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model"}}}},
 				{Name: "lora", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model"}}}},
@@ -315,7 +324,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "overlapping targets parent then child",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model"}}}},
 				{Name: "lora", Target: "/src/weights/lora", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/lora"}}}},
@@ -324,7 +333,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "overlapping targets child then parent",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "lora", Target: "/src/weights/lora", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/lora"}}}},
 				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/model"}}}},
@@ -333,7 +342,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "disjoint targets no false positive",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/base"}}}},
 				{Name: "lora", Target: "/src/weights2", Source: WeightSourceList{Items: []WeightSourceConfig{{URI: "hf://acme/lora"}}}},
@@ -341,7 +350,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "valid include and exclude patterns",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{
 					URI:     "hf://acme/model",
@@ -352,7 +361,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "empty string in include pattern",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{
 					URI:     "hf://acme/model",
@@ -363,7 +372,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "empty string in exclude pattern",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{
 					URI:     "hf://acme/model",
@@ -374,7 +383,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "negation pattern in include",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{
 					URI:     "hf://acme/model",
@@ -385,7 +394,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "negation pattern in exclude",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{
 					URI:     "hf://acme/model",
@@ -396,7 +405,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "whitespace-only pattern rejected after trim",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{
 					URI:     "hf://acme/model",
@@ -407,7 +416,7 @@ func TestValidateWeights(t *testing.T) {
 		},
 		{
 			name:  "backslash in pattern rejected",
-			image: image,
+			model: model,
 			weights: []weightFile{
 				{Name: "base", Target: "/src/weights", Source: WeightSourceList{Items: []WeightSourceConfig{{
 					URI:     "hf://acme/model",
@@ -421,8 +430,9 @@ func TestValidateWeights(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &configFile{
-				Build:   &buildFile{PythonVersion: ptr("3.12")},
+				Build:   &buildFile{PythonVersion: new("3.12")},
 				Image:   tt.image,
+				Model:   tt.model,
 				Weights: tt.weights,
 			}
 			result := ValidateConfigFile(cfg)
@@ -436,5 +446,73 @@ func TestValidateWeights(t *testing.T) {
 	}
 }
 
-// ptr returns a pointer to the given value.
-func ptr[T any](v T) *T { return &v }
+func TestValidateModel(t *testing.T) {
+	tests := []struct {
+		name    string
+		image   *string
+		model   *string
+		wantErr string // empty means expect no error
+	}{
+		{
+			name:  "valid bare repo with registry",
+			model: new("registry.example.com/acme/my-model"),
+		},
+		{
+			name:  "valid bare repo without registry",
+			model: new("acme/my-model"),
+		},
+		{
+			name:  "valid single-segment repo",
+			model: new("my-model"),
+		},
+		{
+			name:  "valid host:port repo",
+			model: new("localhost:5000/acme/my-model"),
+		},
+		{
+			name:    "model with tag rejected",
+			model:   new("registry.example.com/acme/my-model:v1"),
+			wantErr: "must be a bare repository",
+		},
+		{
+			name:    "model with digest rejected",
+			model:   new("registry.example.com/acme/my-model@sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"),
+			wantErr: "must be a bare repository",
+		},
+		{
+			name:    "model and image both set",
+			model:   new("registry.example.com/acme/my-model"),
+			image:   new("registry.example.com/acme/my-image"),
+			wantErr: "'model' and 'image' cannot both be set",
+		},
+		{
+			name:    "model with invalid characters",
+			model:   new("Registry.Example.Com/ACME/Model"),
+			wantErr: "invalid repository",
+		},
+		{
+			name: "no model and no image is fine",
+		},
+		{
+			name:  "image only is fine",
+			image: new("registry.example.com/acme/my-image"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &configFile{
+				Build: &buildFile{PythonVersion: new("3.12")},
+				Image: tt.image,
+				Model: tt.model,
+			}
+			result := ValidateConfigFile(cfg)
+			if tt.wantErr == "" {
+				require.False(t, result.HasErrors(), "expected no errors, got: %v", result.Errors)
+			} else {
+				require.True(t, result.HasErrors())
+				require.Contains(t, result.Err().Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/docker/command/command.go
+++ b/pkg/docker/command/command.go
@@ -14,6 +14,14 @@ type Command interface {
 	// When force is true, it will always attempt to pull the image.
 	Pull(ctx context.Context, ref string, force bool) (*image.InspectResponse, error)
 	Push(ctx context.Context, ref string) error
+	// Tag assigns target as an additional local tag for the image
+	// referenced by source. source accepts anything `docker tag`
+	// accepts on its source side: an existing tag, a digest reference,
+	// or a raw image ID (with or without the sha256: prefix).
+	//
+	// Returns a *command.NotFoundError when source does not resolve
+	// to an image in the local daemon.
+	Tag(ctx context.Context, source, target string) error
 	RemoveImage(ctx context.Context, ref string) error
 	LoadUserInformation(ctx context.Context, registryHost string) (*UserInfo, error)
 	Inspect(ctx context.Context, ref string) (*image.InspectResponse, error)

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -260,6 +260,17 @@ func (c *apiClient) ImageSave(ctx context.Context, imageRef string) (io.ReadClos
 	return c.client.ImageSave(ctx, []string{imageRef})
 }
 
+func (c *apiClient) Tag(ctx context.Context, source, target string) error {
+	console.Debugf("=== APIClient.Tag %s -> %s", source, target)
+	if err := c.client.ImageTag(ctx, source, target); err != nil {
+		if errdefs.IsNotFound(err) {
+			return &command.NotFoundError{Ref: source, Object: "image"}
+		}
+		return fmt.Errorf("tag %q as %q: %w", source, target, err)
+	}
+	return nil
+}
+
 // TODO[md]: this doesn't need to be on the interface, move to auth handler
 func (c *apiClient) LoadUserInformation(ctx context.Context, registryHost string) (*command.UserInfo, error) {
 	console.Debugf("=== APIClient.LoadUserInformation %s", registryHost)

--- a/pkg/docker/docker_client_test.go
+++ b/pkg/docker/docker_client_test.go
@@ -112,6 +112,61 @@ func TestDockerClient(t *testing.T) {
 		})
 	})
 
+	t.Run("Tag", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("tag existing image", func(t *testing.T) {
+			t.Parallel()
+
+			source := dockertest.NewRef(t)
+			dockerHelper.ImageFixture(t, "alpine", source.String())
+
+			target := dockertest.NewRef(t).String()
+			t.Cleanup(func() {
+				_ = dockerClient.RemoveImage(t.Context(), target)
+			})
+
+			err := dockerClient.Tag(t.Context(), source.String(), target)
+			require.NoError(t, err, "Tag should succeed for existing image")
+
+			// Both refs should now resolve to the same image ID.
+			sourceInspect := dockerHelper.InspectImage(t, source.String())
+			targetInspect := dockerHelper.InspectImage(t, target)
+			assert.Equal(t, sourceInspect.ID, targetInspect.ID,
+				"source and target should resolve to the same image")
+		})
+
+		t.Run("tag by image ID", func(t *testing.T) {
+			t.Parallel()
+
+			source := dockertest.NewRef(t)
+			dockerHelper.ImageFixture(t, "alpine", source.String())
+			sourceInspect := dockerHelper.InspectImage(t, source.String())
+
+			target := dockertest.NewRef(t).String()
+			t.Cleanup(func() {
+				_ = dockerClient.RemoveImage(t.Context(), target)
+			})
+
+			err := dockerClient.Tag(t.Context(), sourceInspect.ID, target)
+			require.NoError(t, err, "Tag should accept an image ID as source")
+
+			targetInspect := dockerHelper.InspectImage(t, target)
+			assert.Equal(t, sourceInspect.ID, targetInspect.ID)
+		})
+
+		t.Run("missing source", func(t *testing.T) {
+			t.Parallel()
+
+			missing := "not-a-real-image:nope"
+			target := dockertest.NewRef(t).String()
+
+			err := dockerClient.Tag(t.Context(), missing, target)
+			require.Error(t, err)
+			assertNotFoundError(t, err, missing, "image")
+		})
+	})
+
 	t.Run("ContainerStop", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/docker/dockertest/command_mocks.go
+++ b/pkg/docker/dockertest/command_mocks.go
@@ -351,80 +351,12 @@ func (_c *MockCommand2_ImageBuild_Call) Run(run func(ctx context.Context, option
 	return _c
 }
 
-func (_c *MockCommand2_ImageBuild_Call) Return(imageID string, err error) *MockCommand2_ImageBuild_Call {
-	_c.Call.Return(imageID, err)
+func (_c *MockCommand2_ImageBuild_Call) Return(s string, err error) *MockCommand2_ImageBuild_Call {
+	_c.Call.Return(s, err)
 	return _c
 }
 
 func (_c *MockCommand2_ImageBuild_Call) RunAndReturn(run func(ctx context.Context, options command.ImageBuildOptions) (string, error)) *MockCommand2_ImageBuild_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ImageSave provides a mock function for the type MockCommand2
-func (_mock *MockCommand2) ImageSave(ctx context.Context, imageRef string) (io.ReadCloser, error) {
-	ret := _mock.Called(ctx, imageRef)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ImageSave")
-	}
-
-	var r0 io.ReadCloser
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (io.ReadCloser, error)); ok {
-		return returnFunc(ctx, imageRef)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) io.ReadCloser); ok {
-		r0 = returnFunc(ctx, imageRef)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(io.ReadCloser)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, imageRef)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockCommand2_ImageSave_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ImageSave'
-type MockCommand2_ImageSave_Call struct {
-	*mock.Call
-}
-
-// ImageSave is a helper method to define mock.On call
-//   - ctx context.Context
-//   - imageRef string
-func (_e *MockCommand2_Expecter) ImageSave(ctx interface{}, imageRef interface{}) *MockCommand2_ImageSave_Call {
-	return &MockCommand2_ImageSave_Call{Call: _e.mock.On("ImageSave", ctx, imageRef)}
-}
-
-func (_c *MockCommand2_ImageSave_Call) Run(run func(ctx context.Context, imageRef string)) *MockCommand2_ImageSave_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockCommand2_ImageSave_Call) Return(rc io.ReadCloser, err error) *MockCommand2_ImageSave_Call {
-	_c.Call.Return(rc, err)
-	return _c
-}
-
-func (_c *MockCommand2_ImageSave_Call) RunAndReturn(run func(ctx context.Context, imageRef string) (io.ReadCloser, error)) *MockCommand2_ImageSave_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -491,6 +423,74 @@ func (_c *MockCommand2_ImageExists_Call) Return(b bool, err error) *MockCommand2
 }
 
 func (_c *MockCommand2_ImageExists_Call) RunAndReturn(run func(ctx context.Context, ref string) (bool, error)) *MockCommand2_ImageExists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ImageSave provides a mock function for the type MockCommand2
+func (_mock *MockCommand2) ImageSave(ctx context.Context, imageRef string) (io.ReadCloser, error) {
+	ret := _mock.Called(ctx, imageRef)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ImageSave")
+	}
+
+	var r0 io.ReadCloser
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (io.ReadCloser, error)); ok {
+		return returnFunc(ctx, imageRef)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) io.ReadCloser); ok {
+		r0 = returnFunc(ctx, imageRef)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(io.ReadCloser)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, imageRef)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockCommand2_ImageSave_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ImageSave'
+type MockCommand2_ImageSave_Call struct {
+	*mock.Call
+}
+
+// ImageSave is a helper method to define mock.On call
+//   - ctx context.Context
+//   - imageRef string
+func (_e *MockCommand2_Expecter) ImageSave(ctx interface{}, imageRef interface{}) *MockCommand2_ImageSave_Call {
+	return &MockCommand2_ImageSave_Call{Call: _e.mock.On("ImageSave", ctx, imageRef)}
+}
+
+func (_c *MockCommand2_ImageSave_Call) Run(run func(ctx context.Context, imageRef string)) *MockCommand2_ImageSave_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockCommand2_ImageSave_Call) Return(readCloser io.ReadCloser, err error) *MockCommand2_ImageSave_Call {
+	_c.Call.Return(readCloser, err)
+	return _c
+}
+
+func (_c *MockCommand2_ImageSave_Call) RunAndReturn(run func(ctx context.Context, imageRef string) (io.ReadCloser, error)) *MockCommand2_ImageSave_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -872,6 +872,69 @@ func (_c *MockCommand2_Run_Call) Return(err error) *MockCommand2_Run_Call {
 }
 
 func (_c *MockCommand2_Run_Call) RunAndReturn(run func(ctx context.Context, options command.RunOptions) error) *MockCommand2_Run_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Tag provides a mock function for the type MockCommand2
+func (_mock *MockCommand2) Tag(ctx context.Context, source string, target string) error {
+	ret := _mock.Called(ctx, source, target)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Tag")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = returnFunc(ctx, source, target)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockCommand2_Tag_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Tag'
+type MockCommand2_Tag_Call struct {
+	*mock.Call
+}
+
+// Tag is a helper method to define mock.On call
+//   - ctx context.Context
+//   - source string
+//   - target string
+func (_e *MockCommand2_Expecter) Tag(ctx interface{}, source interface{}, target interface{}) *MockCommand2_Tag_Call {
+	return &MockCommand2_Tag_Call{Call: _e.mock.On("Tag", ctx, source, target)}
+}
+
+func (_c *MockCommand2_Tag_Call) Run(run func(ctx context.Context, source string, target string)) *MockCommand2_Tag_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockCommand2_Tag_Call) Return(err error) *MockCommand2_Tag_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockCommand2_Tag_Call) RunAndReturn(run func(ctx context.Context, source string, target string) error) *MockCommand2_Tag_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/docker/dockertest/mock_command.go
+++ b/pkg/docker/dockertest/mock_command.go
@@ -32,6 +32,10 @@ func (c *MockCommand) Push(ctx context.Context, image string) error {
 	return PushError
 }
 
+func (c *MockCommand) Tag(ctx context.Context, source, target string) error {
+	return nil
+}
+
 func (c *MockCommand) LoadUserInformation(ctx context.Context, registryHost string) (*command.UserInfo, error) {
 	userInfo := command.UserInfo{
 		Token:    "test-token",

--- a/pkg/model/artifact_image.go
+++ b/pkg/model/artifact_image.go
@@ -122,6 +122,19 @@ func NewImageArtifact(name string, desc v1.Descriptor, reference string) *ImageA
 	}
 }
 
+// WithDigest returns a copy of a with Reference rewritten to
+// "{repo}@{digest}", Digest set to the descriptor's digest, and
+// descriptor populated from desc. Used by the push path to pin an
+// artifact to the digest the registry assigned after the manifest
+// went over the wire.
+func (a *ImageArtifact) WithDigest(repo string, desc v1.Descriptor) *ImageArtifact {
+	out := *a
+	out.Reference = repo + "@" + desc.Digest.String()
+	out.Digest = desc.Digest.String()
+	out.descriptor = desc
+	return &out
+}
+
 // Type returns ArtifactTypeImage.
 func (a *ImageArtifact) Type() ArtifactType { return ArtifactTypeImage }
 

--- a/pkg/model/artifact_image.go
+++ b/pkg/model/artifact_image.go
@@ -219,6 +219,7 @@ func (a *ImageArtifact) ToModel() (*Model, error) {
 	}
 
 	return &Model{
+		Format:     FormatImage,
 		Image:      a,
 		Config:     cfg,
 		Schema:     schema,

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -11,8 +11,42 @@ import (
 	"github.com/replicate/cog/pkg/weights/lockfile"
 )
 
+// Format identifies the output format produced for a Model.
+//
+// On Build, it is derived from the resolved configuration (cog.yaml plus
+// any COG_MODEL* env var overrides) — a model ref resolving to a
+// registry/repo selects FormatBundle even when there are no managed
+// weights. On load (Inspect/Pull), it is derived from the underlying
+// manifest shape: an OCI image index is FormatBundle, anything else is
+// FormatImage.
+type Format int
+
+const (
+	// FormatImage is the legacy single Docker image output.
+	FormatImage Format = iota + 1
+	// FormatBundle is an OCI image index containing an image manifest
+	// and zero or more weight artifact manifests.
+	FormatBundle
+)
+
+// String returns the canonical name for the format.
+func (f Format) String() string {
+	switch f {
+	case FormatImage:
+		return "image"
+	case FormatBundle:
+		return "bundle"
+	default:
+		return "unknown"
+	}
+}
+
 // Model represents a Cog model extracted from an image.
 type Model struct {
+	// Format is the output format for this model. FormatImage is the
+	// legacy single-image output; FormatBundle is the OCI index output.
+	Format Format
+
 	Image      *ImageArtifact // Underlying OCI image
 	Config     *config.Config // Parsed cog.yaml
 	Schema     *openapi3.T    // OpenAPI schema
@@ -94,9 +128,13 @@ func (m *Model) ImageRef() string {
 	return m.Image.Reference
 }
 
-// IsBundle returns true if this model has managed weights.
+// IsBundle returns true if this model uses the OCI index output format.
+//
+// A FormatBundle model may have zero weights — in that case the bundle
+// is an OCI index containing only the image manifest. This is the
+// forward-compatible shape for all models migrating off FormatImage.
 func (m *Model) IsBundle() bool {
-	return len(m.Weights) > 0
+	return m.Format == FormatBundle
 }
 
 // GetImageArtifact returns the first ImageArtifact from the artifacts collection,

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -47,6 +47,18 @@ type Model struct {
 	// legacy single-image output; FormatBundle is the OCI index output.
 	Format Format
 
+	// Ref is the canonical model reference for this model: registry,
+	// repo, and either a tag or a digest. Set by Resolver.Build from
+	// the resolved cog.yaml + COG_MODEL* env vars; consumed by
+	// Resolver.Push to decide where to push.
+	//
+	// Resolver.Push does not mutate the input Model; the digest-pinned
+	// post-push Ref lives on the returned Model.
+	//
+	// Nil for FormatImage models loaded from the legacy `image:`
+	// field, which have no model reference to resolve.
+	Ref *ResolvedRef
+
 	Image      *ImageArtifact // Underlying OCI image
 	Config     *config.Config // Parsed cog.yaml
 	Schema     *openapi3.T    // OpenAPI schema
@@ -54,6 +66,16 @@ type Model struct {
 
 	// Artifacts is the collection of all artifacts produced by building this model.
 	// Populated by Resolver.Build(). Contains ImageArtifact instances only.
+	//
+	// Invariant: when both Image and Artifacts are populated by the
+	// build path, the *ImageArtifact in Image is the same instance as
+	// the first ImageArtifact in Artifacts. Push preserves this by
+	// rebuilding both with the enriched copy.
+	//
+	// Models produced by Inspect/Pull leave Artifacts nil because no
+	// build ran; ImageArtifact.ToModel only sets Image. Code that
+	// relies on the invariant must therefore also tolerate a nil
+	// Artifacts slice.
 	Artifacts []Artifact
 
 	// Weights are the model's managed weights, loaded from the lockfile
@@ -76,6 +98,17 @@ type Weight struct {
 	Size      int64
 	// SizeCompressed is the total compressed (over-the-wire) size.
 	SizeCompressed int64
+
+	// Reference is the fully-qualified registry reference for this
+	// weight manifest, in digest form ("registry/repo@sha256:..."),
+	// populated after a successful push verifies the manifest exists.
+	// Empty until then.
+	Reference string
+
+	// Tag is the registry tag the weight manifest was pushed under,
+	// of the form "cog-weight.{name}.{short-digest}". Populated
+	// alongside Reference after verification. Empty until then.
+	Tag string
 }
 
 // WeightFromLockEntry creates a Weight from a lockfile entry.

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -230,13 +230,14 @@ func TestModel_ArtifactsByType(t *testing.T) {
 }
 
 func TestModel_IsBundle(t *testing.T) {
-	t.Run("returns false with no artifacts", func(t *testing.T) {
+	t.Run("returns false for zero-value model", func(t *testing.T) {
 		m := &Model{}
 		require.False(t, m.IsBundle())
 	})
 
-	t.Run("returns false with only image artifact", func(t *testing.T) {
+	t.Run("returns false for FormatImage", func(t *testing.T) {
 		m := &Model{
+			Format: FormatImage,
 			Artifacts: []Artifact{
 				&ImageArtifact{name: "model", Reference: "r8.im/user/model:latest"},
 			},
@@ -244,8 +245,9 @@ func TestModel_IsBundle(t *testing.T) {
 		require.False(t, m.IsBundle())
 	})
 
-	t.Run("returns true with weights", func(t *testing.T) {
+	t.Run("returns true for FormatBundle with weights", func(t *testing.T) {
 		m := &Model{
+			Format: FormatBundle,
 			Artifacts: []Artifact{
 				&ImageArtifact{name: "model", Reference: "r8.im/user/model:latest"},
 			},
@@ -255,4 +257,46 @@ func TestModel_IsBundle(t *testing.T) {
 		}
 		require.True(t, m.IsBundle())
 	})
+
+	t.Run("returns true for FormatBundle with no weights", func(t *testing.T) {
+		// FormatBundle is now driven by Format, not by weight count — a
+		// model with model: in cog.yaml but no managed weights still
+		// produces a bundle (an OCI index containing only the image).
+		m := &Model{
+			Format: FormatBundle,
+			Artifacts: []Artifact{
+				&ImageArtifact{name: "model", Reference: "r8.im/user/model:latest"},
+			},
+		}
+		require.True(t, m.IsBundle())
+	})
+
+	t.Run("ignores weights when Format is FormatImage", func(t *testing.T) {
+		// Format is the single source of truth. Weights alone do not
+		// promote a model to FormatBundle.
+		m := &Model{
+			Format: FormatImage,
+			Weights: []Weight{
+				{Name: "w1", Target: "/src/weights/w1", SetDigest: "sha256:abc123"},
+			},
+		}
+		require.False(t, m.IsBundle())
+	})
+}
+
+func TestFormat_String(t *testing.T) {
+	tests := []struct {
+		format Format
+		want   string
+	}{
+		{FormatImage, "image"},
+		{FormatBundle, "bundle"},
+		{Format(0), "unknown"},
+		{Format(99), "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.format.String())
+		})
+	}
 }

--- a/pkg/model/modeltest/env.go
+++ b/pkg/model/modeltest/env.go
@@ -1,0 +1,22 @@
+// Package modeltest provides shared test helpers for model-ref code.
+package modeltest
+
+import (
+	"testing"
+
+	"github.com/replicate/cog/pkg/model"
+)
+
+// ClearEnv isolates the test from the developer's shell by blanking
+// every COG_MODEL* env var. Without this, a shell-exported COG_MODEL_REPO
+// (or similar) would leak into the test process and silently change what
+// ResolveModelRef sees. t.Setenv handles restoration at cleanup;
+// ResolveModelRef treats "" as unset, so blanking is equivalent to
+// unsetting.
+func ClearEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(model.EnvModel, "")
+	t.Setenv(model.EnvModelRegistry, "")
+	t.Setenv(model.EnvModelRepo, "")
+	t.Setenv(model.EnvModelTag, "")
+}

--- a/pkg/model/pusher.go
+++ b/pkg/model/pusher.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/replicate/cog/pkg/docker/command"
 	"github.com/replicate/cog/pkg/registry"
+	"github.com/replicate/cog/pkg/util/console"
 )
 
 // PushOptions configures push behavior.
@@ -30,10 +31,16 @@ type PushOptions struct {
 }
 
 // BundlePusher pushes an OCI Image Index containing a model image + its
-// weight manifests. It pushes the image, HEAD-checks each weight
-// manifest (which was pushed by `cog weights import`), then assembles
-// the index from the descriptors.
+// weight manifests. It pushes the image under a cog-image.* tag,
+// HEAD-checks each weight manifest (which was pushed by `cog weights
+// import`), then assembles and pushes the index under the model tag.
+//
+// Push mutates the local Docker daemon: it adds a "{repo}:cog-image.*"
+// tag to the existing image before pushing and removes that tag on
+// successful return. Callers reusing BundlePusher outside the
+// build-then-push flow should be aware of this side effect.
 type BundlePusher struct {
+	docker      command.Command
 	imagePusher *ImagePusher
 	registry    registry.Client
 }
@@ -41,30 +48,90 @@ type BundlePusher struct {
 // NewBundlePusher creates a BundlePusher.
 func NewBundlePusher(docker command.Command, reg registry.Client) *BundlePusher {
 	return &BundlePusher{
+		docker:      docker,
 		imagePusher: newImagePusher(docker, reg),
 		registry:    reg,
 	}
 }
 
-// Push pushes the model as an OCI Index. Weight manifests are
-// verified via HEAD *before* the image is pushed — if any are missing,
-// the push fails fast with a message to re-run import, without leaving
-// an orphaned image in the registry. The image is then pushed via
-// ImagePusher, followed by a HEAD to get its descriptor, and finally
-// the OCI Index is assembled and pushed.
-func (p *BundlePusher) Push(ctx context.Context, m *Model, opts PushOptions) error {
+// Push pushes the model as an OCI Index and returns an enriched copy
+// of the Model with all registry references populated.
+//
+// Algorithm:
+//
+//  1. Verify every weight manifest exists at repo@digest *before*
+//     anything else; missing weights fail fast so we don't leave an
+//     orphan image in the registry.
+//  2. Re-tag the locally-built image to "{repo}:cog-image.{tag}" so
+//     the image manifest lands at a stable, namespaced tag in the
+//     registry, independent of whatever tag the model index will
+//     carry. Push from that tag.
+//  3. HEAD the image to capture its registry-side digest.
+//  4. Build and push the OCI index at the model ref; capture its
+//     descriptor locally from the index bytes (content-addressed —
+//     no second registry round-trip needed).
+//  5. Return a Model with Ref pinned to the index digest, the image
+//     artifact's Reference rewritten to repo@digest, and each weight
+//     enriched with its registry reference and tag.
+//
+// The caller's Model.Ref drives the destination. Models loaded by
+// Inspect/Pull have a Format derived from manifest shape and leave
+// Ref nil — those are not push-ready; only models produced by
+// Resolver.Build carry the resolved Ref this method needs.
+func (p *BundlePusher) Push(ctx context.Context, m *Model, opts PushOptions) (*Model, error) {
 	imgArtifact := m.GetImageArtifact()
 	if imgArtifact == nil {
-		return fmt.Errorf("no image artifact in model")
+		return nil, fmt.Errorf("no image artifact in model")
+	}
+	if m.Ref == nil {
+		return nil, fmt.Errorf("bundle push requires Model.Ref to be set")
+	}
+	if m.Ref.Tag == "" {
+		// ResolveModelRef pairs Digest with empty Tag; a digest-pinned
+		// ref describes an already-published model and can't be a push
+		// destination.
+		return nil, fmt.Errorf("cannot push to digest-pinned ref %q: model push requires a tag", m.Ref.String())
 	}
 
-	repo := repoFromReference(imgArtifact.Reference)
+	repo := m.Ref.Repository()
 
 	// Verify weight manifests exist before pushing the image.
 	weightDescs, err := p.verifyWeights(ctx, repo, m.Weights)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	// Pair the image tag with the model tag (e.g. v2 → cog-image.v2,
+	// 20260512T...Z → cog-image.20260512T...Z) so the two manifests
+	// are visibly related when browsing the registry.
+	imageRef := repo + ":" + ImageTag(m.Ref.Tag)
+
+	// Re-tag the locally-built image at the cog-image ref so push
+	// (whether OCI or docker push) targets the right place in the
+	// registry. The build-path tag (imgArtifact.Reference) still
+	// points at the same image, so the deferred RemoveImage just
+	// untags the cog-image alias.
+	//
+	// Skip the tag+cleanup pair when the build already produced an
+	// image at the cog-image ref (e.g. a caller pre-named their
+	// image): removing it would delete the only local tag and the
+	// underlying image with it.
+	if imgArtifact.Reference != imageRef {
+		if err := p.docker.Tag(ctx, imgArtifact.Reference, imageRef); err != nil {
+			return nil, err
+		}
+		defer func() {
+			if err := p.docker.RemoveImage(context.WithoutCancel(ctx), imageRef); err != nil {
+				console.Debugf("removing local cog-image tag %q: %v", imageRef, err)
+			}
+		}()
+	}
+
+	// Wholesale copy preserves the unexported descriptor that a
+	// constructor can't reach; overwrite only the reference.
+	imageCopy := *imgArtifact
+	imageCopy.Reference = imageRef
+	pushedImage := &imageCopy
 
 	var imagePushOpts []ImagePushOption
 	if opts.ImageProgressFn != nil {
@@ -73,14 +140,13 @@ func (p *BundlePusher) Push(ctx context.Context, m *Model, opts PushOptions) err
 	if opts.OnFallback != nil {
 		imagePushOpts = append(imagePushOpts, WithOnFallback(opts.OnFallback))
 	}
-	if err := p.imagePusher.Push(ctx, imgArtifact, imagePushOpts...); err != nil {
-		return fmt.Errorf("push image %q: %w", imgArtifact.Reference, err)
+	if err := p.imagePusher.Push(ctx, pushedImage, imagePushOpts...); err != nil {
+		return nil, fmt.Errorf("push image %q: %w", imageRef, err)
 	}
 
-	// HEAD the pushed image to get its descriptor for the index.
-	imgDesc, err := p.registry.GetDescriptor(ctx, imgArtifact.Reference)
+	imgDesc, err := p.registry.GetDescriptor(ctx, imageRef)
 	if err != nil {
-		return fmt.Errorf("get image descriptor: %w", err)
+		return nil, fmt.Errorf("get image descriptor: %w", err)
 	}
 
 	platform := opts.Platform
@@ -101,15 +167,61 @@ func (p *BundlePusher) Push(ctx context.Context, m *Model, opts PushOptions) err
 
 	idx, err := builder.BuildFromDescriptors()
 	if err != nil {
-		return fmt.Errorf("build OCI index: %w", err)
+		return nil, fmt.Errorf("build OCI index: %w", err)
 	}
 
-	// Overwrites the tag with the index.
-	if err := p.registry.PushIndex(ctx, imgArtifact.Reference, idx); err != nil {
-		return fmt.Errorf("push OCI index: %w", err)
+	if err := p.registry.PushIndex(ctx, m.Ref.String(), idx); err != nil {
+		return nil, fmt.Errorf("push OCI index: %w", err)
 	}
 
-	return nil
+	// The index is content-addressed: its bytes are exactly what the
+	// registry stored, so idx.Digest() returns the registry-side
+	// digest without a HEAD round-trip.
+	indexDigest, err := idx.Digest()
+	if err != nil {
+		return nil, fmt.Errorf("compute index digest: %w", err)
+	}
+
+	return enrichBundleModel(m, repo, imgArtifact, imgDesc, indexDigest.String()), nil
+}
+
+// enrichBundleModel returns a shallow copy of m with Ref pinned to
+// the index digest, the image artifact's Reference rewritten to its
+// repo@digest form, and each weight enriched with its registry
+// reference and tag.
+//
+// imgArtifact is the original artifact returned by GetImageArtifact;
+// it identifies which entry in m.Artifacts to substitute, by pointer
+// identity.
+func enrichBundleModel(
+	m *Model,
+	repo string,
+	imgArtifact *ImageArtifact,
+	imgDesc v1.Descriptor,
+	indexDigest string,
+) *Model {
+	out := *m
+	out.Ref = &ResolvedRef{
+		Registry: m.Ref.Registry,
+		Repo:     m.Ref.Repo,
+		Tag:      m.Ref.Tag,
+		Digest:   indexDigest,
+	}
+
+	enrichedImage := imgArtifact.WithDigest(repo, imgDesc)
+	out.Image, out.Artifacts = replaceImageArtifact(imgArtifact, m.Artifacts, enrichedImage)
+
+	if len(m.Weights) > 0 {
+		weights := make([]Weight, len(m.Weights))
+		for i, w := range m.Weights {
+			w.Reference = repo + "@" + w.Digest
+			w.Tag = WeightTag(w.Name, w.SetDigest)
+			weights[i] = w
+		}
+		out.Weights = weights
+	}
+
+	return &out
 }
 
 // verifyWeights HEAD-checks each weight manifest by digest. Tags are
@@ -157,6 +269,26 @@ func (p *BundlePusher) verifyWeights(
 	}
 
 	return descs, nil
+}
+
+// replaceImageArtifact returns a new Image and Artifacts slice with
+// enriched substituted for old by pointer identity. Callers pass the
+// artifact pointer they actually used (typically the result of
+// Model.GetImageArtifact), so the match doesn't depend on the
+// Model.Image-vs-Artifacts[0] invariant.
+func replaceImageArtifact(old *ImageArtifact, artifacts []Artifact, enriched *ImageArtifact) (*ImageArtifact, []Artifact) {
+	if len(artifacts) == 0 {
+		return enriched, nil
+	}
+	out := make([]Artifact, len(artifacts))
+	for i, a := range artifacts {
+		if ia, ok := a.(*ImageArtifact); ok && ia == old {
+			out[i] = enriched
+			continue
+		}
+		out[i] = a
+	}
+	return enriched, out
 }
 
 // repoFromReference extracts the repository (without tag or digest) from an

--- a/pkg/model/pusher_test.go
+++ b/pkg/model/pusher_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -13,7 +14,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testImageRef = "r8.im/user/model:latest"
+const (
+	testImageRef = "r8.im/user/model:latest"
+	testRepo     = "r8.im/user/model"
+	testModelTag = "20260512T120000Z"
+)
+
+// testCogImageRef and testModelRef are the registry destinations
+// BundlePusher should produce for a Model built from testBundleModel.
+// Derived from ImageTag/ResolvedRef.String so the fixtures track the
+// helpers; tag_test.go covers ImageTag's formatting independently.
+var (
+	testCogImageRef = testRepo + ":" + ImageTag(testModelTag)
+	testModelRef    = testRepo + ":" + testModelTag
+)
 
 // Valid 64-char hex digests for use in test fixtures. v1.NewHash
 // rejects non-hex strings, so the verifyWeights digest-equality check
@@ -23,15 +37,23 @@ const (
 	testW2Digest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
 )
 
-// testBundleModel builds a Model with a fixed image ref and optional weights.
+// testBundleModel builds a Model with a deterministic Ref so tests
+// can assert on exact destination refs. The same *ImageArtifact
+// instance is shared between Model.Image and Model.Artifacts[0] —
+// production builds (see modelFromImage) maintain this invariant
+// and Push relies on it.
 func testBundleModel(weights ...Weight) *Model {
+	img := &ImageArtifact{name: "model", Reference: testImageRef}
 	return &Model{
 		Format: FormatBundle,
-		Image:  &ImageArtifact{Reference: testImageRef},
-		Artifacts: []Artifact{
-			&ImageArtifact{name: "model", Reference: testImageRef},
+		Ref: &ResolvedRef{
+			Registry: "r8.im",
+			Repo:     "user/model",
+			Tag:      testModelTag,
 		},
-		Weights: weights,
+		Image:     img,
+		Artifacts: []Artifact{img},
+		Weights:   weights,
 	}
 }
 
@@ -49,10 +71,46 @@ func TestBundlePusher_Push(t *testing.T) {
 			Artifacts: []Artifact{}, // no image artifact
 		}
 
-		err := pusher.Push(context.Background(), m, PushOptions{})
+		_, err := pusher.Push(context.Background(), m, PushOptions{})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no image artifact")
+	})
+
+	t.Run("returns error when Model.Ref is missing", func(t *testing.T) {
+		docker := &mockDocker{}
+		reg := &mockRegistry{}
+		pusher := NewBundlePusher(docker, reg)
+		m := &Model{
+			Format: FormatBundle,
+			Image:  &ImageArtifact{Reference: testImageRef},
+			Artifacts: []Artifact{
+				&ImageArtifact{name: "model", Reference: testImageRef},
+			},
+			// Ref deliberately nil.
+		}
+
+		_, err := pusher.Push(context.Background(), m, PushOptions{})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Model.Ref")
+	})
+
+	t.Run("returns error when Model.Ref is digest-pinned", func(t *testing.T) {
+		docker := &mockDocker{}
+		reg := &mockRegistry{}
+		pusher := NewBundlePusher(docker, reg)
+		m := testBundleModel()
+		m.Ref = &ResolvedRef{
+			Registry: "r8.im",
+			Repo:     "user/model",
+			Digest:   testW1Digest, // digest-pinned, no Tag
+		}
+
+		_, err := pusher.Push(context.Background(), m, PushOptions{})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "digest-pinned")
 	})
 
 	t.Run("pushes image-only model as single-entry index", func(t *testing.T) {
@@ -83,7 +141,7 @@ func TestBundlePusher_Push(t *testing.T) {
 
 		pusher := NewBundlePusher(docker, reg)
 
-		err := pusher.Push(context.Background(), testBundleModel(), PushOptions{})
+		_, err := pusher.Push(context.Background(), testBundleModel(), PushOptions{})
 		require.NoError(t, err)
 	})
 
@@ -110,6 +168,14 @@ func TestBundlePusher_Push(t *testing.T) {
 				track("docker:push:" + ref)
 				return nil
 			},
+			tagFunc: func(ctx context.Context, source, target string) error {
+				track("docker:tag:" + source + "->" + target)
+				return nil
+			},
+			removeFunc: func(ctx context.Context, ref string) error {
+				track("docker:remove:" + ref)
+				return nil
+			},
 		}
 
 		imgDesc := v1.Descriptor{
@@ -124,33 +190,42 @@ func TestBundlePusher_Push(t *testing.T) {
 			Digest:    v1.Hash{Algorithm: "sha256", Hex: "weightdigest123"},
 		}
 
-		weightRef := "r8.im/user/model@" + w.Digest
+		weightRef := testRepo + "@" + w.Digest
+
+		// Captured from pushIndexFunc; the index descriptor is
+		// derived locally from idx.Digest() so the test asserts
+		// against whatever the production code computes.
+		var pushedIndexDigest string
 
 		reg := &mockRegistry{
 			getDescriptorFunc: func(ctx context.Context, ref string) (v1.Descriptor, error) {
 				track("registry:getDescriptor:" + ref)
-				if ref == weightRef {
+				switch ref {
+				case weightRef:
 					return weightDesc, nil
+				case testCogImageRef:
+					return imgDesc, nil
 				}
-				return imgDesc, nil
+				return v1.Descriptor{}, fmt.Errorf("unexpected descriptor lookup: %s", ref)
 			},
 			pushIndexFunc: func(ctx context.Context, ref string, idx v1.ImageIndex) error {
 				track("registry:pushIndex:" + ref)
 
-				// Verify the index structure
 				idxManifest, err := idx.IndexManifest()
 				require.NoError(t, err)
 				require.Len(t, idxManifest.Manifests, 2) // image + 1 weight
 
-				// First manifest: image with platform
 				require.Equal(t, imgDesc.Digest, idxManifest.Manifests[0].Digest)
 				require.Equal(t, "linux", idxManifest.Manifests[0].Platform.OS)
 				require.Equal(t, "amd64", idxManifest.Manifests[0].Platform.Architecture)
 
-				// Second manifest: weight with annotations
 				require.Equal(t, PlatformUnknown, idxManifest.Manifests[1].Platform.OS)
 				require.NotEmpty(t, idxManifest.Manifests[1].Annotations[AnnotationV1WeightName])
 				require.NotEmpty(t, idxManifest.Manifests[1].Annotations[AnnotationV1WeightSetDigest])
+
+				digest, err := idx.Digest()
+				require.NoError(t, err)
+				pushedIndexDigest = digest.String()
 
 				return nil
 			},
@@ -158,21 +233,91 @@ func TestBundlePusher_Push(t *testing.T) {
 
 		pusher := NewBundlePusher(docker, reg)
 
-		err := pusher.Push(context.Background(), testBundleModel(w), PushOptions{
+		pushed, err := pusher.Push(context.Background(), testBundleModel(w), PushOptions{
 			Platform: &Platform{OS: "linux", Architecture: "amd64"},
 		})
 
 		require.NoError(t, err)
+		require.NotNil(t, pushed)
 
-		// Verify call sequence. Weight verification happens first
-		// (HEAD by digest), then docker push, then image HEAD, then
-		// index push.
-		require.Len(t, callOrder, 4)
-		require.Equal(t, "registry:getDescriptor:"+weightRef, callOrder[0],
-			"weight verification must happen before image push, by digest")
-		require.Equal(t, "docker:push:r8.im/user/model:latest", callOrder[1])
-		require.Equal(t, "registry:getDescriptor:r8.im/user/model:latest", callOrder[2])
-		require.Equal(t, "registry:pushIndex:r8.im/user/model:latest", callOrder[3])
+		// Verify call sequence: weight verified first (HEAD by digest,
+		// before anything mutates the registry), then local re-tag,
+		// then docker push, then image HEAD, then index push, then
+		// the deferred local-tag cleanup. The index descriptor is
+		// computed locally from the v1.ImageIndex bytes — no HEAD.
+		require.Equal(t,
+			[]string{
+				"registry:getDescriptor:" + weightRef,
+				"docker:tag:" + testImageRef + "->" + testCogImageRef,
+				"docker:push:" + testCogImageRef,
+				"registry:getDescriptor:" + testCogImageRef,
+				"registry:pushIndex:" + testModelRef,
+				"docker:remove:" + testCogImageRef,
+			},
+			callOrder,
+		)
+		// Negative: the local image tag must never reach the registry
+		// directly — push and HEAD always target the cog-image tag.
+		require.NotContains(t, callOrder, "docker:push:"+testImageRef)
+		require.NotContains(t, callOrder, "registry:getDescriptor:"+testImageRef)
+		require.NotContains(t, callOrder, "registry:pushIndex:"+testImageRef)
+
+		// Enriched return values.
+		require.NotNil(t, pushed.Ref)
+		require.NotEmpty(t, pushedIndexDigest, "pushIndexFunc should have captured the index digest")
+		require.Equal(t, pushedIndexDigest, pushed.Ref.Digest)
+		require.Equal(t, testModelTag, pushed.Ref.Tag)
+		require.Equal(t, testRepo+"@"+pushedIndexDigest, pushed.Ref.String())
+
+		require.NotNil(t, pushed.Image)
+		require.Equal(t, testRepo+"@"+imgDesc.Digest.String(), pushed.Image.Reference)
+		require.Equal(t, imgDesc.Digest.String(), pushed.Image.Digest)
+
+		require.Len(t, pushed.Weights, 1)
+		require.Equal(t, weightRef, pushed.Weights[0].Reference)
+		require.Equal(t, WeightTag(w.Name, w.SetDigest), pushed.Weights[0].Tag)
+
+		// Invariant: Model.Image and Model.Artifacts[0] are the same
+		// instance after enrichment, matching the production-build
+		// invariant on Model.
+		require.Len(t, pushed.Artifacts, 1)
+		require.Same(t, pushed.Image, pushed.Artifacts[0],
+			"enriched Image and Artifacts[0] should be the same instance")
+	})
+
+	t.Run("skips tag+remove when local image already at cog-image ref", func(t *testing.T) {
+		// Defends against deleting the underlying image when the
+		// build-path tag and the cog-image tag coincide.
+		var tagCalled, removeCalled bool
+		docker := &mockDocker{
+			pushFunc: func(ctx context.Context, ref string) error { return nil },
+			tagFunc: func(ctx context.Context, source, target string) error {
+				tagCalled = true
+				return nil
+			},
+			removeFunc: func(ctx context.Context, ref string) error {
+				removeCalled = true
+				return nil
+			},
+		}
+		reg := &mockRegistry{
+			getDescriptorFunc: func(ctx context.Context, ref string) (v1.Descriptor, error) {
+				return descriptorFromRef(ref), nil
+			},
+			pushIndexFunc: func(ctx context.Context, ref string, idx v1.ImageIndex) error { return nil },
+		}
+
+		m := testBundleModel()
+		// Force the local image to already live at the cog-image ref.
+		img := &ImageArtifact{name: "model", Reference: testCogImageRef}
+		m.Image = img
+		m.Artifacts = []Artifact{img}
+
+		pusher := NewBundlePusher(docker, reg)
+		_, err := pusher.Push(context.Background(), m, PushOptions{})
+		require.NoError(t, err)
+		require.False(t, tagCalled, "Tag should not be called when source == destination")
+		require.False(t, removeCalled, "RemoveImage should not be called when no tag was added")
 	})
 
 	t.Run("uses default platform when not specified", func(t *testing.T) {
@@ -195,7 +340,7 @@ func TestBundlePusher_Push(t *testing.T) {
 
 		pusher := NewBundlePusher(docker, reg)
 
-		err := pusher.Push(context.Background(), testBundleModel(
+		_, err := pusher.Push(context.Background(), testBundleModel(
 			Weight{Name: "w1", Target: "/src/weights/w1", Digest: testW1Digest, SetDigest: "sha256:abc"},
 		), PushOptions{})
 		require.NoError(t, err)
@@ -216,7 +361,7 @@ func TestBundlePusher_Push(t *testing.T) {
 		pusher := NewBundlePusher(docker, reg)
 		w1 := Weight{Name: "w1", Target: "/src/weights/w1", Digest: testW1Digest, SetDigest: "sha256:abc"}
 
-		err := pusher.Push(context.Background(), testBundleModel(w1), PushOptions{})
+		_, err := pusher.Push(context.Background(), testBundleModel(w1), PushOptions{})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "push image")
@@ -236,7 +381,7 @@ func TestBundlePusher_Push(t *testing.T) {
 		pusher := NewBundlePusher(docker, reg)
 		w1 := Weight{Name: "w1", Target: "/src/weights/w1", Digest: testW1Digest, SetDigest: "sha256:abc"}
 
-		err := pusher.Push(context.Background(), testBundleModel(w1), PushOptions{})
+		_, err := pusher.Push(context.Background(), testBundleModel(w1), PushOptions{})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "manifest not found")
@@ -259,7 +404,7 @@ func TestBundlePusher_Push(t *testing.T) {
 		pusher := NewBundlePusher(docker, reg)
 		w1 := Weight{Name: "w1", Target: "/src/weights/w1", Digest: testW1Digest, SetDigest: "sha256:abc"}
 
-		err := pusher.Push(context.Background(), testBundleModel(w1), PushOptions{})
+		_, err := pusher.Push(context.Background(), testBundleModel(w1), PushOptions{})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "w1")
@@ -294,7 +439,7 @@ func TestBundlePusher_Push(t *testing.T) {
 		pusher := NewBundlePusher(docker, reg)
 		w1 := Weight{Name: "w1", Target: "/src/weights/w1", Digest: testW1Digest, SetDigest: "sha256:abc"}
 
-		err := pusher.Push(context.Background(), testBundleModel(w1), PushOptions{})
+		_, err := pusher.Push(context.Background(), testBundleModel(w1), PushOptions{})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "registry returned digest")
@@ -312,7 +457,7 @@ func TestBundlePusher_Push(t *testing.T) {
 		pusher := NewBundlePusher(docker, reg)
 		w1 := Weight{Name: "w1", Target: "/src/weights/w1", SetDigest: "sha256:abc"}
 
-		err := pusher.Push(context.Background(), testBundleModel(w1), PushOptions{})
+		_, err := pusher.Push(context.Background(), testBundleModel(w1), PushOptions{})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing manifest digest")
@@ -335,7 +480,7 @@ func TestBundlePusher_Push(t *testing.T) {
 		pusher := NewBundlePusher(docker, reg)
 		w1 := Weight{Name: "w1", Target: "/src/weights/w1", Digest: testW1Digest, SetDigest: "sha256:abc"}
 
-		err := pusher.Push(context.Background(), testBundleModel(w1), PushOptions{})
+		_, err := pusher.Push(context.Background(), testBundleModel(w1), PushOptions{})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "push OCI index")
@@ -349,7 +494,8 @@ func TestBundlePusher_Push(t *testing.T) {
 		var headCheckCount atomic.Int32
 		reg := &mockRegistry{
 			getDescriptorFunc: func(ctx context.Context, ref string) (v1.Descriptor, error) {
-				if ref != "r8.im/user/model:latest" {
+				// Count weight HEADs only (those are by repo@digest).
+				if strings.Contains(ref, "@") {
 					headCheckCount.Add(1)
 				}
 				return descriptorFromRef(ref), nil
@@ -363,7 +509,7 @@ func TestBundlePusher_Push(t *testing.T) {
 
 		pusher := NewBundlePusher(docker, reg)
 
-		err := pusher.Push(context.Background(), testBundleModel(
+		_, err := pusher.Push(context.Background(), testBundleModel(
 			Weight{Name: "w1", Target: "/src/weights/w1", Digest: testW1Digest, SetDigest: "sha256:set1"},
 			Weight{Name: "w2", Target: "/src/weights/w2", Digest: testW2Digest, SetDigest: "sha256:set2"},
 		), PushOptions{})
@@ -406,20 +552,74 @@ func TestResolver_Push(t *testing.T) {
 				return nil
 			},
 		}
-		reg := &mockRegistry{}
-		resolver := NewResolver(docker, reg)
-
-		m := &Model{
-			Format: FormatImage,
-			Image:  &ImageArtifact{Reference: testImageRef},
-			Artifacts: []Artifact{
-				&ImageArtifact{name: "model", Reference: testImageRef},
+		imgDesc := v1.Descriptor{
+			MediaType: types.OCIManifestSchema1,
+			Size:      1234,
+			Digest:    v1.Hash{Algorithm: "sha256", Hex: "imagedigestformatimage"},
+		}
+		reg := &mockRegistry{
+			getDescriptorFunc: func(ctx context.Context, ref string) (v1.Descriptor, error) {
+				return imgDesc, nil
 			},
 		}
+		resolver := NewResolver(docker, reg)
 
-		err := resolver.Push(context.Background(), m, PushOptions{})
+		// Share the same *ImageArtifact between Model.Image and
+		// Model.Artifacts so the post-push replacement matches
+		// production builds.
+		img := &ImageArtifact{name: "model", Reference: testImageRef}
+		m := &Model{
+			Format:    FormatImage,
+			Image:     img,
+			Artifacts: []Artifact{img},
+		}
+
+		pushed, err := resolver.Push(context.Background(), m, PushOptions{})
 		require.NoError(t, err)
 		require.True(t, dockerPushed, "FormatImage should use docker push")
+		require.NotNil(t, pushed)
+		require.NotNil(t, pushed.Image)
+		require.Equal(t, testRepo+"@"+imgDesc.Digest.String(), pushed.Image.Reference,
+			"FormatImage push should enrich Image.Reference to repo@digest")
+		// Invariant: Image and the first ImageArtifact in Artifacts
+		// are the same instance after enrichment.
+		require.Len(t, pushed.Artifacts, 1)
+		require.Same(t, pushed.Image, pushed.Artifacts[0],
+			"Image and Artifacts[0] should be the same enriched instance")
+	})
+
+	t.Run("FormatImage falls back to unenriched Model when HEAD fails", func(t *testing.T) {
+		// A successful docker push followed by a HEAD failure should
+		// not fail the operation; Push returns the input Model
+		// unchanged so the caller keeps their original references.
+		// Legacy registries that don't support HEAD on tags hit this
+		// path.
+		var dockerPushed bool
+		docker := &mockDocker{
+			pushFunc: func(ctx context.Context, ref string) error {
+				dockerPushed = true
+				return nil
+			},
+		}
+		reg := &mockRegistry{
+			getDescriptorFunc: func(ctx context.Context, ref string) (v1.Descriptor, error) {
+				return v1.Descriptor{}, errors.New("HEAD unsupported")
+			},
+		}
+		resolver := NewResolver(docker, reg)
+
+		img := &ImageArtifact{name: "model", Reference: testImageRef}
+		m := &Model{
+			Format:    FormatImage,
+			Image:     img,
+			Artifacts: []Artifact{img},
+		}
+
+		pushed, err := resolver.Push(context.Background(), m, PushOptions{})
+		require.NoError(t, err)
+		require.True(t, dockerPushed)
+		require.Same(t, m, pushed,
+			"on HEAD failure, Push should return the input Model unchanged")
 	})
 
 	t.Run("FormatBundle with no weights produces a single-entry index", func(t *testing.T) {
@@ -441,7 +641,7 @@ func TestResolver_Push(t *testing.T) {
 		}
 		resolver := NewResolver(docker, reg)
 
-		err := resolver.Push(context.Background(), testBundleModel(), PushOptions{})
+		_, err := resolver.Push(context.Background(), testBundleModel(), PushOptions{})
 		require.NoError(t, err)
 		require.True(t, indexPushed, "FormatBundle should push an OCI index even with no weights")
 	})
@@ -462,7 +662,7 @@ func TestResolver_Push(t *testing.T) {
 		}
 		resolver := NewResolver(docker, reg)
 
-		err := resolver.Push(context.Background(), testBundleModel(
+		_, err := resolver.Push(context.Background(), testBundleModel(
 			Weight{Name: "w1", Target: "/src/weights/w1", Digest: testW1Digest, SetDigest: "sha256:abc"},
 		), PushOptions{})
 		require.NoError(t, err)
@@ -479,7 +679,7 @@ func TestResolver_Push(t *testing.T) {
 			Artifacts: []Artifact{},
 		}
 
-		err := resolver.Push(context.Background(), m, PushOptions{})
+		_, err := resolver.Push(context.Background(), m, PushOptions{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no image artifact")
 	})
@@ -496,7 +696,7 @@ func TestResolver_Push(t *testing.T) {
 			},
 		}
 
-		err := resolver.Push(context.Background(), m, PushOptions{})
+		_, err := resolver.Push(context.Background(), m, PushOptions{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no image artifact")
 	})

--- a/pkg/model/pusher_test.go
+++ b/pkg/model/pusher_test.go
@@ -26,7 +26,8 @@ const (
 // testBundleModel builds a Model with a fixed image ref and optional weights.
 func testBundleModel(weights ...Weight) *Model {
 	return &Model{
-		Image: &ImageArtifact{Reference: testImageRef},
+		Format: FormatBundle,
+		Image:  &ImageArtifact{Reference: testImageRef},
 		Artifacts: []Artifact{
 			&ImageArtifact{name: "model", Reference: testImageRef},
 		},
@@ -397,7 +398,7 @@ func descriptorFromRef(ref string) v1.Descriptor {
 // =============================================================================
 
 func TestResolver_Push(t *testing.T) {
-	t.Run("default uses docker push", func(t *testing.T) {
+	t.Run("FormatImage uses docker push", func(t *testing.T) {
 		var dockerPushed bool
 		docker := &mockDocker{
 			pushFunc: func(ctx context.Context, ref string) error {
@@ -408,25 +409,41 @@ func TestResolver_Push(t *testing.T) {
 		reg := &mockRegistry{}
 		resolver := NewResolver(docker, reg)
 
-		err := resolver.Push(context.Background(), testBundleModel(), PushOptions{})
+		m := &Model{
+			Format: FormatImage,
+			Image:  &ImageArtifact{Reference: testImageRef},
+			Artifacts: []Artifact{
+				&ImageArtifact{name: "model", Reference: testImageRef},
+			},
+		}
+
+		err := resolver.Push(context.Background(), m, PushOptions{})
 		require.NoError(t, err)
-		require.True(t, dockerPushed, "standalone should use docker push")
+		require.True(t, dockerPushed, "FormatImage should use docker push")
 	})
 
-	t.Run("no weights uses docker push", func(t *testing.T) {
-		var dockerPushed bool
+	t.Run("FormatBundle with no weights produces a single-entry index", func(t *testing.T) {
+		// Behavioral change: a FormatBundle model with zero weights is
+		// still pushed as an OCI index (containing only the image
+		// manifest), not as a legacy single image.
+		var indexPushed bool
 		docker := &mockDocker{
-			pushFunc: func(ctx context.Context, ref string) error {
-				dockerPushed = true
+			pushFunc: func(ctx context.Context, ref string) error { return nil },
+		}
+		reg := &mockRegistry{
+			getDescriptorFunc: func(ctx context.Context, ref string) (v1.Descriptor, error) {
+				return descriptorFromRef(ref), nil
+			},
+			pushIndexFunc: func(ctx context.Context, ref string, idx v1.ImageIndex) error {
+				indexPushed = true
 				return nil
 			},
 		}
-		reg := &mockRegistry{}
 		resolver := NewResolver(docker, reg)
 
 		err := resolver.Push(context.Background(), testBundleModel(), PushOptions{})
 		require.NoError(t, err)
-		require.True(t, dockerPushed, "model without weights should use docker push")
+		require.True(t, indexPushed, "FormatBundle should push an OCI index even with no weights")
 	})
 
 	t.Run("bundle with weights produces an OCI index", func(t *testing.T) {
@@ -473,6 +490,7 @@ func TestResolver_Push(t *testing.T) {
 		resolver := NewResolver(docker, reg)
 
 		m := &Model{
+			Format: FormatBundle,
 			Weights: []Weight{
 				{Name: "w1", Target: "/src/weights/w1", Digest: testW1Digest, SetDigest: "sha256:abc"},
 			},

--- a/pkg/model/resolve.go
+++ b/pkg/model/resolve.go
@@ -40,11 +40,6 @@ const (
 	EnvModelTag = "COG_MODEL_TAG"
 )
 
-// reservedTagPrefix guards auto-generated image/weight tags
-// (cog-image.*, cog-weight.*) from colliding with a tag the user
-// picked. User-supplied tags using this prefix are rejected.
-const reservedTagPrefix = "cog-"
-
 // timestampTagFormat is ISO 8601 basic (compact) form, UTC. Example:
 // 20260508T153042Z. The basic form has no separators so the value is
 // a valid OCI tag as-is; Go's stdlib only ships the extended form
@@ -223,8 +218,8 @@ func validateTagEnv(v string) error {
 	if v == "" {
 		return nil
 	}
-	if strings.HasPrefix(v, reservedTagPrefix) {
-		return fmt.Errorf("invalid %s %q: %q is a reserved prefix — choose a different tag", EnvModelTag, v, reservedTagPrefix)
+	if IsReservedTag(v) {
+		return fmt.Errorf("invalid %s %q: %q is a reserved prefix — choose a different tag", EnvModelTag, v, ReservedTagPrefix)
 	}
 	if !tagRegex.MatchString(v) {
 		return fmt.Errorf("invalid %s %q: must match OCI tag regex %s", EnvModelTag, v, tagRegex.String())

--- a/pkg/model/resolve.go
+++ b/pkg/model/resolve.go
@@ -72,9 +72,16 @@ type ResolvedRef struct {
 // "registry/repo@digest" form.
 func (r *ResolvedRef) String() string {
 	if r.Digest != "" {
-		return r.Registry + "/" + r.Repo + "@" + r.Digest
+		return r.Repository() + "@" + r.Digest
 	}
-	return r.Registry + "/" + r.Repo + ":" + r.Tag
+	return r.Repository() + ":" + r.Tag
+}
+
+// Repository returns the bare "registry/repo" prefix, with no tag or
+// digest. Use this as the base for constructing related refs (image
+// manifest tag, weight manifest tag, weight repo@digest).
+func (r *ResolvedRef) Repository() string {
+	return r.Registry + "/" + r.Repo
 }
 
 // ErrNoModelRef is returned when no model reference can be determined

--- a/pkg/model/resolve.go
+++ b/pkg/model/resolve.go
@@ -90,6 +90,16 @@ func (r *ResolvedRef) Repository() string {
 // surfacing it to the user.
 var ErrNoModelRef = errors.New("no model ref — set 'model' in cog.yaml or COG_MODEL")
 
+// ErrImageModelEnvConflict is returned when cog.yaml has `image:` set
+// and the COG_MODEL* env vars promote to a resolvable model ref.
+// cog.yaml's schema enforces image:/model: as mutex, but env-var
+// promotion bypasses that check.
+var ErrImageModelEnvConflict = errors.New(
+	"'image' in cog.yaml cannot be combined with COG_MODEL* env vars\n" +
+		"  remove 'image' from cog.yaml (use 'model' instead), or\n" +
+		"  unset COG_MODEL, COG_MODEL_REGISTRY, COG_MODEL_REPO, COG_MODEL_TAG",
+)
+
 // GenerateTimestampTag returns the current UTC time formatted as a
 // compact ISO 8601 timestamp suitable for use as an OCI tag. Calls
 // within the same second return identical values.
@@ -100,7 +110,7 @@ func GenerateTimestampTag() string {
 // ResolveModelRef composes the final model reference from the
 // cog.yaml `model` field plus any COG_MODEL* environment overrides.
 //
-// Resolution algorithm (see also: epic cog.md-model-refs-pqk7):
+// Resolution algorithm:
 //
 //  1. If COG_MODEL is set, it wins outright. Parse it and append a
 //     timestamp tag if none was supplied. All other env vars are
@@ -111,11 +121,26 @@ func GenerateTimestampTag() string {
 //     registry ← COG_MODEL_REGISTRY, repo ← COG_MODEL_REPO,
 //     tag ← COG_MODEL_TAG (or a freshly generated timestamp).
 //  3. If no repository can be determined, return ErrNoModelRef.
+//  4. If a ref resolved and `image:` is also set, return
+//     ErrImageModelEnvConflict.
 //
-// configModel is the raw cog.yaml `model` value; pass "" if absent.
-// The function only reads environment variables — it never touches
-// the filesystem or network.
-func ResolveModelRef(configModel string) (*ResolvedRef, error) {
+// configImage and configModel are the raw cog.yaml `image` and
+// `model` values; pass "" if absent. The function only reads
+// environment variables — it never touches the filesystem or network.
+func ResolveModelRef(configImage, configModel string) (*ResolvedRef, error) {
+	ref, err := resolveModelRef(configModel)
+	if err != nil {
+		return nil, err
+	}
+	if ref != nil && configImage != "" {
+		return nil, ErrImageModelEnvConflict
+	}
+	return ref, nil
+}
+
+// resolveModelRef does the env+config composition. ResolveModelRef
+// wraps it with the image:/model: mode-mix check.
+func resolveModelRef(configModel string) (*ResolvedRef, error) {
 	if full := os.Getenv(EnvModel); full != "" {
 		return resolveFromFullRef(full)
 	}

--- a/pkg/model/resolve.go
+++ b/pkg/model/resolve.go
@@ -1,0 +1,233 @@
+package model
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+
+	"github.com/replicate/cog/pkg/global"
+)
+
+// Environment overrides for the resolved model reference. Only
+// consulted when the configuration produces a model ref; otherwise
+// ignored.
+const (
+	// EnvModel is the full reference override. When set, it bypasses
+	// every other source and the value is parsed as a complete ref
+	// (registry/repo[:tag] or registry/repo@digest). If no tag is
+	// present, an auto-generated timestamp tag is appended.
+	EnvModel = "COG_MODEL"
+
+	// EnvModelRegistry overrides only the registry host of the
+	// resolved reference (e.g. "registry.example.com").
+	EnvModelRegistry = "COG_MODEL_REGISTRY"
+
+	// EnvModelRepo overrides only the repository path of the resolved
+	// reference (e.g. "acct/testing/model"). The value must not include
+	// a host, tag, or digest.
+	EnvModelRepo = "COG_MODEL_REPO"
+
+	// EnvModelTag overrides only the tag of the resolved reference.
+	// User-supplied tags starting with "cog-" are rejected because that
+	// prefix is reserved for tags Cog generates itself (cog-image.*,
+	// cog-weight.*).
+	EnvModelTag = "COG_MODEL_TAG"
+)
+
+// reservedTagPrefix guards auto-generated image/weight tags
+// (cog-image.*, cog-weight.*) from colliding with a tag the user
+// picked. User-supplied tags using this prefix are rejected.
+const reservedTagPrefix = "cog-"
+
+// timestampTagFormat is ISO 8601 basic (compact) form, UTC. Example:
+// 20260508T153042Z. The basic form has no separators so the value is
+// a valid OCI tag as-is; Go's stdlib only ships the extended form
+// (time.RFC3339, "2006-01-02T15:04:05Z07:00") which contains "-" and
+// ":" — the colon is illegal in tags.
+const timestampTagFormat = "20060102T150405Z"
+
+// tagRegex enforces the OCI distribution-spec tag grammar. We pin to
+// the spec rather than delegating to name.NewTag because the
+// go-containerregistry parser is more permissive (it accepts a leading
+// hyphen, for example) and we want to reject inputs the spec rules out.
+var tagRegex = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$`)
+
+// ResolvedRef is the fully composed model reference produced by
+// ResolveModelRef. Exactly one of Tag or Digest is populated.
+type ResolvedRef struct {
+	// Registry is the registry host (e.g. "registry.example.com").
+	Registry string
+	// Repo is the repository path (e.g. "acct/testing/model").
+	Repo string
+	// Tag is the resolved tag (e.g. "20260508T153042Z" or "v2").
+	// Empty for digest refs.
+	Tag string
+	// Digest is the OCI manifest digest (e.g. "sha256:abc..."), set
+	// when the user pinned the ref with @digest. Empty for tag refs.
+	Digest string
+}
+
+// String returns the canonical "registry/repo:tag" or
+// "registry/repo@digest" form.
+func (r *ResolvedRef) String() string {
+	if r.Digest != "" {
+		return r.Registry + "/" + r.Repo + "@" + r.Digest
+	}
+	return r.Registry + "/" + r.Repo + ":" + r.Tag
+}
+
+// ErrNoModelRef is returned when no model reference can be determined
+// from configuration or environment overrides. Callers handle this by
+// either falling back to FormatImage (when an image: ref exists) or
+// surfacing it to the user.
+var ErrNoModelRef = errors.New("no model ref — set 'model' in cog.yaml or COG_MODEL")
+
+// GenerateTimestampTag returns the current UTC time formatted as a
+// compact ISO 8601 timestamp suitable for use as an OCI tag. Calls
+// within the same second return identical values.
+func GenerateTimestampTag() string {
+	return time.Now().UTC().Format(timestampTagFormat)
+}
+
+// ResolveModelRef composes the final model reference from the
+// cog.yaml `model` field plus any COG_MODEL* environment overrides.
+//
+// Resolution algorithm (see also: epic cog.md-model-refs-pqk7):
+//
+//  1. If COG_MODEL is set, it wins outright. Parse it and append a
+//     timestamp tag if none was supplied. All other env vars are
+//     ignored. This matches the "I know exactly what I want" path
+//     used by CI and `cog push`-from-script workflows.
+//  2. Otherwise, start from the cog.yaml `model` value (which may be
+//     empty or partial) and layer the per-field env vars on top:
+//     registry ← COG_MODEL_REGISTRY, repo ← COG_MODEL_REPO,
+//     tag ← COG_MODEL_TAG (or a freshly generated timestamp).
+//  3. If no repository can be determined, return ErrNoModelRef.
+//
+// configModel is the raw cog.yaml `model` value; pass "" if absent.
+// The function only reads environment variables — it never touches
+// the filesystem or network.
+func ResolveModelRef(configModel string) (*ResolvedRef, error) {
+	if full := os.Getenv(EnvModel); full != "" {
+		return resolveFromFullRef(full)
+	}
+
+	envRegistry := os.Getenv(EnvModelRegistry)
+	envRepo := os.Getenv(EnvModelRepo)
+	envTag := os.Getenv(EnvModelTag)
+
+	if err := validateRegistryEnv(envRegistry); err != nil {
+		return nil, err
+	}
+	if err := validateRepoEnv(envRepo); err != nil {
+		return nil, err
+	}
+	if err := validateTagEnv(envTag); err != nil {
+		return nil, err
+	}
+
+	// Parse the cog.yaml base. An empty configModel is fine — it just
+	// means every component must come from env vars.
+	var baseRegistry, baseRepo string
+	if configModel != "" {
+		parsedBase, err := name.NewRepository(configModel, name.Insecure)
+		if err != nil {
+			return nil, fmt.Errorf("invalid 'model' in cog.yaml: %w", err)
+		}
+		baseRegistry = parsedBase.RegistryStr()
+		baseRepo = parsedBase.RepositoryStr()
+	}
+
+	registry := cmp.Or(envRegistry, baseRegistry, global.ReplicateRegistryHost)
+	repo := cmp.Or(envRepo, baseRepo)
+	if repo == "" {
+		return nil, ErrNoModelRef
+	}
+	tag := cmp.Or(envTag, GenerateTimestampTag())
+
+	return buildResolved(registry, repo, tag)
+}
+
+// resolveFromFullRef parses a complete COG_MODEL value. Pre-seeding
+// name.WithDefaultTag with a fresh timestamp means an input without a
+// tag silently picks up the auto-versioned tag, with no need to
+// re-scan the source string. Digest refs pass through unchanged
+// because the caller is pinning to a specific manifest.
+func resolveFromFullRef(full string) (*ResolvedRef, error) {
+	parsed, err := ParseRef(full, Insecure(), WithDefaultTag(GenerateTimestampTag()))
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s value: %w", EnvModel, err)
+	}
+	return &ResolvedRef{
+		Registry: parsed.Registry(),
+		Repo:     parsed.Repository(),
+		Tag:      parsed.Tag(),
+		Digest:   parsed.Digest(),
+	}, nil
+}
+
+// buildResolved composes a tag-based ResolvedRef and runs the result
+// through name.NewTag to catch combinations that only fail when
+// stitched together (an OCI-illegal tag, for example). Digest refs
+// don't pass through here — resolveFromFullRef returns them directly.
+func buildResolved(registry, repo, tag string) (*ResolvedRef, error) {
+	r := &ResolvedRef{Registry: registry, Repo: repo, Tag: tag}
+	if _, err := name.NewTag(r.String(), name.Insecure); err != nil {
+		return nil, fmt.Errorf("invalid resolved ref %q: %w", r.String(), err)
+	}
+	return r, nil
+}
+
+// validateRegistryEnv checks that COG_MODEL_REGISTRY is just a host
+// (no path, tag, or digest). The pre-check on / and @ exists so the
+// error message names the env var; name.NewRegistry handles the rest.
+func validateRegistryEnv(v string) error {
+	if v == "" {
+		return nil
+	}
+	if strings.ContainsAny(v, "/@") {
+		return fmt.Errorf("invalid %s %q: must be a bare host (no path, tag, or digest)", EnvModelRegistry, v)
+	}
+	if _, err := name.NewRegistry(v, name.Insecure); err != nil {
+		return fmt.Errorf("invalid %s %q: %w", EnvModelRegistry, v, err)
+	}
+	return nil
+}
+
+// validateRepoEnv checks that COG_MODEL_REPO is a bare repository
+// path. The pre-check on : is load-bearing — name.NewRepository
+// accepts "host:port/repo", so without it "user/model:v1" would be
+// silently misparsed.
+func validateRepoEnv(v string) error {
+	if v == "" {
+		return nil
+	}
+	if strings.ContainsAny(v, ":@") {
+		return fmt.Errorf("invalid %s %q: must be a bare repository path (no host, tag, or digest)", EnvModelRepo, v)
+	}
+	if _, err := name.NewRepository(v, name.Insecure); err != nil {
+		return fmt.Errorf("invalid %s %q: %w", EnvModelRepo, v, err)
+	}
+	return nil
+}
+
+// validateTagEnv checks that COG_MODEL_TAG is a valid OCI tag and
+// does not use the reserved "cog-" prefix.
+func validateTagEnv(v string) error {
+	if v == "" {
+		return nil
+	}
+	if strings.HasPrefix(v, reservedTagPrefix) {
+		return fmt.Errorf("invalid %s %q: %q is a reserved prefix — choose a different tag", EnvModelTag, v, reservedTagPrefix)
+	}
+	if !tagRegex.MatchString(v) {
+		return fmt.Errorf("invalid %s %q: must match OCI tag regex %s", EnvModelTag, v, tagRegex.String())
+	}
+	return nil
+}

--- a/pkg/model/resolve_test.go
+++ b/pkg/model/resolve_test.go
@@ -288,12 +288,10 @@ func TestResolveModelRef_TimestampTagShape(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// clearModelEnv isolates the test from the developer's shell by
-// blanking every COG_MODEL* env var. Without this, a shell-exported
-// COG_MODEL_REPO (or similar) would leak into the test process and
-// silently change what ResolveModelRef sees. t.Setenv handles
-// restoration at cleanup; ResolveModelRef treats "" as unset, so
-// blanking is equivalent to unsetting.
+// clearModelEnv is the in-package twin of modeltest.ClearEnv. Tests
+// in package model can't import pkg/model/modeltest (which itself
+// imports pkg/model) without creating a build cycle, so this copy
+// stays local. External callers should use modeltest.ClearEnv.
 func clearModelEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv(EnvModel, "")

--- a/pkg/model/resolve_test.go
+++ b/pkg/model/resolve_test.go
@@ -23,7 +23,7 @@ func TestGenerateTimestampTag(t *testing.T) {
 func TestResolveModelRef_ConfigOnly_GeneratesTimestamp(t *testing.T) {
 	clearModelEnv(t)
 
-	got, err := ResolveModelRef("registry.example.com/user/model")
+	got, err := ResolveModelRef("", "registry.example.com/user/model")
 	require.NoError(t, err)
 	require.Equal(t, "registry.example.com", got.Registry)
 	require.Equal(t, "user/model", got.Repo)
@@ -36,7 +36,7 @@ func TestResolveModelRef_PartialConfigPlusEnv(t *testing.T) {
 	clearModelEnv(t)
 	t.Setenv(EnvModelRegistry, "staging.io")
 
-	got, err := ResolveModelRef("user/model")
+	got, err := ResolveModelRef("", "user/model")
 	require.NoError(t, err)
 	require.Equal(t, "staging.io", got.Registry)
 	require.Equal(t, "user/model", got.Repo)
@@ -53,7 +53,7 @@ func TestResolveModelRef_FullEnvOverridesEverything(t *testing.T) {
 	t.Setenv(EnvModelRepo, "user/model:tag")
 	t.Setenv(EnvModelTag, "cog-reserved")
 
-	got, err := ResolveModelRef("INVALID UPPERCASE/with spaces")
+	got, err := ResolveModelRef("", "INVALID UPPERCASE/with spaces")
 	require.NoError(t, err)
 	require.Equal(t, "staging.io", got.Registry)
 	require.Equal(t, "foo/bar", got.Repo)
@@ -65,7 +65,7 @@ func TestResolveModelRef_FullEnvNoTag_GeneratesTimestamp(t *testing.T) {
 	clearModelEnv(t)
 	t.Setenv(EnvModel, "staging.io/foo/bar")
 
-	got, err := ResolveModelRef("")
+	got, err := ResolveModelRef("", "")
 	require.NoError(t, err)
 	require.Equal(t, "staging.io", got.Registry)
 	require.Equal(t, "foo/bar", got.Repo)
@@ -78,7 +78,7 @@ func TestResolveModelRef_FullEnvWithPortNoTag(t *testing.T) {
 	clearModelEnv(t)
 	t.Setenv(EnvModel, "localhost:5000/foo/bar")
 
-	got, err := ResolveModelRef("")
+	got, err := ResolveModelRef("", "")
 	require.NoError(t, err)
 	require.Equal(t, "localhost:5000", got.Registry)
 	require.Equal(t, "foo/bar", got.Repo)
@@ -89,7 +89,7 @@ func TestResolveModelRef_FullEnvWithPortAndTag(t *testing.T) {
 	clearModelEnv(t)
 	t.Setenv(EnvModel, "localhost:5000/foo/bar:v3")
 
-	got, err := ResolveModelRef("")
+	got, err := ResolveModelRef("", "")
 	require.NoError(t, err)
 	require.Equal(t, "localhost:5000", got.Registry)
 	require.Equal(t, "foo/bar", got.Repo)
@@ -101,7 +101,7 @@ func TestResolveModelRef_FullEnvWithDigest(t *testing.T) {
 	digest := "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
 	t.Setenv(EnvModel, "staging.io/foo/bar@"+digest)
 
-	got, err := ResolveModelRef("")
+	got, err := ResolveModelRef("", "")
 	require.NoError(t, err)
 	require.Equal(t, "staging.io", got.Registry)
 	require.Equal(t, "foo/bar", got.Repo)
@@ -114,7 +114,7 @@ func TestResolveModelRef_TagEnvOverridesTimestamp(t *testing.T) {
 	clearModelEnv(t)
 	t.Setenv(EnvModelTag, "pr-42")
 
-	got, err := ResolveModelRef("registry.example.com/user/model")
+	got, err := ResolveModelRef("", "registry.example.com/user/model")
 	require.NoError(t, err)
 	require.Equal(t, "pr-42", got.Tag)
 	require.Equal(t, "registry.example.com/user/model:pr-42", got.String())
@@ -124,7 +124,7 @@ func TestResolveModelRef_RepoEnvOverridesConfig(t *testing.T) {
 	clearModelEnv(t)
 	t.Setenv(EnvModelRepo, "different/repo")
 
-	got, err := ResolveModelRef("registry.example.com/user/model")
+	got, err := ResolveModelRef("", "registry.example.com/user/model")
 	require.NoError(t, err)
 	require.Equal(t, "registry.example.com", got.Registry)
 	require.Equal(t, "different/repo", got.Repo)
@@ -133,7 +133,7 @@ func TestResolveModelRef_RepoEnvOverridesConfig(t *testing.T) {
 func TestResolveModelRef_NoRefAnywhere(t *testing.T) {
 	clearModelEnv(t)
 
-	_, err := ResolveModelRef("")
+	_, err := ResolveModelRef("", "")
 	require.ErrorIs(t, err, ErrNoModelRef)
 }
 
@@ -141,8 +141,42 @@ func TestResolveModelRef_OnlyRegistryEnv_StillNeedsRepo(t *testing.T) {
 	clearModelEnv(t)
 	t.Setenv(EnvModelRegistry, "staging.io")
 
-	_, err := ResolveModelRef("")
+	_, err := ResolveModelRef("", "")
 	require.ErrorIs(t, err, ErrNoModelRef)
+}
+
+func TestResolveModelRef_ImageModelEnvConflict(t *testing.T) {
+	// cog.yaml `image:` set + COG_MODEL* env vars promote to a
+	// resolvable model ref = mode mix-up. cog.yaml validation enforces
+	// image:/model: as mutex; this check covers the env-var promotion
+	// path that bypasses that mutex.
+	t.Run("COG_MODEL_REPO promotion conflicts with image:", func(t *testing.T) {
+		clearModelEnv(t)
+		t.Setenv(EnvModelRepo, "acct/model")
+
+		_, err := ResolveModelRef("ghcr.io/owner/repo", "")
+		require.ErrorIs(t, err, ErrImageModelEnvConflict)
+	})
+
+	t.Run("COG_MODEL full-ref promotion conflicts with image:", func(t *testing.T) {
+		// resolveFromFullRef is a different code path inside
+		// ResolveModelRef; cover it explicitly.
+		clearModelEnv(t)
+		t.Setenv(EnvModel, "registry.example.com/acct/model:v1")
+
+		_, err := ResolveModelRef("ghcr.io/owner/repo", "")
+		require.ErrorIs(t, err, ErrImageModelEnvConflict)
+	})
+
+	t.Run("image: alone without env vars does not conflict", func(t *testing.T) {
+		// FormatImage path — no model ref resolves, no conflict.
+		// ErrNoModelRef surfaces so the caller can fall back to
+		// image: handling.
+		clearModelEnv(t)
+
+		_, err := ResolveModelRef("ghcr.io/owner/repo", "")
+		require.ErrorIs(t, err, ErrNoModelRef)
+	})
 }
 
 func TestResolveModelRef_ReservedTagPrefix(t *testing.T) {
@@ -156,7 +190,7 @@ func TestResolveModelRef_ReservedTagPrefix(t *testing.T) {
 			clearModelEnv(t)
 			t.Setenv(EnvModelTag, tag)
 
-			_, err := ResolveModelRef("registry.example.com/user/model")
+			_, err := ResolveModelRef("", "registry.example.com/user/model")
 			require.Error(t, err)
 			require.Contains(t, err.Error(), `reserved prefix`)
 			require.Contains(t, err.Error(), `cog-`)
@@ -178,7 +212,7 @@ func TestResolveModelRef_InvalidRegistryEnv(t *testing.T) {
 			clearModelEnv(t)
 			t.Setenv(EnvModelRegistry, tc.val)
 
-			_, err := ResolveModelRef("user/model")
+			_, err := ResolveModelRef("", "user/model")
 			require.Error(t, err)
 			require.Contains(t, err.Error(), EnvModelRegistry)
 		})
@@ -198,7 +232,7 @@ func TestResolveModelRef_InvalidRepoEnv(t *testing.T) {
 			clearModelEnv(t)
 			t.Setenv(EnvModelRepo, tc.val)
 
-			_, err := ResolveModelRef("")
+			_, err := ResolveModelRef("", "")
 			require.Error(t, err)
 			require.Contains(t, err.Error(), EnvModelRepo)
 		})
@@ -210,7 +244,7 @@ func TestResolveModelRef_InvalidTagFormat(t *testing.T) {
 	// Leading hyphen is disallowed by the OCI tag regex.
 	t.Setenv(EnvModelTag, "-bad-tag")
 
-	_, err := ResolveModelRef("registry.example.com/user/model")
+	_, err := ResolveModelRef("", "registry.example.com/user/model")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), EnvModelTag)
 }
@@ -218,7 +252,7 @@ func TestResolveModelRef_InvalidTagFormat(t *testing.T) {
 func TestResolveModelRef_InvalidConfigModel(t *testing.T) {
 	clearModelEnv(t)
 
-	_, err := ResolveModelRef("INVALID UPPERCASE/with spaces")
+	_, err := ResolveModelRef("", "INVALID UPPERCASE/with spaces")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "'model' in cog.yaml")
 }
@@ -228,7 +262,7 @@ func TestResolveModelRef_BareConfigPath_InheritsGCRDefault(t *testing.T) {
 	// go-containerregistry fills in Docker Hub when the config has no
 	// explicit host. Cog's own Replicate-host fallback only applies
 	// when configModel is empty (see RepoEnvOnly_UsesReplicateDefault).
-	got, err := ResolveModelRef("user/model")
+	got, err := ResolveModelRef("", "user/model")
 	require.NoError(t, err)
 	require.Equal(t, "index.docker.io", got.Registry)
 	require.Equal(t, "user/model", got.Repo)
@@ -238,7 +272,7 @@ func TestResolveModelRef_RepoEnvOnly_UsesReplicateDefault(t *testing.T) {
 	clearModelEnv(t)
 	t.Setenv(EnvModelRepo, "user/model")
 
-	got, err := ResolveModelRef("")
+	got, err := ResolveModelRef("", "")
 	require.NoError(t, err)
 	require.Equal(t, global.ReplicateRegistryHost, got.Registry)
 	require.Equal(t, "user/model", got.Repo)
@@ -247,7 +281,7 @@ func TestResolveModelRef_RepoEnvOnly_UsesReplicateDefault(t *testing.T) {
 func TestResolveModelRef_TimestampTagShape(t *testing.T) {
 	clearModelEnv(t)
 
-	got, err := ResolveModelRef("registry.example.com/user/model")
+	got, err := ResolveModelRef("", "registry.example.com/user/model")
 	require.NoError(t, err)
 	require.True(t, strings.HasSuffix(got.Tag, "Z"))
 	_, err = time.Parse("20060102T150405Z", got.Tag)

--- a/pkg/model/resolve_test.go
+++ b/pkg/model/resolve_test.go
@@ -1,0 +1,269 @@
+package model
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/replicate/cog/pkg/global"
+)
+
+func TestGenerateTimestampTag(t *testing.T) {
+	tag := GenerateTimestampTag()
+
+	// Round-trip through the timestamp format to confirm the output
+	// is a valid time at the expected precision.
+	parsed, err := time.Parse("20060102T150405Z", tag)
+	require.NoError(t, err)
+	require.WithinDuration(t, time.Now().UTC(), parsed, 5*time.Second)
+}
+
+func TestResolveModelRef_ConfigOnly_GeneratesTimestamp(t *testing.T) {
+	clearModelEnv(t)
+
+	got, err := ResolveModelRef("registry.example.com/user/model")
+	require.NoError(t, err)
+	require.Equal(t, "registry.example.com", got.Registry)
+	require.Equal(t, "user/model", got.Repo)
+	require.Regexp(t, `^\d{8}T\d{6}Z$`, got.Tag)
+	require.Empty(t, got.Digest)
+	require.Equal(t, "registry.example.com/user/model:"+got.Tag, got.String())
+}
+
+func TestResolveModelRef_PartialConfigPlusEnv(t *testing.T) {
+	clearModelEnv(t)
+	t.Setenv(EnvModelRegistry, "staging.io")
+
+	got, err := ResolveModelRef("user/model")
+	require.NoError(t, err)
+	require.Equal(t, "staging.io", got.Registry)
+	require.Equal(t, "user/model", got.Repo)
+	require.NotEmpty(t, got.Tag)
+	require.Equal(t, "staging.io/user/model:"+got.Tag, got.String())
+}
+
+func TestResolveModelRef_FullEnvOverridesEverything(t *testing.T) {
+	clearModelEnv(t)
+	t.Setenv(EnvModel, "staging.io/foo/bar:v3")
+	// Locks in "full ref wins outright": values that would normally
+	// fail validation are tolerated because we never look at them.
+	t.Setenv(EnvModelRegistry, "not/a/host")
+	t.Setenv(EnvModelRepo, "user/model:tag")
+	t.Setenv(EnvModelTag, "cog-reserved")
+
+	got, err := ResolveModelRef("INVALID UPPERCASE/with spaces")
+	require.NoError(t, err)
+	require.Equal(t, "staging.io", got.Registry)
+	require.Equal(t, "foo/bar", got.Repo)
+	require.Equal(t, "v3", got.Tag)
+	require.Equal(t, "staging.io/foo/bar:v3", got.String())
+}
+
+func TestResolveModelRef_FullEnvNoTag_GeneratesTimestamp(t *testing.T) {
+	clearModelEnv(t)
+	t.Setenv(EnvModel, "staging.io/foo/bar")
+
+	got, err := ResolveModelRef("")
+	require.NoError(t, err)
+	require.Equal(t, "staging.io", got.Registry)
+	require.Equal(t, "foo/bar", got.Repo)
+	require.Regexp(t, `^\d{8}T\d{6}Z$`, got.Tag)
+}
+
+func TestResolveModelRef_FullEnvWithPortNoTag(t *testing.T) {
+	// "host:port/repo" must not be misread as "repo:tag" — the
+	// localhost-registry workflow depends on this.
+	clearModelEnv(t)
+	t.Setenv(EnvModel, "localhost:5000/foo/bar")
+
+	got, err := ResolveModelRef("")
+	require.NoError(t, err)
+	require.Equal(t, "localhost:5000", got.Registry)
+	require.Equal(t, "foo/bar", got.Repo)
+	require.Regexp(t, `^\d{8}T\d{6}Z$`, got.Tag)
+}
+
+func TestResolveModelRef_FullEnvWithPortAndTag(t *testing.T) {
+	clearModelEnv(t)
+	t.Setenv(EnvModel, "localhost:5000/foo/bar:v3")
+
+	got, err := ResolveModelRef("")
+	require.NoError(t, err)
+	require.Equal(t, "localhost:5000", got.Registry)
+	require.Equal(t, "foo/bar", got.Repo)
+	require.Equal(t, "v3", got.Tag)
+}
+
+func TestResolveModelRef_FullEnvWithDigest(t *testing.T) {
+	clearModelEnv(t)
+	digest := "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	t.Setenv(EnvModel, "staging.io/foo/bar@"+digest)
+
+	got, err := ResolveModelRef("")
+	require.NoError(t, err)
+	require.Equal(t, "staging.io", got.Registry)
+	require.Equal(t, "foo/bar", got.Repo)
+	require.Empty(t, got.Tag)
+	require.Equal(t, digest, got.Digest)
+	require.Equal(t, "staging.io/foo/bar@"+digest, got.String())
+}
+
+func TestResolveModelRef_TagEnvOverridesTimestamp(t *testing.T) {
+	clearModelEnv(t)
+	t.Setenv(EnvModelTag, "pr-42")
+
+	got, err := ResolveModelRef("registry.example.com/user/model")
+	require.NoError(t, err)
+	require.Equal(t, "pr-42", got.Tag)
+	require.Equal(t, "registry.example.com/user/model:pr-42", got.String())
+}
+
+func TestResolveModelRef_RepoEnvOverridesConfig(t *testing.T) {
+	clearModelEnv(t)
+	t.Setenv(EnvModelRepo, "different/repo")
+
+	got, err := ResolveModelRef("registry.example.com/user/model")
+	require.NoError(t, err)
+	require.Equal(t, "registry.example.com", got.Registry)
+	require.Equal(t, "different/repo", got.Repo)
+}
+
+func TestResolveModelRef_NoRefAnywhere(t *testing.T) {
+	clearModelEnv(t)
+
+	_, err := ResolveModelRef("")
+	require.ErrorIs(t, err, ErrNoModelRef)
+}
+
+func TestResolveModelRef_OnlyRegistryEnv_StillNeedsRepo(t *testing.T) {
+	clearModelEnv(t)
+	t.Setenv(EnvModelRegistry, "staging.io")
+
+	_, err := ResolveModelRef("")
+	require.ErrorIs(t, err, ErrNoModelRef)
+}
+
+func TestResolveModelRef_ReservedTagPrefix(t *testing.T) {
+	tests := []string{
+		"cog-image.foo",
+		"cog-weight.bar",
+		"cog-something",
+	}
+	for _, tag := range tests {
+		t.Run(tag, func(t *testing.T) {
+			clearModelEnv(t)
+			t.Setenv(EnvModelTag, tag)
+
+			_, err := ResolveModelRef("registry.example.com/user/model")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), `reserved prefix`)
+			require.Contains(t, err.Error(), `cog-`)
+		})
+	}
+}
+
+func TestResolveModelRef_InvalidRegistryEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		val  string
+	}{
+		{"with path", "not-a-host/with/path"},
+		{"with tag", "host.example.com:tag"},
+		{"with digest", "host.example.com@sha256:abc"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clearModelEnv(t)
+			t.Setenv(EnvModelRegistry, tc.val)
+
+			_, err := ResolveModelRef("user/model")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), EnvModelRegistry)
+		})
+	}
+}
+
+func TestResolveModelRef_InvalidRepoEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		val  string
+	}{
+		{"with tag", "user/model:v1"},
+		{"with digest", "user/model@sha256:abc"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clearModelEnv(t)
+			t.Setenv(EnvModelRepo, tc.val)
+
+			_, err := ResolveModelRef("")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), EnvModelRepo)
+		})
+	}
+}
+
+func TestResolveModelRef_InvalidTagFormat(t *testing.T) {
+	clearModelEnv(t)
+	// Leading hyphen is disallowed by the OCI tag regex.
+	t.Setenv(EnvModelTag, "-bad-tag")
+
+	_, err := ResolveModelRef("registry.example.com/user/model")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), EnvModelTag)
+}
+
+func TestResolveModelRef_InvalidConfigModel(t *testing.T) {
+	clearModelEnv(t)
+
+	_, err := ResolveModelRef("INVALID UPPERCASE/with spaces")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "'model' in cog.yaml")
+}
+
+func TestResolveModelRef_BareConfigPath_InheritsGCRDefault(t *testing.T) {
+	clearModelEnv(t)
+	// go-containerregistry fills in Docker Hub when the config has no
+	// explicit host. Cog's own Replicate-host fallback only applies
+	// when configModel is empty (see RepoEnvOnly_UsesReplicateDefault).
+	got, err := ResolveModelRef("user/model")
+	require.NoError(t, err)
+	require.Equal(t, "index.docker.io", got.Registry)
+	require.Equal(t, "user/model", got.Repo)
+}
+
+func TestResolveModelRef_RepoEnvOnly_UsesReplicateDefault(t *testing.T) {
+	clearModelEnv(t)
+	t.Setenv(EnvModelRepo, "user/model")
+
+	got, err := ResolveModelRef("")
+	require.NoError(t, err)
+	require.Equal(t, global.ReplicateRegistryHost, got.Registry)
+	require.Equal(t, "user/model", got.Repo)
+}
+
+func TestResolveModelRef_TimestampTagShape(t *testing.T) {
+	clearModelEnv(t)
+
+	got, err := ResolveModelRef("registry.example.com/user/model")
+	require.NoError(t, err)
+	require.True(t, strings.HasSuffix(got.Tag, "Z"))
+	_, err = time.Parse("20060102T150405Z", got.Tag)
+	require.NoError(t, err)
+}
+
+// clearModelEnv isolates the test from the developer's shell by
+// blanking every COG_MODEL* env var. Without this, a shell-exported
+// COG_MODEL_REPO (or similar) would leak into the test process and
+// silently change what ResolveModelRef sees. t.Setenv handles
+// restoration at cleanup; ResolveModelRef treats "" as unset, so
+// blanking is equivalent to unsetting.
+func clearModelEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(EnvModel, "")
+	t.Setenv(EnvModelRegistry, "")
+	t.Setenv(EnvModelRepo, "")
+	t.Setenv(EnvModelTag, "")
+}

--- a/pkg/model/resolver.go
+++ b/pkg/model/resolver.go
@@ -221,6 +221,20 @@ func (r *Resolver) Build(ctx context.Context, src *Source, opts BuildOptions) (*
 	}
 	opts = opts.WithDefaults(src)
 
+	// Resolve the model ref up front so any user-facing config or env
+	// errors (malformed COG_MODEL_TAG, reserved prefix, etc.) surface
+	// before we kick off a Docker build that could take minutes.
+	// ErrNoModelRef is not an error here — it just means we fall back
+	// to FormatImage.
+	format := FormatImage
+	if _, err := ResolveModelRef(src.Config.Model); err != nil {
+		if !errors.Is(err, ErrNoModelRef) {
+			return nil, err
+		}
+	} else {
+		format = FormatBundle
+	}
+
 	ib := NewImageBuilder(r.factory, r.docker, src, opts)
 	imageSpec := NewImageSpec("model", opts.ImageName)
 	imgResult, err := ib.Build(ctx, imageSpec)
@@ -238,20 +252,19 @@ func (r *Resolver) Build(ctx context.Context, src *Source, opts BuildOptions) (*
 	}
 
 	m.Artifacts = []Artifact{ia}
+	// modelFromImage defaults Format to FormatImage; override with the
+	// format chosen by resolution.
+	m.Format = format
 
-	// Build's format is driven by the resolved config: a model: ref or any
-	// managed weights select FormatBundle, otherwise the default FormatImage
-	// (set by modelFromImage) stands.
+	// Load managed weights when declared. Config validation enforces
+	// "weights require model", so a healthy config only reaches this
+	// branch when Format == FormatBundle.
 	if len(src.Config.Weights) > 0 {
 		weights, weightErr := WeightsFromLockfile(src.ProjectDir)
 		if weightErr != nil {
 			return nil, weightErr
 		}
 		m.Weights = weights
-		m.Format = FormatBundle
-	}
-	if src.Config.Model != "" {
-		m.Format = FormatBundle
 	}
 
 	return m, nil

--- a/pkg/model/resolver.go
+++ b/pkg/model/resolver.go
@@ -239,12 +239,19 @@ func (r *Resolver) Build(ctx context.Context, src *Source, opts BuildOptions) (*
 
 	m.Artifacts = []Artifact{ia}
 
+	// Build's format is driven by the resolved config: a model: ref or any
+	// managed weights select FormatBundle, otherwise the default FormatImage
+	// (set by modelFromImage) stands.
 	if len(src.Config.Weights) > 0 {
 		weights, weightErr := WeightsFromLockfile(src.ProjectDir)
 		if weightErr != nil {
 			return nil, weightErr
 		}
 		m.Weights = weights
+		m.Format = FormatBundle
+	}
+	if src.Config.Model != "" {
+		m.Format = FormatBundle
 	}
 
 	return m, nil
@@ -309,6 +316,7 @@ func (r *Resolver) modelFromImage(img *ImageArtifact, cfg *config.Config) (*Mode
 	}
 
 	return &Model{
+		Format:     FormatImage,
 		Image:      img,
 		Config:     cfg,
 		Schema:     schema,
@@ -382,6 +390,9 @@ func (r *Resolver) modelFromIndex(ref *ParsedRef, manifest *registry.ManifestRes
 	if err != nil {
 		return nil, fmt.Errorf("image %s: %w", ref.Original, err)
 	}
+	// Override the FormatImage default from ToModel — an OCI index is
+	// always a bundle, regardless of how many weight manifests it carries.
+	m.Format = FormatBundle
 
 	return m, nil
 }

--- a/pkg/model/resolver.go
+++ b/pkg/model/resolver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/replicate/cog/pkg/config"
 	"github.com/replicate/cog/pkg/docker/command"
 	"github.com/replicate/cog/pkg/registry"
+	"github.com/replicate/cog/pkg/util/console"
 )
 
 // Option configures how Resolver methods behave.
@@ -221,17 +222,16 @@ func (r *Resolver) Build(ctx context.Context, src *Source, opts BuildOptions) (*
 	}
 	opts = opts.WithDefaults(src)
 
-	// Resolve the model ref up front so any user-facing config or env
+	// Resolve the model ref up front so user-facing config or env
 	// errors (malformed COG_MODEL_TAG, reserved prefix, etc.) surface
-	// before we kick off a Docker build that could take minutes.
-	// ErrNoModelRef is not an error here — it just means we fall back
-	// to FormatImage.
+	// before kicking off a Docker build. ErrNoModelRef just means
+	// there's no model field — fall back to FormatImage.
 	format := FormatImage
-	if _, err := ResolveModelRef(src.Config.Model); err != nil {
-		if !errors.Is(err, ErrNoModelRef) {
-			return nil, err
-		}
-	} else {
+	ref, err := ResolveModelRef(src.Config.Model)
+	if err != nil && !errors.Is(err, ErrNoModelRef) {
+		return nil, err
+	}
+	if ref != nil {
 		format = FormatBundle
 	}
 
@@ -252,9 +252,8 @@ func (r *Resolver) Build(ctx context.Context, src *Source, opts BuildOptions) (*
 	}
 
 	m.Artifacts = []Artifact{ia}
-	// modelFromImage defaults Format to FormatImage; override with the
-	// format chosen by resolution.
 	m.Format = format
+	m.Ref = ref
 
 	// Load managed weights when declared. Config validation enforces
 	// "weights require model", so a healthy config only reaches this
@@ -270,12 +269,15 @@ func (r *Resolver) Build(ctx context.Context, src *Source, opts BuildOptions) (*
 	return m, nil
 }
 
-// Push pushes a Model to a container registry.
+// Push pushes a Model to a container registry and returns an
+// enriched copy of the Model with all registry references populated
+// (Model.Ref pinned to the resulting digest, image artifact and
+// weights carrying repo@digest references).
 //
-// Uses the OCI chunked push path (via ImagePusher) which bypasses Docker's
-// monolithic push and supports layers of any size through chunked uploads.
-// Falls back to legacy Docker push if OCI push is not available.
-func (r *Resolver) Push(ctx context.Context, m *Model, opts PushOptions) error {
+// FormatBundle delegates to BundlePusher; FormatImage falls back to
+// the legacy single-image push and the returned Model has only the
+// image artifact's repo@digest captured.
+func (r *Resolver) Push(ctx context.Context, m *Model, opts PushOptions) (*Model, error) {
 	if m.IsBundle() {
 		pusher := NewBundlePusher(r.docker, r.registry)
 		return pusher.Push(ctx, m, opts)
@@ -283,7 +285,7 @@ func (r *Resolver) Push(ctx context.Context, m *Model, opts PushOptions) error {
 
 	imgArtifact := m.GetImageArtifact()
 	if imgArtifact == nil {
-		return fmt.Errorf("no image artifact in model")
+		return nil, fmt.Errorf("no image artifact in model")
 	}
 
 	var imagePushOpts []ImagePushOption
@@ -293,7 +295,24 @@ func (r *Resolver) Push(ctx context.Context, m *Model, opts PushOptions) error {
 	if opts.OnFallback != nil {
 		imagePushOpts = append(imagePushOpts, WithOnFallback(opts.OnFallback))
 	}
-	return r.imagePusher.Push(ctx, imgArtifact, imagePushOpts...)
+	if err := r.imagePusher.Push(ctx, imgArtifact, imagePushOpts...); err != nil {
+		return nil, err
+	}
+
+	// Enrich the image artifact with the pushed digest. On registries
+	// that don't support HEAD on tags, fall back to the original Model
+	// rather than failing a successful push. FormatImage is the legacy
+	// single-image path; bundle pushes surface HEAD failures as errors.
+	desc, err := r.registry.GetDescriptor(ctx, imgArtifact.Reference)
+	if err != nil {
+		console.Debugf("post-push HEAD on %q failed; returning Model without digest enrichment: %v", imgArtifact.Reference, err)
+		return m, nil
+	}
+
+	enrichedImage := imgArtifact.WithDigest(repoFromReference(imgArtifact.Reference), desc)
+	out := *m
+	out.Image, out.Artifacts = replaceImageArtifact(imgArtifact, m.Artifacts, enrichedImage)
+	return &out, nil
 }
 
 // loadLocal loads a Model from the local docker daemon.

--- a/pkg/model/resolver.go
+++ b/pkg/model/resolver.go
@@ -223,11 +223,12 @@ func (r *Resolver) Build(ctx context.Context, src *Source, opts BuildOptions) (*
 	opts = opts.WithDefaults(src)
 
 	// Resolve the model ref up front so user-facing config or env
-	// errors (malformed COG_MODEL_TAG, reserved prefix, etc.) surface
-	// before kicking off a Docker build. ErrNoModelRef just means
-	// there's no model field — fall back to FormatImage.
+	// errors (malformed COG_MODEL_TAG, reserved prefix, image:+env
+	// mode mix-up, etc.) surface before kicking off a Docker build.
+	// ErrNoModelRef just means there's no model field — fall back to
+	// FormatImage.
 	format := FormatImage
-	ref, err := ResolveModelRef(src.Config.Model)
+	ref, err := ResolveModelRef(src.Config.Image, src.Config.Model)
 	if err != nil && !errors.Is(err, ErrNoModelRef) {
 		return nil, err
 	}

--- a/pkg/model/resolver_test.go
+++ b/pkg/model/resolver_test.go
@@ -987,6 +987,7 @@ func TestResolver_Pull_LocalInspectRealError(t *testing.T) {
 // =============================================================================
 
 func TestResolver_Build_NoWeightsManifestWithoutWeights(t *testing.T) {
+	clearModelEnv(t)
 	validDigest := "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
 
 	docker := &mockDocker{
@@ -1024,6 +1025,7 @@ func TestResolver_Build_NoWeightsManifestWithoutWeights(t *testing.T) {
 }
 
 func TestResolver_Build_PopulatesArtifacts(t *testing.T) {
+	clearModelEnv(t)
 	imageDigest := "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
 
 	docker := &mockDocker{
@@ -1077,6 +1079,7 @@ func TestResolver_Build_PopulatesArtifacts(t *testing.T) {
 }
 
 func TestResolver_Build_PopulatesWeights(t *testing.T) {
+	clearModelEnv(t)
 	imageDigest := "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
 
 	docker := &mockDocker{
@@ -1130,6 +1133,9 @@ func TestResolver_Build_PopulatesWeights(t *testing.T) {
 	src := &Source{
 		Config: &config.Config{
 			Build: &config.Build{},
+			// Weights require a model ref to be a valid bundle. Config
+			// validation enforces this, so we mirror it here.
+			Model: "registry.example.com/user/model",
 			Weights: []config.WeightSource{
 				{Name: "my-model", Target: "/srv/weights/model", Source: config.WeightSourceList{Items: []config.WeightSourceConfig{{URI: "weights/model"}}}},
 			},
@@ -1159,6 +1165,7 @@ func TestResolver_Build_PopulatesWeights(t *testing.T) {
 }
 
 func TestResolver_Build_WithWeightsIsBundle(t *testing.T) {
+	clearModelEnv(t)
 	imageDigest := "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
 
 	docker := &mockDocker{
@@ -1211,6 +1218,7 @@ func TestResolver_Build_WithWeightsIsBundle(t *testing.T) {
 	src := &Source{
 		Config: &config.Config{
 			Build: &config.Build{},
+			Model: "registry.example.com/user/model",
 			Weights: []config.WeightSource{
 				{Name: "my-model", Target: "/src/weights", Source: config.WeightSourceList{Items: []config.WeightSourceConfig{{URI: "weights"}}}},
 			},
@@ -1230,6 +1238,78 @@ func TestResolver_Build_WithWeightsIsBundle(t *testing.T) {
 	require.NotNil(t, m.GetImageArtifact())
 	require.Len(t, m.Weights, 1)
 	require.Equal(t, "my-model", m.Weights[0].Name)
+}
+
+// newFormatTestResolver builds a Resolver wired to mocks that succeed
+// the build step without touching Docker. Returned source has a
+// minimal Config the caller mutates as needed.
+func newFormatTestResolver(t *testing.T) (*Resolver, *Source) {
+	t.Helper()
+	const imageDigest = "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	docker := &mockDocker{
+		inspectFunc: func(_ context.Context, _ string) (*image.InspectResponse, error) {
+			return &image.InspectResponse{
+				ID: imageDigest,
+				Config: &dockerspec.DockerOCIImageConfig{
+					ImageConfig: ocispec.ImageConfig{
+						Labels: map[string]string{
+							LabelConfig:  `{"build":{"python_version":"3.11"}}`,
+							LabelVersion: "0.15.0",
+						},
+					},
+				},
+			}, nil
+		},
+	}
+	factory := &mockFactory{
+		buildFunc: func(_ context.Context, _ *Source, opts BuildOptions) (*ImageArtifact, error) {
+			return &ImageArtifact{Reference: opts.ImageName, Digest: imageDigest, Source: ImageSourceBuild}, nil
+		},
+	}
+	resolver := NewResolver(docker, &mockRegistry{}).WithFactory(factory)
+	src := &Source{
+		Config:     &config.Config{Build: &config.Build{}},
+		ProjectDir: ".",
+	}
+	return resolver, src
+}
+
+func TestResolver_Build_ModelFieldSelectsBundle(t *testing.T) {
+	// A model: ref with no weights still produces FormatBundle —
+	// the forward-compatible shape for models migrating off image:.
+	clearModelEnv(t)
+	resolver, src := newFormatTestResolver(t)
+	src.Config.Model = "registry.example.com/user/model"
+
+	m, err := resolver.Build(context.Background(), src, BuildOptions{ImageName: "test-image:latest"})
+	require.NoError(t, err)
+	require.True(t, m.IsBundle())
+	require.Empty(t, m.Weights)
+}
+
+func TestResolver_Build_EnvVarPromotesToBundle(t *testing.T) {
+	// COG_MODEL_REPO alone is enough to flip to FormatBundle — the
+	// CI override path.
+	clearModelEnv(t)
+	t.Setenv(EnvModelRepo, "user/model")
+	resolver, src := newFormatTestResolver(t)
+
+	m, err := resolver.Build(context.Background(), src, BuildOptions{ImageName: "test-image:latest"})
+	require.NoError(t, err)
+	require.True(t, m.IsBundle())
+}
+
+func TestResolver_Build_InvalidEnvVarSurfaces(t *testing.T) {
+	// Validation errors must surface before the slow Docker build
+	// runs, so a malformed COG_MODEL_TAG fails fast.
+	clearModelEnv(t)
+	t.Setenv(EnvModelTag, "cog-reserved")
+	resolver, src := newFormatTestResolver(t)
+	src.Config.Model = "registry.example.com/user/model"
+
+	_, err := resolver.Build(context.Background(), src, BuildOptions{ImageName: "test-image:latest"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reserved prefix")
 }
 
 func TestIndexDetectionHelpers(t *testing.T) {

--- a/pkg/model/resolver_test.go
+++ b/pkg/model/resolver_test.go
@@ -25,6 +25,8 @@ type mockDocker struct {
 	inspectFunc   func(ctx context.Context, ref string) (*image.InspectResponse, error)
 	pullFunc      func(ctx context.Context, ref string, force bool) (*image.InspectResponse, error)
 	pushFunc      func(ctx context.Context, ref string) error
+	tagFunc       func(ctx context.Context, source, target string) error
+	removeFunc    func(ctx context.Context, ref string) error
 	imageSaveFunc func(ctx context.Context, imageRef string) (io.ReadCloser, error)
 }
 
@@ -69,8 +71,18 @@ func (m *mockDocker) ContainerStop(ctx context.Context, containerID string) erro
 	return errors.New("mockDocker.ContainerStop not implemented")
 }
 
+func (m *mockDocker) Tag(ctx context.Context, source, target string) error {
+	if m.tagFunc != nil {
+		return m.tagFunc(ctx, source, target)
+	}
+	return nil
+}
+
 func (m *mockDocker) RemoveImage(ctx context.Context, ref string) error {
-	return errors.New("mockDocker.RemoveImage not implemented")
+	if m.removeFunc != nil {
+		return m.removeFunc(ctx, ref)
+	}
+	return nil
 }
 
 func (m *mockDocker) ImageBuild(ctx context.Context, options command.ImageBuildOptions) (string, error) {

--- a/pkg/model/tag.go
+++ b/pkg/model/tag.go
@@ -1,0 +1,209 @@
+package model
+
+import (
+	"strings"
+)
+
+// Tag namespace conventions:
+//
+// All tags Cog generates live under the ReservedTagPrefix ("cog-").
+// Within that prefix, dots separate structural segments and hyphens
+// live inside segments. The fixed shapes are:
+//
+//	cog-weight.{sanitized-name}.{12-char-digest-prefix}
+//	cog-image.{timestamp}
+//
+// User-supplied model index tags carry no prefix (e.g. "v2",
+// "20260508T153042Z"). Tags starting with "cog-" are rejected at the
+// CLI/env-var entry point so the cog-* namespace stays exclusively
+// Cog's. The trailing dot in the prefix constants is what gives us a
+// machine-parseable namespace: any "cog-x.…" tag belongs to type "x".
+const (
+	// ReservedTagPrefix is the prefix Cog uses on every tag it
+	// auto-generates. User-supplied tags starting with this prefix
+	// are rejected.
+	ReservedTagPrefix = "cog-"
+
+	// weightTagPrefix is the prefix for weight artifact manifest
+	// tags. The trailing dot makes the prefix unambiguous so
+	// ParseWeightTag can split on the first dot after it.
+	weightTagPrefix = ReservedTagPrefix + "weight."
+
+	// imageTagPrefix is the prefix for image manifest tags pushed as
+	// part of a bundle.
+	imageTagPrefix = ReservedTagPrefix + "image."
+
+	// maxTagSegmentLen caps a sanitized segment so the full tag
+	// stays under the OCI tag length limit (128 chars). 24 chars
+	// of overhead covers the prefix + dot + 12-char short digest
+	// with room to spare.
+	maxTagSegmentLen = 104
+
+	// unnamedSegment is the placeholder returned when a name
+	// sanitizes to the empty string. Picking a fixed value keeps
+	// the resulting tag valid rather than blowing up at the
+	// registry boundary.
+	unnamedSegment = "unnamed"
+)
+
+// WeightTag returns the OCI tag for a weight manifest combining the
+// sanitized weight name and the 12-char prefix of digest. digest is
+// expected as "sha256:…"; if it's empty or missing the algorithm
+// prefix the tag omits the digest segment and returns
+// "cog-weight.{name}". The no-digest form is a defensive fallback —
+// the real push path always has a SetDigest by the time it gets here
+// — so the result lives in the cog-weight namespace but does NOT
+// round-trip through ParseWeightTag, which requires both segments.
+func WeightTag(name, digest string) string {
+	sanitized := SanitizeTagSegment(name)
+	short := ShortDigest(digest)
+	if short == "" {
+		return weightTagPrefix + sanitized
+	}
+	return weightTagPrefix + sanitized + "." + short
+}
+
+// ImageTag returns the OCI tag for an image manifest pushed as part
+// of a bundle. timestamp is typically the model index push timestamp,
+// e.g. GenerateTimestampTag(); ImageTag does not validate that the
+// input is itself a valid OCI tag — callers feeding generated tags
+// produce valid output by construction, and rejecting at this layer
+// would just duplicate the timestamp-generator contract. Garbage in,
+// garbage out: it is the caller's responsibility to supply input that
+// makes the combined tag conform to the OCI tag grammar.
+func ImageTag(timestamp string) string {
+	return imageTagPrefix + timestamp
+}
+
+// SanitizeTagSegment makes a string safe for use as a single segment
+// (between dots) within an OCI tag. The full tag grammar is
+// [a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}; since we use dots as namespace
+// separators ourselves, segments must restrict to [a-zA-Z0-9_-].
+//
+// Sanitization rules:
+//   - Replace any character not in [a-zA-Z0-9_-] with '-'.
+//   - Collapse consecutive '-' into a single '-'.
+//   - Strip leading and trailing '-'.
+//   - If the result is empty, return "unnamed" so the tag stays valid.
+//   - Truncate to maxTagSegmentLen so the full tag fits within OCI limits.
+//
+// The result is always non-empty and always starts with a character
+// in [a-zA-Z0-9_], which keeps it valid as the leading segment of an
+// OCI tag.
+func SanitizeTagSegment(s string) string {
+	if s == "" {
+		return unnamedSegment
+	}
+
+	// First pass: replace invalid chars with '-'.
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if isValidSegmentChar(r) {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+
+	// Second pass: collapse consecutive '-' and strip leading/trailing.
+	collapsed := collapseHyphens(b.String())
+	collapsed = strings.Trim(collapsed, "-")
+
+	if collapsed == "" {
+		return unnamedSegment
+	}
+
+	if len(collapsed) > maxTagSegmentLen {
+		collapsed = strings.TrimRight(collapsed[:maxTagSegmentLen], "-")
+		if collapsed == "" {
+			return unnamedSegment
+		}
+	}
+
+	return collapsed
+}
+
+// isValidSegmentChar reports whether r is allowed inside a tag
+// segment (between dots).
+func isValidSegmentChar(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z':
+		return true
+	case r >= 'A' && r <= 'Z':
+		return true
+	case r >= '0' && r <= '9':
+		return true
+	case r == '_' || r == '-':
+		return true
+	}
+	return false
+}
+
+// collapseHyphens returns s with runs of '-' replaced by a single '-'.
+func collapseHyphens(s string) string {
+	if !strings.Contains(s, "--") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	prevHyphen := false
+	for i := range len(s) {
+		c := s[i]
+		if c == '-' {
+			if prevHyphen {
+				continue
+			}
+			prevHyphen = true
+		} else {
+			prevHyphen = false
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+// IsReservedTag reports whether tag uses the Cog-reserved prefix
+// ("cog-"). Tags matching this are rejected when supplied by users
+// via cog.yaml or COG_MODEL_TAG so the namespace stays exclusively
+// Cog's.
+func IsReservedTag(tag string) bool {
+	return strings.HasPrefix(tag, ReservedTagPrefix)
+}
+
+// ParseWeightTag extracts the sanitized name and short digest from a
+// weight manifest tag of the form "cog-weight.{name}.{short}". It
+// returns ok=false for any tag that doesn't match the weight prefix or
+// doesn't carry both segments.
+//
+// The short digest is the third dot-separated segment — that's where
+// WeightTag puts it. We deliberately split on '.', not '-', because
+// dots are the namespace separator; hyphens inside the name segment
+// (e.g. "my-model") must stay intact.
+func ParseWeightTag(tag string) (name, shortDigest string, ok bool) {
+	rest, ok := strings.CutPrefix(tag, weightTagPrefix)
+	if !ok {
+		return "", "", false
+	}
+	name, shortDigest, ok = strings.Cut(rest, ".")
+	if !ok || name == "" || shortDigest == "" {
+		return "", "", false
+	}
+	// A weight tag has exactly two segments after the prefix; reject
+	// anything with extra dots so callers can rely on the shape.
+	if strings.Contains(shortDigest, ".") {
+		return "", "", false
+	}
+	return name, shortDigest, true
+}
+
+// ParseImageTag extracts the timestamp from an image manifest tag of
+// the form "cog-image.{timestamp}". Returns ok=false for any tag that
+// doesn't match the image prefix or has an empty timestamp.
+func ParseImageTag(tag string) (timestamp string, ok bool) {
+	rest, ok := strings.CutPrefix(tag, imageTagPrefix)
+	if !ok || rest == "" {
+		return "", false
+	}
+	return rest, true
+}

--- a/pkg/model/tag_test.go
+++ b/pkg/model/tag_test.go
@@ -1,0 +1,280 @@
+package model
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ociTagRegex is the OCI distribution-spec tag grammar, duplicated
+// here so we can assert that every tag the helpers produce matches.
+// Keeping the regex local to the test avoids tying production code to
+// the spec at runtime — that's the env-var validator's job.
+var ociTagRegex = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$`)
+
+func TestWeightTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		digest   string
+		expected string
+	}{
+		{
+			name:     "simple name with digest",
+			input:    "resnet50",
+			digest:   "sha256:52924993c7ef0123456789abcdef0123456789abcdef0123456789abcdef0123",
+			expected: "cog-weight.resnet50.52924993c7ef",
+		},
+		{
+			name:     "name with spaces and parens sanitized",
+			input:    "my model (v2)",
+			digest:   "sha256:abc123456789def0123456789abcdef0123456789abcdef0123456789abcdef0",
+			expected: "cog-weight.my-model-v2.abc123456789",
+		},
+		{
+			name:     "empty name falls back to unnamed",
+			input:    "",
+			digest:   "sha256:abc123456789def0123456789abcdef0123456789abcdef0123456789abcdef0",
+			expected: "cog-weight.unnamed.abc123456789",
+		},
+		{
+			name:     "missing digest omits digest segment",
+			input:    "resnet50",
+			digest:   "",
+			expected: "cog-weight.resnet50",
+		},
+		{
+			name:     "digest without algorithm prefix omits digest segment",
+			input:    "resnet50",
+			digest:   "abc123",
+			expected: "cog-weight.resnet50",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := WeightTag(tc.input, tc.digest)
+			assert.Equal(t, tc.expected, got)
+			assert.Regexp(t, ociTagRegex, got, "generated tag must be a valid OCI tag")
+		})
+	}
+}
+
+func TestImageTag(t *testing.T) {
+	tests := []struct {
+		name      string
+		timestamp string
+		expected  string
+	}{
+		{
+			name:      "iso timestamp",
+			timestamp: "20260508T153042Z",
+			expected:  "cog-image.20260508T153042Z",
+		},
+		{
+			name:      "generated timestamp round-trips through regex",
+			timestamp: GenerateTimestampTag(),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ImageTag(tc.timestamp)
+			if tc.expected != "" {
+				assert.Equal(t, tc.expected, got)
+			}
+			assert.True(t, strings.HasPrefix(got, "cog-image."))
+			assert.Regexp(t, ociTagRegex, got, "generated tag must be a valid OCI tag")
+		})
+	}
+}
+
+func TestSanitizeTagSegment(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"already valid", "resnet50", "resnet50"},
+		{"with spaces and bang", "hello world!", "hello-world"},
+		{"strips leading and trailing hyphens", "---foo---", "foo"},
+		{"collapses consecutive hyphens", "a---b---c", "a-b-c"},
+		{"empty becomes unnamed", "", "unnamed"},
+		{"only invalid chars becomes unnamed", "!!!", "unnamed"},
+		{"underscores preserved", "my_name_here", "my_name_here"},
+		{"unicode replaced", "résumé", "r-sum"},
+		{"dots replaced (we own dot-as-separator)", "a.b.c", "a-b-c"},
+		{"slashes replaced", "user/model", "user-model"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SanitizeTagSegment(tc.input)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestSanitizeTagSegment_TruncatesLongInput(t *testing.T) {
+	input := strings.Repeat("a", 200)
+	got := SanitizeTagSegment(input)
+	assert.LessOrEqual(t, len(got), maxTagSegmentLen)
+	assert.Equal(t, strings.Repeat("a", maxTagSegmentLen), got)
+}
+
+func TestSanitizeTagSegment_TruncationTrimsTrailingHyphen(t *testing.T) {
+	// 103 valid chars + a long run of '-' so the truncation boundary
+	// lands inside the hyphen run. Without the trailing-trim, the
+	// result would end in '-' which is technically valid mid-tag
+	// but ugly and would re-trip the strip rule if used as a
+	// standalone tag.
+	input := strings.Repeat("a", 103) + strings.Repeat("-", 50) + "tail"
+	got := SanitizeTagSegment(input)
+	assert.False(t, strings.HasSuffix(got, "-"),
+		"sanitized segment should not end in hyphen even after truncation; got %q", got)
+	assert.LessOrEqual(t, len(got), maxTagSegmentLen)
+}
+
+func TestParseWeightTag(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantName     string
+		wantDigest   string
+		wantOK       bool
+	}{
+		{
+			name:       "valid weight tag",
+			input:      "cog-weight.resnet50.abc123456789",
+			wantName:   "resnet50",
+			wantDigest: "abc123456789",
+			wantOK:     true,
+		},
+		{
+			name:       "name with internal hyphens",
+			input:      "cog-weight.my-model-v2.abc123456789",
+			wantName:   "my-model-v2",
+			wantDigest: "abc123456789",
+			wantOK:     true,
+		},
+		{
+			name:   "not a weight tag",
+			input:  "something-else",
+			wantOK: false,
+		},
+		{
+			name:   "image tag",
+			input:  "cog-image.20260508T153042Z",
+			wantOK: false,
+		},
+		{
+			name:   "weight prefix only",
+			input:  "cog-weight.",
+			wantOK: false,
+		},
+		{
+			name:   "weight prefix plus name but no digest",
+			input:  "cog-weight.resnet50",
+			wantOK: false,
+		},
+		{
+			name:   "weight tag with extra dots is rejected",
+			input:  "cog-weight.name.digest.extra",
+			wantOK: false,
+		},
+		{
+			name:   "user tag that happens to share a substring",
+			input:  "v2-cog-weight.x.y",
+			wantOK: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			name, digest, ok := ParseWeightTag(tc.input)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantName, name)
+			assert.Equal(t, tc.wantDigest, digest)
+		})
+	}
+}
+
+func TestParseWeightTag_RoundTripsThroughWeightTag(t *testing.T) {
+	cases := []struct {
+		name   string
+		digest string
+	}{
+		{"resnet50", "sha256:52924993c7ef0123456789abcdef0123456789abcdef0123456789abcdef0123"},
+		{"my-model-v2", "sha256:abc123456789def0123456789abcdef0123456789abcdef0123456789abcdef0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tag := WeightTag(tc.name, tc.digest)
+			gotName, gotShort, ok := ParseWeightTag(tag)
+			require.True(t, ok, "tag %q should parse", tag)
+			assert.Equal(t, tc.name, gotName)
+			assert.Equal(t, ShortDigest(tc.digest), gotShort)
+		})
+	}
+}
+
+func TestParseImageTag(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantTimestamp string
+		wantOK        bool
+	}{
+		{
+			name:          "valid image tag",
+			input:         "cog-image.20260508T153042Z",
+			wantTimestamp: "20260508T153042Z",
+			wantOK:        true,
+		},
+		{
+			name:   "not an image tag",
+			input:  "something-else",
+			wantOK: false,
+		},
+		{
+			name:   "weight tag",
+			input:  "cog-weight.foo.bar",
+			wantOK: false,
+		},
+		{
+			name:   "image prefix only",
+			input:  "cog-image.",
+			wantOK: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts, ok := ParseImageTag(tc.input)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantTimestamp, ts)
+		})
+	}
+}
+
+func TestIsReservedTag(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"cog-foo", true},
+		{"cog-image.20260508T153042Z", true},
+		{"cog-weight.x.y", true},
+		{"cog-", true},
+		{"v2", false},
+		{"20260508T153042Z", false},
+		{"latest", false},
+		{"", false},
+		// Substring match must not trigger; the prefix must be at
+		// position 0.
+		{"my-cog-tag", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsReservedTag(tc.input))
+		})
+	}
+}

--- a/pkg/model/tag_test.go
+++ b/pkg/model/tag_test.go
@@ -137,11 +137,11 @@ func TestSanitizeTagSegment_TruncationTrimsTrailingHyphen(t *testing.T) {
 
 func TestParseWeightTag(t *testing.T) {
 	tests := []struct {
-		name         string
-		input        string
-		wantName     string
-		wantDigest   string
-		wantOK       bool
+		name       string
+		input      string
+		wantName   string
+		wantDigest string
+		wantOK     bool
 	}{
 		{
 			name:       "valid weight tag",

--- a/pkg/model/weight_pusher.go
+++ b/pkg/model/weight_pusher.go
@@ -65,7 +65,7 @@ type WeightRetryEvent struct {
 // WeightPushResult describes a successful weight push.
 type WeightPushResult struct {
 	// Ref is the full image reference the manifest was pushed to
-	// (e.g. "registry/repo:weights-name-abc123").
+	// (e.g. "registry/repo:cog-weight.name.abc123456789").
 	Ref string
 	// Descriptor is the OCI descriptor for the pushed manifest.
 	Descriptor v1.Descriptor
@@ -226,20 +226,6 @@ func descriptorFromImage(img v1.Image) (v1.Descriptor, error) {
 		Size:      int64(len(rawManifest)),
 		Digest:    digest,
 	}, nil
-}
-
-const weightTagPrefix = "weights-"
-
-// WeightTag returns the tag for a weight manifest combining name and the
-// short prefix of a digest. digest is "sha256:…"; the 12 hex chars after
-// the algorithm prefix are used. Falls back to "weights-<name>" if digest
-// is empty or missing the algorithm prefix.
-func WeightTag(name, digest string) string {
-	short := ShortDigest(digest)
-	if short == "" {
-		return weightTagPrefix + name
-	}
-	return weightTagPrefix + name + "-" + short
 }
 
 // ShortDigest returns the 12-hex-char prefix of a "sha256:…" digest, or the

--- a/pkg/model/weight_pusher_test.go
+++ b/pkg/model/weight_pusher_test.go
@@ -121,7 +121,7 @@ func TestWeightPusher_Push_PushesExpectedManifest(t *testing.T) {
 	require.NotNil(t, result)
 
 	// Tag derives from the set digest (12-char prefix after "sha256:").
-	require.Contains(t, pushedRef, "weights-model-v1-")
+	require.Contains(t, pushedRef, "cog-weight.model-v1.")
 	require.Equal(t, pushedRef, result.Ref)
 
 	// Manifest shape matches spec §2.2: OCI manifest, config blob, layers
@@ -173,7 +173,7 @@ func TestWeightPusher_Push_TagDerivesFromSetDigest(t *testing.T) {
 	_, err := pusher.Push(context.Background(), "r8.im/user/model", artifact)
 	require.NoError(t, err)
 
-	require.Contains(t, pushedRef, "weights-model-v1-")
+	require.Contains(t, pushedRef, "cog-weight.model-v1.")
 	require.Contains(t, pushedRef, ShortDigest(artifact.Entry.SetDigest))
 }
 

--- a/pkg/provider/generic/generic.go
+++ b/pkg/provider/generic/generic.go
@@ -71,11 +71,10 @@ func (p *GenericProvider) Login(ctx context.Context, opts provider.LoginOptions)
 }
 
 func (p *GenericProvider) PostPush(ctx context.Context, opts provider.PushOptions, pushErr error) error {
-	// No special post-push handling for generic registries
-	// Just show a simple success message if push succeeded
-	if pushErr == nil {
-		console.Successf("Image %s pushed", console.Bold(opts.Image))
-	}
+	// No special post-push handling for generic registries.
+	// Success output is the structured ref tree printed by the CLI
+	// (see pkg/cli/push.go:printPushResult); we have nothing to add
+	// here.
 	return nil
 }
 

--- a/pkg/provider/generic/generic_test.go
+++ b/pkg/provider/generic/generic_test.go
@@ -41,6 +41,11 @@ func TestGenericProvider_Login(t *testing.T) {
 func TestGenericProvider_PostPush(t *testing.T) {
 	p := New()
 
+	// On success, PostPush is intentionally silent — the CLI prints
+	// a structured ref tree (see pkg/cli/push.go:printPushResult) as
+	// the success indicator. Asserting "silent" via stderr capture
+	// adds plumbing we don't have elsewhere in this package; rely on
+	// printPushResult's own tests for the success-output contract.
 	t.Run("success", func(t *testing.T) {
 		opts := provider.PushOptions{
 			Image: "ghcr.io/org/model",

--- a/pkg/provider/replicate/replicate.go
+++ b/pkg/provider/replicate/replicate.go
@@ -90,8 +90,10 @@ If the model already exists, you may be getting this error because you're not lo
 		return pushErr
 	}
 
-	// Success - show Replicate model URL
-	console.Successf("Image %s pushed", console.Bold(opts.Image))
+	// Success — the CLI prints a structured ref tree as the success
+	// indicator (see pkg/cli/push.go:printPushResult). We add the
+	// Replicate-specific model URL on top of that so users get a
+	// direct link to their published model.
 	replicatePage := fmt.Sprintf("https://%s", strings.Replace(opts.Image, global.ReplicateRegistryHost, global.ReplicateWebsiteHost, 1))
 	console.Infof("\nRun your model on Replicate:\n    %s", console.Bold(replicatePage))
 

--- a/pkg/weights/setup.go
+++ b/pkg/weights/setup.go
@@ -13,9 +13,10 @@ import (
 )
 
 // NewFromSource constructs a Manager from a model.Source and an
-// already-parsed repository string. Callers (typically CLI commands)
-// are responsible for parsing their `--image` flag / `cog.yaml image:`
-// value into a bare repo before calling.
+// already-resolved repository string. Callers (typically CLI commands)
+// are responsible for resolving the bundle ref (from `model:` in
+// cog.yaml plus any COG_MODEL* env vars) into a bare repo before
+// calling.
 //
 // repo may be empty for models that declare no weights — the returned
 // Manager is a valid no-op in that case, so CLI callers can construct
@@ -33,7 +34,7 @@ func NewFromSource(src *model.Source, repo string) (*Manager, error) {
 	var lock *lockfile.WeightsLock
 	if len(src.Config.Weights) > 0 {
 		if repo == "" {
-			return nil, errors.New("cog.yaml declares weights but no repository was resolved; set 'image:' in cog.yaml or pass --image")
+			return nil, errors.New("cog.yaml declares weights but no repository was resolved; set 'model' in cog.yaml, or export COG_MODEL / COG_MODEL_REPO")
 		}
 		lockPath := filepath.Join(src.ProjectDir, lockfile.WeightsLockFilename)
 		loaded, err := lockfile.LoadWeightsLock(lockPath)


### PR DESCRIPTION
Today cog push targets are baked into config (`image:`) and the weights commands take an `--image` flag — there's no way to point one cog.yaml at different registries across dev/staging/prod without rewriting the file or passing flags everywhere. This PR introduces a `model:` field plus `COG_MODEL*` env vars that drive both `cog push` and the weights subcommands.

A weights-bearing cog.yaml now looks like:

```yaml
model: registry.example.com/team/llama
weights:
  - tag: alpha
    source: weights/alpha
  - tag: beta
    source: weights/beta
```

Resolution layers, lowest to highest precedence: `model:` in cog.yaml, then `COG_MODEL_REGISTRY` / `COG_MODEL_REPO` / `COG_MODEL_TAG` for piecewise override, then `COG_MODEL` for a full-ref override. `cog push` accepts no positional `[IMAGE]` arg in model mode — refs come from config and env, full stop. Pushed bundles carry `cog-image.*` and `cog-weight.*` tag conventions so the structured ref tree printed at the end is reconstructible from registry contents alone:

```
Pushing to registry.example.com/team/llama:20251114T203045Z...
  model     registry.example.com/team/llama@sha256:abc...
  ├─ image   registry.example.com/team/llama:cog-image.20251114T203045Z@sha256:f3c...
  ├─ weight  alpha  registry.example.com/team/llama:cog-weight.alpha.20251114T203045Z@sha256:d2d...
  └─ weight  beta   registry.example.com/team/llama:cog-weight.beta.20251114T203045Z@sha256:e4f...
```

`image:` and `model:` are mutex at config-parse time; `image:` + `weights:` is now also rejected (a weights-bearing model is a bundle, and bundle targets live under `model:`). The weights subcommands (`import`, `pull`, `status`) drop the `--image` flag and route through the same `model.ResolveModelRef` path as push, so a cog.yaml that `cog push` accepts also works for `cog weights *` with no extra flags.

### What's deliberately out of scope

- `Resolver.Build` re-resolves the model ref instead of accepting the already-resolved one from `validatePushArgs`. Latent (today's calls always agree), but a future change that uses validation's `ref` would silently disagree with the push tag. Tracked separately.
- The `image:` field stays in the schema for now; existing models without weights keep working unchanged.

### How to poke at it

```bash
# image-mode (unchanged)
cat > cog.yaml <<EOF
image: registry.example.com/me/old-model
predict: predict.py:Predictor
EOF
cog push

# model-mode + weights
cat > cog.yaml <<EOF
model: registry.example.com/me/bundle-model
predict: predict.py:Predictor
weights:
  - tag: w1
    source: weights/w1
EOF
cog push                                              # uses cog.yaml
COG_MODEL_TAG=v2 cog push                             # pin the tag
COG_MODEL=registry.example.com/me/other:v1 cog push   # override entirely
```
