### PR TITLE
fix: show doctor remediation for unfixed findings

### DIFF
--- a/integration-tests/tests/doctor_fix_shows_remediation.txtar
+++ b/integration-tests/tests/doctor_fix_shows_remediation.txtar
@@ -1,0 +1,11 @@
+# Test that cog doctor --fix prints the remediation text for unfixed findings.
+
+! cog doctor --fix
+stderr 'predict.py not found'
+stderr 'Remediation: Create predict.py or update the predict field in cog.yaml'
+! stderr '(no auto-fix available)'
+
+-- cog.yaml --
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"

--- a/pkg/cli/doctor.go
+++ b/pkg/cli/doctor.go
@@ -151,8 +151,12 @@ func printDoctorResults(result *doctor.Result, fix bool, hasFixableErrors bool) 
 			}
 			console.Infof("  %s%s", location, f.Message)
 
-			if fix && !cr.Fixed && f.Remediation != "" {
-				console.Infof("  (no auto-fix available)")
+			if fix && !cr.Fixed {
+				if f.Remediation != "" {
+					console.Infof("  Remediation: %s", f.Remediation)
+				} else {
+					console.Infof("  (no auto-fix available)")
+				}
 			}
 		}
 	}

--- a/pkg/cli/doctor_test.go
+++ b/pkg/cli/doctor_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/replicate/cog/pkg/doctor"
+	"github.com/replicate/cog/pkg/util/console"
+)
+
+func TestPrintDoctorResultsFixShowsRemediationForUnfixedFinding(t *testing.T) {
+	result := &doctor.Result{
+		Results: []doctor.CheckResult{
+			{
+				Check: unfixedDoctorCheck{},
+				Findings: []doctor.Finding{
+					{
+						Severity:    doctor.SeverityError,
+						Message:     "predict.py not found",
+						Remediation: `Create predict.py or update the predict field in cog.yaml`,
+						File:        "cog.yaml",
+						Line:        3,
+					},
+				},
+			},
+		},
+	}
+
+	output := captureDoctorStderr(t, func() {
+		console.SetColor(false)
+		printDoctorResults(result, true, false)
+	})
+
+	require.Contains(t, output, "predict.py not found")
+	require.Contains(t, output, "Remediation: Create predict.py or update the predict field in cog.yaml")
+	require.NotContains(t, output, "(no auto-fix available)")
+}
+
+func TestPrintDoctorResultsFixShowsNoAutoFixWhenRemediationMissing(t *testing.T) {
+	result := &doctor.Result{
+		Results: []doctor.CheckResult{
+			{
+				Check: unfixedDoctorCheck{},
+				Findings: []doctor.Finding{
+					{
+						Severity: doctor.SeverityWarning,
+						Message:  "something could not be fixed",
+					},
+				},
+			},
+		},
+	}
+
+	output := captureDoctorStderr(t, func() {
+		console.SetColor(false)
+		printDoctorResults(result, true, false)
+	})
+
+	require.Contains(t, output, "(no auto-fix available)")
+}
+
+type unfixedDoctorCheck struct{}
+
+func (unfixedDoctorCheck) Name() string        { return "unfixed-check" }
+func (unfixedDoctorCheck) Group() doctor.Group { return doctor.GroupConfig }
+func (unfixedDoctorCheck) Description() string { return "Unfixed check" }
+func (unfixedDoctorCheck) Check(*doctor.CheckContext) ([]doctor.Finding, error) {
+	return nil, nil
+}
+func (unfixedDoctorCheck) Fix(*doctor.CheckContext, []doctor.Finding) error {
+	return doctor.ErrNoAutoFix
+}
+
+func captureDoctorStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	originalStderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stderr = w
+	defer func() {
+		os.Stderr = originalStderr
+	}()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+
+	return strings.ReplaceAll(string(out), "\r\n", "\n")
+}


### PR DESCRIPTION
Small paper cut fix.

`cog doctor --fix` could print `(no auto-fix available)` even when the finding already had a remediation message. So the command knew what to say, it just wasnt showing it.

Repro:
1. Make a `cog.yaml` with:
   ```yaml
   build:
     python_version: "3.12"
   predict: "predict.py:Predictor"
   ```
2. Do not create `predict.py`
3. Run `cog doctor --fix`
4. Before this patch, `Predict reference` ended with `(no auto-fix available)`
5. Now it prints the actual remediation, like `Create predict.py or update the predict field in cog.yaml`

Also adds a unit test and a small integration test, nice and tidy.
