### PR TITLE
Send layer media type for Cog weight uploads

### DIFF
--- a/pkg/model/image_pusher_test.go
+++ b/pkg/model/image_pusher_test.go
@@ -25,12 +25,13 @@ import (
 
 // ociMockClient implements registry.Client for testing ImagePusher.
 type ociMockClient struct {
-	mu              sync.Mutex
-	writtenLayers   []v1.Hash
-	pushedImages    []string
-	writeLayerErr   error
-	pushImageErr    error
-	writeLayerCount int
+	mu                    sync.Mutex
+	writtenLayers         []v1.Hash
+	layerMediaTypeHeaders []string
+	pushedImages          []string
+	writeLayerErr         error
+	pushImageErr          error
+	writeLayerCount       int
 }
 
 func (m *ociMockClient) WriteLayer(_ context.Context, opts registry.WriteLayerOptions) error {
@@ -45,6 +46,7 @@ func (m *ociMockClient) WriteLayer(_ context.Context, opts registry.WriteLayerOp
 		return err
 	}
 	m.writtenLayers = append(m.writtenLayers, digest)
+	m.layerMediaTypeHeaders = append(m.layerMediaTypeHeaders, opts.LayerMediaTypeHeader)
 
 	// Send progress if channel is provided
 	if opts.ProgressCh != nil {
@@ -122,6 +124,7 @@ func TestImagePusher_Push(t *testing.T) {
 
 		// Should have pushed 2 layers + 1 config blob = 3 WriteLayer calls
 		assert.Equal(t, 3, mock.writeLayerCount)
+		assert.Equal(t, []string{"", "", ""}, mock.layerMediaTypeHeaders)
 
 		// Should have pushed the manifest
 		require.Len(t, mock.pushedImages, 1)

--- a/pkg/model/weight_pusher.go
+++ b/pkg/model/weight_pusher.go
@@ -194,9 +194,10 @@ func (p *WeightPusher) pushSingleLayer(
 	}
 
 	err := writeLayerWithProgress(ctx, p.registry, registry.WriteLayerOptions{
-		Repo:  repo,
-		Layer: layer,
-		Retry: retryConfig,
+		Repo:                 repo,
+		Layer:                layer,
+		LayerMediaTypeHeader: string(lr.MediaType),
+		Retry:                retryConfig,
 	}, onProgress)
 	if err != nil {
 		return fmt.Errorf("push layer %s: %w", digestStr, err)

--- a/pkg/model/weight_pusher_test.go
+++ b/pkg/model/weight_pusher_test.go
@@ -274,6 +274,28 @@ func TestWeightPusher_Push_ReportsProgressPerLayer(t *testing.T) {
 	}
 }
 
+func TestWeightPusher_Push_SendsLayerMediaTypeHeader(t *testing.T) {
+	artifact := newTestWeightArtifact(t, "model-v1", "/src/weights")
+
+	var mediaTypes []string
+	reg := &mockRegistry{
+		writeLayerFunc: func(ctx context.Context, opts registry.WriteLayerOptions) error {
+			mediaTypes = append(mediaTypes, opts.LayerMediaTypeHeader)
+			return nil
+		},
+		pushImageFunc: func(ctx context.Context, ref string, img v1.Image) error { return nil },
+	}
+
+	pusher := NewWeightPusher(reg)
+	_, err := pusher.Push(context.Background(), "r8.im/user/model", artifact)
+	require.NoError(t, err)
+	require.NotEmpty(t, mediaTypes)
+
+	for i, lr := range artifact.Layers {
+		require.Equal(t, string(lr.MediaType), mediaTypes[i])
+	}
+}
+
 func TestWeightPusher_Push_ForwardsRetryCallback(t *testing.T) {
 	artifact := newTestWeightArtifact(t, "model-v1", "/src/weights")
 

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -49,12 +49,18 @@ type RetryConfig struct {
 	OnRetry RetryCallback
 }
 
+const OCILayerMediaTypeHeader = "OCI-Layer-Media-Type"
+
 // WriteLayerOptions configures the WriteLayer operation.
 type WriteLayerOptions struct {
 	// Repo is the repository to push to.
 	Repo string
 	// Layer is the layer to push.
 	Layer v1.Layer
+	// LayerMediaTypeHeader, when set, is sent as OCI-Layer-Media-Type on the
+	// final upload commit request. This is intentionally opt-in so image layers
+	// keep registry image-layer size enforcement.
+	LayerMediaTypeHeader string
 	// ProgressCh receives progress updates. Use a buffered channel to avoid deadlocks.
 	// If nil, no progress updates are sent.
 	ProgressCh chan<- v1.Update

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -6,10 +6,13 @@ import (
 	"errors"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"syscall"
 	"testing"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -79,6 +82,48 @@ func TestInspect(t *testing.T) {
 		assert.ErrorContains(t, err, "platform not found")
 		assert.Nil(t, resp)
 	})
+}
+
+func TestCommitUploadSendsLayerMediaTypeHeaderWhenConfigured(t *testing.T) {
+	var gotMediaType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPut, r.Method)
+		gotMediaType = r.Header.Get(OCILayerMediaTypeHeader)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(server.Close)
+
+	client := &RegistryClient{}
+	err := client.commitUpload(
+		context.Background(),
+		server.Client(),
+		server.URL+"/v2/test/blobs/uploads/uuid",
+		v1.Hash{Algorithm: "sha256", Hex: "abc123"},
+		"application/vnd.oci.image.layer.v1.tar+gzip",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "application/vnd.oci.image.layer.v1.tar+gzip", gotMediaType)
+}
+
+func TestCommitUploadOmitsLayerMediaTypeHeaderWhenUnset(t *testing.T) {
+	var gotMediaType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPut, r.Method)
+		gotMediaType = r.Header.Get(OCILayerMediaTypeHeader)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(server.Close)
+
+	client := &RegistryClient{}
+	err := client.commitUpload(
+		context.Background(),
+		server.Client(),
+		server.URL+"/v2/test/blobs/uploads/uuid",
+		v1.Hash{Algorithm: "sha256", Hex: "abc123"},
+		"",
+	)
+	require.NoError(t, err)
+	require.Empty(t, gotMediaType)
 }
 
 func TestIsRetryableError(t *testing.T) {

--- a/pkg/registry/registry_client.go
+++ b/pkg/registry/registry_client.go
@@ -571,7 +571,7 @@ func (c *RegistryClient) writeLayerMultipart(ctx context.Context, repo name.Repo
 	}
 
 	// Commit the upload using the final location (which contains updated state hash)
-	err = c.commitUpload(ctx, client, finalLocation, digest)
+	err = c.commitUpload(ctx, client, finalLocation, digest, opts.LayerMediaTypeHeader)
 	if err != nil {
 		return fmt.Errorf("committing upload: %w", err)
 	}
@@ -998,7 +998,7 @@ func (pr *progressReader) Read(p []byte) (int, error) {
 }
 
 // commitUpload finalizes the upload by sending a PUT request with the digest.
-func (c *RegistryClient) commitUpload(ctx context.Context, client *http.Client, location string, digest v1.Hash) error {
+func (c *RegistryClient) commitUpload(ctx context.Context, client *http.Client, location string, digest v1.Hash, layerMediaType string) error {
 	u, err := url.Parse(location)
 	if err != nil {
 		return fmt.Errorf("parsing location URL: %w", err)
@@ -1015,6 +1015,9 @@ func (c *RegistryClient) commitUpload(ctx context.Context, client *http.Client, 
 	}
 
 	req.Header.Set("Content-Type", "application/octet-stream")
+	if layerMediaType != "" {
+		req.Header.Set(OCILayerMediaTypeHeader, layerMediaType)
+	}
 
 	resp, err := client.Do(req) //nolint:gosec // G704: URL from registry upload session, not user input
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add an opt-in `OCI-Layer-Media-Type` finalize header path to registry layer uploads.
- Send the header only for Cog managed weight layers, preserving image-layer size enforcement.
- Cover weight header propagation, image non-propagation, and commit request header behavior in tests.

## Test Plan
- [x] `go test -count=1 ./pkg/model ./pkg/registry`