### PR TITLE
fix: handle PEP 563 string annotations in predictor validator

### DIFF
--- a/python/cog/_inspector.py
+++ b/python/cog/_inspector.py
@@ -70,7 +70,10 @@ def _validate_setup(f: Callable[..., Any]) -> None:
         raise ValueError("setup() must not have keyword-only args")
     if spec.kwonlydefaults:
         raise ValueError("setup() must not have keyword-only defaults")
-    if spec.annotations.get("return") is not None:
+    # With `from __future__ import annotations` (PEP 563), `-> None` is stored as
+    # the string "None" rather than the None value, so check both forms.
+    return_annotation = spec.annotations.get("return")
+    if return_annotation is not None and return_annotation != "None":
         raise ValueError("setup() must return None")
 
 
@@ -93,7 +96,10 @@ def _validate_run_or_predict(
         raise ValueError(f"{f_name}() must not have keyword-only args")
     if spec.kwonlydefaults:
         raise ValueError(f"{f_name}() must not have keyword-only defaults")
-    if spec.annotations.get("return") is None:
+    # With `from __future__ import annotations` (PEP 563), `-> None` is stored as
+    # the string "None" rather than the None value, so treat both as missing.
+    return_annotation = spec.annotations.get("return")
+    if return_annotation is None or return_annotation == "None":
         raise ValueError(f"{f_name}() must have a return type annotation")
 
 

--- a/python/tests/test_inspector.py
+++ b/python/tests/test_inspector.py
@@ -391,3 +391,47 @@ def test_inspector_preserves_nested_non_opaque_annotated_optional_behavior() -> 
     field = info.inputs["value"]
     assert field.type.primitive is adt.PrimitiveType.STRING
     assert field.type.repetition is adt.Repetition.OPTIONAL
+
+
+def test_inspector_accepts_setup_with_none_return_annotation_and_future_annotations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """setup() -> None must be accepted even when from __future__ import annotations is active.
+
+    With PEP 563 string annotations, -> None is stored as the string "None" rather than
+    the NoneType object, so a naive `is not None` check incorrectly rejects it.
+    """
+    module_name = "future_annotations_setup"
+    (tmp_path / f"{module_name}.py").write_text(
+        "from __future__ import annotations\n"
+        "class Runner:\n"
+        "    def setup(self) -> None:\n"
+        "        pass\n"
+        "    def run(self, value: str) -> str:\n"
+        "        return value\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    info = create_predictor(module_name, "Runner")
+    assert "value" in info.inputs
+
+
+def test_inspector_rejects_predict_with_none_return_annotation_and_future_annotations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """predict() -> None must be rejected even when from __future__ import annotations is active.
+
+    With PEP 563 string annotations, -> None is stored as the string "None" rather than
+    the NoneType object, so a naive `is None` check incorrectly accepts it.
+    """
+    module_name = "future_annotations_predict_none"
+    (tmp_path / f"{module_name}.py").write_text(
+        "from __future__ import annotations\n"
+        "class Runner:\n"
+        "    def run(self, value: str) -> None:\n"
+        "        pass\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    with pytest.raises(ValueError, match="return type annotation"):
+        create_predictor(module_name, "Runner")


### PR DESCRIPTION
Two bugs in `_validate_setup` / `_validate_run_or_predict` when the predictor file uses `from __future__ import annotations` (PEP 563).

With PEP 563, all annotations are stored as strings at compile time. So `-> None` becomes the string `"None"`, not the `None` value.

Bug 1 - false positive that blocks valid code: `_validate_setup` checks `spec.annotations.get("return") is not None`, which is `True` for `"None"`, so a correctly annotated `setup(self) -> None` raises `ValueError: setup() must return None`.

Bug 2 - false negative: `_validate_run_or_predict` checks `is None`, which is `False` for `"None"`, so `run(self, ...) -> None` incorrectly passes validation instead of being rejected.

**Reproduce bug 1:**

```python
# predict.py
from __future__ import annotations
from cog import BasePredictor

class Predictor(BasePredictor):
    def setup(self) -> None:   # <- valid, but cog crashes here
        pass
    def predict(self, text: str) -> str:
        return text
```

Running `cog build` against this gives `ValueError: setup() must return None`.

Fix: compare against both `None` and the string `"None"` when checking the return annotation, consistent with PEP 563 behavior.