### PR TITLE
fix: recurse through nested JSON file inputs

### DIFF
--- a/integration-tests/tests/predict_json_path_list_input.txtar
+++ b/integration-tests/tests/predict_json_path_list_input.txtar
@@ -1,0 +1,28 @@
+# Test `--json` with list[Path] input
+
+cog build -t $TEST_IMAGE
+cog predict $TEST_IMAGE --json '{"paths": ["@1.txt", "@2.txt"]}'
+stdout '"status": "succeeded"'
+stdout '"output": "test1test2"'
+
+-- cog.yaml --
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"
+
+-- predict.py --
+from cog import BasePredictor, Path
+
+
+class Predictor(BasePredictor):
+    def predict(self, paths: list[Path]) -> str:
+        output_parts = []
+        for path in paths:
+            with open(path) as f:
+                output_parts.append(f.read())
+        return "".join(output_parts)
+
+-- 1.txt --
+test1
+-- 2.txt --
+test2

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -159,33 +159,59 @@ func transformPathsToBase64URLs(inputs map[string]any) (map[string]any, error) {
 	result := make(map[string]any)
 
 	for key, value := range inputs {
-		if strValue, ok := value.(string); ok && strings.HasPrefix(strValue, "@") {
-			// This is a file path, convert to base64 data URL
-			filePath := strValue[1:]
-
-			// Read file
-			data, err := os.ReadFile(filePath)
-			if err != nil {
-				return nil, fmt.Errorf("Failed to read file %q: %w", filePath, err)
-			}
-
-			// Get MIME type
-			mimeType := mime.TypeByExtension(filepath.Ext(filePath))
-			if mimeType == "" {
-				mimeType = "application/octet-stream"
-			}
-
-			// Create base64 data URL
-			base64Data := base64.StdEncoding.EncodeToString(data)
-			dataURL := fmt.Sprintf("data:%s;base64,%s", mimeType, base64Data)
-
-			result[key] = dataURL
-		} else {
-			result[key] = value
+		transformed, err := transformJSONValuePathsToBase64URLs(value)
+		if err != nil {
+			return nil, err
 		}
+		result[key] = transformed
 	}
 
 	return result, nil
+}
+
+func transformJSONValuePathsToBase64URLs(value any) (any, error) {
+	switch v := value.(type) {
+	case string:
+		if !strings.HasPrefix(v, "@") {
+			return v, nil
+		}
+
+		filePath := v[1:]
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to read file %q: %w", filePath, err)
+		}
+
+		mimeType := mime.TypeByExtension(filepath.Ext(filePath))
+		if mimeType == "" {
+			mimeType = "application/octet-stream"
+		}
+
+		base64Data := base64.StdEncoding.EncodeToString(data)
+		return fmt.Sprintf("data:%s;base64,%s", mimeType, base64Data), nil
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			transformed, err := transformJSONValuePathsToBase64URLs(item)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = transformed
+		}
+		return out, nil
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for key, item := range v {
+			transformed, err := transformJSONValuePathsToBase64URLs(item)
+			if err != nil {
+				return nil, err
+			}
+			out[key] = transformed
+		}
+		return out, nil
+	default:
+		return value, nil
+	}
 }
 
 func cmdPredict(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/predict.go
+++ b/pkg/cli/predict.go
@@ -179,7 +179,7 @@ func transformJSONValuePathsToBase64URLs(value any) (any, error) {
 		filePath := v[1:]
 		data, err := os.ReadFile(filePath)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to read file %q: %w", filePath, err)
+			return nil, fmt.Errorf("values starting with '@' are treated as file paths; failed to read %q: %w", filePath, err)
 		}
 
 		mimeType := mime.TypeByExtension(filepath.Ext(filePath))

--- a/pkg/cli/predict_test.go
+++ b/pkg/cli/predict_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -168,4 +170,45 @@ func TestExtractOutputSchemaFromValidSchema(t *testing.T) {
 	outputSchema := safeExtractOutputSchema(s, "/predictions")
 	require.NotNil(t, outputSchema, "expected non-nil output schema for valid input")
 	require.Contains(t, outputSchema.Type.Slice(), "string", "expected string type")
+}
+
+func TestTransformPathsToBase64URLsRecursesIntoNestedJSON(t *testing.T) {
+	dir := t.TempDir()
+	fileA := filepath.Join(dir, "a.txt")
+	fileB := filepath.Join(dir, "b.txt")
+	fileC := filepath.Join(dir, "c.txt")
+	require.NoError(t, os.WriteFile(fileA, []byte("alpha"), 0o644))
+	require.NoError(t, os.WriteFile(fileB, []byte("beta"), 0o644))
+	require.NoError(t, os.WriteFile(fileC, []byte("gamma"), 0o644))
+
+	inputs := map[string]any{
+		"single": "@" + fileA,
+		"files": []any{
+			"@" + fileB,
+			map[string]any{
+				"inner": "@" + fileC,
+			},
+		},
+		"count": float64(3),
+		"plain": "hello",
+	}
+
+	transformed, err := transformPathsToBase64URLs(inputs)
+	require.NoError(t, err)
+
+	require.IsType(t, "", transformed["single"])
+	require.Contains(t, transformed["single"].(string), "data:text/plain;base64,")
+
+	files, ok := transformed["files"].([]any)
+	require.True(t, ok)
+	require.IsType(t, "", files[0])
+	require.Contains(t, files[0].(string), "data:text/plain;base64,")
+
+	innerObj, ok := files[1].(map[string]any)
+	require.True(t, ok)
+	require.IsType(t, "", innerObj["inner"])
+	require.Contains(t, innerObj["inner"].(string), "data:text/plain;base64,")
+
+	require.Equal(t, float64(3), transformed["count"])
+	require.Equal(t, "hello", transformed["plain"])
 }


### PR DESCRIPTION
`cog predict --json` only rewrites top level `@file` values rn. If those paths sit inside arrays or nested objects, they go through as raw `@...` strings, so `list[Path]` style inputs via JSON are kinda busted.

This makes the rewrite recursive for JSON arrays and objects. Added a unit test and an integration test too.

Repro:
`cog build -t $TEST_IMAGE`
`cog predict $TEST_IMAGE --json '{"paths": ["@1.txt", "@2.txt"]}'`

Before this, the CLI sends literal `@1.txt` strings and the prediction falls over.
After this, those entries become data URLs and it works.

Related: #1344
