### PR TITLE
fix: mount weights in cog serve like cog run does

### DIFF
--- a/integration-tests/harness/harness.go
+++ b/integration-tests/harness/harness.go
@@ -244,6 +244,7 @@ func (h *Harness) Commands() map[string]func(ts *testscript.TestScript, neg bool
 		// Built-in commands (defined in this file)
 		NewCommand("cog", h.cmdCog),
 		NewCommand("curl", h.cmdCurl),
+		NewCommand("server-stop", h.cmdServerStop),
 		NewCommand("wait-for", h.cmdWaitFor),
 		NewCommand("docker-run", h.cmdDockerRun),
 
@@ -620,6 +621,17 @@ func (h *Harness) cmdCurl(ts *testscript.TestScript, neg bool, args []string) {
 	ts.Fatalf("curl: all %d attempts failed with status %d: %s", maxAttempts, lastStatus, errorMsg)
 }
 
+// cmdServerStop stops the background 'cog serve' process for the current test.
+func (h *Harness) cmdServerStop(ts *testscript.TestScript, neg bool, args []string) {
+	if neg {
+		ts.Fatalf("server-stop: negation is not supported")
+	}
+	if len(args) != 0 {
+		ts.Fatalf("server-stop: usage: server-stop")
+	}
+	h.StopServer(ts)
+}
+
 // StopServer stops the background server process for a test script.
 func (h *Harness) StopServer(ts *testscript.TestScript) {
 	workDir := ts.Getenv("WORK")
@@ -645,11 +657,24 @@ func (h *Harness) stopServerByWorkDir(workDir string) {
 		_ = resp.Body.Close()
 	}
 
-	// Force kill the cog process if still running
+	// Give the cog process time to exit after /shutdown so defers can run.
+	done := make(chan struct{})
+	go func() {
+		_ = info.cmd.Wait()
+		close(done)
+	}()
+
+	// Force kill the cog process if still running.
 	if info.cmd.Process != nil {
-		_ = info.cmd.Process.Kill()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			_ = info.cmd.Process.Kill()
+			<-done
+		}
+	} else {
+		<-done
 	}
-	_ = info.cmd.Wait()
 
 	// Also kill any Docker container that may still be running on this port
 	// Find container by port and kill it

--- a/integration-tests/harness/harness.go
+++ b/integration-tests/harness/harness.go
@@ -29,12 +29,14 @@ import (
 // into testscript environments (Setup) and background processes (cmdCogServe).
 // Keep this list in sync: if you add a new env var to propagate, add it here.
 var propagatedEnvVars = []string{
-	"COG_SDK_WHEEL",     // SDK wheel override
-	"COGLET_WHEEL",      // coglet wheel override
-	"RUST_LOG",          // Rust logging control
-	"COG_CA_CERT",       // custom CA certificates (e.g. Cloudflare WARP)
-	"BUILDKIT_PROGRESS", // Docker build output format
-	"COG_REGISTRY_HOST", // registry host for cog base image resolution
+	"COG_SDK_WHEEL",      // SDK wheel override
+	"COGLET_WHEEL",       // coglet wheel override
+	"COG_CACHE_DIR",      // isolated cache for managed weights
+	"COG_MODEL_REGISTRY", // test registry override for model refs
+	"RUST_LOG",           // Rust logging control
+	"COG_CA_CERT",        // custom CA certificates (e.g. Cloudflare WARP)
+	"BUILDKIT_PROGRESS",  // Docker build output format
+	"COG_REGISTRY_HOST",  // registry host for cog base image resolution
 }
 
 // Harness provides utilities for running cog integration tests.

--- a/integration-tests/tests/weights_import_serve.txtar
+++ b/integration-tests/tests/weights_import_serve.txtar
@@ -36,6 +36,7 @@ stdout '"status":"succeeded"'
 stdout 'hello world \(weight-size=1024\)'
 
 # Per-invocation mount dir must be cleaned up after serve exits.
+server-stop
 exec sh -c 'test ! -d .cog/mounts || test -z "$(ls -A .cog/mounts)"'
 
 -- cog.yaml --

--- a/integration-tests/tests/weights_import_serve.txtar
+++ b/integration-tests/tests/weights_import_serve.txtar
@@ -1,0 +1,68 @@
+# End-to-end test that `cog weights import` warms the local store
+# enough for `cog serve` to mount the weights without a separate
+# `cog weights pull`.
+#
+# This is the serve-side companion to weights_import_predict.txtar.
+
+[short] skip 'requires local registry'
+
+env COG_CACHE_DIR=$WORK/cache
+
+registry-start
+
+# Point the model ref at the ephemeral test registry. cog.yaml carries
+# the bare repo via 'model:'; COG_MODEL_REGISTRY swaps in the host
+# now that registry-start has assigned a port.
+env COG_MODEL_REGISTRY=$TEST_REGISTRY
+
+# Build a deterministic weight directory.
+mkdir weights-src
+exec sh -c 'dd if=/dev/zero bs=1024 count=1 2>/dev/null | tr "\0" "X" > weights-src/greeting.txt'
+
+# Step 1: import. After this, the local content store under
+# $COG_CACHE_DIR/weights/files/sha256/ must contain greeting.txt's
+# bytes — that's the cog-i12u guarantee.
+cog weights import
+exists weights.lock
+
+# Step 2: serve, with NO intervening `cog weights pull`. The
+# import path warmed the store; serve's hardlink-assemble must
+# work straight off the back of import.
+cog serve
+
+# Step 3: predict via HTTP API and verify the weight is mounted.
+curl POST /predictions '{"input":{"s":"world"}}'
+stdout '"status":"succeeded"'
+stdout 'hello world \(weight-size=1024\)'
+
+# Per-invocation mount dir must be cleaned up after serve exits.
+exec sh -c 'test ! -d .cog/mounts || test -z "$(ls -A .cog/mounts)"'
+
+-- cog.yaml --
+# 'model:' carries the bare repo. The registry host is set via
+# COG_MODEL_REGISTRY in the test body since $TEST_REGISTRY varies
+# per run.
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"
+model: test/import-serve-model
+weights:
+  - name: greeting
+    target: /src/mounted-weights/greeting
+    source:
+      uri: file://./weights-src
+
+-- predict.py --
+import os
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def predict(self, s: str) -> str:
+        # Prove the weight was mounted at the target path by reading
+        # its size. Any failure to mount would raise FileNotFoundError
+        # here and the prediction would fail.
+        path = "/src/mounted-weights/greeting/greeting.txt"
+        size = os.path.getsize(path)
+        return f"hello {s} (weight-size={size})"

--- a/integration-tests/tests/weights_pull_serve.txtar
+++ b/integration-tests/tests/weights_pull_serve.txtar
@@ -45,6 +45,7 @@ stdout 'hello world \(weight-size=1024\)'
 # Step 4: the per-invocation mount dir must be cleaned up after
 # serve exits. .cog/mounts/ either doesn't exist (everything
 # cleaned) or is empty.
+server-stop
 exec sh -c 'test ! -d .cog/mounts || test -z "$(ls -A .cog/mounts)"'
 
 -- cog.yaml --

--- a/integration-tests/tests/weights_pull_serve.txtar
+++ b/integration-tests/tests/weights_pull_serve.txtar
@@ -1,0 +1,77 @@
+# End-to-end test of the managed-weights local-run flow via `cog serve`.
+# Verifies: cog weights import -> cog weights pull -> cog serve, where
+# the predictor container sees the weight files at the configured target
+# path via the HTTP API. Also verifies mount cleanup after serve exits.
+#
+# This is the serve-side companion to weights_pull_predict.txtar.
+
+[short] skip 'requires local registry'
+
+env COG_CACHE_DIR=$WORK/cache
+
+registry-start
+
+# Point the model ref at the ephemeral test registry. cog serve
+# picks this up via newWeightManager → resolveWeightRepo → ResolveModelRef.
+env COG_MODEL_REGISTRY=$TEST_REGISTRY
+
+# Build a deterministic weight directory.
+mkdir weights-src
+exec sh -c 'dd if=/dev/zero bs=1024 count=1 2>/dev/null | tr "\0" "X" > weights-src/greeting.txt'
+
+# Step 1: import to the local registry. This also warms the local
+# cache as a side effect of import (cog-i12u guarantee).
+cog weights import
+exists weights.lock
+
+# Purge the cache so step 2 exercises pull's cold-fetch path. The
+# realistic scenario for `cog weights pull` is "lockfile checked in,
+# cache empty" — e.g. a fresh clone.
+exec sh -c 'rm -rf $WORK/cache/weights/files'
+
+# Step 2: pull into the isolated cache.
+cog weights pull
+stderr 'Pulled'
+
+# Step 3: serve. The predictor opens the file at the configured
+# target path and returns its size, proving the mount is visible
+# and readable inside the container.
+cog serve
+
+curl POST /predictions '{"input":{"s":"world"}}'
+stdout '"status":"succeeded"'
+stdout 'hello world \(weight-size=1024\)'
+
+# Step 4: the per-invocation mount dir must be cleaned up after
+# serve exits. .cog/mounts/ either doesn't exist (everything
+# cleaned) or is empty.
+exec sh -c 'test ! -d .cog/mounts || test -z "$(ls -A .cog/mounts)"'
+
+-- cog.yaml --
+# 'model:' carries the bare repo. The registry host is set via
+# COG_MODEL_REGISTRY in the test body since $TEST_REGISTRY varies
+# per run.
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"
+model: test/pull-serve-model
+weights:
+  - name: greeting
+    target: /src/mounted-weights/greeting
+    source:
+      uri: file://./weights-src
+
+-- predict.py --
+import os
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def predict(self, s: str) -> str:
+        # Prove the weight was mounted at the target path by reading
+        # its size. Any failure to mount would raise FileNotFoundError
+        # here and the prediction would fail.
+        path = "/src/mounted-weights/greeting/greeting.txt"
+        size = os.path.getsize(path)
+        return f"hello {s} (weight-size={size})"

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -13,6 +13,7 @@ import (
 	"github.com/replicate/cog/pkg/model"
 	"github.com/replicate/cog/pkg/registry"
 	"github.com/replicate/cog/pkg/util/console"
+	"github.com/replicate/cog/pkg/weights"
 )
 
 var (
@@ -84,6 +85,10 @@ func cmdServe(cmd *cobra.Command, arg []string) error {
 	}
 	defer src.Close()
 
+	if err := weights.CheckDrift(src.ProjectDir, src.Config.Weights); err != nil {
+		return err
+	}
+
 	console.Info("Building Docker image from environment in cog.yaml...")
 	console.Info("")
 	resolver := model.NewResolver(dockerClient, registry.NewRegistryClient())
@@ -123,6 +128,27 @@ func cmdServe(cmd *cobra.Command, arg []string) error {
 		Image:   m.ImageRef(),
 		Volumes: []command.Volume{{Source: src.ProjectDir, Destination: "/src"}},
 		Workdir: "/src",
+	}
+
+	wm, err := newWeightManager(src)
+	if err != nil {
+		return err
+	}
+	mounts, err := wm.Prepare(ctx)
+	if err != nil {
+		return fmt.Errorf("prepare weights: %w", err)
+	}
+	defer func() {
+		if err := mounts.Release(); err != nil {
+			console.Warnf("Failed to clean up weight mounts: %s", err)
+		}
+	}()
+	for _, spec := range mounts.Specs {
+		runOptions.Volumes = append(runOptions.Volumes, command.Volume{
+			Source:      spec.Source,
+			Destination: spec.Target,
+			ReadOnly:    true,
+		})
 	}
 
 	// On Linux, host.docker.internal is not available by default — add it.


### PR DESCRIPTION
## Problem

`cog serve` was not mounting managed weights into the container, while `cog run` (via `predict.Predictor`) did. This caused models with weights to fail during setup with errors like:



## Fix

Adds the same weight-handling pattern to `cmdServe` in `pkg/cli/serve.go`:

1. `weights.CheckDrift()` to validate `weights.lock` is in sync with `cog.yaml`
2. `newWeightManager(src)` to create a weights manager
3. `wm.Prepare(ctx)` to assemble hardlinks from the local store into per-invocation mount directories
4. Append mount specs to `runOptions.Volumes` as read-only binds
5. `defer mounts.Release()` to clean up the per-invocation mount directory when the server exits