### PR TITLE
ci: pin mise version in release workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,6 +138,7 @@ jobs:
           fetch-depth: 0
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Build SDK
         run: mise run ci:build:sdk
@@ -190,6 +191,7 @@ jobs:
           fetch-depth: 0
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Get version from VERSION.txt
         id: version
@@ -221,6 +223,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Check Go formatting
         run: mise run fmt:go
@@ -233,6 +236,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Ensure Rust components
         run: rustup component add rustfmt clippy
@@ -247,6 +251,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Check Python formatting
         run: mise run fmt:python
@@ -259,6 +264,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Check llms.txt is up to date
         run: mise run docs:llm:check
@@ -283,6 +289,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Check stubs are up to date
         run: |
@@ -302,6 +309,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Lint Go
         run: mise run lint:go
@@ -318,6 +326,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Ensure Rust components
         run: rustup component add rustfmt clippy
@@ -332,6 +341,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Check licenses, bans, and sources
         run: cargo deny --manifest-path crates/Cargo.toml check bans licenses sources
@@ -349,6 +359,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Check advisories (informational)
         run: cargo deny --manifest-path crates/Cargo.toml check advisories
@@ -373,6 +384,7 @@ jobs:
         run: tar xf dist/*.tar.gz --strip-components=1
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Ensure nox is installed
         run: mise install pipx:nox --force
@@ -387,6 +399,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Lint Markdown
         run: mise run lint:docs
@@ -407,6 +420,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Test Go
         shell: bash
@@ -433,6 +447,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Fuzz schema type resolution
         run: go test ./pkg/schema/ -run='^$' -fuzz=FuzzResolveSchemaType -fuzztime=30s
@@ -455,6 +470,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Test Rust
         run: mise run test:rust
@@ -478,6 +494,7 @@ jobs:
         run: tar xf dist/*.tar.gz --strip-components=1
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Remove src to ensure tests run against wheel
         run: rm -rf python/cog
@@ -508,6 +525,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Test coglet-python bindings
         run: uvx nox -s coglet -p ${{ matrix.python-version }}
@@ -628,6 +646,7 @@ jobs:
           chmod +x ./cog
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Set wheel environment
         run: |
@@ -787,6 +806,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Check coglet crates.io publish
         run: cargo publish --dry-run -p coglet --manifest-path crates/Cargo.toml

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-docs-${{ github.job }}
 
       - name: Generate CLI docs

--- a/.github/workflows/mirror-cog-base-images.yaml
+++ b/.github/workflows/mirror-cog-base-images.yaml
@@ -26,6 +26,7 @@ jobs:
 
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-mirror-${{ github.job }}
 
       - name: Install crane

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -129,6 +129,7 @@ jobs:
 
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-rel-${{ github.job }}
 
       - name: Update coglet version constraint
@@ -219,6 +220,7 @@ jobs:
 
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-rel-${{ github.job }}
 
       - name: Check for existing release

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -115,6 +115,7 @@ jobs:
 
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-pub-${{ github.job }}
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth

--- a/.github/workflows/rust-advisories.yaml
+++ b/.github/workflows/rust-advisories.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache_key_prefix: mise-ci-${{ github.job }}
       - name: Check advisories
         id: advisories

--- a/.github/workflows/update-compatibility-matrices.yaml
+++ b/.github/workflows/update-compatibility-matrices.yaml
@@ -27,6 +27,7 @@ jobs:
       - name: Install tools
         uses: jdx/mise-action@v4
         with:
+          version: 2026.4.27
           cache: true
           cache_key_prefix: mise-compatibility-matrices
 


### PR DESCRIPTION
## Problem

The rc.2 release build fails during the workflow's `jdx/mise-action@v4` setup step with:

```text
core:rust@1.93.0: rust@1.93.0 is not in the lockfile
```

The same failure also hits normal CI jobs on this PR because they use `jdx/mise-action@v4` without a pinned mise version. The action currently downloads mise `2026.5.18`, and that version fails fresh locked installs for this repo with `MISE_LOCKED=1`.

Running local `mise install` did not change the lockfile because local machines may have an older mise version and/or existing installed tools, which avoids the fresh locked-resolution path.

## Fix

Pin all repository uses of `jdx/mise-action@v4` to mise `2026.4.27`, which successfully resolves `rust@1.93.0` under locked mode.

This includes CI, release, docs, advisory, mirror, and compatibility-matrix workflows.

## Verification

- Reproduced the failure with mise `2026.5.18` and a fresh `MISE_DATA_DIR`.
- Verified mise `2026.4.27` can install `rust@1.93.0` with `MISE_LOCKED=1` and a fresh data directory.
- Parsed all workflow YAML files successfully.
- Verified every `jdx/mise-action@v4` use has `version: 2026.4.27`.

## After merge

The old `v0.21.0-rc.2` tag pointed at a commit with the old workflow, so rerunning it would keep failing. The remote and local tag have been deleted.

After this merges to `main`, recreate the tag on the fixed `main` commit:

```bash
git checkout main
git pull --ff-only origin main
git tag v0.21.0-rc.2
git push origin v0.21.0-rc.2
```
