### PR TITLE
fix: resolve omitted Optional inputs to None at the HTTP edge

### DIFF
--- a/crates/coglet/src/input_validation.rs
+++ b/crates/coglet/src/input_validation.rs
@@ -26,6 +26,26 @@ pub struct InputValidator {
     properties: HashSet<String>,
     /// Required field names from the schema.
     required: Vec<String>,
+    /// Properties that should resolve to `null` when omitted from the request.
+    ///
+    /// These are inputs declared `Optional[T]` / `T | None` that carry no
+    /// real default (schema: `nullable: true`, absent from `required`, no
+    /// `default` key). The Python signature may not have a usable
+    /// `__defaults__` entry for these (e.g. a bare `value: Optional[str]`),
+    /// so omitting them would raise `TypeError: missing 1 required positional
+    /// argument` in the worker. Injecting an explicit `null` makes the
+    /// documented behaviour ("optional inputs default to None") hold, with the
+    /// generated schema staying the source of truth for what is optional.
+    ///
+    /// This rule mirrors the schema-generation discriminator in
+    /// `pkg/schema/openapi.go` (`buildInputSchema`), which emits `nullable`,
+    /// `required` membership, and the `default` key independently. The unit
+    /// tests below hand-build schema JSON, so they cannot catch drift if that
+    /// generator changes shape (e.g. `anyOf`-with-null instead of
+    /// `nullable: true`). The end-to-end guard against such drift is the
+    /// integration test `integration-tests/tests/optional_input_no_default.txtar`,
+    /// which runs the real generator through coglet.
+    inject_null: Vec<String>,
 }
 
 impl InputValidator {
@@ -63,6 +83,30 @@ impl InputValidator {
             })
             .unwrap_or_default();
 
+        // Properties that should resolve to `null` when omitted: nullable,
+        // not required, and with no `default` key. This mirrors the
+        // schema-generation discriminator in pkg/schema/openapi.go, where
+        // `nullable`, membership in `required`, and the presence of a
+        // `default` key are emitted independently.
+        let required_set: HashSet<&str> = required.iter().map(String::as_str).collect();
+        let inject_null: Vec<String> = input_schema
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .map(|obj| {
+                obj.iter()
+                    .filter(|(name, prop)| {
+                        let nullable = prop
+                            .get("nullable")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false);
+                        let has_default = prop.get("default").is_some();
+                        nullable && !has_default && !required_set.contains(name.as_str())
+                    })
+                    .map(|(name, _)| name.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+
         let mut resolved = input_schema.clone();
 
         // Inline $ref pointers so the validator can resolve them without
@@ -81,11 +125,32 @@ impl InputValidator {
             validator,
             properties,
             required,
+            inject_null,
         })
     }
 
     pub fn required_count(&self) -> usize {
         self.required.len()
+    }
+
+    /// Inject an explicit `null` for any optional-with-no-default property that
+    /// is absent from the input.
+    ///
+    /// Only injects on true absence — a value already present (including an
+    /// explicit `null`) is never overwritten. Call this only after
+    /// `validate()` succeeds so missing *required* fields still error.
+    pub fn inject_missing_optionals(&self, input: &mut Value) {
+        if self.inject_null.is_empty() {
+            return;
+        }
+        let Some(obj) = input.as_object_mut() else {
+            return;
+        };
+        for name in &self.inject_null {
+            if !obj.contains_key(name) {
+                obj.insert(name.clone(), Value::Null);
+            }
+        }
     }
 
     /// Strip unknown input fields in place, returning the names of removed fields.
@@ -421,5 +486,148 @@ mod tests {
 
         assert!(validator.validate(&json!({"s": "hello"})).is_ok());
         assert!(validator.validate(&json!({"s": "hello", "n": 42})).is_ok());
+    }
+
+    #[test]
+    fn injects_null_for_omitted_optional_without_default() {
+        // `value: Optional[str]` / `value: Optional[str] = Input(description=...)`
+        // emit: nullable, not required, no `default` key.
+        let schema = make_schema(json!({
+            "type": "object",
+            "properties": {
+                "s": {"type": "string", "title": "S"},
+                "value": {"type": "string", "title": "Value", "nullable": true}
+            },
+            "required": ["s"]
+        }));
+
+        let validator = InputValidator::from_openapi_schema(&schema).unwrap();
+
+        let mut input = json!({"s": "hello"});
+        validator.inject_missing_optionals(&mut input);
+        assert_eq!(input, json!({"s": "hello", "value": null}));
+    }
+
+    #[test]
+    fn does_not_override_present_optional_value() {
+        let schema = make_schema(json!({
+            "type": "object",
+            "properties": {
+                "value": {"type": "string", "title": "Value", "nullable": true}
+            }
+        }));
+
+        let validator = InputValidator::from_openapi_schema(&schema).unwrap();
+
+        // Present value (including explicit null) is never overwritten.
+        let mut input = json!({"value": "present"});
+        validator.inject_missing_optionals(&mut input);
+        assert_eq!(input, json!({"value": "present"}));
+
+        let mut input = json!({"value": null});
+        validator.inject_missing_optionals(&mut input);
+        assert_eq!(input, json!({"value": null}));
+    }
+
+    #[test]
+    fn does_not_inject_for_optional_with_explicit_default() {
+        // `Optional[str] = Input(default=None)` emits `default: null`;
+        // `seed: int = Input(default=42)` emits `default: 42`. Python's
+        // __defaults__ already resolves these, so injection must skip them.
+        let schema = make_schema(json!({
+            "type": "object",
+            "properties": {
+                "opt_none": {"type": "string", "title": "OptNone", "nullable": true, "default": null},
+                "with_default": {"type": "integer", "title": "WithDefault", "default": 42}
+            }
+        }));
+
+        let validator = InputValidator::from_openapi_schema(&schema).unwrap();
+
+        let mut input = json!({});
+        validator.inject_missing_optionals(&mut input);
+        assert_eq!(
+            input,
+            json!({}),
+            "fields with a default key are left absent"
+        );
+    }
+
+    #[test]
+    fn injects_null_for_omitted_optional_list() {
+        // `Optional[list[str]]` / `list[str] | None` emits a top-level
+        // `nullable: true` array with no default and is absent from `required`.
+        let schema = make_schema(json!({
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "title": "Items",
+                    "nullable": true
+                }
+            }
+        }));
+
+        let validator = InputValidator::from_openapi_schema(&schema).unwrap();
+
+        let mut input = json!({});
+        validator.inject_missing_optionals(&mut input);
+        assert_eq!(input, json!({"items": null}));
+    }
+
+    #[test]
+    fn injects_null_for_omitted_optional_enum() {
+        // An optional choices field emits `allOf` + `$ref` with a sibling
+        // `nullable: true` and no default. The discriminator reads `nullable`
+        // at the property top level, so it should still inject.
+        let schema = json!({
+            "components": {
+                "schemas": {
+                    "Input": {
+                        "type": "object",
+                        "properties": {
+                            "color": {
+                                "allOf": [{"$ref": "#/components/schemas/Color"}],
+                                "title": "Color",
+                                "nullable": true,
+                                "x-order": 0
+                            }
+                        }
+                    },
+                    "Color": {
+                        "title": "Color",
+                        "description": "An enumeration.",
+                        "enum": ["red", "green", "blue"],
+                        "type": "string"
+                    }
+                }
+            }
+        });
+
+        let validator = InputValidator::from_openapi_schema(&schema).unwrap();
+
+        let mut input = json!({});
+        validator.inject_missing_optionals(&mut input);
+        assert_eq!(input, json!({"color": null}));
+    }
+
+    #[test]
+    fn does_not_inject_for_required_field() {
+        // A required field is never nullable-without-default in practice, but
+        // guard against injecting for anything listed in `required`.
+        let schema = make_schema(json!({
+            "type": "object",
+            "properties": {
+                "r": {"type": "string", "title": "R", "nullable": true}
+            },
+            "required": ["r"]
+        }));
+
+        let validator = InputValidator::from_openapi_schema(&schema).unwrap();
+
+        let mut input = json!({});
+        validator.inject_missing_optionals(&mut input);
+        assert_eq!(input, json!({}), "required fields are not injected");
     }
 }

--- a/crates/coglet/src/service.rs
+++ b/crates/coglet/src/service.rs
@@ -436,12 +436,32 @@ impl PredictionService {
     ) {
         let guard = self.input_validator.read().await;
         if let Some(ref validator) = *guard {
-            let stripped = validator.strip_unknown(input);
-            let result = validator.validate(input);
-            (stripped, result)
+            Self::strip_validate_inject(validator, input)
         } else {
             (Vec::new(), Ok(()))
         }
+    }
+
+    /// Strip unknown fields, validate, then inject `null` for omitted
+    /// optional-with-no-default inputs.
+    ///
+    /// Injection runs only when validation passes, so missing *required*
+    /// fields still error before any default is filled in. Centralizing this
+    /// keeps the ordering invariant identical across the predict and train
+    /// (including fallback) paths.
+    fn strip_validate_inject(
+        validator: &InputValidator,
+        input: &mut serde_json::Value,
+    ) -> (
+        Vec<String>,
+        Result<(), Vec<crate::input_validation::ValidationError>>,
+    ) {
+        let stripped = validator.strip_unknown(input);
+        let result = validator.validate(input);
+        if result.is_ok() {
+            validator.inject_missing_optionals(input);
+        }
+        (stripped, result)
     }
 
     /// Strip unknown fields from training input and validate in one pass.
@@ -456,16 +476,12 @@ impl PredictionService {
     ) {
         let train_guard = self.train_validator.read().await;
         if let Some(ref validator) = *train_guard {
-            let stripped = validator.strip_unknown(input);
-            let result = validator.validate(input);
-            return (stripped, result);
+            return Self::strip_validate_inject(validator, input);
         }
         drop(train_guard);
         let predict_guard = self.input_validator.read().await;
         if let Some(ref validator) = *predict_guard {
-            let stripped = validator.strip_unknown(input);
-            let result = validator.validate(input);
-            return (stripped, result);
+            return Self::strip_validate_inject(validator, input);
         }
         (Vec::new(), Ok(()))
     }
@@ -1791,5 +1807,77 @@ mod tests {
         assert_eq!(id, "p3");
         assert_eq!(rehydrated, input);
         assert_eq!(output_dir, "/tmp/out");
+    }
+
+    /// OpenAPI doc with an optional-with-no-default field under the given
+    /// schema component key (e.g. "Input" or "TrainingInput").
+    fn optional_schema(key: &str) -> serde_json::Value {
+        serde_json::json!({
+            "components": {
+                "schemas": {
+                    key: {
+                        "type": "object",
+                        "properties": {
+                            "s": {"type": "string", "title": "S"},
+                            "value": {"type": "string", "title": "Value", "nullable": true}
+                        },
+                        "required": ["s"]
+                    }
+                }
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn strip_and_validate_input_injects_missing_optional() {
+        let svc = PredictionService::new_no_pool();
+        svc.set_schema(optional_schema("Input")).await;
+
+        let mut input = serde_json::json!({"s": "hello"});
+        let (_stripped, result) = svc.strip_and_validate_input(&mut input).await;
+
+        assert!(result.is_ok(), "valid input should pass validation");
+        assert_eq!(
+            input,
+            serde_json::json!({"s": "hello", "value": null}),
+            "omitted optional-with-no-default should be injected with null"
+        );
+    }
+
+    #[tokio::test]
+    async fn strip_and_validate_input_does_not_inject_when_required_missing() {
+        let svc = PredictionService::new_no_pool();
+        svc.set_schema(optional_schema("Input")).await;
+
+        // "s" is required and absent: validation must fail and nothing should
+        // be injected (the request is rejected before defaults are filled in).
+        let mut input = serde_json::json!({});
+        let (_stripped, result) = svc.strip_and_validate_input(&mut input).await;
+
+        assert!(result.is_err(), "missing required field should fail");
+        assert_eq!(
+            input,
+            serde_json::json!({}),
+            "injection must not run when validation fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn strip_and_validate_train_input_injects_missing_optional() {
+        let svc = PredictionService::new_no_pool();
+        svc.set_schema(optional_schema("TrainingInput")).await;
+
+        let mut input = serde_json::json!({"s": "hello"});
+        let (_stripped, result) = svc.strip_and_validate_train_input(&mut input).await;
+
+        assert!(
+            result.is_ok(),
+            "valid training input should pass validation"
+        );
+        assert_eq!(
+            input,
+            serde_json::json!({"s": "hello", "value": null}),
+            "train path should inject omitted optional-with-no-default"
+        );
     }
 }

--- a/integration-tests/tests/optional_input_no_default.txtar
+++ b/integration-tests/tests/optional_input_no_default.txtar
@@ -1,0 +1,52 @@
+# Test that an Optional input with no default resolves to None when omitted.
+#
+# A bare `value: Optional[str]` (no `= Input(...)`) is emitted as an optional
+# field in the OpenAPI schema (nullable, absent from `required`, no default),
+# but the Python signature has no usable __defaults__ entry. Historically,
+# omitting it raised `TypeError: missing 1 required positional argument` at
+# prediction time. Coglet now injects an explicit null for omitted
+# optional-with-no-default inputs at the HTTP edge, so omission resolves to
+# None as documented.
+
+cog build -t $TEST_IMAGE
+
+# --- Test via cog predict (CLI) ---
+
+# Providing the optional input should work.
+cog predict $TEST_IMAGE -i value=hello
+stdout 'type=str value=hello'
+
+# Omitting the bare optional input should yield None (not a TypeError).
+cog predict $TEST_IMAGE
+stdout 'type=NoneType value=none'
+
+# --- Test via cog serve (HTTP API) ---
+
+cog serve
+
+# POST with the value present.
+curl POST /predictions '{"input":{"value":"world"}}'
+stdout '"status":"succeeded"'
+stdout 'type=str value=world'
+
+# POST omitting the optional input — should resolve to None.
+curl POST /predictions '{"input":{}}'
+stdout '"status":"succeeded"'
+stdout 'type=NoneType value=none'
+
+-- cog.yaml --
+build:
+  python_version: "3.12"
+predict: "predict.py:Predictor"
+
+-- predict.py --
+from typing import Optional
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    def predict(self, value: Optional[str]) -> str:
+        if value is None:
+            return "type=NoneType value=none"
+        return f"type={type(value).__name__} value={value}"


### PR DESCRIPTION
## Problem

A predictor input declared `Optional[T]` / `T | None` is emitted as an optional field in the OpenAPI schema (`nullable: true`, absent from `required`), but whether it can actually be **omitted** at request time depended on a Python-level detail the schema doesn't capture: whether the parameter had a usable `__defaults__` entry.

| Signature | Omitted at runtime |
| --- | --- |
| `value: Optional[str]` (bare, no `Input`) | ❌ `TypeError: missing 1 required positional argument` |
| `value: Optional[str] = Input(description="…")` | ✅ resolves to `None` |
| `value: Optional[str] = Input(default=None)` | ✅ resolves to `None` |

All three generate a correct "optional" schema. The bare form was a silent footgun: it built and served fine, advertised the field as optional, then failed at prediction time whenever a caller omitted it.

## Fix

Validation against the OpenAPI schema already runs at coglet's **HTTP edge** (`InputValidator`), not in the worker. After validation passes, inject an explicit `null` for every property that is `nullable: true`, **not** in `required`, and has **no** `default` key, when it is absent from the request.

This rule mirrors the schema-generation discriminator in `pkg/schema/openapi.go` (`buildInputSchema`), keeps the OpenAPI schema as the source of truth for what is optional, and leaves the worker unchanged (it needs no schema).

The rule safely skips:
- `Optional[T] = Input(default=None)` — emits `default: null`, already handled by `unwrap_field_info_defaults`
- real defaults like `Input(default=42)` — emits `default: 42`
- required fields — the validator rejects omission first

Injection runs only after successful validation, so missing **required** fields still return 422. Training inputs (`TrainingInput`) are covered via the same path. Union optionals (`A | B | None`) are forced into `required` by the generator and are correctly skipped (they 422 on omission rather than resolving to `None` — pre-existing behavior, not a regression).

## Tests

- **Unit (`input_validation.rs`)**: inject for bare optional / optional list / optional enum; skip explicit-default and required fields; never override a present value.
- **Unit (`service.rs`)**: predict injects after `Ok`, does **not** inject when a required field is missing, train path injects.
- **Integration (`optional_input_no_default.txtar`)**: a bare `value: Optional[str]` omitted via both `cog predict` and `POST /predictions {"input":{}}` resolves to `None`.