### PR TITLE
fix: correct cog download URL for Linux arm64 (aarch64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ If you're using macOS, you can install Cog using Homebrew:
 brew install replicate/tap/cog
 ```
 
-You can also download and install the latest release using our
-[install script](https://cog.run/install):
+Otherwise, we recommend our [install script](https://cog.run/install):
 
 ```sh
 # bash, zsh, and other shells
@@ -143,11 +142,10 @@ wget -qO- https://cog.run/install.sh
 sh ./install.sh
 ```
 
-You can manually install the latest release of Cog directly from GitHub
-by running the following commands in a terminal:
+Alternatively, install the latest release manually from GitHub:
 
 ```console
-sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m)"
+sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m | sed 's/aarch64/arm64/')"
 sudo chmod +x /usr/local/bin/cog
 ```
 

--- a/docs/getting-started-own-model.md
+++ b/docs/getting-started-own-model.md
@@ -20,7 +20,7 @@ brew install replicate/tap/cog
 **Linux or macOS (manual):**
 
 ```sh
-sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
+sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m | sed 's/aarch64/arm64/')"
 sudo chmod +x /usr/local/bin/cog
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,7 +25,7 @@ brew install replicate/tap/cog
 **Linux or macOS (manual):**
 
 ```bash
-sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
+sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m | sed 's/aarch64/arm64/')"
 sudo chmod +x /usr/local/bin/cog
 sudo xattr -d com.apple.quarantine /usr/local/bin/cog 2>/dev/null || true
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -128,8 +128,7 @@ If you're using macOS, you can install Cog using Homebrew:
 brew install replicate/tap/cog
 ```
 
-You can also download and install the latest release using our
-[install script](https://cog.run/install):
+Otherwise, we recommend our [install script](https://cog.run/install):
 
 ```sh
 # bash, zsh, and other shells
@@ -143,11 +142,10 @@ wget -qO- https://cog.run/install.sh
 sh ./install.sh
 ```
 
-You can manually install the latest release of Cog directly from GitHub
-by running the following commands in a terminal:
+Alternatively, install the latest release manually from GitHub:
 
 ```console
-sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m)"
+sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m | sed 's/aarch64/arm64/')"
 sudo chmod +x /usr/local/bin/cog
 ```
 
@@ -956,7 +954,7 @@ brew install replicate/tap/cog
 **Linux or macOS (manual):**
 
 ```sh
-sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
+sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m | sed 's/aarch64/arm64/')"
 sudo chmod +x /usr/local/bin/cog
 ```
 
@@ -1138,7 +1136,7 @@ brew install replicate/tap/cog
 **Linux or macOS (manual):**
 
 ```bash
-sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
+sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m | sed 's/aarch64/arm64/')"
 sudo chmod +x /usr/local/bin/cog
 sudo xattr -d com.apple.quarantine /usr/local/bin/cog 2>/dev/null || true
 
@@ -3186,7 +3184,7 @@ wsl.exe
 Download and install `cog` inside the VM:
 
 ```bash
-sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
+sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m | sed 's/aarch64/arm64/')"
 sudo chmod +x /usr/local/bin/cog
 ```
 

--- a/docs/wsl2/wsl2.md
+++ b/docs/wsl2/wsl2.md
@@ -159,7 +159,7 @@ wsl.exe
 Download and install `cog` inside the VM:
 
 ```bash
-sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
+sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m | sed 's/aarch64/arm64/')"
 sudo chmod +x /usr/local/bin/cog
 ```
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -104,7 +104,15 @@ check_docker() {
 
 setup_cog() {
   COG_LOCATION="${INSTALL_DIR}/cog"
-  BINARY_URI="https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_$(uname -m)"
+  # Normalize the machine architecture to match the names of the released
+  # assets. `uname -m` reports `aarch64` on Linux arm64, but the release assets
+  # are named `arm64`, and `x86_64` rather than `amd64`.
+  ARCH="$(uname -m)"
+  case "$ARCH" in
+    aarch64) ARCH="arm64" ;;
+    amd64) ARCH="x86_64" ;;
+  esac
+  BINARY_URI="https://github.com/replicate/cog/releases/latest/download/cog_$(uname -s)_${ARCH}"
   if [ -f "$COG_LOCATION" ]; then
     echo "A file already exists at $COG_LOCATION"
     echo "Do you want to delete this file and continue with this installation anyway?"


### PR DESCRIPTION
- The documented install commands (README, `docs/`) and `tools/install.sh` build the release asset download URL from `uname -m`. 
- On Linux arm64, `uname -m` reports `aarch64`, but the GitHub release assets are named `cog_Linux_arm64`. As a result the URL resolves to a nonexistent `cog_Linux_aarch64` asset and returns a 404.
- macOS arm64 was unaffected because `uname -m` already returns `arm64` there.

Fixes #1309.

## Fix

Normalize the architecture before constructing the URL:

- `tools/install.sh`: map `aarch64` → `arm64` and `amd64` → `x86_64` via a `case`.
- README and docs one-liners: `$(uname -m | sed 's/aarch64/arm64/')`.