### PR TITLE
test: cover CUDA minor version base image selection

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -468,6 +468,21 @@ func TestCUDABaseImageTag(t *testing.T) {
 	require.Equal(t, "nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04", imageTag)
 }
 
+func TestCUDABaseImageTagChoosesLatestPatchForMinorCUDA(t *testing.T) {
+	config := &Config{
+		Build: &Build{
+			GPU:           true,
+			PythonVersion: "3.10",
+			CUDA:          "11.6",
+			CuDNN:         "8",
+		},
+	}
+
+	imageTag, err := config.CUDABaseImageTag()
+	require.NoError(t, err)
+	require.Equal(t, "nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04", imageTag)
+}
+
 func TestBuildRunItemStringYAML(t *testing.T) {
 	type BuildWrapper struct {
 		Build *Build `yaml:"build"`


### PR DESCRIPTION
## What does this PR do?

Adds regression coverage for CUDA minor-version base image selection.

Issue #813 describes the case where specifying a minor CUDA version like `11.6` should select the latest available patch version. Current `main` already appears to do this correctly, resolving `CUDA: "11.6"` and `CuDNN: "8"` to:

```text
nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04
```

This PR adds a focused test so that behavior stays covered.

Fixes #813.

## Testing

```bash
go test ./pkg/config
```
