### PR TITLE
fix: allow explicit CuDNN with CUDA minor versions

### DIFF
--- a/pkg/config/compatibility.go
+++ b/pkg/config/compatibility.go
@@ -195,7 +195,7 @@ func cudaFromTF(ver string) (cuda string, cuDNN string, err error) {
 func compatibleCuDNNsForCUDA(cuda string) []string {
 	cuDNNs := []string{}
 	for _, image := range CUDABaseImages {
-		if image.CUDA == cuda {
+		if version.Matches(cuda, image.CUDA) {
 			cuDNNs = append(cuDNNs, image.CuDNN)
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -468,6 +468,24 @@ func TestCUDABaseImageTag(t *testing.T) {
 	require.Equal(t, "nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04", imageTag)
 }
 
+func TestCUDABaseImageTagWithExplicitMinorCUDAAndCuDNN(t *testing.T) {
+	config := &Config{
+		Build: &Build{
+			GPU:           true,
+			PythonVersion: "3.10",
+			CUDA:          "11.6",
+			CuDNN:         "8",
+		},
+	}
+
+	err := config.Complete("")
+	require.NoError(t, err)
+
+	imageTag, err := config.CUDABaseImageTag()
+	require.NoError(t, err)
+	require.Equal(t, "nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04", imageTag)
+}
+
 func TestBuildRunItemStringYAML(t *testing.T) {
 	type BuildWrapper struct {
 		Build *Build `yaml:"build"`


### PR DESCRIPTION
## Summary
- Fix CUDA/CuDNN compatibility validation to treat user-specified CUDA minor versions like `11.6` as selectors for compatible patch-level base images such as `11.6.2`.
- Add a regression test that completes a GPU config with explicit `cuda: "11.6"` and `cudnn: "8"`, then verifies the selected NVIDIA base image.

## Why
`latestCuDNNForCUDA` and `cudaBaseImageFor` already use `version.Matches`, so `cuda: "11.6"` can resolve to `nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04`. The validation path used an exact string comparison, which meant the same config failed early when `cudnn` was set explicitly.

## Test plan
- `git diff --check`
- `go test ./pkg/config -run 'TestCUDABaseImageTag|TestLatestCuDNNForCUDA|TestValidateAndCompleteCUDA' -count=1`
- `go test ./pkg/config -count=1`
