### PR TITLE
fix: set correct cog version in OpenAPI schema

### DIFF
--- a/integration-tests/tests/build_openapi_schema.txtar
+++ b/integration-tests/tests/build_openapi_schema.txtar
@@ -12,6 +12,35 @@ stdout '"text":'
 stdout '"path":'
 stdout '"type":"string"'
 stdout '"format":"uri"'
+stdout '"version":"[^"]*"'
+
+# Check the schema version matches the CLI version
+exec python3 check_schema_version.py
+stdout '^OK$'
+
+-- check_schema_version.py --
+import json
+import os
+import subprocess
+import sys
+
+image = os.environ["TEST_IMAGE"]
+schema_label = subprocess.check_output(
+    ["docker", "inspect", image, '--format={{index .Config.Labels "run.cog.openapi_schema"}}'],
+    text=True,
+).strip()
+schema = json.loads(schema_label)
+schema_version = schema["info"]["version"]
+
+cog_version_output = subprocess.check_output(["cog", "--version"], text=True).strip()
+# Output format: "cog version <version> (built <date>)"
+cli_version = cog_version_output.split()[2]
+
+if schema_version != cli_version:
+    print(f"Schema version {schema_version!r} does not match CLI version {cli_version!r}", file=sys.stderr)
+    sys.exit(1)
+
+print("OK")
 
 -- cog.yaml --
 build:

--- a/integration-tests/tests/build_openapi_schema.txtar
+++ b/integration-tests/tests/build_openapi_schema.txtar
@@ -14,7 +14,7 @@ stdout '"type":"string"'
 stdout '"format":"uri"'
 stdout '"version":"[^"]*"'
 
-# Check the schema version matches the CLI version
+# Check the schema version matches the image's run.cog.version label
 exec python3 check_schema_version.py
 stdout '^OK$'
 
@@ -25,6 +25,7 @@ import subprocess
 import sys
 
 image = os.environ["TEST_IMAGE"]
+
 schema_label = subprocess.check_output(
     ["docker", "inspect", image, '--format={{index .Config.Labels "run.cog.openapi_schema"}}'],
     text=True,
@@ -32,12 +33,16 @@ schema_label = subprocess.check_output(
 schema = json.loads(schema_label)
 schema_version = schema["info"]["version"]
 
-cog_version_output = subprocess.check_output(["cog", "--version"], text=True).strip()
-# Output format: "cog version <version> (built <date>)"
-cli_version = cog_version_output.split()[2]
+cog_version_label = subprocess.check_output(
+    ["docker", "inspect", image, '--format={{index .Config.Labels "run.cog.version"}}'],
+    text=True,
+).strip()
 
-if schema_version != cli_version:
-    print(f"Schema version {schema_version!r} does not match CLI version {cli_version!r}", file=sys.stderr)
+if schema_version != cog_version_label:
+    print(
+        f"Schema version {schema_version!r} does not match image version label {cog_version_label!r}",
+        file=sys.stderr,
+    )
     sys.exit(1)
 
 print("OK")

--- a/pkg/model/image_test.go
+++ b/pkg/model/image_test.go
@@ -1,13 +1,19 @@
 package model
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog/pkg/config"
+	"github.com/replicate/cog/pkg/global"
 )
+
+func openapiSchemaFixture(version string) string {
+	return fmt.Sprintf(`{"openapi":"3.0.2","info":{"title":"Cog","version":%q},"paths":{}}`, version)
+}
 
 func TestImage_IsCogModel(t *testing.T) {
 	tests := []struct {
@@ -284,7 +290,7 @@ func TestImage_ToModel(t *testing.T) {
 				Labels: map[string]string{
 					LabelConfig:        `{"build":{"python_version":"3.12"},"predict":"predict.py:Predictor"}`,
 					LabelVersion:       "0.10.0",
-					LabelOpenAPISchema: `{"openapi":"3.0.2","info":{"title":"Cog","version":"0.1.0"},"paths":{}}`,
+					LabelOpenAPISchema: openapiSchemaFixture(global.Version),
 				},
 				Source: ImageSourceLocal,
 			},
@@ -388,7 +394,7 @@ func TestImage_ParsedOpenAPISchema(t *testing.T) {
 			name: "valid OpenAPI JSON parses correctly",
 			image: &ImageArtifact{
 				Labels: map[string]string{
-					LabelOpenAPISchema: `{"openapi":"3.0.2","info":{"title":"Cog","version":"0.1.0"},"paths":{}}`,
+					LabelOpenAPISchema: openapiSchemaFixture(global.Version),
 				},
 			},
 			expectNil: false,
@@ -396,7 +402,7 @@ func TestImage_ParsedOpenAPISchema(t *testing.T) {
 			checkSchema: func(t *testing.T, schema *openapi3.T) {
 				require.Equal(t, "3.0.2", schema.OpenAPI)
 				require.Equal(t, "Cog", schema.Info.Title)
-				require.Equal(t, "0.1.0", schema.Info.Version)
+				require.Equal(t, global.Version, schema.Info.Version)
 			},
 		},
 		{

--- a/pkg/schema/openapi.go
+++ b/pkg/schema/openapi.go
@@ -3,6 +3,8 @@ package schema
 import (
 	"encoding/json"
 	"maps"
+
+	"github.com/replicate/cog/pkg/global"
 )
 
 // GenerateOpenAPISchema produces a complete OpenAPI 3.0.2 specification
@@ -254,7 +256,7 @@ func buildOpenAPISpec(info *PredictorInfo) map[string]any {
 
 	return map[string]any{
 		"openapi": "3.0.2",
-		"info":    map[string]any{"title": "Cog", "version": "0.1.0"},
+		"info":    map[string]any{"title": "Cog", "version": global.Version},
 		"paths":   paths,
 		"components": map[string]any{
 			"schemas": components,

--- a/pkg/schema/openapi_test.go
+++ b/pkg/schema/openapi_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/replicate/cog/pkg/global"
 )
 
 // ---------------------------------------------------------------------------
@@ -80,7 +82,7 @@ func TestGeneratesValidOpenAPI(t *testing.T) {
 
 	assert.Equal(t, "3.0.2", spec["openapi"])
 	assert.Equal(t, "Cog", getPath(spec, "info", "title"))
-	assert.Equal(t, "0.1.0", getPath(spec, "info", "version"))
+	assert.Equal(t, global.Version, getPath(spec, "info", "version"))
 }
 
 func TestPredictEndpoints(t *testing.T) {


### PR DESCRIPTION
Fixes #446.

Replaces the hard-coded `"0.1.0"` in generated OpenAPI schemas with the CLI/build-time version from `pkg/global.Version`.

### Changes
- `pkg/schema/openapi.go`: use `global.Version` for `info.version`
- `pkg/schema/openapi_test.go`: assert `info.version == global.Version`
- `pkg/model/image_test.go`: use `global.Version` in OpenAPI parser fixtures and add `openapiSchemaFixture` helper
- `integration-tests/tests/build_openapi_schema.txtar`: verify `info.version` exists and matches `cog --version`

### Verification
- `go test ./pkg/schema/... ./pkg/model/...` passes
- `mise run lint:go` passes
- `mise run test:integration build_openapi_schema` passes
- Manual `cog serve` on `examples/hello-world` returns `info.version` matching `cog --version`