### PR TITLE
fix: add ignore for tar directories

### DIFF
--- a/pkg/weights/pull.go
+++ b/pkg/weights/pull.go
@@ -231,6 +231,9 @@ func (m *Manager) pullLayer(
 		if err != nil {
 			return fmt.Errorf("read layer %s: %w", layerDigest, err)
 		}
+		if hdr.Typeflag == tar.TypeDir {
+			continue
+		}
 		if hdr.Typeflag != tar.TypeReg {
 			// Spec §1.3 says producers MUST emit only regular
 			// files. A non-regular entry indicates a producer bug


### PR DESCRIPTION
adds an ignore for tar directories in the weights pulling step. this reduces unnecessary `a606: skipping unexpected tar entry "text_encoder/" (typeflag 53)` style logs.