### PR TITLE
6. Add playground connection feature

### DIFF
--- a/playground/src/features/connection/components/ConnectionBar.test.tsx
+++ b/playground/src/features/connection/components/ConnectionBar.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ConnectionBar } from "@/features/connection/components/ConnectionBar";
+
+describe("ConnectionBar", () => {
+  it("edits and connects with both Enter and the button", () => {
+    const onDraftChange = vi.fn();
+    const onConnect = vi.fn();
+    render(
+      <ConnectionBar
+        draft="http://localhost:8393"
+        status="healthy"
+        disabled={false}
+        onDraftChange={onDraftChange}
+        onConnect={onConnect}
+      />,
+    );
+    const target = screen.getByRole("textbox", { name: "Target" });
+
+    fireEvent.input(target, { target: { value: "http://localhost:9000" } });
+    fireEvent.keyDown(target, { key: "Enter" });
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    expect(onDraftChange).toHaveBeenCalledWith("http://localhost:9000");
+    expect(onConnect).toHaveBeenCalledTimes(2);
+    expect(screen.getByText("healthy")).toBeVisible();
+  });
+
+  it("disables connection controls when unavailable", () => {
+    const { rerender } = render(
+      <ConnectionBar draft=" " disabled={false} onDraftChange={vi.fn()} onConnect={vi.fn()} />,
+    );
+    expect(screen.getByRole("button", { name: "Connect" })).toBeDisabled();
+
+    rerender(
+      <ConnectionBar
+        draft="http://localhost:8393"
+        disabled
+        onDraftChange={vi.fn()}
+        onConnect={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("textbox", { name: "Target" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Connect" })).toBeDisabled();
+  });
+});

--- a/playground/src/features/connection/components/ConnectionBar.tsx
+++ b/playground/src/features/connection/components/ConnectionBar.tsx
@@ -1,0 +1,35 @@
+import { Button } from "@cloudflare/kumo/components/button";
+import { Input } from "@cloudflare/kumo/components/input";
+
+type Props = {
+  draft: string;
+  status?: string;
+  disabled: boolean;
+  onDraftChange: (value: string) => void;
+  onConnect: () => void;
+};
+
+/** Submits the target on Enter as well as button activation without owning connection state. */
+export function ConnectionBar({ draft, status, disabled, onDraftChange, onConnect }: Props) {
+  return (
+    <fieldset id="target-bar">
+      <legend className="sr-only">Target connection</legend>
+      <div className="target-input">
+        <Input
+          label="Target"
+          type="url"
+          value={draft}
+          disabled={disabled}
+          onInput={(event) => onDraftChange(event.currentTarget.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") onConnect();
+          }}
+        />
+      </div>
+      <Button variant="primary" disabled={disabled || !draft.trim()} onClick={onConnect}>
+        Connect
+      </Button>
+      <output className="muted">{status}</output>
+    </fieldset>
+  );
+}

--- a/playground/src/features/connection/components/SetupPanel.test.tsx
+++ b/playground/src/features/connection/components/SetupPanel.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SetupPanel } from "@/features/connection/components/SetupPanel";
+
+describe("SetupPanel", () => {
+  it("renders nothing without setup and expands setup logs", () => {
+    const { rerender } = render(<SetupPanel setup={undefined} />);
+    expect(screen.queryByText("Setup")).not.toBeInTheDocument();
+
+    rerender(
+      <SetupPanel setup={{ status: "processing", logs: "downloading 10%\rdownloading 100%\n" }} />,
+    );
+    const summary = screen.getByText("Setup");
+    fireEvent.click(summary);
+
+    expect(screen.getByText("processing")).toBeVisible();
+    expect(screen.getByLabelText("Setup logs")).toHaveTextContent("downloading 10%");
+    expect(screen.getByLabelText("Setup logs")).toHaveTextContent("downloading 100%");
+    expect(screen.getByLabelText("Setup logs")).toHaveAttribute("tabindex", "0");
+  });
+});

--- a/playground/src/features/connection/components/SetupPanel.tsx
+++ b/playground/src/features/connection/components/SetupPanel.tsx
@@ -1,0 +1,19 @@
+import { StatusBadge } from "@/components/StatusBadge";
+import type { HealthResponse } from "@/types/health";
+import { renderTerminalText } from "@/utils/terminal";
+
+/** Returns no UI when setup telemetry is absent; otherwise keeps potentially large logs collapsed. */
+export function SetupPanel({ setup }: { setup: HealthResponse["setup"] }) {
+  if (!setup) return null;
+  return (
+    <details id="setup-panel">
+      <summary>
+        <span className="setup-label">Setup</span> <StatusBadge status={setup.status} />
+      </summary>
+      {/* oxlint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- scrollable logs must be keyboard reachable */}
+      <pre id="setup-logs" aria-label="Setup logs" tabIndex={0}>
+        {renderTerminalText(setup.logs ?? "")}
+      </pre>
+    </details>
+  );
+}

--- a/playground/src/features/connection/hooks/useConnection.test.tsx
+++ b/playground/src/features/connection/hooks/useConnection.test.tsx
@@ -1,0 +1,148 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useConnection } from "@/features/connection/hooks/useConnection";
+import type { CogApi } from "@/services/cog";
+import type { OpenAPIDocument } from "@/types/openapi";
+import { deferred } from "@/test/deferred";
+
+const document: OpenAPIDocument = {
+  components: {
+    schemas: {
+      Input: { properties: { prompt: { type: "string" } } },
+      Output: { type: "string" },
+    },
+  },
+  paths: { "/predictions": { post: { "x-cog-streaming": true } } },
+};
+
+describe("useConnection", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("loads configuration, health, schema, and prediction capabilities", async () => {
+    const api = fakeApi({
+      config: vi.fn(async () => ({
+        target: " http://localhost:9000 ",
+        webhookBase: "https://hooks.example",
+        cogVersion: "0.21.1-dev+g12345678",
+      })),
+      health: vi.fn(async () => ({ status: "healthy" })),
+      schema: vi.fn(async () => document),
+    });
+    const { result } = renderHook(() => useConnection(api));
+
+    await waitFor(() => expect(result.current.schema).toBe(document));
+
+    expect(result.current).toMatchObject({
+      target: "http://localhost:9000",
+      targetDraft: "http://localhost:9000",
+      health: { status: "healthy" },
+      schemaError: "",
+      webhookBase: "https://hooks.example",
+      cogVersion: "0.21.1-dev+g12345678",
+      capabilities: {
+        endpoint: "/predictions",
+        streaming: true,
+        input: document.components?.schemas?.Input,
+      },
+    });
+    expect(api.schema).toHaveBeenCalledWith("http://localhost:9000", expect.any(AbortSignal));
+    expect(api.health).toHaveBeenCalledWith("http://localhost:9000", expect.any(AbortSignal));
+  });
+
+  it("trims manually entered targets and ignores empty targets", async () => {
+    const api = fakeApi();
+    const { result } = renderHook(() => useConnection(api));
+    await waitFor(() => expect(result.current.target).toBe("http://localhost:8393"));
+
+    act(() => result.current.setTargetDraft("  http://localhost:9001/  "));
+    act(() => result.current.connect());
+    await waitFor(() => expect(result.current.target).toBe("http://localhost:9001/"));
+    await waitFor(() =>
+      expect(api.schema).toHaveBeenLastCalledWith(
+        "http://localhost:9001/",
+        expect.any(AbortSignal),
+      ),
+    );
+
+    act(() => result.current.setTargetDraft("  "));
+    act(() => result.current.connect());
+    expect(result.current.target).toBe("http://localhost:9001/");
+  });
+
+  it("does not replace a manual target when initial configuration arrives late", async () => {
+    const config = deferred<{ target: string; webhookBase: string }>();
+    const api = fakeApi({ config: vi.fn(() => config.promise) });
+    const { result } = renderHook(() => useConnection(api));
+
+    act(() => result.current.setTargetDraft("http://manual.example"));
+    act(() => result.current.connect());
+    await waitFor(() =>
+      expect(api.schema).toHaveBeenCalledWith("http://manual.example", expect.any(AbortSignal)),
+    );
+
+    config.resolve({
+      target: "http://configured.example",
+      webhookBase: "https://hooks.example",
+    });
+    await waitFor(() => expect(result.current.webhookBase).toBe("https://hooks.example"));
+
+    expect(result.current.target).toBe("http://manual.example");
+    expect(result.current.targetDraft).toBe("http://manual.example");
+    expect(api.schema).not.toHaveBeenCalledWith(
+      "http://configured.example",
+      expect.any(AbortSignal),
+    );
+  });
+
+  it("reports failures and retries schema and health requests", async () => {
+    vi.useFakeTimers();
+    const api = fakeApi({
+      config: vi.fn(async () => {
+        throw new Error("config unavailable");
+      }),
+      health: vi.fn(async () => {
+        throw new Error("target unavailable");
+      }),
+      schema: vi.fn(async () => {
+        throw new Error("schema unavailable");
+      }),
+    });
+    const { result } = renderHook(() => useConnection(api));
+
+    await flushPromises();
+    expect(result.current).toMatchObject({
+      target: "http://localhost:8393",
+      health: { status: "unreachable", user_healthcheck_error: "target unreachable" },
+      schemaError: "Waiting for schema... (schema unavailable)",
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(api.schema).toHaveBeenCalledTimes(2);
+    expect(api.health).toHaveBeenCalledTimes(2);
+  });
+});
+
+type ConnectionApi = Pick<CogApi, "config" | "health" | "schema">;
+
+function fakeApi(overrides: Partial<ConnectionApi> = {}): ConnectionApi {
+  return {
+    config: vi.fn(async () => ({})),
+    health: vi.fn(async () => ({ status: "healthy" })),
+    schema: vi.fn(async () => document),
+    ...overrides,
+  };
+}
+
+async function flushPromises(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}

--- a/playground/src/features/connection/hooks/useConnection.ts
+++ b/playground/src/features/connection/hooks/useConnection.ts
@@ -1,0 +1,144 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import type { CogApi } from "@/services/cog";
+import type { HealthResponse } from "@/types/health";
+import type { OpenAPIDocument } from "@/types/openapi";
+import { playgroundCapabilities } from "@/utils/openapi";
+
+const DEFAULT_TARGET = "http://localhost:8393";
+const REQUEST_TIMEOUT = 10_000;
+type ConnectionApi = Pick<CogApi, "config" | "health" | "schema">;
+
+/**
+ * Loads playground configuration, retries schema discovery, polls model health, and exposes
+ * the committed target with its derived prediction capabilities.
+ */
+export function useConnection(api: ConnectionApi) {
+  const [targetDraft, setTargetDraft] = useState("");
+  const [target, setTarget] = useState("");
+  const [health, setHealth] = useState<HealthResponse>({ status: "unknown" });
+  const [schema, setSchema] = useState<OpenAPIDocument>();
+  const [schemaError, setSchemaError] = useState("");
+  const [webhookBase, setWebhookBase] = useState("");
+  const [cogVersion, setCogVersion] = useState("");
+  const targetTouched = useRef(false);
+  const capabilities = useMemo(
+    () => (schema ? playgroundCapabilities(schema) : undefined),
+    [schema],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let canceled = false;
+    api
+      .config(AbortSignal.any([controller.signal, AbortSignal.timeout(REQUEST_TIMEOUT)]))
+      .then((config) => {
+        if (canceled) return;
+        setWebhookBase(config.webhookBase ?? "");
+        setCogVersion(config.cogVersion ?? "");
+        if (targetTouched.current) return;
+        const initialTarget = config.target?.trim() || DEFAULT_TARGET;
+        setTargetDraft(initialTarget);
+        setTarget(initialTarget);
+      })
+      .catch((error: unknown) => {
+        if (canceled || isAbortError(error) || targetTouched.current) return;
+        setTargetDraft(DEFAULT_TARGET);
+        setTarget(DEFAULT_TARGET);
+      });
+    return () => {
+      canceled = true;
+      controller.abort();
+    };
+  }, [api]);
+
+  useEffect(() => {
+    if (!target) return;
+    setHealth({ status: "unknown" });
+    setSchema(undefined);
+    setSchemaError("Loading schema...");
+    let canceled = false;
+    let retry: number | undefined;
+    const controller = new AbortController();
+    const loadSchema = async () => {
+      try {
+        const document = await api.schema(
+          target,
+          AbortSignal.any([controller.signal, AbortSignal.timeout(REQUEST_TIMEOUT)]),
+        );
+        if (canceled) return;
+        setSchema(document);
+        setSchemaError("");
+      } catch (error) {
+        if (canceled || isAbortError(error)) return;
+        setSchema(undefined);
+        setSchemaError(`Waiting for schema... (${errorMessage(error)})`);
+        retry = window.setTimeout(loadSchema, 3000);
+      }
+    };
+    void loadSchema();
+    return () => {
+      canceled = true;
+      controller.abort();
+      if (retry) clearTimeout(retry);
+    };
+  }, [api, target]);
+
+  useEffect(() => {
+    if (!target) return;
+    let canceled = false;
+    let timer: number | undefined;
+    const controller = new AbortController();
+    const poll = async () => {
+      try {
+        const next = await api.health(
+          target,
+          AbortSignal.any([controller.signal, AbortSignal.timeout(REQUEST_TIMEOUT)]),
+        );
+        if (!canceled) setHealth(next);
+      } catch (error) {
+        if (!canceled && !isAbortError(error)) {
+          setHealth({ status: "unreachable", user_healthcheck_error: "target unreachable" });
+        }
+      } finally {
+        if (!canceled) timer = window.setTimeout(poll, 5000);
+      }
+    };
+    void poll();
+    return () => {
+      canceled = true;
+      controller.abort();
+      if (timer) clearTimeout(timer);
+    };
+  }, [api, target]);
+
+  return {
+    target,
+    targetDraft,
+    setTargetDraft: (next: string) => {
+      targetTouched.current = true;
+      setTargetDraft(next);
+    },
+    connect: () => {
+      const next = targetDraft.trim();
+      if (next) {
+        targetTouched.current = true;
+        setTarget(next);
+      }
+    },
+    health,
+    schema,
+    schemaError,
+    webhookBase,
+    cogVersion,
+    capabilities,
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}

--- a/playground/src/features/connection/index.ts
+++ b/playground/src/features/connection/index.ts
@@ -1,0 +1,3 @@
+export { ConnectionBar } from "@/features/connection/components/ConnectionBar";
+export { SetupPanel } from "@/features/connection/components/SetupPanel";
+export { useConnection } from "@/features/connection/hooks/useConnection";


### PR DESCRIPTION
- playground target connection controls, setup logs, schema discovery, and health polling
- includes colocated component/hook unit tests
- cog-playground stack: #3109, #3108, #3114, #3110/#3106, #3105/#3111/#3107, #3113, #3112