### PR TITLE
5. Add Cog playground API client

### DIFF
--- a/playground/src/services/cog/CogApi.test.ts
+++ b/playground/src/services/cog/CogApi.test.ts
@@ -147,12 +147,10 @@ describe("CogApi", () => {
   it("releases an SSE reader lock when cancellation fails", async () => {
     const releaseLock = vi.fn();
     const reader = {
-      read: vi
-        .fn()
-        .mockResolvedValue({
-          done: false,
-          value: new TextEncoder().encode("event: output\\ndata: {}\\n\\n"),
-        }),
+      read: vi.fn().mockResolvedValue({
+        done: false,
+        value: new TextEncoder().encode("event: output\\ndata: {}\\n\\n"),
+      }),
       cancel: vi.fn().mockRejectedValue(new Error("cancel failed")),
       releaseLock,
     };

--- a/playground/src/services/cog/CogApi.test.ts
+++ b/playground/src/services/cog/CogApi.test.ts
@@ -10,7 +10,11 @@ describe("CogApi", () => {
   afterEach(() => vi.unstubAllGlobals());
 
   it("submits asynchronous predictions through the proxy", async () => {
-    const fetch = vi.fn().mockResolvedValue(jsonResponse({ id: "p1", status: "starting" }));
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ id: "p1", status: "starting", error: null, metrics: null }),
+      );
     vi.stubGlobal("fetch", fetch);
     const api = new CogApi();
 
@@ -38,6 +42,29 @@ describe("CogApi", () => {
       webhook: "http://callback/webhook/token",
       webhook_events_filter: ["start", "completed"],
     });
+  });
+
+  it("cancels a prediction through the proxy", async () => {
+    const fetch = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetch);
+    const api = new CogApi();
+
+    await api.cancel(target, "/predictions", "custom/id");
+
+    const [url, request] = fetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/proxy/predictions/custom%2Fid/cancel");
+    expect(request.method).toBe("POST");
+    expect(new Headers(request.headers).get("X-Cog-Target")).toBe(target);
+  });
+
+  it("reads playground configuration", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ target: "http://api", cogVersion: "0.9.0" })),
+    );
+    const api = new CogApi();
+
+    await expect(api.config()).resolves.toEqual({ target: "http://api", cogVersion: "0.9.0" });
   });
 
   it("rejects proxy redirects instead of following them", async () => {
@@ -177,6 +204,47 @@ describe("CogApi", () => {
     const api = new CogApi();
 
     await expect(api.schema(target)).rejects.toThrow("Response body exceeds 16777216 bytes");
+  });
+
+  it("accepts OpenAPI 3.1 schemas and path-level metadata", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({
+          components: {
+            schemas: {
+              Input: { type: ["array", "null"], exclusiveMinimum: 0, items: false },
+            },
+          },
+          paths: {
+            "/predictions": {
+              parameters: [],
+              summary: "Create a prediction",
+              post: { "x-cog-streaming": true },
+            },
+          },
+        }),
+      ),
+    );
+
+    await expect(new CogApi().schema(target)).resolves.toMatchObject({
+      paths: { "/predictions": { post: { "x-cog-streaming": true } } },
+    });
+  });
+
+  it.each([
+    ["configuration", { target: true }, (api: CogApi) => api.config()],
+    ["health", { status: 200 }, (api: CogApi) => api.health(target)],
+    ["OpenAPI", { paths: [] }, (api: CogApi) => api.schema(target)],
+    [
+      "prediction",
+      { id: 1 },
+      (api: CogApi) => api.submit({ target, endpoint: "/predictions", input: {}, signal }),
+    ],
+  ])("rejects invalid %s response shapes", async (_name, body, request) => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(body)));
+
+    await expect(request(new CogApi())).rejects.toThrow(/Invalid/);
   });
 });
 

--- a/playground/src/services/cog/CogApi.test.ts
+++ b/playground/src/services/cog/CogApi.test.ts
@@ -145,19 +145,26 @@ describe("CogApi", () => {
   });
 
   it("releases an SSE reader lock when cancellation fails", async () => {
-    const stream = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode("event: output\\ndata: {}\\n\\n"));
-      },
-      cancel() {
-        return Promise.reject(new Error("cancel failed"));
-      },
-    });
-    const iterator = readSSE(new Response(stream))[Symbol.asyncIterator]();
+    const releaseLock = vi.fn();
+    const reader = {
+      read: vi
+        .fn()
+        .mockResolvedValue({
+          done: false,
+          value: new TextEncoder().encode("event: output\\ndata: {}\\n\\n"),
+        }),
+      cancel: vi.fn().mockRejectedValue(new Error("cancel failed")),
+      releaseLock,
+    };
+    const response = {
+      ok: true,
+      body: { getReader: () => reader },
+    } as unknown as Response;
+    const iterator = readSSE(response)[Symbol.asyncIterator]();
 
     await expect(iterator.next()).resolves.toMatchObject({ value: { type: "output" } });
     await expect(iterator.return(undefined)).rejects.toThrow("cancel failed");
-    expect(stream.locked).toBe(false);
+    expect(releaseLock).toHaveBeenCalledOnce();
   });
 
   it("rejects oversized JSON responses before reading them", async () => {

--- a/playground/src/services/cog/CogApi.test.ts
+++ b/playground/src/services/cog/CogApi.test.ts
@@ -149,7 +149,7 @@ describe("CogApi", () => {
     const reader = {
       read: vi.fn().mockResolvedValue({
         done: false,
-        value: new TextEncoder().encode("event: output\\ndata: {}\\n\\n"),
+        value: new TextEncoder().encode("event: output\ndata: {}\n\n"),
       }),
       cancel: vi.fn().mockRejectedValue(new Error("cancel failed")),
       releaseLock,

--- a/playground/src/services/cog/CogApi.test.ts
+++ b/playground/src/services/cog/CogApi.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CogApi } from "@/services/cog/CogApi";
+import { parseSSE } from "@/services/cog/sse";
+
+const signal = new AbortController().signal;
+const target = "http://localhost:5000";
+
+describe("CogApi", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("submits asynchronous predictions through the proxy", async () => {
+    const fetch = vi.fn().mockResolvedValue(jsonResponse({ id: "p1", status: "starting" }));
+    vi.stubGlobal("fetch", fetch);
+    const api = new CogApi();
+
+    await expect(
+      api.submit({
+        target: `${target}/`,
+        endpoint: "/predictions",
+        id: "custom/id",
+        input: { prompt: "hello" },
+        signal,
+        async: true,
+        webhook: "http://callback/webhook/token",
+        webhookEvents: ["start", "completed"],
+      }),
+    ).resolves.toMatchObject({ id: "p1" });
+
+    const [url, request] = fetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/proxy/predictions/custom%2Fid");
+    expect(request.method).toBe("PUT");
+    expect(request.redirect).toBe("manual");
+    expect(new Headers(request.headers).get("X-Cog-Target")).toBe("http://localhost:5000");
+    expect(new Headers(request.headers).get("Prefer")).toBe("respond-async");
+    expect(JSON.parse(String(request.body))).toEqual({
+      input: { prompt: "hello" },
+      webhook: "http://callback/webhook/token",
+      webhook_events_filter: ["start", "completed"],
+    });
+  });
+
+  it("rejects proxy redirects instead of following them", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(null, {
+          status: 302,
+          headers: { Location: "http://169.254.169.254/" },
+        }),
+      ),
+    );
+    const api = new CogApi();
+
+    await expect(api.health(target)).rejects.toThrow(/unexpected redirect/);
+  });
+
+  it.each([
+    [jsonResponse({ error: "model unavailable" }, 503), "model unavailable"],
+    [jsonResponse({ detail: "bad input" }, 422), "bad input"],
+    [new Response("proxy failed", { status: 502 }), "proxy failed"],
+    [new Response(null, { status: 500 }), "HTTP 500"],
+  ])("preserves useful HTTP errors", async (response, message) => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response));
+    const api = new CogApi();
+
+    await expect(api.health(target)).rejects.toMatchObject({ status: response.status, message });
+  });
+
+  it("preserves validation details", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ detail: [{ loc: ["input"] }] }, 422)),
+    );
+    const api = new CogApi();
+
+    await expect(api.schema(target)).rejects.toMatchObject({ detail: [{ loc: ["input"] }] });
+  });
+
+  it("parses chunked CRLF SSE frames and preserves raw frames", async () => {
+    const body = streamBody([
+      "event: start\r",
+      '\ndata: {"id":"p1"}\r\n\r',
+      '\nevent: output\r\ndata: {"chunk":"hello"}\r\n\r\nevent: completed\r\ndata: {"status":"succeeded"}',
+    ]);
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(body, { headers: { "Content-Type": "text/event-stream" } }),
+        ),
+    );
+    const api = new CogApi();
+    const events = [];
+
+    for await (const event of api.stream({ target, endpoint: "/predictions", input: {}, signal }))
+      events.push(event);
+
+    expect(events).toEqual([
+      { type: "start", data: { id: "p1" }, raw: 'event: start\r\ndata: {"id":"p1"}' },
+      {
+        type: "output",
+        data: { chunk: "hello" },
+        raw: 'event: output\r\ndata: {"chunk":"hello"}',
+      },
+      {
+        type: "completed",
+        data: { status: "succeeded" },
+        raw: 'event: completed\r\ndata: {"status":"succeeded"}',
+      },
+    ]);
+  });
+
+  it("rejects failed and bodyless streams", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("busy", { status: 409 })));
+    const api = new CogApi();
+    await expect(
+      collect(api.stream({ target, endpoint: "/predictions", input: {}, signal })),
+    ).rejects.toMatchObject({
+      status: 409,
+      message: "busy",
+    });
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, body: null }));
+    await expect(
+      collect(api.stream({ target, endpoint: "/predictions", input: {}, signal })),
+    ).rejects.toThrow("Streaming response has no body");
+  });
+
+  it("rejects oversized SSE events", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(streamBody([`event: output\ndata: ${"x".repeat(1024 * 1024)}`])),
+        ),
+    );
+    const api = new CogApi();
+
+    await expect(
+      collect(api.stream({ target, endpoint: "/predictions", input: {}, signal })),
+    ).rejects.toThrow("SSE event is too large");
+  });
+
+  it("rejects oversized JSON responses before reading them", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("{}", {
+          headers: { "Content-Length": String(16 * 1024 * 1024 + 1) },
+        }),
+      ),
+    );
+    const api = new CogApi();
+
+    await expect(api.schema(target)).rejects.toThrow("Response body exceeds 16777216 bytes");
+  });
+});
+
+describe("parseSSE", () => {
+  it("joins non-JSON data lines", () => {
+    expect(parseSSE("event: log\ndata: first\ndata: second")).toMatchObject({
+      type: "log",
+      data: { value: "first\nsecond" },
+    });
+  });
+
+  it("preserves primitive JSON data", () => {
+    expect(parseSSE("event: output\ndata: 42")).toMatchObject({
+      type: "output",
+      data: { value: 42 },
+    });
+  });
+
+  it("ignores frames without an event type", () => {
+    expect(parseSSE("data: no-event")).toBeUndefined();
+  });
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function streamBody(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      chunks.forEach((chunk) => controller.enqueue(encoder.encode(chunk)));
+      controller.close();
+    },
+  });
+}
+
+async function collect<T>(stream: AsyncIterable<T>): Promise<T[]> {
+  const events: T[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}

--- a/playground/src/services/cog/CogApi.test.ts
+++ b/playground/src/services/cog/CogApi.test.ts
@@ -156,7 +156,7 @@ describe("CogApi", () => {
     const iterator = readSSE(new Response(stream))[Symbol.asyncIterator]();
 
     await expect(iterator.next()).resolves.toMatchObject({ value: { type: "output" } });
-    await expect(iterator.return?.()).rejects.toThrow("cancel failed");
+    await expect(iterator.return(undefined)).rejects.toThrow("cancel failed");
     expect(stream.locked).toBe(false);
   });
 

--- a/playground/src/services/cog/CogApi.test.ts
+++ b/playground/src/services/cog/CogApi.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CogApi } from "@/services/cog/CogApi";
-import { parseSSE } from "@/services/cog/sse";
+import { parseSSE, readSSE } from "@/services/cog/sse";
 
 const signal = new AbortController().signal;
 const target = "http://localhost:5000";
@@ -144,6 +144,22 @@ describe("CogApi", () => {
     ).rejects.toThrow("SSE event is too large");
   });
 
+  it("releases an SSE reader lock when cancellation fails", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("event: output\\ndata: {}\\n\\n"));
+      },
+      cancel() {
+        return Promise.reject(new Error("cancel failed"));
+      },
+    });
+    const iterator = readSSE(new Response(stream))[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toMatchObject({ value: { type: "output" } });
+    await expect(iterator.return?.()).rejects.toThrow("cancel failed");
+    expect(stream.locked).toBe(false);
+  });
+
   it("rejects oversized JSON responses before reading them", async () => {
     vi.stubGlobal(
       "fetch",
@@ -176,6 +192,19 @@ describe("parseSSE", () => {
 
   it("ignores frames without an event type", () => {
     expect(parseSSE("data: no-event")).toBeUndefined();
+  });
+});
+
+describe("fileToDataURI", () => {
+  it("rejects files over 16 MiB before creating a FileReader", async () => {
+    const FileReader = vi.fn();
+    vi.stubGlobal("FileReader", FileReader);
+    const { fileToDataURI } = await import("@/services/cog/files");
+
+    await expect(fileToDataURI({ size: 16 * 1024 * 1024 + 1 } as File)).rejects.toThrow(
+      "Local files must be 16 MiB or smaller",
+    );
+    expect(FileReader).not.toHaveBeenCalled();
   });
 });
 

--- a/playground/src/services/cog/CogApi.ts
+++ b/playground/src/services/cog/CogApi.ts
@@ -1,0 +1,132 @@
+import type { HealthResponse } from "@/types/health";
+import type { OpenAPIDocument } from "@/types/openapi";
+import type { PredictionEnvelope, StreamEvent } from "@/types/prediction";
+import { parseJSONResponse, parsePredictionResponse, responseError } from "@/services/cog/http";
+import { readSSE } from "@/services/cog/sse";
+
+const PROXY_PREFIX = "/proxy";
+
+type SubmitOptions = {
+  target: string;
+  endpoint: string;
+  id?: string;
+  input: Record<string, unknown>;
+  signal: AbortSignal;
+  async?: boolean;
+  webhook?: string;
+  webhookEvents?: string[];
+  onResponse?: (response: Response) => void;
+};
+
+type StreamOptions = Pick<
+  SubmitOptions,
+  "target" | "endpoint" | "id" | "input" | "signal" | "onResponse"
+>;
+
+/** Routes model requests through the same-origin proxy rather than exposing cross-origin access. */
+export class CogApi {
+  /** Loads the playground's optional target, webhook, and version configuration. */
+  async config(
+    signal?: AbortSignal,
+  ): Promise<{ target?: string; webhookBase?: string; cogVersion?: string }> {
+    const response = await fetch("/config", { credentials: "omit", signal });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return parseJSONResponse<{ target?: string; webhookBase?: string; cogVersion?: string }>(
+      response,
+    );
+  }
+
+  /** Reads size-limited health JSON from the configured target. */
+  async health(target: string, signal?: AbortSignal): Promise<HealthResponse> {
+    return this.#jsonRequest<HealthResponse>(target, "/health-check", signal);
+  }
+
+  /** Reads the size-limited OpenAPI document from the configured target. */
+  async schema(target: string, signal?: AbortSignal): Promise<OpenAPIDocument> {
+    return this.#jsonRequest<OpenAPIDocument>(target, "/openapi.json", signal);
+  }
+
+  /** Uses PUT for caller-supplied IDs and adds `Prefer: respond-async` for async submissions. */
+  async submit(options: SubmitOptions): Promise<PredictionEnvelope> {
+    const headers = this.#headers(options.target, { "Content-Type": "application/json" });
+    if (options.async) headers.set("Prefer", "respond-async");
+    const response = await this.#proxyFetch(this.#url(options.endpoint, options.id), {
+      method: options.id ? "PUT" : "POST",
+      headers,
+      body: JSON.stringify(this.#body(options.input, options.webhook, options.webhookEvents)),
+      signal: options.signal,
+    });
+    options.onResponse?.(response);
+    return parsePredictionResponse(response);
+  }
+
+  /** Requests SSE and exposes each frame only after bounded incremental parsing. */
+  async *stream(options: StreamOptions): AsyncGenerator<StreamEvent> {
+    const response = await this.#proxyFetch(this.#url(options.endpoint, options.id), {
+      method: options.id ? "PUT" : "POST",
+      headers: this.#headers(options.target, {
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+      }),
+      body: JSON.stringify(this.#body(options.input)),
+      signal: options.signal,
+    });
+    options.onResponse?.(response);
+    yield* readSSE(response);
+  }
+
+  /** URL-encodes the run ID before posting to its cancellation endpoint. */
+  async cancel(target: string, endpoint: string, id: string, signal?: AbortSignal): Promise<void> {
+    const response = await this.#proxyFetch(
+      `${PROXY_PREFIX}${endpoint}/${encodeURIComponent(id)}/cancel`,
+      {
+        method: "POST",
+        headers: this.#headers(target),
+        signal,
+      },
+    );
+    if (!response.ok) throw await responseError(response);
+  }
+
+  #url(endpoint: string, id?: string): string {
+    return id ? `${PROXY_PREFIX}${endpoint}/${encodeURIComponent(id)}` : PROXY_PREFIX + endpoint;
+  }
+
+  #headers(target: string, values?: HeadersInit): Headers {
+    const headers = new Headers(values);
+    headers.set("X-Cog-Target", target.trim().replace(/\/+$/, ""));
+    return headers;
+  }
+
+  #body(
+    input: Record<string, unknown>,
+    webhook?: string,
+    webhookEvents?: string[],
+  ): { input: Record<string, unknown>; webhook?: string; webhook_events_filter?: string[] } {
+    return webhook ? { input, webhook, webhook_events_filter: webhookEvents } : { input };
+  }
+
+  async #jsonRequest<T>(target: string, endpoint: string, signal?: AbortSignal): Promise<T> {
+    const response = await this.#proxyFetch(PROXY_PREFIX + endpoint, {
+      headers: this.#headers(target),
+      signal,
+    });
+    if (!response.ok) throw await responseError(response);
+    return parseJSONResponse<T>(response);
+  }
+
+  /** Never follows redirects so a hostile target cannot pivot the browser off-origin. */
+  async #proxyFetch(url: string, init: RequestInit): Promise<Response> {
+    const response = await fetch(url, {
+      ...init,
+      credentials: "omit",
+      redirect: "manual",
+    });
+    if (response.type === "opaqueredirect" || (response.status >= 300 && response.status < 400)) {
+      throw new Error(
+        `Target API returned an unexpected redirect (${response.status || "opaque"})`,
+      );
+    }
+    return response;
+  }
+}

--- a/playground/src/services/cog/CogApi.ts
+++ b/playground/src/services/cog/CogApi.ts
@@ -1,5 +1,6 @@
-import type { HealthResponse } from "@/types/health";
-import type { OpenAPIDocument } from "@/types/openapi";
+import { isHealthResponse, type HealthResponse } from "@/types/health";
+import { isJsonObject, type JsonObject } from "@/types/json";
+import { isOpenAPIDocument, type OpenAPIDocument } from "@/types/openapi";
 import type { PredictionEnvelope, StreamEvent } from "@/types/prediction";
 import { parseJSONResponse, parsePredictionResponse, responseError } from "@/services/cog/http";
 import { readSSE } from "@/services/cog/sse";
@@ -10,7 +11,7 @@ type SubmitOptions = {
   target: string;
   endpoint: string;
   id?: string;
-  input: Record<string, unknown>;
+  input: JsonObject;
   signal: AbortSignal;
   async?: boolean;
   webhook?: string;
@@ -23,27 +24,31 @@ type StreamOptions = Pick<
   "target" | "endpoint" | "id" | "input" | "signal" | "onResponse"
 >;
 
+type PlaygroundConfig = {
+  target?: string;
+  webhookBase?: string;
+  cogVersion?: string;
+};
+
 /** Routes model requests through the same-origin proxy rather than exposing cross-origin access. */
 export class CogApi {
   /** Loads the playground's optional target, webhook, and version configuration. */
-  async config(
-    signal?: AbortSignal,
-  ): Promise<{ target?: string; webhookBase?: string; cogVersion?: string }> {
+  async config(signal?: AbortSignal): Promise<PlaygroundConfig> {
     const response = await fetch("/config", { credentials: "omit", signal });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    return parseJSONResponse<{ target?: string; webhookBase?: string; cogVersion?: string }>(
-      response,
-    );
+    const config = await parseJSONResponse(response);
+    if (!isPlaygroundConfig(config)) throw new Error("Invalid playground configuration response");
+    return config;
   }
 
   /** Reads size-limited health JSON from the configured target. */
   async health(target: string, signal?: AbortSignal): Promise<HealthResponse> {
-    return this.#jsonRequest<HealthResponse>(target, "/health-check", signal);
+    return this.#jsonRequest(target, "/health-check", signal, "health", isHealthResponse);
   }
 
   /** Reads the size-limited OpenAPI document from the configured target. */
   async schema(target: string, signal?: AbortSignal): Promise<OpenAPIDocument> {
-    return this.#jsonRequest<OpenAPIDocument>(target, "/openapi.json", signal);
+    return this.#jsonRequest(target, "/openapi.json", signal, "OpenAPI", isOpenAPIDocument);
   }
 
   /** Uses PUT for caller-supplied IDs and adds `Prefer: respond-async` for async submissions. */
@@ -99,20 +104,28 @@ export class CogApi {
   }
 
   #body(
-    input: Record<string, unknown>,
+    input: JsonObject,
     webhook?: string,
     webhookEvents?: string[],
-  ): { input: Record<string, unknown>; webhook?: string; webhook_events_filter?: string[] } {
+  ): { input: JsonObject; webhook?: string; webhook_events_filter?: string[] } {
     return webhook ? { input, webhook, webhook_events_filter: webhookEvents } : { input };
   }
 
-  async #jsonRequest<T>(target: string, endpoint: string, signal?: AbortSignal): Promise<T> {
+  async #jsonRequest<T>(
+    target: string,
+    endpoint: string,
+    signal: AbortSignal | undefined,
+    responseName: string,
+    validate: (value: unknown) => value is T,
+  ): Promise<T> {
     const response = await this.#proxyFetch(PROXY_PREFIX + endpoint, {
       headers: this.#headers(target),
       signal,
     });
     if (!response.ok) throw await responseError(response);
-    return parseJSONResponse<T>(response);
+    const body = await parseJSONResponse(response);
+    if (!validate(body)) throw new Error(`Invalid ${responseName} response`);
+    return body;
   }
 
   /** Never follows redirects so a hostile target cannot pivot the browser off-origin. */
@@ -129,4 +142,13 @@ export class CogApi {
     }
     return response;
   }
+}
+
+function isPlaygroundConfig(value: unknown): value is PlaygroundConfig {
+  return (
+    isJsonObject(value) &&
+    ["target", "webhookBase", "cogVersion"].every(
+      (key) => value[key] === undefined || typeof value[key] === "string",
+    )
+  );
 }

--- a/playground/src/services/cog/files.ts
+++ b/playground/src/services/cog/files.ts
@@ -1,0 +1,9 @@
+/** Converts a browser file to a data URI and rejects if the file cannot be read. */
+export function fileToDataURI(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error ?? new Error("Could not read file"));
+    reader.readAsDataURL(file);
+  });
+}

--- a/playground/src/services/cog/files.ts
+++ b/playground/src/services/cog/files.ts
@@ -1,5 +1,10 @@
-/** Converts a browser file to a data URI and rejects if the file cannot be read. */
+const MAX_LOCAL_FILE_SIZE = 16 * 1024 * 1024;
+
+/** Converts a browser file up to 16 MiB to a data URI and rejects if it cannot be read. */
 export function fileToDataURI(file: File): Promise<string> {
+  if (file.size > MAX_LOCAL_FILE_SIZE) {
+    return Promise.reject(new Error("Local files must be 16 MiB or smaller"));
+  }
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => resolve(String(reader.result));

--- a/playground/src/services/cog/http.ts
+++ b/playground/src/services/cog/http.ts
@@ -1,5 +1,5 @@
 import { isJsonObject, type JsonObject } from "@/types/json";
-import type { PredictionEnvelope } from "@/types/prediction";
+import { predictionEnvelope, type PredictionEnvelope } from "@/types/prediction";
 
 const MAX_JSON_RESPONSE_LENGTH = 16 * 1024 * 1024;
 const MAX_ERROR_RESPONSE_LENGTH = 1024 * 1024;
@@ -18,7 +18,9 @@ export class HttpError extends Error {
 /** Rejects unsuccessful responses and parses a size-bounded prediction envelope. */
 export async function parsePredictionResponse(response: Response): Promise<PredictionEnvelope> {
   if (!response.ok) throw await responseError(response);
-  return parseJSONResponse<PredictionEnvelope>(response);
+  const prediction = predictionEnvelope(await parseJSONResponse(response));
+  if (!prediction) throw new Error("Invalid prediction response");
+  return prediction;
 }
 
 /** Converts a bounded JSON or text error response into an `HttpError`. */
@@ -40,9 +42,9 @@ export async function responseError(response: Response): Promise<HttpError> {
   return new HttpError(message, response.status, detail);
 }
 
-/** Reads JSON under the response-size limit without performing runtime shape validation. */
-export async function parseJSONResponse<T>(response: Response): Promise<T> {
-  return JSON.parse(await readResponseText(response, MAX_JSON_RESPONSE_LENGTH)) as T;
+/** Reads JSON under the response-size limit as untrusted data. */
+export async function parseJSONResponse(response: Response): Promise<unknown> {
+  return JSON.parse(await readResponseText(response, MAX_JSON_RESPONSE_LENGTH));
 }
 
 async function readResponseText(response: Response, maxLength: number): Promise<string> {

--- a/playground/src/services/cog/http.ts
+++ b/playground/src/services/cog/http.ts
@@ -1,0 +1,74 @@
+import { isJsonObject, type JsonObject } from "@/types/json";
+import type { PredictionEnvelope } from "@/types/prediction";
+
+const MAX_JSON_RESPONSE_LENGTH = 16 * 1024 * 1024;
+const MAX_ERROR_RESPONSE_LENGTH = 1024 * 1024;
+
+/** Preserves status and structured validation details from an unsuccessful HTTP response. */
+export class HttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly detail?: unknown[],
+  ) {
+    super(message);
+  }
+}
+
+/** Rejects unsuccessful responses and parses a size-bounded prediction envelope. */
+export async function parsePredictionResponse(response: Response): Promise<PredictionEnvelope> {
+  if (!response.ok) throw await responseError(response);
+  return parseJSONResponse<PredictionEnvelope>(response);
+}
+
+/** Converts a bounded JSON or text error response into an `HttpError`. */
+export async function responseError(response: Response): Promise<HttpError> {
+  const text = await readResponseText(response, MAX_ERROR_RESPONSE_LENGTH);
+  let body: JsonObject = {};
+  try {
+    const parsed: unknown = JSON.parse(text);
+    body = isJsonObject(parsed) ? parsed : {};
+  } catch {
+    // Use the response text below.
+  }
+  const detail = Array.isArray(body.detail) ? body.detail : undefined;
+  const message =
+    (typeof body.error === "string" && body.error) ||
+    (typeof body.detail === "string" && body.detail) ||
+    text ||
+    `HTTP ${response.status}`;
+  return new HttpError(message, response.status, detail);
+}
+
+/** Reads JSON under the response-size limit without performing runtime shape validation. */
+export async function parseJSONResponse<T>(response: Response): Promise<T> {
+  return JSON.parse(await readResponseText(response, MAX_JSON_RESPONSE_LENGTH)) as T;
+}
+
+async function readResponseText(response: Response, maxLength: number): Promise<string> {
+  const contentLength = Number(response.headers.get("Content-Length"));
+  if (Number.isFinite(contentLength) && contentLength > maxLength) {
+    await response.body?.cancel();
+    throw new Error(`Response body exceeds ${maxLength} bytes`);
+  }
+  if (!response.body) return "";
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let length = 0;
+  let text = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) return text + decoder.decode();
+      length += value.byteLength;
+      if (length > maxLength) {
+        await reader.cancel();
+        throw new Error(`Response body exceeds ${maxLength} bytes`);
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/playground/src/services/cog/index.ts
+++ b/playground/src/services/cog/index.ts
@@ -1,0 +1,3 @@
+export { CogApi } from "@/services/cog/CogApi";
+export { fileToDataURI } from "@/services/cog/files";
+export { HttpError } from "@/services/cog/http";

--- a/playground/src/services/cog/sse.ts
+++ b/playground/src/services/cog/sse.ts
@@ -1,5 +1,5 @@
 import { responseError } from "@/services/cog/http";
-import { isJsonObject, type JsonObject, type JsonValue } from "@/types/json";
+import { isJsonObject, isJsonValue, type JsonObject } from "@/types/json";
 import type { StreamEvent } from "@/types/prediction";
 
 const MAX_SSE_FRAME_LENGTH = 1024 * 1024;
@@ -79,10 +79,4 @@ function lineBreakLength(value: string, index: number): number {
   if (value[index] !== "\r") return 0;
   if (index + 1 === value.length) return 0;
   return value[index + 1] === "\n" ? 2 : 1;
-}
-
-function isJsonValue(value: unknown): value is JsonValue {
-  if (value === null || ["boolean", "number", "string"].includes(typeof value)) return true;
-  if (Array.isArray(value)) return value.every(isJsonValue);
-  return isJsonObject(value) && Object.values(value).every(isJsonValue);
 }

--- a/playground/src/services/cog/sse.ts
+++ b/playground/src/services/cog/sse.ts
@@ -1,0 +1,85 @@
+import { responseError } from "@/services/cog/http";
+import { isJsonObject, type JsonObject, type JsonValue } from "@/types/json";
+import type { StreamEvent } from "@/types/prediction";
+
+const MAX_SSE_FRAME_LENGTH = 1024 * 1024;
+
+/** Incrementally yields size-bounded SSE frames and always releases the response reader. */
+export async function* readSSE(response: Response): AsyncGenerator<StreamEvent> {
+  if (!response.ok) throw await responseError(response);
+  if (!response.body) throw new Error("Streaming response has no body");
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let done = false;
+  try {
+    for (;;) {
+      const chunk = await reader.read();
+      done = chunk.done;
+      buffer += decoder.decode(chunk.value, { stream: !done });
+      let separator = sseSeparator(buffer);
+      while (separator) {
+        if (separator.index > MAX_SSE_FRAME_LENGTH) throw new Error("SSE event is too large");
+        const raw = buffer.slice(0, separator.index);
+        buffer = buffer.slice(separator.index + separator.length);
+        const event = parseSSE(raw);
+        if (event) yield event;
+        separator = sseSeparator(buffer);
+      }
+      if (buffer.length > MAX_SSE_FRAME_LENGTH) throw new Error("SSE event is too large");
+      if (done) break;
+    }
+    if (buffer.trim()) {
+      const event = parseSSE(buffer);
+      if (event) yield event;
+    }
+  } finally {
+    if (!done) await reader.cancel();
+    reader.releaseLock();
+  }
+}
+
+/** Parses one raw SSE frame, preserving its exact text and ignoring frames without an event type. */
+export function parseSSE(raw: string): StreamEvent | undefined {
+  let type = "";
+  const data: string[] = [];
+  for (const line of raw.replaceAll("\r\n", "\n").replaceAll("\r", "\n").split("\n")) {
+    if (line.startsWith("event:")) type = line.slice(6).trim();
+    if (line.startsWith("data:")) data.push(line.slice(5).replace(/^ /, ""));
+  }
+  if (!type) return undefined;
+  const joined = data.join("\n");
+  let parsed: JsonObject = { value: joined };
+  try {
+    const value: unknown = JSON.parse(joined);
+    parsed = isJsonObject(value) ? value : { value: isJsonValue(value) ? value : joined };
+  } catch {
+    // Preserve non-JSON event payloads.
+  }
+  return { type, data: parsed, raw };
+}
+
+function sseSeparator(buffer: string): { index: number; length: number } | undefined {
+  for (let index = 0; index < buffer.length; index += 1) {
+    const first = lineBreakLength(buffer, index);
+    if (first === 0) continue;
+    const second = lineBreakLength(buffer, index + first);
+    if (second > 0) return { index, length: first + second };
+    index += first - 1;
+  }
+  return undefined;
+}
+
+function lineBreakLength(value: string, index: number): number {
+  if (value[index] === "\n") return 1;
+  if (value[index] !== "\r") return 0;
+  if (index + 1 === value.length) return 0;
+  return value[index + 1] === "\n" ? 2 : 1;
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null || ["boolean", "number", "string"].includes(typeof value)) return true;
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  return isJsonObject(value) && Object.values(value).every(isJsonValue);
+}

--- a/playground/src/services/cog/sse.ts
+++ b/playground/src/services/cog/sse.ts
@@ -35,8 +35,11 @@ export async function* readSSE(response: Response): AsyncGenerator<StreamEvent> 
       if (event) yield event;
     }
   } finally {
-    if (!done) await reader.cancel();
-    reader.releaseLock();
+    try {
+      if (!done) await reader.cancel();
+    } finally {
+      reader.releaseLock();
+    }
   }
 }
 

--- a/playground/src/types/health.ts
+++ b/playground/src/types/health.ts
@@ -1,6 +1,40 @@
+import { isJsonObject } from "@/types/json";
+
 export type HealthResponse = {
   status?: string;
   user_healthcheck_error?: string;
   setup?: { status?: string; logs?: string };
   version?: { coglet?: string; python_sdk?: string; python?: string };
 };
+
+/** Validates the health response fields the playground consumes. */
+export function isHealthResponse(value: unknown): value is HealthResponse {
+  return (
+    isJsonObject(value) &&
+    isOptionalString(value.status) &&
+    isOptionalString(value.user_healthcheck_error) &&
+    isOptionalObject(value.setup, isSetup) &&
+    isOptionalObject(value.version, isVersion)
+  );
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function isOptionalObject<T>(value: unknown, validate: (value: unknown) => value is T): boolean {
+  return value === undefined || validate(value);
+}
+
+function isSetup(value: unknown): value is NonNullable<HealthResponse["setup"]> {
+  return isJsonObject(value) && isOptionalString(value.status) && isOptionalString(value.logs);
+}
+
+function isVersion(value: unknown): value is NonNullable<HealthResponse["version"]> {
+  return (
+    isJsonObject(value) &&
+    isOptionalString(value.coglet) &&
+    isOptionalString(value.python_sdk) &&
+    isOptionalString(value.python)
+  );
+}

--- a/playground/src/types/json.ts
+++ b/playground/src/types/json.ts
@@ -6,3 +6,10 @@ export type JsonObject = { [key: string]: JsonValue };
 export function isJsonObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+
+/** Narrows values that can be represented by JSON. */
+export function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null || ["boolean", "number", "string"].includes(typeof value)) return true;
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  return isJsonObject(value) && Object.values(value).every(isJsonValue);
+}

--- a/playground/src/types/openapi.ts
+++ b/playground/src/types/openapi.ts
@@ -1,25 +1,25 @@
-import type { JsonObject } from "@/types/json";
+import { isJsonObject, type JsonObject, type JsonValue } from "@/types/json";
 
 export type OpenAPISchema = {
   $ref?: string;
-  type?: string;
+  type?: string | string[];
   format?: string;
   title?: string;
   description?: string;
-  default?: unknown;
-  enum?: unknown[];
+  default?: JsonValue;
+  enum?: JsonValue[];
   allOf?: OpenAPISchema[];
   anyOf?: OpenAPISchema[];
   oneOf?: OpenAPISchema[];
-  items?: OpenAPISchema;
+  items?: boolean | OpenAPISchema;
   properties?: Record<string, OpenAPISchema>;
   additionalProperties?: boolean | OpenAPISchema;
   required?: string[];
   nullable?: boolean;
   minimum?: number;
   maximum?: number;
-  exclusiveMinimum?: boolean;
-  exclusiveMaximum?: boolean;
+  exclusiveMinimum?: boolean | number;
+  exclusiveMaximum?: boolean | number;
   multipleOf?: number;
   minLength?: number;
   maxLength?: number;
@@ -30,7 +30,7 @@ export type OpenAPISchema = {
   minProperties?: number;
   maxProperties?: number;
   deprecated?: boolean;
-  [key: `x-${string}`]: unknown;
+  [key: `x-${string}`]: JsonValue;
 };
 
 export type OpenAPIDocument = {
@@ -39,4 +39,123 @@ export type OpenAPIDocument = {
 };
 
 export type OpenAPIOperation = JsonObject & { "x-cog-streaming"?: boolean };
-export type OpenAPIPathItem = Record<string, OpenAPIOperation>;
+export type OpenAPIPathItem = JsonObject & { post?: OpenAPIOperation };
+
+const MAX_SCHEMA_DEPTH = 64;
+const MAX_SCHEMA_NODES = 10_000;
+
+type SchemaValidationState = { remainingNodes: number };
+
+/** Validates the subset of an OpenAPI document that the playground reads. */
+export function isOpenAPIDocument(value: unknown): value is OpenAPIDocument {
+  const state = { remainingNodes: MAX_SCHEMA_NODES };
+  return (
+    isJsonObject(value) &&
+    isOptionalOpenAPIComponents(value.components, state) &&
+    isOptionalRecord(value.paths, isOpenAPIPathItem)
+  );
+}
+
+function isOptionalOpenAPIComponents(value: unknown, state: SchemaValidationState): boolean {
+  return (
+    value === undefined ||
+    (isJsonObject(value) &&
+      isOptionalRecord(value.schemas, (schema) => isOpenAPISchema(schema, state)))
+  );
+}
+
+function isOpenAPIPathItem(value: unknown): value is OpenAPIPathItem {
+  return isJsonObject(value) && (value.post === undefined || isOpenAPIOperation(value.post));
+}
+
+function isOpenAPIOperation(value: unknown): value is OpenAPIOperation {
+  return isJsonObject(value) && isOptionalBoolean(value["x-cog-streaming"]);
+}
+
+function isOpenAPISchema(
+  value: unknown,
+  state: SchemaValidationState,
+  depth = 0,
+): value is OpenAPISchema {
+  return (
+    depth <= MAX_SCHEMA_DEPTH &&
+    state.remainingNodes-- > 0 &&
+    isJsonObject(value) &&
+    ["$ref", "format", "title", "description", "pattern"].every((key) =>
+      isOptionalString(value[key]),
+    ) &&
+    isOptionalSchemaType(value.type) &&
+    [
+      "minimum",
+      "maximum",
+      "multipleOf",
+      "minLength",
+      "maxLength",
+      "minItems",
+      "maxItems",
+      "minProperties",
+      "maxProperties",
+    ].every((key) => isOptionalNumber(value[key])) &&
+    ["exclusiveMinimum", "exclusiveMaximum"].every((key) =>
+      isOptionalBooleanOrNumber(value[key]),
+    ) &&
+    ["nullable", "uniqueItems", "deprecated"].every((key) => isOptionalBoolean(value[key])) &&
+    isOptionalArray(value.enum) &&
+    isOptionalStringArray(value.required) &&
+    ["allOf", "anyOf", "oneOf"].every((key) =>
+      isOptionalArrayOf(value[key], (schema) => isOpenAPISchema(schema, state, depth + 1)),
+    ) &&
+    (value.items === undefined ||
+      typeof value.items === "boolean" ||
+      isOpenAPISchema(value.items, state, depth + 1)) &&
+    isOptionalRecord(value.properties, (schema) => isOpenAPISchema(schema, state, depth + 1)) &&
+    (value.additionalProperties === undefined ||
+      typeof value.additionalProperties === "boolean" ||
+      isOpenAPISchema(value.additionalProperties, state, depth + 1))
+  );
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function isOptionalSchemaType(value: unknown): boolean {
+  return (
+    isOptionalString(value) ||
+    (Array.isArray(value) && value.every((item) => typeof item === "string"))
+  );
+}
+
+function isOptionalNumber(value: unknown): boolean {
+  return value === undefined || typeof value === "number";
+}
+
+function isOptionalBoolean(value: unknown): boolean {
+  return value === undefined || typeof value === "boolean";
+}
+
+function isOptionalBooleanOrNumber(value: unknown): boolean {
+  return value === undefined || typeof value === "boolean" || typeof value === "number";
+}
+
+function isOptionalArray(value: unknown): boolean {
+  return value === undefined || Array.isArray(value);
+}
+
+function isOptionalStringArray(value: unknown): boolean {
+  return (
+    value === undefined || (Array.isArray(value) && value.every((item) => typeof item === "string"))
+  );
+}
+
+function isOptionalArrayOf(value: unknown, validate: (value: unknown) => boolean): boolean {
+  return value === undefined || (Array.isArray(value) && value.every(validate));
+}
+
+function isOptionalRecord(value: unknown, validate: (value: unknown) => boolean): boolean {
+  return value === undefined || isRecord(value, validate);
+}
+
+function isRecord(value: unknown, validate: (value: unknown) => boolean): boolean {
+  return isJsonObject(value) && Object.values(value).every(validate);
+}

--- a/playground/src/types/prediction.ts
+++ b/playground/src/types/prediction.ts
@@ -1,4 +1,4 @@
-import type { JsonObject } from "@/types/json";
+import { isJsonObject, type JsonObject } from "@/types/json";
 
 export type PredictionEnvelope = {
   id?: string;
@@ -38,3 +38,26 @@ export type RequestTrace = {
   responseBody?: unknown;
   events: TraceEvent[];
 };
+
+/** Validates a prediction response and omits legacy nullable fields. */
+export function predictionEnvelope(value: unknown): PredictionEnvelope | undefined {
+  if (
+    !isJsonObject(value) ||
+    !["id", "status", "error", "logs"].every(
+      (key) => value[key] === undefined || value[key] === null || typeof value[key] === "string",
+    ) ||
+    (value.metrics !== undefined && value.metrics !== null && !isJsonObject(value.metrics))
+  ) {
+    return undefined;
+  }
+
+  const { error, id, logs, metrics, status, ...other } = value;
+  return {
+    ...other,
+    ...(typeof id === "string" && { id }),
+    ...(typeof status === "string" && { status }),
+    ...(typeof error === "string" && { error }),
+    ...(typeof logs === "string" && { logs }),
+    ...(isJsonObject(metrics) && { metrics }),
+  };
+}

--- a/playground/src/utils/openapi.test.ts
+++ b/playground/src/utils/openapi.test.ts
@@ -15,13 +15,14 @@ const document: OpenAPIDocument = {
     schemas: {
       Choice: { enum: [1, 2] },
       Input: {
-        required: ["prompt", "enabled", "choice"],
+        required: ["prompt", "enabled", "nullableEnabled", "choice"],
         properties: {
           late: { type: "string", "x-order": 2 },
           prompt: { type: "string", default: "hello", "x-order": 1 },
           optional: { type: "boolean", default: false },
           nullable: { type: "string", nullable: true, default: null },
           enabled: { type: "boolean" },
+          nullableEnabled: { type: ["boolean", "null"] },
           choice: { allOf: [{ $ref: "#/components/schemas/Choice" }] },
         },
       },
@@ -39,7 +40,7 @@ describe("schema helpers", () => {
     expect(
       effectiveSchema(document, {
         title: "Nullable choice",
-        anyOf: [{ $ref: "#/components/schemas/Choice" }, { type: "null" }],
+        anyOf: [{ $ref: "#/components/schemas/Choice" }, { type: ["null"] }],
       }),
     ).toEqual({ title: "Nullable choice", enum: [1, 2] });
   });
@@ -52,6 +53,7 @@ describe("schema helpers", () => {
       "optional",
       "nullable",
       "enabled",
+      "nullableEnabled",
       "choice",
     ]);
     expect(defaultInput(document, input)).toEqual({
@@ -59,6 +61,7 @@ describe("schema helpers", () => {
       optional: false,
       nullable: null,
       enabled: false,
+      nullableEnabled: false,
       choice: 1,
     });
   });

--- a/playground/src/utils/openapi.ts
+++ b/playground/src/utils/openapi.ts
@@ -1,3 +1,4 @@
+import type { JsonObject, JsonValue } from "@/types/json";
 import type { OpenAPIDocument, OpenAPISchema } from "@/types/openapi";
 
 const REF_PREFIX = "#/components/schemas/";
@@ -14,7 +15,7 @@ export function effectiveSchema(root: OpenAPIDocument, value: OpenAPISchema): Op
   if (!schema.anyOf) return schema;
   const nonNull = schema.anyOf
     .map((item) => resolveRef(root, item))
-    .filter((item) => item.type !== "null");
+    .filter((item) => !hasOnlyType(item, "null"));
   if (nonNull.length !== 1) return schema;
   const merged: OpenAPISchema = { ...schema, ...nonNull[0] };
   delete merged.anyOf;
@@ -22,7 +23,7 @@ export function effectiveSchema(root: OpenAPIDocument, value: OpenAPISchema): Op
 }
 
 /** Finds enum choices declared directly or through a referenced `allOf` branch. */
-export function enumValues(root: OpenAPIDocument, value: OpenAPISchema): unknown[] | undefined {
+export function enumValues(root: OpenAPIDocument, value: OpenAPISchema): JsonValue[] | undefined {
   const schema = effectiveSchema(root, value);
   if (schema.enum) return schema.enum;
   for (const item of schema.allOf ?? []) {
@@ -33,22 +34,19 @@ export function enumValues(root: OpenAPIDocument, value: OpenAPISchema): unknown
 }
 
 /** Builds initial input from explicit defaults and required enum or Boolean properties. */
-export function defaultInput(
-  root: OpenAPIDocument,
-  schema: OpenAPISchema,
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
+export function defaultInput(root: OpenAPIDocument, schema: OpenAPISchema): JsonObject {
+  const result: JsonObject = {};
   const required = new Set(schema.required ?? []);
   for (const [name, raw] of orderedProperties(schema)) {
     const property = effectiveSchema(root, raw);
-    if (Object.hasOwn(property, "default")) {
+    if (property.default !== undefined) {
       result[name] = property.default;
       continue;
     }
     if (!required.has(name)) continue;
     const choices = enumValues(root, property);
     if (choices?.length) result[name] = choices[0];
-    else if (property.type === "boolean") result[name] = false;
+    else if (hasType(property, "boolean")) result[name] = false;
   }
   return result;
 }
@@ -77,6 +75,17 @@ export function constraintText(schema: OpenAPISchema): string {
 function formatSchemaValue(value: unknown): string {
   if (typeof value === "string") return value;
   return JSON.stringify(value);
+}
+
+function hasType(schema: OpenAPISchema, type: string): boolean {
+  return schema.type === type || (Array.isArray(schema.type) && schema.type.includes(type));
+}
+
+function hasOnlyType(schema: OpenAPISchema, type: string): boolean {
+  return (
+    schema.type === type ||
+    (Array.isArray(schema.type) && schema.type.length === 1 && schema.type[0] === type)
+  );
 }
 
 export type PlaygroundCapabilities = {


### PR DESCRIPTION
- cog api client for config, health, schema, predictions, sse, and file conversion
- includes http/sse/api unit tests
- cog-playground stack: #3109, #3108, #3114, #3110/#3106, #3105/#3111/#3107, #3113, #3112