### PR TITLE
1. Add Go playground server and handlers

### DIFF
--- a/pkg/cli/playground.go
+++ b/pkg/cli/playground.go
@@ -1,0 +1,529 @@
+package cli
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/exec"
+	"os/signal"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/replicate/cog/pkg/global"
+	"github.com/replicate/cog/pkg/util/console"
+)
+
+const (
+	// maxWebhookBody caps a single webhook payload relayed to the browser.
+	maxWebhookBody = 10 * 1024 * 1024
+	// maxPlaygroundHeaderMetadata keeps inspector metadata below browser header limits.
+	maxPlaygroundHeaderMetadata = 32 * 1024
+	// playgroundUpstreamHeaders identifies model response headers for the request inspector.
+	playgroundUpstreamHeaders = "X-Cog-Upstream-Headers"
+)
+
+var (
+	playgroundPort        = 0
+	playgroundTarget      = "http://localhost:8393"
+	playgroundHost        = "127.0.0.1"
+	playgroundWebhookHost = "host.docker.internal"
+	playgroundNoOpen      = false
+)
+
+func newPlaygroundCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "playground",
+		Short: "Open a browser playground for talking to a running model",
+		Long: `Open a browser playground for talking to a running model.
+
+Starts a local web server that serves a schema-driven UI (a Postman-like tool
+for Cog models). Point it at any running Cog HTTP API -- for example one started
+with 'cog serve' -- and the playground reflects that model's inputs and outputs
+from its OpenAPI schema in real time.
+
+Requests are reverse-proxied through this server, so the target API does not
+need to set CORS headers. The server also hosts a webhook sink so async
+predictions can be observed in the browser.
+
+Async/webhook testing against a containerized model requires the webhook URL to
+be reachable from inside the container. On Docker Desktop the default
+'host.docker.internal' works once the server listens on a reachable interface
+(e.g. --host 0.0.0.0).`,
+		Example: `  # Start a model API in one terminal
+  cog serve -p 8393
+
+  # Open the playground pointing at it
+  cog playground --target http://localhost:8393`,
+		RunE:       cmdPlayground,
+		Args:       cobra.MaximumNArgs(0),
+		SuggestFor: []string{"ui", "gui"},
+	}
+
+	cmd.Flags().IntVarP(&playgroundPort, "port", "p", playgroundPort, "Port to listen on (0 picks a free port)")
+	cmd.Flags().StringVar(&playgroundTarget, "target", playgroundTarget, "Default target model API URL")
+	cmd.Flags().StringVar(&playgroundHost, "host", playgroundHost, "Address to bind (use 0.0.0.0 to receive webhooks from containers)")
+	cmd.Flags().StringVar(&playgroundWebhookHost, "webhook-host", playgroundWebhookHost, "Hostname the model uses to reach this server for webhooks")
+	cmd.Flags().BoolVar(&playgroundNoOpen, "no-open", playgroundNoOpen, "Do not open the browser automatically")
+
+	return cmd
+}
+
+// playgroundServer holds the runtime state for a playground instance.
+type playgroundServer struct {
+	hub           *eventHub
+	webhookBase   string
+	defaultTarget string
+}
+
+// newPlaygroundServer builds a playground server with an initialized event hub.
+func newPlaygroundServer(webhookBase, defaultTarget string) *playgroundServer {
+	return &playgroundServer{
+		hub:           newEventHub(),
+		webhookBase:   webhookBase,
+		defaultTarget: defaultTarget,
+	}
+}
+
+func cmdPlayground(cmd *cobra.Command, _ []string) error {
+	if !playgroundAssetsBuilt {
+		return errors.New("playground assets are not included; build Cog with 'mise run build:cog'")
+	}
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	uiFS, err := fs.Sub(playgroundUI, "playground")
+	if err != nil {
+		return fmt.Errorf("loading playground assets: %w", err)
+	}
+
+	ln, err := net.Listen("tcp", playgroundAddress(playgroundHost, playgroundPort))
+	if err != nil {
+		return fmt.Errorf("starting playground server: %w", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	srvState := newPlaygroundServer(
+		"http://"+playgroundAddress(playgroundWebhookHost, port),
+		playgroundTarget,
+	)
+
+	mux := srvState.routes(uiFS)
+
+	browserHost := playgroundBrowserHost(playgroundHost)
+	uiURL := "http://" + playgroundAddress(browserHost, port) + "/"
+	console.Infof("Cog playground running at %s", uiURL)
+	console.Info("Press Ctrl+C to stop.")
+	if !playgroundNoOpen {
+		maybeOpenBrowser(uiURL)
+	}
+
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       5 * time.Minute,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    64 * 1024,
+		BaseContext:       func(net.Listener) context.Context { return ctx },
+	}
+
+	return servePlayground(ctx, srv, ln, 5*time.Second)
+}
+
+func servePlayground(ctx context.Context, srv *http.Server, ln net.Listener, timeout time.Duration) error {
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ln) }()
+
+	select {
+	case err := <-serveErr:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return nil
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			_ = srv.Close()
+			<-serveErr
+			return fmt.Errorf("shutting down playground server: %w", err)
+		}
+		if err := <-serveErr; err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return nil
+	}
+}
+
+func playgroundAddress(host string, port int) string {
+	return net.JoinHostPort(normalizePlaygroundHost(host), strconv.Itoa(port))
+}
+
+func playgroundBrowserHost(host string) string {
+	host = normalizePlaygroundHost(host)
+	if host == "" {
+		return "127.0.0.1"
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsUnspecified() {
+		return host
+	}
+	if ip.To4() == nil {
+		return "::1"
+	}
+	return "127.0.0.1"
+}
+
+func normalizePlaygroundHost(host string) string {
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		return host[1 : len(host)-1]
+	}
+	return host
+}
+
+// routes builds the HTTP handler: static UI, the reverse proxy, and the webhook
+// sink + event relay.
+func (s *playgroundServer) routes(uiFS fs.FS) http.Handler {
+	mux := http.NewServeMux()
+	mux.Handle("/", http.FileServerFS(uiFS))
+	mux.HandleFunc("/proxy/", handlePlaygroundProxy)
+	mux.HandleFunc("/webhook/", s.handleWebhook)
+	mux.HandleFunc("/events", s.handleEvents)
+	mux.HandleFunc("/config", s.handleConfig)
+	return protectPlayground(mux)
+}
+
+// protectPlayground keeps the UI and user-directed proxy private even when the
+// server listens on 0.0.0.0 for container webhook callbacks. Remote webhook
+// deliveries are the only requests exempt from the browser-origin checks.
+func protectPlayground(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		setPlaygroundSecurityHeaders(w, r.URL.Path)
+		if strings.HasPrefix(r.URL.Path, "/webhook/") {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if !isLoopbackRemote(r.RemoteAddr) || !isLoopbackHost(r.Host) || isCrossSiteRequest(r) {
+			http.Error(w, "playground UI and proxy are only available from this browser", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func setPlaygroundSecurityHeaders(w http.ResponseWriter, path string) {
+	csp := "default-src 'self'; connect-src 'self'; img-src 'self' data: http: https:; media-src 'self' data: http: https:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'"
+	if strings.HasPrefix(path, "/assets/validation.worker-") && strings.HasSuffix(path, ".js") {
+		// Ajv compiles dynamic model schemas. Confine the required code generation
+		// to this network-isolated worker rather than relaxing the page policy.
+		csp = "default-src 'none'; script-src 'self' 'unsafe-eval'; connect-src 'none'; base-uri 'none'; form-action 'none'"
+	}
+	w.Header().Set("Content-Security-Policy", csp)
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Frame-Options", "DENY")
+}
+
+func isLoopbackHost(hostport string) bool {
+	host := hostport
+	if parsed, _, err := net.SplitHostPort(hostport); err == nil {
+		host = parsed
+	}
+	host = strings.Trim(host, "[]")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func isCrossSiteRequest(r *http.Request) bool {
+	if strings.EqualFold(r.Header.Get("Sec-Fetch-Site"), "cross-site") {
+		return true
+	}
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return false
+	}
+	parsed, err := url.Parse(origin)
+	return err != nil || !strings.EqualFold(parsed.Host, r.Host) || (parsed.Scheme != "http" && parsed.Scheme != "https")
+}
+
+func isLoopbackRemote(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// handleConfig reports runtime configuration the UI needs, notably the webhook
+// base URL the model should call back on.
+func (s *playgroundServer) handleConfig(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"target":      s.defaultTarget,
+		"webhookBase": s.webhookBase,
+		"cogVersion":  global.Version,
+	})
+}
+
+// handleWebhook receives a webhook delivery from a model and relays its body to
+// any browser subscribed to the matching token's event stream.
+func (s *playgroundServer) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	token := strings.TrimPrefix(r.URL.Path, "/webhook/")
+	if token == "" || strings.Contains(token, "/") || len(token) > 128 {
+		http.Error(w, "missing token", http.StatusNotFound)
+		return
+	}
+	if !s.hub.hasSubscribers(token) {
+		http.Error(w, "no browser is ready to receive this webhook", http.StatusServiceUnavailable)
+		return
+	}
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxWebhookBody))
+	if err != nil {
+		var maxBytesError *http.MaxBytesError
+		if errors.As(err, &maxBytesError) {
+			http.Error(w, "webhook body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		http.Error(w, "cannot read webhook body", http.StatusBadRequest)
+		return
+	}
+	if !s.hub.publish(token, body) {
+		http.Error(w, "no browser is ready to receive this webhook", http.StatusServiceUnavailable)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = fmt.Fprint(w, "{}")
+}
+
+// handleEvents streams relayed webhook payloads to the browser over SSE.
+func (s *playgroundServer) handleEvents(w http.ResponseWriter, r *http.Request) {
+	token := r.URL.Query().Get("token")
+	if token == "" {
+		http.Error(w, "missing token", http.StatusBadRequest)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	// Subscribe before flushing headers so the caller is guaranteed to be
+	// receiving by the time it observes the response (no missed events).
+	ch := s.hub.subscribe(token)
+	defer s.hub.unsubscribe(token, ch)
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	flusher.Flush()
+
+	keepAlive := time.NewTicker(15 * time.Second)
+	defer keepAlive.Stop()
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-ch:
+			writeSSEData(w, msg)
+			flusher.Flush()
+		case <-keepAlive.C:
+			_, _ = fmt.Fprint(w, ": keep-alive\n\n")
+			flusher.Flush()
+		}
+	}
+}
+
+// writeSSEData emits a payload as a single SSE event, prefixing every line with
+// "data: ". This preserves embedded newlines without letting them terminate the
+// event early or inject additional SSE fields (e.g. a spoofed "event:" line).
+func writeSSEData(w io.Writer, msg []byte) {
+	normalized := strings.NewReplacer("\r\n", "\n", "\r", "\n").Replace(string(msg))
+	for line := range strings.SplitSeq(normalized, "\n") {
+		_, _ = fmt.Fprintf(w, "data: %s\n", line)
+	}
+	_, _ = fmt.Fprint(w, "\n")
+}
+
+// handlePlaygroundProxy reverse-proxies /proxy/* to the target model API. The
+// target origin is taken from the X-Cog-Target header set by the playground UI.
+// Proxying keeps the browser same-origin, sidestepping CORS, and streams SSE
+// responses through unbuffered.
+func handlePlaygroundProxy(w http.ResponseWriter, r *http.Request) {
+	rawTarget := r.Header.Get("X-Cog-Target")
+	if rawTarget == "" {
+		writeProxyError(w, http.StatusBadRequest, "no target API set")
+		return
+	}
+
+	target, err := url.Parse(strings.TrimRight(rawTarget, "/"))
+	if err != nil || target.Host == "" || target.User != nil || target.Fragment != "" || (target.Scheme != "http" && target.Scheme != "https") {
+		writeProxyError(w, http.StatusBadRequest, "invalid target API URL")
+		return
+	}
+
+	proxy := &httputil.ReverseProxy{
+		FlushInterval: -1, // flush immediately so SSE streams in real time
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			// Forward the path after /proxy.
+			escapedPath := strings.TrimPrefix(pr.In.URL.EscapedPath(), "/proxy")
+			if escapedPath == "" {
+				escapedPath = "/"
+			}
+			path, err := url.PathUnescape(escapedPath)
+			if err != nil {
+				path = strings.TrimPrefix(pr.In.URL.Path, "/proxy")
+			}
+			pr.Out.URL.Path = path
+			pr.Out.URL.RawPath = escapedPath
+			pr.SetURL(target)
+			pr.Out.Host = target.Host
+			pr.Out.Header.Del("X-Cog-Target")
+			pr.Out.Header.Del("Authorization")
+			pr.Out.Header.Del("Cookie")
+			pr.Out.Header.Del("Origin")
+			pr.Out.Header.Del("Referer")
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			resp.Header.Del("Clear-Site-Data")
+			resp.Header.Del("Service-Worker-Allowed")
+			resp.Header.Del("Set-Cookie")
+			// Drop absolute redirects so the browser cannot be pivoted off the
+			// intended target (fetch uses redirect: "manual" as a second line).
+			if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+				if location := resp.Header.Get("Location"); location != "" {
+					if parsed, err := url.Parse(location); err != nil || parsed.IsAbs() {
+						resp.Header.Del("Location")
+					}
+				}
+			}
+			upstreamHeaders := resp.Header.Clone()
+			upstreamHeaders.Del(playgroundUpstreamHeaders)
+			resp.Header.Del(playgroundUpstreamHeaders)
+			encodedHeaders, err := json.Marshal(upstreamHeaders)
+			if err != nil {
+				return fmt.Errorf("encode upstream response headers: %w", err)
+			}
+			metadata := base64.RawURLEncoding.EncodeToString(encodedHeaders)
+			if len(metadata) <= maxPlaygroundHeaderMetadata {
+				resp.Header.Set(playgroundUpstreamHeaders, metadata)
+			}
+			return nil
+		},
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			writeProxyError(w, http.StatusBadGateway, "cannot reach target API: "+err.Error())
+		},
+	}
+	// The proxy target is user-specified by design (a local model API); SSRF to
+	// it is the intended behavior of this dev tool, not a vulnerability.
+	proxy.ServeHTTP(w, r) //nolint:gosec // user-directed proxy target is intentional
+}
+
+func writeProxyError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	// message is server-controlled text; encode minimally as a JSON string.
+	_, _ = fmt.Fprintf(w, `{"error":%q}`, message)
+}
+
+// maybeOpenBrowser best-effort opens a URL in the default browser.
+func maybeOpenBrowser(target string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", target)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", target)
+	default:
+		cmd = exec.Command("xdg-open", target)
+	}
+	if err := cmd.Start(); err == nil {
+		go func() { _ = cmd.Wait() }()
+	}
+}
+
+// eventHub fans out relayed webhook payloads to browser SSE subscribers keyed
+// by an opaque token.
+type eventHub struct {
+	mu   sync.Mutex
+	subs map[string]map[chan []byte]struct{}
+}
+
+func newEventHub() *eventHub {
+	return &eventHub{subs: make(map[string]map[chan []byte]struct{})}
+}
+
+func (h *eventHub) subscribe(token string) chan []byte {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	ch := make(chan []byte, 4)
+	if h.subs[token] == nil {
+		h.subs[token] = make(map[chan []byte]struct{})
+	}
+	h.subs[token][ch] = struct{}{}
+	return ch
+}
+
+func (h *eventHub) hasSubscribers(token string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.subs[token]) > 0
+}
+
+func (h *eventHub) unsubscribe(token string, ch chan []byte) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	subs := h.subs[token]
+	if subs == nil {
+		return
+	}
+	delete(subs, ch)
+	if len(subs) == 0 {
+		delete(h.subs, token)
+	}
+}
+
+// publish delivers msg to every subscriber of token, best-effort. It reports
+// whether at least one subscriber received it. Delivery is non-blocking: a
+// subscriber whose buffer is momentarily full is skipped rather than stalling
+// the webhook. The depth-buffered channels absorb any realistic burst for a
+// single-user tool.
+func (h *eventHub) publish(token string, msg []byte) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	delivered := false
+	for ch := range h.subs[token] {
+		select {
+		case ch <- msg:
+			delivered = true
+		default:
+		}
+	}
+	return delivered
+}

--- a/pkg/cli/playground.go
+++ b/pkg/cli/playground.go
@@ -413,14 +413,10 @@ func handlePlaygroundProxy(w http.ResponseWriter, r *http.Request) {
 			resp.Header.Del("Clear-Site-Data")
 			resp.Header.Del("Service-Worker-Allowed")
 			resp.Header.Del("Set-Cookie")
-			// Drop external redirects so the browser cannot be pivoted off the
+			// Drop redirects so browser URL normalization cannot pivot off the
 			// intended target (fetch uses redirect: "manual" as a second line).
 			if resp.StatusCode >= 300 && resp.StatusCode < 400 {
-				if location := resp.Header.Get("Location"); location != "" {
-					if parsed, err := url.Parse(location); err != nil || parsed.IsAbs() || parsed.Host != "" {
-						resp.Header.Del("Location")
-					}
-				}
+				resp.Header.Del("Location")
 			}
 			upstreamHeaders := resp.Header.Clone()
 			upstreamHeaders.Del(playgroundUpstreamHeaders)

--- a/pkg/cli/playground.go
+++ b/pkg/cli/playground.go
@@ -413,11 +413,11 @@ func handlePlaygroundProxy(w http.ResponseWriter, r *http.Request) {
 			resp.Header.Del("Clear-Site-Data")
 			resp.Header.Del("Service-Worker-Allowed")
 			resp.Header.Del("Set-Cookie")
-			// Drop absolute redirects so the browser cannot be pivoted off the
+			// Drop external redirects so the browser cannot be pivoted off the
 			// intended target (fetch uses redirect: "manual" as a second line).
 			if resp.StatusCode >= 300 && resp.StatusCode < 400 {
 				if location := resp.Header.Get("Location"); location != "" {
-					if parsed, err := url.Parse(location); err != nil || parsed.IsAbs() {
+					if parsed, err := url.Parse(location); err != nil || parsed.IsAbs() || parsed.Host != "" {
 						resp.Header.Del("Location")
 					}
 				}

--- a/pkg/cli/playground_assets_stub.go
+++ b/pkg/cli/playground_assets_stub.go
@@ -1,0 +1,11 @@
+//go:build !playground_assets
+
+package cli
+
+import "testing/fstest"
+
+var playgroundUI = fstest.MapFS{
+	"playground/index.html": {Data: []byte("<!doctype html><title>Cog Playground</title>")},
+}
+
+const playgroundAssetsBuilt = false

--- a/pkg/cli/playground_test.go
+++ b/pkg/cli/playground_test.go
@@ -1,0 +1,635 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/replicate/cog/pkg/global"
+)
+
+var _ = newPlaygroundCommand
+
+func newTestPlayground(t *testing.T) *httptest.Server {
+	t.Helper()
+	uiFS, err := fs.Sub(playgroundUI, "playground")
+	require.NoError(t, err)
+	s := newPlaygroundServer("http://wh.example/cb", "http://localhost:8393")
+	ts := httptest.NewServer(s.routes(uiFS))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// echoServer reports the received path and (forwarded) query as JSON.
+func echoServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"path":%q,"escaped_path":%q,"query":%q}`, r.URL.Path, r.URL.EscapedPath(), r.URL.RawQuery)
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestPlaygroundServesUI(t *testing.T) {
+	ts := newTestPlayground(t)
+
+	resp, err := http.Get(ts.URL + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, string(body), "Cog Playground")
+
+	assets := regexp.MustCompile(`(?:src|href)="(/?assets/[^"]+)"`).FindAllStringSubmatch(string(body), -1)
+	if !playgroundAssetsBuilt {
+		assert.Empty(t, assets, "stub index should not reference generated assets")
+		return
+	}
+	require.NotEmpty(t, assets, "generated index should reference bundled assets")
+	for _, match := range assets {
+		path := "/" + strings.TrimPrefix(match[1], "/")
+		assetResp, err := http.Get(ts.URL + path)
+		require.NoError(t, err, "requesting %s", path)
+		assetResp.Body.Close()
+		assert.Equal(t, http.StatusOK, assetResp.StatusCode, "%s should be served", path)
+		if strings.HasSuffix(path, ".css") {
+			assert.Contains(t, assetResp.Header.Get("Content-Type"), "text/css")
+		} else if strings.HasSuffix(path, ".js") {
+			assert.Contains(t, assetResp.Header.Get("Content-Type"), "javascript")
+		}
+	}
+}
+
+func TestServePlaygroundWaitsForHandlers(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	release := make(chan struct{})
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			close(started)
+			<-r.Context().Done()
+			close(canceled)
+			<-release
+		}),
+		BaseContext: func(net.Listener) context.Context { return ctx },
+	}
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- servePlayground(ctx, srv, ln, time.Second) }()
+	requestDone := make(chan struct{})
+	go func() {
+		defer close(requestDone)
+		resp, requestErr := http.Get("http://" + ln.Addr().String())
+		if requestErr == nil {
+			resp.Body.Close()
+		}
+	}()
+
+	<-started
+	cancel()
+	<-canceled
+	select {
+	case err := <-serveDone:
+		require.FailNow(t, "server returned before the active handler finished", "%v", err)
+	default:
+	}
+	close(release)
+	require.NoError(t, <-serveDone)
+	<-requestDone
+}
+
+func TestPlaygroundConfig(t *testing.T) {
+	ts := newTestPlayground(t)
+	resp, err := http.Get(ts.URL + "/config")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var config map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&config))
+	assert.Equal(t, "http://wh.example/cb", config["webhookBase"])
+	assert.Equal(t, "http://localhost:8393", config["target"])
+	assert.Equal(t, global.Version, config["cogVersion"])
+}
+
+func TestPlaygroundRejectsRemoteUIAndProxyRequests(t *testing.T) {
+	uiFS, err := fs.Sub(playgroundUI, "playground")
+	require.NoError(t, err)
+	s := newPlaygroundServer("http://wh.example/cb", "")
+
+	for _, path := range []string{"/", "/config", "/proxy/health-check"} {
+		req := httptest.NewRequest(http.MethodGet, "http://playground.example"+path, nil)
+		req.RemoteAddr = "192.0.2.10:1234"
+		resp := httptest.NewRecorder()
+		s.routes(uiFS).ServeHTTP(resp, req)
+		assert.Equal(t, http.StatusForbidden, resp.Code, path)
+	}
+}
+
+func TestPlaygroundAllowsRemoteWebhookRequests(t *testing.T) {
+	uiFS, err := fs.Sub(playgroundUI, "playground")
+	require.NoError(t, err)
+	s := newPlaygroundServer("http://wh.example/cb", "")
+	ch := s.hub.subscribe("token")
+	defer s.hub.unsubscribe("token", ch)
+
+	req := httptest.NewRequest(http.MethodPost, "http://playground.example/webhook/token", strings.NewReader(`{"status":"succeeded"}`))
+	req.RemoteAddr = "192.0.2.10:1234"
+	resp := httptest.NewRecorder()
+	s.routes(uiFS).ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+}
+
+func TestPlaygroundProxyHeaderTarget(t *testing.T) {
+	ts := newTestPlayground(t)
+	stub := echoServer(t)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/proxy/openapi.json?foo=bar", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Cog-Target", stub.URL)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var got map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, "/openapi.json", got["path"], "/proxy prefix should be stripped")
+	assert.Equal(t, "foo=bar", got["query"])
+}
+
+func TestPlaygroundProxyRejectsQueryTarget(t *testing.T) {
+	ts := newTestPlayground(t)
+	stub := echoServer(t)
+
+	u := ts.URL + "/proxy/health-check?x=1&cog_target=" + url.QueryEscape(stub.URL)
+	resp, err := http.Get(u)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestPlaygroundProxyPreservesEscapedPathSegments(t *testing.T) {
+	ts := newTestPlayground(t)
+	stub := echoServer(t)
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/proxy/predictions/custom%2Fid/cancel", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Cog-Target", stub.URL+"/api")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var got map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, "/api/predictions/custom/id/cancel", got["path"])
+	assert.Equal(t, "/api/predictions/custom%2Fid/cancel", got["escaped_path"])
+}
+
+func TestPlaygroundProxyForwardsRequestAndResponse(t *testing.T) {
+	ts := newTestPlayground(t)
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/predictions/p1", r.URL.Path)
+		assert.Equal(t, `{"input":{"prompt":"hello"}}`, string(body))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Empty(t, r.Header.Get("X-Cog-Target"))
+		assert.Empty(t, r.Header.Get("Authorization"))
+		assert.Empty(t, r.Header.Get("Cookie"))
+		w.Header().Set("X-Upstream", "preserved")
+		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		w.Header().Set("Set-Cookie", "session=upstream")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"detail":"invalid input"}`))
+	}))
+	t.Cleanup(stub.Close)
+
+	req, err := http.NewRequest(http.MethodPut, ts.URL+"/proxy/predictions/p1", bytes.NewBufferString(`{"input":{"prompt":"hello"}}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer local-secret")
+	req.Header.Set("Cookie", "session=local-secret")
+	req.Header.Set("X-Cog-Target", stub.URL+"/api")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+	assert.Equal(t, "preserved", resp.Header.Get("X-Upstream"))
+	assert.Empty(t, resp.Header.Get("Set-Cookie"))
+	encodedHeaders, err := base64.RawURLEncoding.DecodeString(resp.Header.Get(playgroundUpstreamHeaders))
+	require.NoError(t, err)
+	var upstreamHeaders http.Header
+	require.NoError(t, json.Unmarshal(encodedHeaders, &upstreamHeaders))
+	assert.Equal(t, "preserved", upstreamHeaders.Get("X-Upstream"))
+	assert.Equal(t, "SAMEORIGIN", upstreamHeaders.Get("X-Frame-Options"))
+	assert.Empty(t, upstreamHeaders.Get("Set-Cookie"))
+	assert.JSONEq(t, `{"detail":"invalid input"}`, string(body))
+}
+
+func TestPlaygroundProxyRoutesConcurrentWorkspacesIndependently(t *testing.T) {
+	ts := newTestPlayground(t)
+	models := map[string]*httptest.Server{}
+	for _, name := range []string{"first", "second"} {
+		models[name] = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = fmt.Fprint(w, name)
+		}))
+		t.Cleanup(models[name].Close)
+	}
+
+	errs := make(chan error, 40)
+	var requests sync.WaitGroup
+	for name, model := range models {
+		for range 20 {
+			requests.Go(func() {
+				req, err := http.NewRequest(http.MethodGet, ts.URL+"/proxy/identity", nil)
+				if err != nil {
+					errs <- err
+					return
+				}
+				req.Header.Set("X-Cog-Target", model.URL)
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					errs <- err
+					return
+				}
+				body, readErr := io.ReadAll(resp.Body)
+				resp.Body.Close()
+				if readErr != nil {
+					errs <- readErr
+					return
+				}
+				if string(body) != name {
+					errs <- fmt.Errorf("request for %s reached %q", name, body)
+				}
+			})
+		}
+	}
+	requests.Wait()
+	close(errs)
+	for err := range errs {
+		assert.NoError(t, err)
+	}
+}
+
+func TestPlaygroundProxyOmitsOversizedHeaderMetadata(t *testing.T) {
+	ts := newTestPlayground(t)
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Large", strings.Repeat("x", maxPlaygroundHeaderMetadata))
+		w.Header().Set(playgroundUpstreamHeaders, "spoofed")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(stub.Close)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/proxy/health-check", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Cog-Target", stub.URL)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, strings.Repeat("x", maxPlaygroundHeaderMetadata), resp.Header.Get("X-Large"))
+	assert.Empty(t, resp.Header.Get(playgroundUpstreamHeaders))
+}
+
+func TestPlaygroundProxyMissingTarget(t *testing.T) {
+	ts := newTestPlayground(t)
+	resp, err := http.Get(ts.URL + "/proxy/health-check")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestPlaygroundProxyInvalidTarget(t *testing.T) {
+	ts := newTestPlayground(t)
+	for _, target := range []string{"ftp://example.com", "garbage", "", "http://user@example.com", "http://example.com/#fragment"} {
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/proxy/health-check", nil)
+		require.NoError(t, err)
+		if target != "" {
+			req.Header.Set("X-Cog-Target", target)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "target %q should be rejected", target)
+	}
+}
+
+func TestPlaygroundWebhookRejectsNonPost(t *testing.T) {
+	ts := newTestPlayground(t)
+	resp, err := http.Get(ts.URL + "/webhook/token")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	assert.Equal(t, http.MethodPost, resp.Header.Get("Allow"))
+}
+
+func TestPlaygroundRecognizesIPv6Loopback(t *testing.T) {
+	assert.True(t, isLoopbackRemote("[::1]:8080"))
+	assert.False(t, isLoopbackRemote("not-an-address"))
+	assert.True(t, isLoopbackHost("[::1]:8080"))
+	assert.True(t, isLoopbackHost("localhost:8080"))
+	assert.False(t, isLoopbackHost("playground.example:8080"))
+}
+
+func TestPlaygroundFormatsIPv6Address(t *testing.T) {
+	assert.Equal(t, "[::1]:8080", playgroundAddress("::1", 8080))
+	assert.Equal(t, "[::1]:8080", playgroundAddress("[::1]", 8080))
+}
+
+func TestPlaygroundUsesLoopbackBrowserHostForWildcard(t *testing.T) {
+	assert.Equal(t, "127.0.0.1", playgroundBrowserHost("0.0.0.0"))
+	assert.Equal(t, "::1", playgroundBrowserHost("::"))
+	assert.Equal(t, "::1", playgroundBrowserHost("[::]"))
+}
+
+func TestPlaygroundRejectsCrossSiteBrowserRequests(t *testing.T) {
+	ts := newTestPlayground(t)
+
+	for name, mutate := range map[string]func(*http.Request){
+		"host": func(req *http.Request) { req.Host = "attacker.example" },
+		"origin": func(req *http.Request) {
+			req.Header.Set("Origin", "https://attacker.example")
+		},
+		"fetch metadata": func(req *http.Request) {
+			req.Header.Set("Sec-Fetch-Site", "cross-site")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, ts.URL+"/config", nil)
+			require.NoError(t, err)
+			mutate(req)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		})
+	}
+}
+
+func TestPlaygroundSetsBrowserSecurityHeaders(t *testing.T) {
+	ts := newTestPlayground(t)
+	resp, err := http.Get(ts.URL + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "frame-ancestors 'none'")
+	assert.NotContains(t, resp.Header.Get("Content-Security-Policy"), "'unsafe-eval'")
+	assert.Equal(t, "no-referrer", resp.Header.Get("Referrer-Policy"))
+	assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/assets/validation.worker-test.js", nil)
+	request.RemoteAddr = "127.0.0.1:1234"
+	request.Host = "127.0.0.1"
+	protectPlayground(http.NotFoundHandler()).ServeHTTP(recorder, request)
+	workerCSP := recorder.Header().Get("Content-Security-Policy")
+	assert.Contains(t, workerCSP, "script-src 'self' 'unsafe-eval'")
+	assert.Contains(t, workerCSP, "connect-src 'none'")
+}
+
+func TestPlaygroundProxyUnreachableTarget(t *testing.T) {
+	ts := newTestPlayground(t)
+	dead := httptest.NewServer(http.NotFoundHandler())
+	deadURL := dead.URL
+	dead.Close() // now refuses connections
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/proxy/health-check", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Cog-Target", deadURL)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+}
+
+func TestPlaygroundProxyStreamsSSE(t *testing.T) {
+	ts := newTestPlayground(t)
+	sse := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		fmt.Fprint(w, "event: start\ndata: {\"a\":1}\n\n")
+		w.(http.Flusher).Flush()
+	}))
+	t.Cleanup(sse.Close)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/proxy/predictions", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Cog-Target", sse.URL)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+	body, _ := io.ReadAll(resp.Body)
+	assert.Contains(t, string(body), "event: start")
+	assert.Contains(t, string(body), `data: {"a":1}`)
+}
+
+func TestPlaygroundWebhookRelay(t *testing.T) {
+	ts := newTestPlayground(t)
+	const token = "tok123"
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"/events?token="+token, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+	// The subscription is registered before headers are flushed, so by now the
+	// hub has our channel; deliver a webhook and expect it relayed.
+	got := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			if line := scanner.Text(); strings.HasPrefix(line, "data: ") {
+				got <- strings.TrimPrefix(line, "data: ")
+				return
+			}
+		}
+	}()
+
+	whResp, err := http.Post(ts.URL+"/webhook/"+token, "application/json",
+		strings.NewReader(`{"status":"succeeded","id":"p1"}`))
+	require.NoError(t, err)
+	whResp.Body.Close()
+	assert.Equal(t, http.StatusOK, whResp.StatusCode)
+
+	select {
+	case data := <-got:
+		assert.JSONEq(t, `{"status":"succeeded","id":"p1"}`, data)
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "timed out waiting for relayed webhook event")
+	}
+}
+
+// A payload containing newlines must be framed as one SSE event with a
+// "data: " prefix per line, not terminate the event early or inject fields.
+func TestPlaygroundWebhookRelayPreservesNewlines(t *testing.T) {
+	ts := newTestPlayground(t)
+	const token = "tok-nl"
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"/events?token="+token, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	got := make(chan []string, 1)
+	go func() {
+		scanner := bufio.NewScanner(resp.Body)
+		var data []string
+		for scanner.Scan() {
+			line := scanner.Text()
+			if after, ok := strings.CutPrefix(line, "data: "); ok {
+				data = append(data, after)
+			} else if line == "" && len(data) > 0 {
+				got <- data
+				return
+			}
+		}
+	}()
+
+	whResp, err := http.Post(ts.URL+"/webhook/"+token, "application/json",
+		strings.NewReader("{\"a\":1}\n{\"b\":2}"))
+	require.NoError(t, err)
+	whResp.Body.Close()
+
+	select {
+	case data := <-got:
+		assert.Equal(t, []string{`{"a":1}`, `{"b":2}`}, data)
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "timed out waiting for relayed webhook event")
+	}
+}
+
+func TestWriteSSEDataNormalizesLineEndings(t *testing.T) {
+	for name, input := range map[string]string{
+		"LF":   "first\nsecond",
+		"CRLF": "first\r\nsecond",
+		"CR":   "first\rsecond",
+	} {
+		t.Run(name, func(t *testing.T) {
+			var output strings.Builder
+			writeSSEData(&output, []byte(input))
+			assert.Equal(t, "data: first\ndata: second\n\n", output.String())
+		})
+	}
+}
+
+func TestPlaygroundEventsMissingToken(t *testing.T) {
+	ts := newTestPlayground(t)
+	resp, err := http.Get(ts.URL + "/events")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestPlaygroundWebhookMissingToken(t *testing.T) {
+	ts := newTestPlayground(t)
+	resp, err := http.Post(ts.URL+"/webhook/", "application/json", strings.NewReader("{}"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestPlaygroundWebhookRejectsOversizedBody(t *testing.T) {
+	uiFS, err := fs.Sub(playgroundUI, "playground")
+	require.NoError(t, err)
+	// Keep a subscriber active so the handler reaches its body-size check.
+	s := newPlaygroundServer("http://wh.example/cb", "")
+	ch := s.hub.subscribe("token")
+	defer s.hub.unsubscribe("token", ch)
+	ts := httptest.NewServer(s.routes(uiFS))
+	t.Cleanup(ts.Close)
+	resp, err := http.Post(ts.URL+"/webhook/token", "application/json",
+		strings.NewReader(strings.Repeat("x", maxWebhookBody+1)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+}
+
+func TestPlaygroundWebhookRejectsMissingSubscriber(t *testing.T) {
+	ts := newTestPlayground(t)
+	resp, err := http.Post(ts.URL+"/webhook/token", "application/json", strings.NewReader("{}"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+func TestPlaygroundProxyStripsAbsoluteRedirectLocation(t *testing.T) {
+	ts := newTestPlayground(t)
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "http://169.254.169.254/latest/meta-data/")
+		w.WriteHeader(http.StatusFound)
+	}))
+	t.Cleanup(stub.Close)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/proxy/health-check", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Cog-Target", stub.URL)
+	// Do not follow redirects; we want the proxy response as the browser would with redirect:manual.
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Location"))
+}
+
+// A stalled subscriber (full buffer) must not block or deny delivery to a
+// healthy one: publish is best-effort and non-blocking.
+func TestEventHubPublishDeliversDespiteStalledSubscriber(t *testing.T) {
+	hub := newEventHub()
+	stalled := hub.subscribe("token")
+	healthy := hub.subscribe("token")
+	// Fill the stalled subscriber's buffer so any send to it would block.
+	for len(stalled) < cap(stalled) {
+		stalled <- []byte("fill")
+	}
+
+	assert.True(t, hub.publish("token", []byte("msg")), "healthy subscriber should receive the message")
+
+	select {
+	case msg := <-healthy:
+		assert.Equal(t, []byte("msg"), msg)
+	case <-time.After(time.Second):
+		require.FailNow(t, "healthy subscriber did not receive the message")
+	}
+}
+
+func TestEventHubPublishReturnsFalseWithoutSubscribers(t *testing.T) {
+	hub := newEventHub()
+	assert.False(t, hub.publish("token", []byte("msg")))
+}

--- a/pkg/cli/playground_test.go
+++ b/pkg/cli/playground_test.go
@@ -585,10 +585,12 @@ func TestPlaygroundWebhookRejectsMissingSubscriber(t *testing.T) {
 	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 }
 
-func TestPlaygroundProxyStripsExternalRedirectLocation(t *testing.T) {
+func TestPlaygroundProxyStripsRedirectLocation(t *testing.T) {
 	for name, location := range map[string]string{
 		"absolute":          "http://169.254.169.254/latest/meta-data/",
 		"protocol-relative": "//169.254.169.254/latest/meta-data/",
+		"triple-slash":      "///169.254.169.254/latest/meta-data/",
+		"backslash":         `\\169.254.169.254\latest\meta-data\`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			ts := newTestPlayground(t)

--- a/pkg/cli/playground_test.go
+++ b/pkg/cli/playground_test.go
@@ -585,27 +585,34 @@ func TestPlaygroundWebhookRejectsMissingSubscriber(t *testing.T) {
 	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 }
 
-func TestPlaygroundProxyStripsAbsoluteRedirectLocation(t *testing.T) {
-	ts := newTestPlayground(t)
-	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Location", "http://169.254.169.254/latest/meta-data/")
-		w.WriteHeader(http.StatusFound)
-	}))
-	t.Cleanup(stub.Close)
+func TestPlaygroundProxyStripsExternalRedirectLocation(t *testing.T) {
+	for name, location := range map[string]string{
+		"absolute":          "http://169.254.169.254/latest/meta-data/",
+		"protocol-relative": "//169.254.169.254/latest/meta-data/",
+	} {
+		t.Run(name, func(t *testing.T) {
+			ts := newTestPlayground(t)
+			stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Location", location)
+				w.WriteHeader(http.StatusFound)
+			}))
+			t.Cleanup(stub.Close)
 
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/proxy/health-check", nil)
-	require.NoError(t, err)
-	req.Header.Set("X-Cog-Target", stub.URL)
-	// Do not follow redirects; we want the proxy response as the browser would with redirect:manual.
-	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
-		return http.ErrUseLastResponse
-	}}
-	resp, err := client.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
+			req, err := http.NewRequest(http.MethodGet, ts.URL+"/proxy/health-check", nil)
+			require.NoError(t, err)
+			req.Header.Set("X-Cog-Target", stub.URL)
+			// Do not follow redirects; we want the proxy response as the browser would with redirect:manual.
+			client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			}}
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
 
-	assert.Equal(t, http.StatusFound, resp.StatusCode)
-	assert.Empty(t, resp.Header.Get("Location"))
+			assert.Equal(t, http.StatusFound, resp.StatusCode)
+			assert.Empty(t, resp.Header.Get("Location"))
+		})
+	}
 }
 
 // A stalled subscriber (full buffer) must not block or deny delivery to a


### PR DESCRIPTION
- go playground server, request proxy, webhook/event relay, and unit tests
- command registration and the final app are split into later prs
- cog-playground stack: #3109, #3108, #3114, #3110/#3106, #3105/#3111/#3107, #3113, #3112