### PR TITLE
7. Add playground input controls and validation

### DIFF
--- a/playground/src/features/inputs/components/FileInputControl.tsx
+++ b/playground/src/features/inputs/components/FileInputControl.tsx
@@ -1,0 +1,120 @@
+import { Input } from "@cloudflare/kumo/components/input";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
+
+import type { InputControlProps } from "@/features/inputs/components/InputField";
+import { formatBytes, isDataURI } from "@/features/inputs/utils/inputControl";
+import { fileToDataURI } from "@/services/cog";
+import { constraintText } from "@/utils/openapi";
+
+/**
+ * Accepts uploaded files or URLs, reports loading and validity, and previews supported media
+ * after converting local files to data URIs.
+ */
+export function FileInputControl(props: InputControlProps) {
+  const { disabled } = props;
+  const [fileName, setFileName] = useState("");
+  const [error, setError] = useState("");
+  const readToken = useRef(0);
+  const descriptionId =
+    props.schema.description || constraintText(props.schema)
+      ? `field-${props.name}-description`
+      : undefined;
+  const errorId = `field-${props.name}-error`;
+  const validationId = props.errors.length > 0 ? `field-${props.name}-validation` : undefined;
+  const describedBy =
+    [descriptionId, validationId, error ? errorId : undefined].filter(Boolean).join(" ") ||
+    undefined;
+  const clearBusy = useEffectEvent(() => props.onBusyChange(false));
+
+  useEffect(() => {
+    if (!disabled) return;
+    readToken.current += 1;
+    clearBusy();
+  }, [disabled]);
+  useEffect(
+    () => () => {
+      readToken.current += 1;
+    },
+    [],
+  );
+
+  const accept = Array.isArray(props.schema["x-cog-accept"])
+    ? props.schema["x-cog-accept"].join(",")
+    : typeof props.schema["x-cog-accept"] === "string"
+      ? props.schema["x-cog-accept"]
+      : undefined;
+
+  return (
+    <div className="file-widget">
+      <input
+        id={`field-${props.name}`}
+        type="file"
+        accept={accept}
+        disabled={disabled}
+        aria-describedby={describedBy}
+        aria-invalid={Boolean(error) || props.errors.length > 0 || undefined}
+        onChange={async (event) => {
+          const file = event.currentTarget.files?.[0];
+          if (!file) return;
+          const token = ++readToken.current;
+          props.onBusyChange(true);
+          setError("");
+          try {
+            const data = await fileToDataURI(file);
+            if (readToken.current !== token) return;
+            props.onChange(data);
+            props.onValidityChange(true);
+            setFileName(`${file.name} (${formatBytes(file.size)})`);
+          } catch (readError) {
+            if (readToken.current !== token) return;
+            props.onValidityChange(false);
+            setFileName("");
+            setError(readError instanceof Error ? readError.message : "Could not read file");
+          } finally {
+            if (readToken.current === token) props.onBusyChange(false);
+          }
+        }}
+      />
+      {fileName && <span className="file-name">{fileName}</span>}
+      <span className="muted">or URL</span>
+      <Input
+        aria-label={`${props.name} URL`}
+        aria-describedby={describedBy}
+        aria-invalid={Boolean(error) || props.errors.length > 0 || undefined}
+        disabled={disabled}
+        placeholder="https://..."
+        value={typeof props.value === "string" && !isDataURI(props.value) ? props.value : ""}
+        onInput={(event) => {
+          readToken.current += 1;
+          props.onBusyChange(false);
+          setFileName("");
+          setError("");
+          props.onValidityChange(true);
+          props.onChange(event.currentTarget.value);
+        }}
+      />
+      {error && (
+        <small id={errorId} className="field-error" role="alert">
+          {error}
+        </small>
+      )}
+      {typeof props.value === "string" && <MediaPreview value={props.value} />}
+    </div>
+  );
+}
+
+function MediaPreview({ value }: { value: string }) {
+  if (!isDataURI(value)) return null;
+  if (/^data:image\//i.test(value)) {
+    return <img className="input-media" src={value} alt="Selected input preview" />;
+  }
+  if (/^data:audio\//i.test(value)) {
+    // oxlint-disable-next-line jsx-a11y/media-has-caption -- model inputs do not include caption tracks
+    return <audio controls src={value} />;
+  }
+  if (/^data:video\//i.test(value)) {
+    // oxlint-disable-next-line jsx-a11y/media-has-caption -- model inputs do not include caption tracks
+    return <video controls src={value} />;
+  }
+  return null;
+}

--- a/playground/src/features/inputs/components/InputField.tsx
+++ b/playground/src/features/inputs/components/InputField.tsx
@@ -1,0 +1,156 @@
+import { Checkbox } from "@cloudflare/kumo/components/checkbox";
+import { Input, InputArea } from "@cloudflare/kumo/components/input";
+
+import { FileInputControl } from "@/features/inputs/components/FileInputControl";
+import { StructuredInputControl } from "@/features/inputs/components/StructuredInputControl";
+import type { ValidationIssue } from "@/features/inputs/validation/inputValidation";
+import type { OpenAPIDocument, OpenAPISchema } from "@/types/openapi";
+import { constraintText, enumValues } from "@/utils/openapi";
+
+export type InputFieldProps = {
+  document: OpenAPIDocument;
+  name: string;
+  schema: OpenAPISchema;
+  required: boolean;
+  included: boolean;
+  errors: readonly ValidationIssue[];
+  value: unknown;
+  onIncludedChange: (included: boolean) => void;
+  onChange: (value: unknown) => void;
+  onBusyChange: (busy: boolean) => void;
+  onValidityChange: (valid: boolean) => void;
+};
+
+export type InputControlProps = InputFieldProps & { disabled: boolean };
+
+/** Keeps omitted optional fields inert and delegates included values to a schema-specific control. */
+export function InputField(props: InputFieldProps) {
+  const { schema, name, required, included } = props;
+  const description = [schema.description, constraintText(schema)].filter(Boolean).join(" · ");
+  const descriptionId = `field-${name}-description`;
+  const validationId = `field-${name}-validation`;
+  return (
+    <div className="field">
+      <div className="field-heading">
+        {!required && (
+          <Checkbox
+            aria-label={`Include optional field ${name}`}
+            checked={included}
+            onCheckedChange={(checked) => props.onIncludedChange(checked === true)}
+          />
+        )}
+        <label htmlFor={`field-${name}`}>
+          {name}
+          {required && <span className="req"> *</span>}
+          {schema.deprecated && <span className="deprecated-tag"> (deprecated)</span>}
+        </label>
+      </div>
+      {description && (
+        <small id={descriptionId} className="desc">
+          {description}
+        </small>
+      )}
+      <div
+        inert={!included}
+        aria-disabled={!included}
+        className={!included ? "field-disabled" : undefined}
+      >
+        <InputControl {...props} disabled={!included} />
+      </div>
+      {props.errors.length > 0 && (
+        <ul id={validationId} className="field-errors">
+          {props.errors.map((error) => (
+            <li key={`${error.path}:${error.keyword}:${error.message}`}>{error.message}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function InputControl(props: InputControlProps) {
+  const choices = enumValues(props.document, props.schema);
+  const describedBy =
+    props.schema.description || constraintText(props.schema)
+      ? `field-${props.name}-description`
+      : undefined;
+  const validationId = props.errors.length > 0 ? `field-${props.name}-validation` : undefined;
+  const common = {
+    id: `field-${props.name}`,
+    disabled: props.disabled,
+    required: props.required,
+    "aria-describedby": [describedBy, validationId].filter(Boolean).join(" ") || undefined,
+    "aria-invalid": props.errors.length > 0 || undefined,
+  };
+
+  if (choices) {
+    return (
+      <select
+        {...common}
+        value={String(choices.findIndex((choice) => Object.is(choice, props.value)))}
+        onChange={(event) => props.onChange(choices[Number(event.currentTarget.value)])}
+      >
+        {!props.required && <option value="-1">Select a value</option>}
+        {choices.map((choice, index) => (
+          <option key={index} value={String(index)}>
+            {String(choice)}
+          </option>
+        ))}
+      </select>
+    );
+  }
+  if (props.schema.type === "string" && props.schema.format === "uri") {
+    return <FileInputControl {...props} />;
+  }
+  if (props.schema.type === "string" && props.schema.format === "password") {
+    return (
+      <Input
+        {...common}
+        type="password"
+        aria-label={props.name}
+        value={String(props.value ?? "")}
+        onInput={(event) => props.onChange(event.currentTarget.value)}
+      />
+    );
+  }
+  if (props.schema.type === "string") {
+    return (
+      <InputArea
+        {...common}
+        aria-label={props.name}
+        value={String(props.value ?? "")}
+        onInput={(event) => props.onChange(event.currentTarget.value)}
+      />
+    );
+  }
+  if (props.schema.type === "integer" || props.schema.type === "number") {
+    return (
+      <Input
+        {...common}
+        type="number"
+        aria-label={props.name}
+        min={props.schema.minimum}
+        max={props.schema.maximum}
+        step={props.schema.type === "integer" ? 1 : "any"}
+        value={props.value === undefined ? "" : String(props.value)}
+        onInput={(event) => {
+          const raw = event.currentTarget.value;
+          props.onChange(raw === "" ? "" : Number(raw));
+        }}
+      />
+    );
+  }
+  if (props.schema.type === "boolean") {
+    return (
+      <select
+        {...common}
+        value={String(props.value ?? false)}
+        onChange={(event) => props.onChange(event.currentTarget.value === "true")}
+      >
+        <option value="true">true</option>
+        <option value="false">false</option>
+      </select>
+    );
+  }
+  return <StructuredInputControl {...props} />;
+}

--- a/playground/src/features/inputs/components/InputForm.test.tsx
+++ b/playground/src/features/inputs/components/InputForm.test.tsx
@@ -290,6 +290,34 @@ describe("InputForm", () => {
     expect(onBusyChange).toHaveBeenLastCalledWith(false);
   });
 
+  it("clears busy state when unmounted during a file read", async () => {
+    const pending = deferred<string>();
+    mockFileToDataURI.mockReturnValue(pending.promise);
+    const onBusyChange = vi.fn();
+    const { container, unmount } = render(
+      <InputForm
+        document={document}
+        schema={{
+          required: ["file"],
+          properties: { file: { type: "string", format: "uri" } },
+        }}
+        value={{ file: "" }}
+        onChange={vi.fn()}
+        onBusyChange={onBusyChange}
+        onValidityChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(container.querySelector('input[type="file"]')!, {
+      target: { files: [new File(["data"], "pending.txt")] },
+    });
+    await waitFor(() => expect(onBusyChange).toHaveBeenLastCalledWith(true));
+
+    unmount();
+
+    expect(onBusyChange).toHaveBeenLastCalledWith(false);
+  });
+
   it("invalidates a file control when reading the selected file fails", async () => {
     mockFileToDataURI.mockRejectedValue(new Error("read failed"));
     const onBusyChange = vi.fn();

--- a/playground/src/features/inputs/components/InputForm.test.tsx
+++ b/playground/src/features/inputs/components/InputForm.test.tsx
@@ -1,0 +1,342 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { deferred } from "@/test/deferred";
+
+const { mockFileToDataURI } = vi.hoisted(() => ({ mockFileToDataURI: vi.fn() }));
+
+vi.mock("@/services/cog/files", () => ({ fileToDataURI: mockFileToDataURI }));
+
+vi.mock("@/components/editor/LazyJsonEditor", async () => {
+  const { FakeJsonEditor } = await import("@/test/FakeJsonEditor");
+  return { LazyJsonEditor: FakeJsonEditor };
+});
+
+import { InputForm } from "@/features/inputs/components/InputForm";
+
+const document = {
+  components: { schemas: {} },
+};
+
+describe("InputForm", () => {
+  beforeEach(() => {
+    mockFileToDataURI.mockReset();
+    mockFileToDataURI.mockImplementation(
+      async (file: File) => `data:${file.type};base64,${file.name}`,
+    );
+  });
+
+  it("preserves typed enum and numeric values", () => {
+    const onChange = vi.fn();
+    const onValidityChange = vi.fn();
+    render(
+      <InputForm
+        document={document}
+        schema={{
+          required: ["count", "choice"],
+          properties: {
+            count: { type: "integer", minimum: 1, maximum: 3 },
+            choice: { enum: [1, 2] },
+          },
+        }}
+        value={{ count: 1, choice: 1 }}
+        onChange={onChange}
+        onBusyChange={vi.fn()}
+        onValidityChange={onValidityChange}
+      />,
+    );
+
+    fireEvent.input(screen.getByRole("spinbutton", { name: "count" }), { target: { value: "4" } });
+    expect(onChange).toHaveBeenLastCalledWith({ count: 4, choice: 1 });
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+    fireEvent.change(screen.getByRole("combobox", { name: /choice/ }), { target: { value: "1" } });
+    expect(onChange).toHaveBeenLastCalledWith({ count: 1, choice: 2 });
+  });
+
+  it("distinguishes enum values with identical labels", () => {
+    const onChange = vi.fn();
+    render(
+      <InputForm
+        document={document}
+        schema={{ required: ["choice"], properties: { choice: { enum: [1, "1"] } } }}
+        value={{ choice: 1 }}
+        onChange={onChange}
+        onBusyChange={vi.fn()}
+        onValidityChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox", { name: /choice/ }), {
+      target: { value: "1" },
+    });
+    expect(onChange).toHaveBeenCalledWith({ choice: "1" });
+  });
+
+  it("removes an optional field and does not retain its invalid state", () => {
+    const onChange = vi.fn();
+    const onValidityChange = vi.fn();
+    const props = {
+      document,
+      schema: { properties: { optional: { type: "object" } } },
+      onChange,
+      onBusyChange: vi.fn(),
+      onValidityChange,
+    };
+    const { rerender } = render(<InputForm {...props} value={{ optional: {} }} />);
+
+    fireEvent.change(screen.getByLabelText("optional JSON"), { target: { value: "{" } });
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+    fireEvent.click(screen.getByRole("checkbox", { name: "Include optional field optional" }));
+    expect(onChange).toHaveBeenLastCalledWith({});
+    rerender(<InputForm {...props} value={{}} />);
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it("refreshes structured editor values after a reset", () => {
+    const props = {
+      document,
+      schema: { required: ["config"], properties: { config: { type: "object" } } },
+      onChange: vi.fn(),
+      onBusyChange: vi.fn(),
+      onValidityChange: vi.fn(),
+    };
+    const { rerender } = render(<InputForm {...props} value={{ config: { version: 1 } }} />);
+    const editor = screen.getByLabelText("config JSON") as HTMLTextAreaElement;
+    expect(editor.value).toContain('"version": 1');
+
+    rerender(<InputForm {...props} value={{ config: { version: 2 } }} />);
+    expect(editor.value).toContain('"version": 2');
+  });
+
+  it("updates password, boolean, and optional string controls", () => {
+    const onChange = vi.fn();
+    const props = {
+      document,
+      schema: {
+        required: ["secret", "enabled"],
+        properties: {
+          secret: { type: "string", format: "password" },
+          enabled: { type: "boolean" },
+          note: { type: "string" },
+        },
+      },
+      onChange,
+      onBusyChange: vi.fn(),
+      onValidityChange: vi.fn(),
+    };
+    const { rerender } = render(<InputForm {...props} value={{ secret: "old", enabled: false }} />);
+
+    fireEvent.input(screen.getByLabelText("secret"), { target: { value: "new" } });
+    expect(onChange).toHaveBeenLastCalledWith({ secret: "new", enabled: false });
+    fireEvent.change(screen.getByRole("combobox", { name: /enabled/ }), {
+      target: { value: "true" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith({ secret: "old", enabled: true });
+    expect(screen.getByLabelText("note")).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Include optional field note" }));
+    expect(onChange).toHaveBeenLastCalledWith({ secret: "old", enabled: false, note: "" });
+    rerender(<InputForm {...props} value={{ secret: "old", enabled: false, note: "" }} />);
+    expect(screen.getByLabelText("note")).toBeEnabled();
+  });
+
+  it("shows defaults and leaves optional fields without defaults unchecked", () => {
+    render(
+      <InputForm
+        document={document}
+        schema={{
+          properties: {
+            guidance: { type: "number", default: 0.5, minimum: 0, maximum: 1 },
+            omitted: { type: "string" },
+          },
+        }}
+        value={{ guidance: 0.5 }}
+        onChange={vi.fn()}
+        onBusyChange={vi.fn()}
+        onValidityChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("default 0.5 · min 0 · max 1")).toBeVisible();
+    expect(screen.getByRole("checkbox", { name: "Include optional field guidance" })).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "Include optional field omitted" }),
+    ).not.toBeChecked();
+    expect(screen.getByLabelText("omitted")).toBeDisabled();
+  });
+
+  it("associates required controls with constraints and invalid state", () => {
+    render(
+      <InputForm
+        document={document}
+        schema={{
+          required: ["prompt"],
+          properties: {
+            prompt: { type: "string", description: "Model prompt", minLength: 2 },
+          },
+        }}
+        value={{ prompt: "" }}
+        errors={[
+          {
+            path: "prompt",
+            field: "prompt",
+            keyword: "minLength",
+            message: "must be at least 2 characters long",
+          },
+        ]}
+        onChange={vi.fn()}
+        onBusyChange={vi.fn()}
+        onValidityChange={vi.fn()}
+      />,
+    );
+
+    const prompt = screen.getByRole("textbox", { name: "prompt" });
+    expect(prompt).toBeRequired();
+    expect(prompt).toHaveAttribute("aria-invalid", "true");
+    expect(prompt).toHaveAccessibleDescription(
+      "Model prompt · min 2 chars must be at least 2 characters long",
+    );
+  });
+
+  it("reports and recovers from structured JSON errors", () => {
+    const onChange = vi.fn();
+    const onValidityChange = vi.fn();
+    render(
+      <InputForm
+        document={document}
+        schema={{ required: ["config"], properties: { config: { type: "object" } } }}
+        value={{ config: {} }}
+        onChange={onChange}
+        onBusyChange={vi.fn()}
+        onValidityChange={onValidityChange}
+      />,
+    );
+    const editor = screen.getByLabelText("config JSON");
+
+    fireEvent.change(editor, { target: { value: "{" } });
+    expect(screen.getByText(/Invalid JSON/)).toBeVisible();
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+
+    fireEvent.change(editor, { target: { value: '{"version":2}' } });
+    expect(onChange).toHaveBeenLastCalledWith({ config: { version: 2 } });
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it("loads a selected file as a data URI", async () => {
+    const onChange = vi.fn();
+    const onBusyChange = vi.fn();
+    const { container } = render(
+      <InputForm
+        document={document}
+        schema={{
+          required: ["file"],
+          properties: {
+            file: { type: "string", format: "uri", "x-cog-accept": ["text/plain"] },
+          },
+        }}
+        value={{ file: "" }}
+        onChange={onChange}
+        onBusyChange={onBusyChange}
+        onValidityChange={vi.fn()}
+      />,
+    );
+    const input = container.querySelector('input[type="file"]');
+    expect(input).toHaveAttribute("accept", "text/plain");
+
+    fireEvent.change(input!, {
+      target: { files: [new File(["hello"], "hello.txt", { type: "text/plain" })] },
+    });
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith({ file: expect.stringMatching(/^data:/) }),
+    );
+    expect(onBusyChange).toHaveBeenCalledWith(true);
+    await waitFor(() => expect(onBusyChange).toHaveBeenLastCalledWith(false));
+    expect(screen.getByText("hello.txt (5 B)")).toBeVisible();
+  });
+
+  it("ignores a stale file read when a newer selection finishes later", async () => {
+    const first = deferred<string>();
+    const second = deferred<string>();
+    mockFileToDataURI.mockImplementation((file: File) =>
+      file.name === "first.txt" ? first.promise : second.promise,
+    );
+    const onChange = vi.fn();
+    const onBusyChange = vi.fn();
+    const { container } = render(
+      <InputForm
+        document={document}
+        schema={{
+          required: ["file"],
+          properties: { file: { type: "string", format: "uri" } },
+        }}
+        value={{ file: "" }}
+        onChange={onChange}
+        onBusyChange={onBusyChange}
+        onValidityChange={vi.fn()}
+      />,
+    );
+    const input = container.querySelector('input[type="file"]')!;
+
+    fireEvent.change(input, { target: { files: [new File(["a"], "first.txt")] } });
+    fireEvent.change(input, { target: { files: [new File(["b"], "second.txt")] } });
+    first.resolve("data:first");
+    await first.promise;
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onBusyChange).toHaveBeenLastCalledWith(true);
+
+    second.resolve("data:second");
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith({ file: "data:second" }));
+    expect(onBusyChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("invalidates a file control when reading the selected file fails", async () => {
+    mockFileToDataURI.mockRejectedValue(new Error("read failed"));
+    const onBusyChange = vi.fn();
+    const onValidityChange = vi.fn();
+    const { container } = render(
+      <InputForm
+        document={document}
+        schema={{
+          required: ["file"],
+          properties: { file: { type: "string", format: "uri" } },
+        }}
+        value={{ file: "" }}
+        onChange={vi.fn()}
+        onBusyChange={onBusyChange}
+        onValidityChange={onValidityChange}
+      />,
+    );
+
+    fireEvent.change(container.querySelector('input[type="file"]')!, {
+      target: { files: [new File(["data"], "broken.txt")] },
+    });
+
+    expect(await screen.findByText("read failed")).toBeVisible();
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+    expect(onBusyChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("renders the no-input and selected-image states", () => {
+    const props = {
+      document,
+      onChange: vi.fn(),
+      onBusyChange: vi.fn(),
+      onValidityChange: vi.fn(),
+    };
+    const { rerender } = render(<InputForm {...props} schema={{ properties: {} }} value={{}} />);
+    expect(screen.getByText("This model takes no inputs.")).toBeVisible();
+
+    rerender(
+      <InputForm
+        {...props}
+        schema={{
+          required: ["image"],
+          properties: { image: { type: "string", format: "uri" } },
+        }}
+        value={{ image: "data:image/png;base64,AA==" }}
+      />,
+    );
+    expect(screen.getByRole("img", { name: "Selected input preview" })).toBeVisible();
+  });
+});

--- a/playground/src/features/inputs/components/InputForm.tsx
+++ b/playground/src/features/inputs/components/InputForm.tsx
@@ -45,6 +45,7 @@ export function InputForm({
     onValidityChange(controlsValid);
   }, [onValidityChange, properties, required, validity, value]);
   useEffect(() => onBusyChange(Object.values(busy).some(Boolean)), [busy, onBusyChange]);
+  useEffect(() => () => onBusyChange(false), [onBusyChange]);
 
   if (properties.length === 0) return <p className="muted">This model takes no inputs.</p>;
 

--- a/playground/src/features/inputs/components/InputForm.tsx
+++ b/playground/src/features/inputs/components/InputForm.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { InputField } from "@/features/inputs/components/InputField";
+import { emptyInputValue } from "@/features/inputs/utils/inputControl";
+import type { ValidationIssue } from "@/features/inputs/validation/inputValidation";
+import type { OpenAPIDocument, OpenAPISchema } from "@/types/openapi";
+import { effectiveSchema, enumValues, orderedProperties } from "@/utils/openapi";
+
+type Props = {
+  document: OpenAPIDocument;
+  schema: OpenAPISchema;
+  value: Record<string, unknown>;
+  errors?: readonly ValidationIssue[];
+  onChange: (value: Record<string, unknown>) => void;
+  onBusyChange: (busy: boolean) => void;
+  onValidityChange: (valid: boolean) => void;
+};
+
+/** Reports aggregate busy/valid state while adding or removing optional properties from the value. */
+export function InputForm({
+  document,
+  schema,
+  value,
+  errors = [],
+  onChange,
+  onBusyChange,
+  onValidityChange,
+}: Props) {
+  const properties = useMemo(
+    () =>
+      orderedProperties(schema).map(
+        ([name, property]) => [name, effectiveSchema(document, property)] as const,
+      ),
+    [document, schema],
+  );
+  const required = useMemo(() => new Set(schema.required ?? []), [schema.required]);
+  const [validity, setValidity] = useState<Record<string, boolean>>({});
+  const [busy, setBusy] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    const controlsValid = properties.every(([name]) => {
+      const included = required.has(name) || Object.hasOwn(value, name);
+      return !included || validity[name] !== false;
+    });
+    onValidityChange(controlsValid);
+  }, [onValidityChange, properties, required, validity, value]);
+  useEffect(() => onBusyChange(Object.values(busy).some(Boolean)), [busy, onBusyChange]);
+
+  if (properties.length === 0) return <p className="muted">This model takes no inputs.</p>;
+
+  const setField = (name: string, next: unknown) => onChange({ ...value, [name]: next });
+  const setIncluded = (name: string, included: boolean) => {
+    setValidity(({ [name]: _removed, ...current }) => current);
+    setBusy(({ [name]: _removed, ...current }) => current);
+    if (included) {
+      const property = effectiveSchema(document, schema.properties?.[name] ?? {});
+      setField(
+        name,
+        Object.hasOwn(property, "default")
+          ? property.default
+          : (enumValues(document, property)?.[0] ?? emptyInputValue(property)),
+      );
+      return;
+    }
+    const next = { ...value };
+    delete next[name];
+    onChange(next);
+  };
+
+  return (
+    <div>
+      {properties.map(([name, property]) => {
+        const included = required.has(name) || Object.hasOwn(value, name);
+        return (
+          <InputField
+            key={name}
+            document={document}
+            name={name}
+            schema={property}
+            required={required.has(name)}
+            included={included}
+            errors={errors.filter((error) => error.field === name)}
+            value={value[name]}
+            onIncludedChange={(next) => setIncluded(name, next)}
+            onChange={(next) => setField(name, next)}
+            onBusyChange={(next) => setBusy((current) => ({ ...current, [name]: next }))}
+            onValidityChange={(next) => setValidity((current) => ({ ...current, [name]: next }))}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/playground/src/features/inputs/components/InputPanel.tsx
+++ b/playground/src/features/inputs/components/InputPanel.tsx
@@ -1,0 +1,96 @@
+import { Button } from "@cloudflare/kumo/components/button";
+
+import { SegmentedTabs, tabId, tabPanelId } from "@/components/SegmentedTabs";
+import { LazyJsonEditor } from "@/components/editor/LazyJsonEditor";
+import { InputForm } from "@/features/inputs/components/InputForm";
+import type { PlaygroundInputState } from "@/features/inputs/hooks/usePlaygroundInput";
+import type { OpenAPIDocument, OpenAPISchema } from "@/types/openapi";
+
+type Props = {
+  document?: OpenAPIDocument;
+  schema?: OpenAPISchema;
+  schemaError: string;
+  state: PlaygroundInputState;
+};
+
+/** Preserves one input value across form and JSON modes while showing mode-specific validation. */
+export function InputPanel({ document, schema, schemaError, state }: Props) {
+  return (
+    <section id="input-panel">
+      <div className="panel-head">
+        <h2>Input</h2>
+        <SegmentedTabs
+          id="input-mode"
+          label="Input editor mode"
+          items={[
+            { value: "form", label: "Form" },
+            { value: "json", label: "JSON" },
+          ]}
+          value={state.inputMode}
+          onChange={state.changeInputMode}
+        />
+      </div>
+      {schemaError && <output className="notice">{schemaError}</output>}
+      <div
+        id={tabPanelId("input-mode", state.inputMode)}
+        role="tabpanel"
+        aria-labelledby={tabId("input-mode", state.inputMode)}
+        tabIndex={0}
+      >
+        {document && schema && state.inputMode === "form" && (
+          <InputForm
+            key={state.formRevision}
+            document={document}
+            schema={schema}
+            value={state.input}
+            errors={state.validationIssues}
+            onChange={state.changeFormInput}
+            onBusyChange={state.setFormBusy}
+            onValidityChange={state.setFormValid}
+          />
+        )}
+        {state.inputMode === "json" && (
+          <div id="json-container">
+            <LazyJsonEditor
+              value={state.jsonInput}
+              label="Prediction input JSON"
+              className="json-input"
+              describedBy={
+                [
+                  state.jsonError ? "json-input-error" : undefined,
+                  state.validationIssues.length > 0 ? "input-validation-errors" : undefined,
+                ]
+                  .filter(Boolean)
+                  .join(" ") || undefined
+              }
+              invalid={Boolean(state.jsonError) || state.validationIssues.length > 0}
+              onChange={state.changeJsonInput}
+            />
+            {state.jsonError && (
+              <small id="json-input-error" className="field-error" role="alert">
+                {state.jsonError}
+              </small>
+            )}
+            <Button size="sm" variant="ghost" onClick={state.formatJsonInput}>
+              Format
+            </Button>
+          </div>
+        )}
+        <div id="input-validation-errors" aria-live="polite" aria-atomic="true">
+          {state.validationIssues.length > 0 && (
+            <div className="error-container">
+              <strong>Input does not match the OpenAPI schema.</strong>
+              <ul className="validation-summary">
+                {state.validationIssues.map((error) => (
+                  <li key={`${error.path}:${error.keyword}:${error.message}`}>
+                    <code>{error.path}</code>: {error.message}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/playground/src/features/inputs/components/StructuredInputControl.tsx
+++ b/playground/src/features/inputs/components/StructuredInputControl.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+
+import { LazyJsonEditor } from "@/components/editor/LazyJsonEditor";
+import type { InputControlProps } from "@/features/inputs/components/InputField";
+import { emptyInputValue } from "@/features/inputs/utils/inputControl";
+import { constraintText } from "@/utils/openapi";
+
+/** Retains invalid JSON locally and updates the form value only after parsing succeeds. */
+export function StructuredInputControl(props: InputControlProps) {
+  const initial = props.value === undefined ? emptyInputValue(props.schema) : props.value;
+  const [raw, setRaw] = useState(JSON.stringify(initial, null, 2));
+  const [error, setError] = useState("");
+  const descriptionId =
+    props.schema.description || constraintText(props.schema)
+      ? `field-${props.name}-description`
+      : undefined;
+  const errorId = `field-${props.name}-error`;
+  const validationId = props.errors.length > 0 ? `field-${props.name}-validation` : undefined;
+
+  useEffect(() => {
+    setRaw(
+      JSON.stringify(
+        props.value === undefined ? emptyInputValue(props.schema) : props.value,
+        null,
+        2,
+      ),
+    );
+    setError("");
+  }, [props.schema, props.value]);
+
+  return (
+    <>
+      <LazyJsonEditor
+        value={raw}
+        label={`${props.name} JSON`}
+        className="json-field"
+        readOnly={props.disabled}
+        disabled={props.disabled}
+        invalid={Boolean(error) || props.errors.length > 0}
+        describedBy={
+          [descriptionId, validationId, error ? errorId : undefined].filter(Boolean).join(" ") ||
+          undefined
+        }
+        onChange={(next) => {
+          setRaw(next);
+          try {
+            props.onChange(JSON.parse(next));
+            setError("");
+            props.onValidityChange(true);
+          } catch (parseError) {
+            setError(parseError instanceof Error ? parseError.message : "Invalid JSON");
+            props.onValidityChange(false);
+          }
+        }}
+      />
+      {error && (
+        <small id={errorId} className="field-error" role="alert">
+          Invalid JSON: {error}
+        </small>
+      )}
+    </>
+  );
+}

--- a/playground/src/features/inputs/hooks/usePlaygroundInput.ts
+++ b/playground/src/features/inputs/hooks/usePlaygroundInput.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import type { InputMode } from "@/features/inputs/types";
 import { errorMessage, parseInputObject, serializeInput } from "@/features/inputs/utils/input";
@@ -33,10 +33,13 @@ export function usePlaygroundInput({ target, document, capabilities }: Options) 
   const [formRevision, setFormRevision] = useState(0);
   const validationAttempt = useRef(0);
   const connectionState = useRef({ target, document, capabilities });
-  connectionState.current = { target, document, capabilities };
   // Identifies the connected schema so the validation worker compiles it once
   // and reuses the compiled validator across runs.
   const schemaId = useRef(0);
+
+  useLayoutEffect(() => {
+    connectionState.current = { target, document, capabilities };
+  }, [capabilities, document, target]);
 
   useEffect(
     () => () => {

--- a/playground/src/features/inputs/hooks/usePlaygroundInput.ts
+++ b/playground/src/features/inputs/hooks/usePlaygroundInput.ts
@@ -1,0 +1,189 @@
+import { useEffect, useRef, useState } from "react";
+
+import type { InputMode } from "@/features/inputs/types";
+import { errorMessage, parseInputObject, serializeInput } from "@/features/inputs/utils/input";
+import { disposeValidationWorker, validateInput } from "@/features/inputs/validation/validateInput";
+import type { ValidationIssue } from "@/features/inputs/validation/inputValidation";
+import type { OpenAPIDocument } from "@/types/openapi";
+import { defaultInput, type PlaygroundCapabilities } from "@/utils/openapi";
+
+type Options = {
+  target: string;
+  document?: OpenAPIDocument;
+  capabilities?: PlaygroundCapabilities;
+};
+
+type ValidatedInput = {
+  input: Record<string, unknown>;
+};
+
+/**
+ * Keeps form and JSON input synchronized with schema defaults and exposes a stale-result-safe
+ * validation lifecycle for prediction runs.
+ */
+export function usePlaygroundInput({ target, document, capabilities }: Options) {
+  const [input, setInput] = useState<Record<string, unknown>>({});
+  const [jsonInput, setJsonInput] = useState("{}");
+  const [jsonError, setJsonError] = useState("");
+  const [inputMode, setInputMode] = useState<InputMode>("form");
+  const [formBusy, setFormBusy] = useState(false);
+  const [formValid, setFormValid] = useState(true);
+  const [validating, setValidating] = useState(false);
+  const [validationIssues, setValidationIssues] = useState<ValidationIssue[]>([]);
+  const [formRevision, setFormRevision] = useState(0);
+  const validationAttempt = useRef(0);
+  const connectionState = useRef({ target, document, capabilities });
+  connectionState.current = { target, document, capabilities };
+  // Identifies the connected schema so the validation worker compiles it once
+  // and reuses the compiled validator across runs.
+  const schemaId = useRef(0);
+
+  useEffect(
+    () => () => {
+      validationAttempt.current += 1;
+      disposeValidationWorker();
+    },
+    [],
+  );
+
+  useEffect(() => {
+    validationAttempt.current += 1;
+    setValidationIssues([]);
+    setValidating(false);
+    if (!document || !capabilities) {
+      setFormBusy(false);
+      setFormValid(true);
+      return;
+    }
+    // A new connection means a new (immutable) schema to compile once.
+    schemaId.current += 1;
+    const defaults = defaultInput(document, capabilities.input);
+    setInput(defaults);
+    setJsonInput(serializeInput(defaults));
+    setJsonError("");
+    setFormBusy(false);
+    setFormValid(true);
+    setFormRevision((current) => current + 1);
+  }, [capabilities, document, target]);
+
+  const clearValidation = () => {
+    validationAttempt.current += 1;
+    setValidating(false);
+    setValidationIssues([]);
+  };
+
+  const validateForRun = async (): Promise<ValidatedInput | undefined> => {
+    if (!document || !capabilities || formBusy) return undefined;
+
+    let nextInput = input;
+    if (inputMode === "json") {
+      try {
+        nextInput = parseInputObject(jsonInput);
+        setJsonError("");
+      } catch (error) {
+        setJsonError(errorMessage(error));
+        return undefined;
+      }
+    }
+    if (inputMode === "form" && !formValid) return undefined;
+
+    const validationTarget = target;
+    const validationDocument = document;
+    const validationCapabilities = capabilities;
+    const attempt = ++validationAttempt.current;
+    setValidationIssues([]);
+    setValidating(true);
+    const issues = await validateInput(
+      validationDocument,
+      validationCapabilities.input,
+      nextInput,
+      schemaId.current,
+    );
+    if (
+      attempt !== validationAttempt.current ||
+      validationTarget !== connectionState.current.target ||
+      validationDocument !== connectionState.current.document ||
+      validationCapabilities !== connectionState.current.capabilities
+    ) {
+      return undefined;
+    }
+    setValidating(false);
+    if (issues.length > 0) {
+      setValidationIssues(issues);
+      return undefined;
+    }
+    return { input: nextInput };
+  };
+
+  const reset = () => {
+    if (!document || !capabilities) return;
+    const defaults = defaultInput(document, capabilities.input);
+    setInput(defaults);
+    setJsonInput(serializeInput(defaults));
+    setJsonError("");
+    setFormBusy(false);
+    setFormValid(true);
+    clearValidation();
+    setFormRevision((current) => current + 1);
+  };
+
+  const changeJsonInput = (next: string) => {
+    clearValidation();
+    setJsonInput(next);
+    try {
+      const parsed = parseInputObject(next);
+      setInput(parsed);
+      setJsonError("");
+    } catch (error) {
+      setJsonError(errorMessage(error));
+    }
+  };
+
+  const changeFormInput = (next: Record<string, unknown>) => {
+    clearValidation();
+    setInput(next);
+    setJsonInput(serializeInput(next));
+    setJsonError("");
+  };
+
+  const changeInputMode = (next: InputMode) => {
+    if (next === inputMode) return;
+    clearValidation();
+    setJsonInput(serializeInput(input));
+    setJsonError("");
+    setInputMode(next);
+  };
+
+  const formatJsonInput = () => {
+    clearValidation();
+    try {
+      const parsed = parseInputObject(jsonInput);
+      setInput(parsed);
+      setJsonInput(serializeInput(parsed));
+      setJsonError("");
+    } catch (error) {
+      setJsonError(errorMessage(error));
+    }
+  };
+
+  return {
+    input,
+    jsonInput,
+    jsonError,
+    inputMode,
+    formBusy,
+    validating,
+    validationIssues,
+    formRevision,
+    setFormBusy,
+    setFormValid,
+    validateForRun,
+    reset,
+    changeJsonInput,
+    changeFormInput,
+    changeInputMode,
+    formatJsonInput,
+  };
+}
+
+export type PlaygroundInputState = ReturnType<typeof usePlaygroundInput>;

--- a/playground/src/features/inputs/index.ts
+++ b/playground/src/features/inputs/index.ts
@@ -1,0 +1,2 @@
+export { InputPanel } from "@/features/inputs/components/InputPanel";
+export { usePlaygroundInput } from "@/features/inputs/hooks/usePlaygroundInput";

--- a/playground/src/features/inputs/types.ts
+++ b/playground/src/features/inputs/types.ts
@@ -1,0 +1,1 @@
+export type InputMode = "form" | "json";

--- a/playground/src/features/inputs/utils/input.ts
+++ b/playground/src/features/inputs/utils/input.ts
@@ -1,0 +1,20 @@
+/** Parses JSON and requires its root value to be a non-array object. */
+export function parseInputObject(value: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(value);
+  if (!isInputObject(parsed)) throw new Error("Input must be a JSON object");
+  return parsed;
+}
+
+/** Returns the canonical pretty-printed JSON representation used by the input editor. */
+export function serializeInput(input: Record<string, unknown>): string {
+  return JSON.stringify(input, null, 2);
+}
+
+/** Preserves `Error.message` and stringifies non-Error thrown values. */
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isInputObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/playground/src/features/inputs/utils/inputControl.ts
+++ b/playground/src/features/inputs/utils/inputControl.ts
@@ -1,0 +1,21 @@
+import type { OpenAPISchema } from "@/types/openapi";
+
+/** Returns the schema-type-specific initial value for a newly included optional field. */
+export function emptyInputValue(schema: OpenAPISchema): unknown {
+  if (schema.type === "array") return [];
+  if (schema.type === "object" || schema.properties) return {};
+  if (schema.type === "boolean") return false;
+  return "";
+}
+
+/** Checks whether a string has the basic metadata-and-payload shape of a data URI. */
+export function isDataURI(value: string): boolean {
+  return /^data:[^,]*,/i.test(value);
+}
+
+/** Formats a byte count using compact B, KB, or MB units. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}

--- a/playground/src/features/inputs/validation/inputValidation.test.ts
+++ b/playground/src/features/inputs/validation/inputValidation.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+
+import type { OpenAPIDocument, OpenAPISchema } from "@/types/openapi";
+import { createInputValidator } from "@/features/inputs/validation/inputValidation";
+
+const document: OpenAPIDocument = {
+  components: {
+    schemas: {
+      Choice: { type: "string", enum: ["red", "blue"] },
+    },
+  },
+};
+
+describe("createInputValidator", () => {
+  it("validates OpenAPI types, constraints, formats, refs, and nested values", () => {
+    const schema: OpenAPISchema = {
+      type: "object",
+      additionalProperties: false,
+      required: ["name", "count", "choice", "url", "items", "config"],
+      properties: {
+        name: { type: "string", minLength: 2, maxLength: 5, pattern: "^[a-z]+$" },
+        count: { type: "integer", minimum: 1, maximum: 3 },
+        choice: { allOf: [{ $ref: "#/components/schemas/Choice" }] },
+        url: { type: "string", format: "uri" },
+        items: { type: "array", minItems: 1, items: { type: "number" } },
+        config: {
+          type: "object",
+          required: ["enabled"],
+          properties: { enabled: { type: "boolean" } },
+        },
+        note: { type: "string", nullable: true },
+        variant: { anyOf: [{ type: "string" }, { type: "number" }], nullable: true },
+      },
+    };
+    const validate = createInputValidator(document, schema);
+
+    expect(
+      validate({
+        name: "model",
+        count: 2,
+        choice: "red",
+        url: "https://example.com/input.png",
+        items: [1, 2],
+        config: { enabled: true },
+        note: null,
+        variant: null,
+      }),
+    ).toEqual([]);
+
+    const issues = validate({
+      count: 1.5,
+      choice: "green",
+      url: "not a uri",
+      items: ["wrong"],
+      config: {},
+      variant: false,
+      extra: true,
+    });
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "name", keyword: "required" }),
+        expect.objectContaining({ path: "count", keyword: "type" }),
+        expect.objectContaining({ path: "choice", keyword: "enum" }),
+        expect.objectContaining({ path: "url", keyword: "format" }),
+        expect.objectContaining({ path: "items[0]", keyword: "type" }),
+        expect.objectContaining({ path: "config.enabled", keyword: "required" }),
+        expect.objectContaining({ path: "variant", keyword: "anyOf" }),
+        expect.objectContaining({ path: "extra", keyword: "additionalProperties" }),
+      ]),
+    );
+  });
+
+  it("flags required fields that are present but empty", () => {
+    const validate = createInputValidator(document, {
+      type: "object",
+      required: ["prompt", "tags"],
+      properties: {
+        prompt: { type: "string" },
+        tags: { type: "array", items: { type: "string" } },
+      },
+    });
+
+    expect(validate({ prompt: "hi", tags: ["a"] })).toEqual([]);
+    expect(validate({ prompt: "   ", tags: [] })).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "prompt", keyword: "required" }),
+        expect.objectContaining({ path: "tags", keyword: "required" }),
+      ]),
+    );
+    // An absent required field is reported once, not duplicated.
+    expect(validate({ tags: ["a"] }).filter((issue) => issue.path === "prompt")).toHaveLength(1);
+  });
+
+  it("keeps additional properties when the OpenAPI schema allows them", () => {
+    const validate = createInputValidator(document, {
+      type: "object",
+      properties: { prompt: { type: "string" } },
+    });
+
+    expect(validate({ prompt: "hello", custom: { nested: true } })).toEqual([]);
+  });
+
+  it("enforces the remaining scalar, array, object, and composition constraints", () => {
+    const validate = createInputValidator(document, {
+      type: "object",
+      properties: {
+        text: { type: "string", minLength: 2, maxLength: 4, pattern: "^[a-z]+$" },
+        number: {
+          type: "number",
+          minimum: 1,
+          maximum: 5,
+          exclusiveMinimum: true,
+          exclusiveMaximum: true,
+          multipleOf: 0.5,
+        },
+        list: {
+          type: "array",
+          minItems: 2,
+          maxItems: 3,
+          uniqueItems: true,
+          items: { type: "integer" },
+        },
+        object: {
+          type: "object",
+          minProperties: 1,
+          maxProperties: 2,
+          additionalProperties: { type: "string" },
+        },
+        exact: { oneOf: [{ type: "string" }, { type: "integer" }] },
+      },
+    });
+
+    expect(
+      validate({
+        text: "test",
+        number: 1.5,
+        list: [1, 2],
+        object: { custom: "value" },
+        exact: "value",
+      }),
+    ).toEqual([]);
+    expect(validate({ text: "A", number: 1, list: [1, 1, 2, 3], object: {} })).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "text", keyword: "minLength" }),
+        expect.objectContaining({ path: "text", keyword: "pattern" }),
+        expect.objectContaining({ path: "number", keyword: "minimum" }),
+        expect.objectContaining({ path: "list", keyword: "maxItems" }),
+        expect.objectContaining({ path: "list", keyword: "uniqueItems" }),
+        expect.objectContaining({ path: "object", keyword: "minProperties" }),
+      ]),
+    );
+  });
+
+  it("translates Python regex syntax that has a browser equivalent", () => {
+    const validate = createInputValidator(document, {
+      type: "object",
+      properties: { value: { type: "string", pattern: "(?P<name>value)" } },
+    });
+
+    expect(validate({ value: "value" })).toEqual([]);
+
+    const validateUnsupportedPattern = createInputValidator(document, {
+      type: "object",
+      properties: { value: { type: "string", pattern: "(?i)value" } },
+    });
+    expect(validateUnsupportedPattern({ value: "VALUE" })).toEqual([]);
+  });
+
+  it("does not normalize schema-like keys inside enum payloads", () => {
+    const payload = { nullable: true, pattern: "(?i)literal" };
+    const validate = createInputValidator(document, {
+      type: "object",
+      properties: { payload: { enum: [payload], default: payload } },
+    });
+
+    expect(validate({ payload })).toEqual([]);
+    expect(validate({ payload: { nullable: false, pattern: "(?i)literal" } })).toEqual([
+      expect.objectContaining({ path: "payload", keyword: "enum" }),
+    ]);
+  });
+
+  it("validates large uploaded data URIs without overflowing the URI formatter", () => {
+    const validate = createInputValidator(document, {
+      type: "object",
+      properties: { file: { type: "string", format: "uri" } },
+    });
+    const dataURI = `data:application/octet-stream;base64,${"A".repeat(9 * 1024 * 1024)}`;
+
+    expect(validate({ file: dataURI })).toEqual([]);
+    expect(validate({ file: "DATA:text/plain;base64,QQ%3D%3D" })).toEqual([]);
+    expect(validate({ file: "not a uri" })).toEqual([
+      expect.objectContaining({ path: "file", keyword: "format" }),
+    ]);
+    expect(validate({ file: "data:text/plain;base64,QQ%3D" })).toEqual([
+      expect.objectContaining({ path: "file", keyword: "format" }),
+    ]);
+    expect(validate({ file: "data:text/plain;base64,QQ%ZZ" })).toEqual([
+      expect.objectContaining({ path: "file", keyword: "format" }),
+    ]);
+  });
+});

--- a/playground/src/features/inputs/validation/inputValidation.ts
+++ b/playground/src/features/inputs/validation/inputValidation.ts
@@ -1,0 +1,286 @@
+import type { ErrorObject, SchemaObject } from "ajv";
+import Ajv from "ajv-draft-04";
+import addFormats from "ajv-formats";
+
+import type { OpenAPIDocument, OpenAPISchema } from "@/types/openapi";
+
+export type ValidationIssue = {
+  field?: string;
+  keyword: string;
+  message: string;
+  path: string;
+};
+
+export type InputValidator = (value: unknown) => ValidationIssue[];
+
+const INVALID_URI_TEXT = /[\p{Cc}\s]|%(?![0-9a-f]{2})/iu;
+const BASE64_DATA = /^[A-Za-z0-9+/]*={0,2}$/;
+
+/**
+ * Normalizes an OpenAPI schema and compiles a synchronous AJV validator that returns
+ * field-oriented issues instead of throwing schema or validation errors.
+ */
+export function createInputValidator(
+  document: OpenAPIDocument,
+  inputSchema: OpenAPISchema,
+): InputValidator {
+  const root = normalizeOpenAPISchema({
+    ...inputSchema,
+    components: document.components,
+  }) as SchemaObject;
+  const required = Array.isArray(inputSchema.required) ? inputSchema.required : [];
+  let validate: ReturnType<Ajv["compile"]>;
+  try {
+    const ajv = new Ajv({
+      allErrors: true,
+      formats: { password: true },
+      logger: false,
+      strictSchema: false,
+      strictTypes: false,
+    });
+    addFormats(ajv);
+    ajv.addFormat("uri", validateURI);
+    validate = ajv.compile(root);
+  } catch (error) {
+    const issue = schemaValidationIssue(error);
+    return () => [issue];
+  }
+
+  return (value) => {
+    try {
+      const valid = validate(value);
+      const issues = valid ? [] : normalizeIssues(validate.errors ?? []);
+      return withRequiredEmptyIssues(issues, required, value);
+    } catch (error) {
+      return [schemaValidationIssue(error)];
+    }
+  };
+}
+
+/**
+ * Flags required fields that are present but empty. AJV's `required` keyword only checks for
+ * a key's presence, so a blank string (e.g. a cleared text field) would otherwise pass.
+ */
+function withRequiredEmptyIssues(
+  issues: ValidationIssue[],
+  required: string[],
+  value: unknown,
+): ValidationIssue[] {
+  if (!isObject(value)) return issues;
+  const result = [...issues];
+  for (const name of required) {
+    if (!isEmptyRequiredValue(value[name])) continue;
+    if (result.some((issue) => issue.path === name)) continue;
+    result.push({
+      field: name,
+      keyword: "required",
+      message: "This field is required.",
+      path: name,
+    });
+  }
+  return result;
+}
+
+function isEmptyRequiredValue(value: unknown): boolean {
+  if (typeof value === "string") return value.trim() === "";
+  return Array.isArray(value) && value.length === 0;
+}
+
+function schemaValidationIssue(error: unknown): ValidationIssue {
+  return {
+    keyword: "schema",
+    message: `Cannot validate this OpenAPI schema: ${errorMessage(error)}`,
+    path: "input",
+  };
+}
+
+function normalizeOpenAPISchema(value: unknown): unknown {
+  if (!isObject(value) || Array.isArray(value)) return value;
+
+  const normalized = { ...value };
+  for (const keyword of ["allOf", "anyOf", "oneOf"] as const) {
+    if (Array.isArray(value[keyword])) {
+      normalized[keyword] = value[keyword].map(normalizeOpenAPISchema);
+    }
+  }
+  for (const keyword of ["properties", "patternProperties", "definitions"] as const) {
+    if (isObject(value[keyword])) {
+      normalized[keyword] = Object.fromEntries(
+        Object.entries(value[keyword]).map(([key, schema]) => [
+          key,
+          normalizeOpenAPISchema(schema),
+        ]),
+      );
+    }
+  }
+  for (const keyword of ["items", "additionalItems", "additionalProperties", "not"] as const) {
+    const child = value[keyword];
+    if (Array.isArray(child)) {
+      normalized[keyword] = child.map(normalizeOpenAPISchema);
+    } else if (isObject(child)) {
+      normalized[keyword] = normalizeOpenAPISchema(child);
+    }
+  }
+  if (isObject(value.dependencies)) {
+    normalized.dependencies = Object.fromEntries(
+      Object.entries(value.dependencies).map(([key, dependency]) => [
+        key,
+        isObject(dependency) && !Array.isArray(dependency)
+          ? normalizeOpenAPISchema(dependency)
+          : dependency,
+      ]),
+    );
+  }
+  if (isObject(value.components) && isObject(value.components.schemas)) {
+    normalized.components = {
+      ...value.components,
+      schemas: Object.fromEntries(
+        Object.entries(value.components.schemas).map(([key, schema]) => [
+          key,
+          normalizeOpenAPISchema(schema),
+        ]),
+      ),
+    };
+  }
+  if (typeof normalized.pattern === "string") {
+    const pattern = normalizePythonPattern(normalized.pattern);
+    try {
+      new RegExp(pattern, "u");
+      normalized.pattern = pattern;
+    } catch {
+      // Cog accepts Python regex syntax that browsers cannot execute. The
+      // server remains authoritative for those patterns.
+      delete normalized.pattern;
+    }
+  }
+  if (normalized.nullable !== true) return normalized;
+
+  if (typeof normalized.type === "string") {
+    normalized.type = [normalized.type, "null"];
+  } else if (Array.isArray(normalized.type) && !normalized.type.includes("null")) {
+    normalized.type = [...normalized.type, "null"];
+  } else {
+    const components = normalized.components;
+    delete normalized.components;
+    delete normalized.nullable;
+    return {
+      ...(components ? { components } : {}),
+      anyOf: [normalized, { type: "null" }],
+    };
+  }
+  delete normalized.nullable;
+  return normalized;
+}
+
+function normalizePythonPattern(pattern: string): string {
+  return pattern
+    .replaceAll(/\(\?P<([A-Za-z_]\w*)>/g, "(?<$1>")
+    .replaceAll(/\(\?P=([A-Za-z_]\w*)\)/g, String.raw`\k<$1>`)
+    .replaceAll(String.raw`\A`, "^")
+    .replaceAll(String.raw`\Z`, "$");
+}
+
+function validateURI(value: string): boolean {
+  if (value.slice(0, 5).toLowerCase() !== "data:") {
+    const standardURI = addFormats.get("uri");
+    return typeof standardURI === "function" && standardURI(value);
+  }
+
+  const separator = value.indexOf(",", 5);
+  if (separator < 0) return false;
+  const metadata = value.slice(5, separator);
+  if (hasInvalidURIText(metadata)) return false;
+
+  const data = value.slice(separator + 1);
+  if (!metadata.toLowerCase().endsWith(";base64")) return !hasInvalidURIText(data);
+  try {
+    const decoded = decodeURIComponent(data);
+    return decoded.length % 4 === 0 && BASE64_DATA.test(decoded);
+  } catch {
+    return false;
+  }
+}
+
+function hasInvalidURIText(value: string): boolean {
+  return INVALID_URI_TEXT.test(value);
+}
+
+function normalizeIssues(errors: ErrorObject[]): ValidationIssue[] {
+  const unionErrors = errors.filter(
+    (error) => error.keyword === "anyOf" || error.keyword === "oneOf",
+  );
+  const issues = errors
+    .filter(
+      (error) =>
+        !unionErrors.some(
+          (union) => error !== union && error.schemaPath.startsWith(`${union.schemaPath}/`),
+        ),
+    )
+    .map(toIssue);
+
+  return issues.filter(
+    (issue, index) =>
+      issues.findIndex(
+        (candidate) => candidate.path === issue.path && candidate.message === issue.message,
+      ) === index,
+  );
+}
+
+function toIssue(error: ErrorObject): ValidationIssue {
+  const segments = pointerSegments(error.instancePath);
+  const property = errorProperty(error);
+  if (property) segments.push(property);
+  const path = formatPath(segments);
+  return {
+    field: segments[0],
+    keyword: error.keyword,
+    message: issueMessage(error),
+    path,
+  };
+}
+
+function issueMessage(error: ErrorObject): string {
+  if (error.keyword === "required") return "This field is required.";
+  if (error.keyword === "additionalProperties") return "This field is not allowed.";
+  if (error.keyword === "pattern") return "Does not match the required pattern.";
+  if (error.keyword === "anyOf" || error.keyword === "oneOf") {
+    return "Must match one of the allowed schemas.";
+  }
+  return error.message ?? "Invalid value.";
+}
+
+function pointerSegments(pointer: string): string[] {
+  if (pointer === "#" || pointer === "") return [];
+  return pointer
+    .replace(/^#\/?/, "")
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => segment.replaceAll("~1", "/").replaceAll("~0", "~"));
+}
+
+function errorProperty(error: ErrorObject): string | undefined {
+  if (error.keyword === "required" && "missingProperty" in error.params) {
+    return String(error.params.missingProperty);
+  }
+  if (error.keyword === "additionalProperties" && "additionalProperty" in error.params) {
+    return String(error.params.additionalProperty);
+  }
+  return undefined;
+}
+
+function formatPath(segments: string[]): string {
+  if (segments.length === 0) return "input";
+  return segments.reduce(
+    (path, segment) =>
+      /^\d+$/.test(segment) ? `${path}[${segment}]` : path ? `${path}.${segment}` : segment,
+    "",
+  );
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/playground/src/features/inputs/validation/validateInput.test.ts
+++ b/playground/src/features/inputs/validation/validateInput.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { disposeValidationWorker, validateInput } from "@/features/inputs/validation/validateInput";
+import type { ValidationIssue } from "@/features/inputs/validation/inputValidation";
+
+const document = { components: { schemas: {} } };
+const schema = { type: "object", properties: { prompt: { type: "string" } } };
+
+type Request = { requestId: number; schemaId: number; value: unknown };
+type Response = { requestId: number; issues: ValidationIssue[] };
+
+class FakeWorker {
+  static instances: FakeWorker[] = [];
+
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  onmessage: ((event: MessageEvent<Response>) => void) | null = null;
+  postMessage = vi.fn();
+  terminate = vi.fn();
+
+  constructor() {
+    FakeWorker.instances.push(this);
+  }
+
+  get lastRequest(): Request {
+    return this.postMessage.mock.lastCall?.[0] as Request;
+  }
+
+  respond(requestId: number, issues: ValidationIssue[]): void {
+    this.onmessage?.({ data: { requestId, issues } } as MessageEvent<Response>);
+  }
+}
+
+describe("validateInput", () => {
+  beforeEach(() => {
+    vi.stubGlobal("Worker", FakeWorker);
+    disposeValidationWorker();
+    FakeWorker.instances = [];
+  });
+
+  afterEach(() => {
+    disposeValidationWorker();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves with the worker result", async () => {
+    const value = { prompt: "hello" };
+    const result = validateInput(document, schema, value, 1);
+
+    const worker = FakeWorker.instances[0];
+    expect(worker.lastRequest).toMatchObject({ schemaId: 1, document, schema, value });
+    worker.respond(worker.lastRequest.requestId, []);
+
+    await expect(result).resolves.toEqual([]);
+  });
+
+  it("reuses a single shared worker across runs", async () => {
+    const first = validateInput(document, schema, { prompt: "a" }, 1);
+    const second = validateInput(document, schema, { prompt: "b" }, 1);
+
+    expect(FakeWorker.instances).toHaveLength(1);
+    const worker = FakeWorker.instances[0];
+    for (const call of worker.postMessage.mock.calls) worker.respond(call[0].requestId, []);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([[], []]);
+  });
+
+  it("resolves with a timeout issue when the worker exceeds the deadline", async () => {
+    vi.useFakeTimers();
+    const result = validateInput(document, schema, { prompt: "hello" }, 1);
+
+    vi.advanceTimersByTime(10_000);
+
+    await expect(result).resolves.toEqual([
+      expect.objectContaining({ keyword: "schema", message: expect.stringContaining("timed out") }),
+    ]);
+  });
+
+  it("turns synchronous worker posting failures into validation issues", async () => {
+    class ThrowingWorker extends FakeWorker {
+      override postMessage = vi.fn(() => {
+        throw new DOMException("could not clone", "DataCloneError");
+      });
+    }
+    vi.stubGlobal("Worker", ThrowingWorker);
+    disposeValidationWorker();
+    const failed = validateInput(document, schema, { prompt: "hello" }, 1);
+
+    await expect(failed).resolves.toEqual([
+      expect.objectContaining({
+        keyword: "schema",
+        message: expect.stringContaining("could not clone"),
+      }),
+    ]);
+  });
+});

--- a/playground/src/features/inputs/validation/validateInput.ts
+++ b/playground/src/features/inputs/validation/validateInput.ts
@@ -1,0 +1,93 @@
+import type { OpenAPIDocument, OpenAPISchema } from "@/types/openapi";
+import type { ValidationIssue } from "@/features/inputs/validation/inputValidation";
+
+const VALIDATION_TIMEOUT_MS = 10_000;
+
+type PendingRequest = {
+  resolve: (issues: ValidationIssue[]) => void;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+type WorkerResponse = { requestId: number; issues: ValidationIssue[] };
+
+// A single long-lived worker is shared across runs. The worker compiles the
+// validator once per schemaId and reuses it: a connected model's schema is
+// immutable for the life of its server, so it never needs recompiling.
+let worker: Worker | undefined;
+let nextRequestId = 1;
+const pending = new Map<number, PendingRequest>();
+
+function settle(requestId: number, issues: ValidationIssue[]): void {
+  const request = pending.get(requestId);
+  if (!request) return;
+  pending.delete(requestId);
+  clearTimeout(request.timeout);
+  request.resolve(issues);
+}
+
+function ensureWorker(): Worker {
+  if (worker) return worker;
+  const created = new Worker(new URL("./validation.worker.ts", import.meta.url), {
+    type: "module",
+  });
+  created.onmessage = (event: MessageEvent<WorkerResponse>) => {
+    settle(event.data.requestId, event.data.issues);
+  };
+  created.onerror = (event) => {
+    // The worker is unusable; fail everything in flight and rebuild lazily.
+    const issue = schemaIssue(event.message);
+    for (const requestId of pending.keys()) settle(requestId, [issue]);
+    created.terminate();
+    if (worker === created) worker = undefined;
+  };
+  worker = created;
+  return created;
+}
+
+/**
+ * Validates input against a model's schema in the shared worker. `schemaId` identifies the
+ * connected schema so the worker compiles its validator once and reuses it across runs.
+ */
+export function validateInput(
+  document: OpenAPIDocument,
+  schema: OpenAPISchema,
+  value: unknown,
+  schemaId: number,
+): Promise<ValidationIssue[]> {
+  return new Promise((resolve) => {
+    let active: Worker;
+    try {
+      active = ensureWorker();
+    } catch (error) {
+      resolve([schemaIssue(error)]);
+      return;
+    }
+    const requestId = nextRequestId++;
+    const timeout = setTimeout(
+      () => settle(requestId, [schemaIssue(new Error("validation timed out"))]),
+      VALIDATION_TIMEOUT_MS,
+    );
+    pending.set(requestId, { resolve, timeout });
+    try {
+      active.postMessage({ requestId, schemaId, document, schema, value });
+    } catch (error) {
+      settle(requestId, [schemaIssue(error)]);
+    }
+  });
+}
+
+/** Tears down the shared validation worker, resolving any in-flight requests. */
+export function disposeValidationWorker(): void {
+  worker?.terminate();
+  worker = undefined;
+  for (const requestId of pending.keys()) settle(requestId, []);
+}
+
+function schemaIssue(error: unknown): ValidationIssue {
+  const detail = error instanceof Error ? error.message : String(error);
+  return {
+    keyword: "schema",
+    message: `Cannot validate this OpenAPI schema: ${detail}`,
+    path: "input",
+  };
+}

--- a/playground/src/features/inputs/validation/validation.worker.ts
+++ b/playground/src/features/inputs/validation/validation.worker.ts
@@ -1,0 +1,37 @@
+import type { OpenAPIDocument, OpenAPISchema } from "@/types/openapi";
+import {
+  createInputValidator,
+  type InputValidator,
+  type ValidationIssue,
+} from "@/features/inputs/validation/inputValidation";
+
+type ValidationRequest = {
+  requestId: number;
+  schemaId: number;
+  document: OpenAPIDocument;
+  schema: OpenAPISchema;
+  value: unknown;
+};
+
+// Compile the validator once per schema and reuse it: a connected model's
+// schema is immutable, so subsequent runs only re-run the cached validator.
+let cached: { schemaId: number; validate: InputValidator } | undefined;
+
+self.onmessage = (event: MessageEvent<ValidationRequest>) => {
+  const { requestId, schemaId, document, schema, value } = event.data;
+  try {
+    if (!cached || cached.schemaId !== schemaId) {
+      cached = { schemaId, validate: createInputValidator(document, schema) };
+    }
+    self.postMessage({ requestId, issues: cached.validate(value) });
+  } catch (error) {
+    cached = undefined;
+    const detail = error instanceof Error ? error.message : String(error);
+    const issue: ValidationIssue = {
+      keyword: "schema",
+      message: `Cannot validate this OpenAPI schema: ${detail}`,
+      path: "input",
+    };
+    self.postMessage({ requestId, issues: [issue] });
+  }
+};


### PR DESCRIPTION
- schema-driven playground input controls and worker-backed validation
- includes colocated form/validation unit tests
- cog-playground stack: #3109, #3108, #3114, #3110/#3106, #3105/#3111/#3107, #3113, #3112