### PR TITLE
3. Add core playground types and utilities

### DIFF
--- a/playground/src/config/theme.ts
+++ b/playground/src/config/theme.ts
@@ -1,0 +1,12 @@
+export type ThemeMode = "light" | "dark";
+
+/** Returns light only when explicitly selected; the playground otherwise defaults to dark. */
+export function currentTheme(): ThemeMode {
+  return document.documentElement.dataset.mode === "light" ? "light" : "dark";
+}
+
+/** Updates Kumo's root color mode and persists it in local storage. */
+export function setTheme(mode: ThemeMode) {
+  document.documentElement.dataset.mode = mode;
+  localStorage.setItem("cog-playground-theme", mode);
+}

--- a/playground/src/test/deferred.ts
+++ b/playground/src/test/deferred.ts
@@ -1,0 +1,14 @@
+/** Creates a test promise whose resolve and reject callbacks are controlled externally. */
+export function deferred<Value>(): {
+  promise: Promise<Value>;
+  resolve: (value: Value) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: Value) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<Value>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}

--- a/playground/src/test/setup.ts
+++ b/playground/src/test/setup.ts
@@ -1,0 +1,27 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
+
+afterEach(cleanup);
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  },
+);
+
+HTMLElement.prototype.scrollIntoView = vi.fn();
+Object.defineProperty(Range.prototype, "getClientRects", {
+  configurable: true,
+  value: () => [] as unknown as DOMRectList,
+});
+Object.defineProperty(Range.prototype, "getBoundingClientRect", {
+  configurable: true,
+  value: () => new DOMRect(),
+});
+window.requestAnimationFrame = (callback) =>
+  window.setTimeout(() => callback(performance.now()), 0);
+window.cancelAnimationFrame = window.clearTimeout;

--- a/playground/src/types/health.ts
+++ b/playground/src/types/health.ts
@@ -1,0 +1,6 @@
+export type HealthResponse = {
+  status?: string;
+  user_healthcheck_error?: string;
+  setup?: { status?: string; logs?: string };
+  version?: { coglet?: string; python_sdk?: string; python?: string };
+};

--- a/playground/src/types/json.ts
+++ b/playground/src/types/json.ts
@@ -1,0 +1,8 @@
+export type JsonPrimitive = boolean | null | number | string;
+export type JsonValue = JsonObject | JsonPrimitive | JsonValue[];
+export type JsonObject = { [key: string]: JsonValue };
+
+/** Narrows to a plain JSON object, excluding arrays and null. */
+export function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/playground/src/types/openapi.ts
+++ b/playground/src/types/openapi.ts
@@ -1,0 +1,42 @@
+import type { JsonObject } from "@/types/json";
+
+export type OpenAPISchema = {
+  $ref?: string;
+  type?: string;
+  format?: string;
+  title?: string;
+  description?: string;
+  default?: unknown;
+  enum?: unknown[];
+  allOf?: OpenAPISchema[];
+  anyOf?: OpenAPISchema[];
+  oneOf?: OpenAPISchema[];
+  items?: OpenAPISchema;
+  properties?: Record<string, OpenAPISchema>;
+  additionalProperties?: boolean | OpenAPISchema;
+  required?: string[];
+  nullable?: boolean;
+  minimum?: number;
+  maximum?: number;
+  exclusiveMinimum?: boolean;
+  exclusiveMaximum?: boolean;
+  multipleOf?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  minItems?: number;
+  maxItems?: number;
+  uniqueItems?: boolean;
+  minProperties?: number;
+  maxProperties?: number;
+  deprecated?: boolean;
+  [key: `x-${string}`]: unknown;
+};
+
+export type OpenAPIDocument = {
+  components?: { schemas?: Record<string, OpenAPISchema> };
+  paths?: Record<string, OpenAPIPathItem>;
+};
+
+export type OpenAPIOperation = JsonObject & { "x-cog-streaming"?: boolean };
+export type OpenAPIPathItem = Record<string, OpenAPIOperation>;

--- a/playground/src/types/prediction.ts
+++ b/playground/src/types/prediction.ts
@@ -1,0 +1,40 @@
+import type { JsonObject } from "@/types/json";
+
+export type PredictionEnvelope = {
+  id?: string;
+  status?: string;
+  output?: unknown;
+  error?: string;
+  logs?: string;
+  metrics?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type StreamEvent = {
+  type: string;
+  data: JsonObject;
+  raw: string;
+};
+
+export type TraceEventKind = "request" | "response" | "sse" | "webhook" | "cancel" | "error";
+
+export type TraceEvent = {
+  id: string;
+  elapsedMs: number;
+  kind: TraceEventKind;
+  label: string;
+  data?: unknown;
+  count?: number;
+};
+
+export type RequestTrace = {
+  startedAtLabel: string;
+  method: "POST" | "PUT";
+  endpoint: string;
+  requestHeaders: Record<string, string>;
+  requestBody: unknown;
+  responseStatus?: number;
+  responseHeaders?: Record<string, string>;
+  responseBody?: unknown;
+  events: TraceEvent[];
+};

--- a/playground/src/utils/openapi.test.ts
+++ b/playground/src/utils/openapi.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  constraintText,
+  defaultInput,
+  effectiveSchema,
+  enumValues,
+  playgroundCapabilities,
+  orderedProperties,
+} from "@/utils/openapi";
+import type { OpenAPIDocument } from "@/types/openapi";
+
+const document: OpenAPIDocument = {
+  components: {
+    schemas: {
+      Choice: { enum: [1, 2] },
+      Input: {
+        required: ["prompt", "enabled", "choice"],
+        properties: {
+          late: { type: "string", "x-order": 2 },
+          prompt: { type: "string", default: "hello", "x-order": 1 },
+          optional: { type: "boolean", default: false },
+          nullable: { type: "string", nullable: true, default: null },
+          enabled: { type: "boolean" },
+          choice: { allOf: [{ $ref: "#/components/schemas/Choice" }] },
+        },
+      },
+      Output: { type: "string" },
+    },
+  },
+  paths: {
+    "/predictions": { post: { "x-cog-streaming": true } },
+    "/predictions/{prediction_id}/cancel": {},
+  },
+};
+
+describe("schema helpers", () => {
+  it("resolves nullable references without losing metadata", () => {
+    expect(
+      effectiveSchema(document, {
+        title: "Nullable choice",
+        anyOf: [{ $ref: "#/components/schemas/Choice" }, { type: "null" }],
+      }),
+    ).toEqual({ title: "Nullable choice", enum: [1, 2] });
+  });
+
+  it("initializes explicit defaults and required controls", () => {
+    const input = document.components?.schemas?.Input ?? {};
+    expect(orderedProperties(input).map(([name]) => name)).toEqual([
+      "prompt",
+      "late",
+      "optional",
+      "nullable",
+      "enabled",
+      "choice",
+    ]);
+    expect(defaultInput(document, input)).toEqual({
+      prompt: "hello",
+      optional: false,
+      nullable: null,
+      enabled: false,
+      choice: 1,
+    });
+  });
+
+  it("discovers enums from direct and composed schemas", () => {
+    expect(enumValues(document, { $ref: "#/components/schemas/Choice" })).toEqual([1, 2]);
+    expect(enumValues(document, { allOf: [{ $ref: "#/components/schemas/Choice" }] })).toEqual([
+      1, 2,
+    ]);
+  });
+
+  it("derives prediction capabilities", () => {
+    expect(playgroundCapabilities(document)).toMatchObject({
+      endpoint: "/predictions",
+      streaming: true,
+      async: true,
+      input: document.components?.schemas?.Input,
+    });
+  });
+
+  it("derives training capabilities", () => {
+    const training: OpenAPIDocument = {
+      components: {
+        schemas: { TrainingInput: { type: "object" }, TrainingOutput: { type: "object" } },
+      },
+      paths: { "/trainings": { post: {} } },
+    };
+    expect(playgroundCapabilities(training)).toMatchObject({
+      endpoint: "/trainings",
+      streaming: false,
+      async: false,
+    });
+  });
+
+  it("formats constraints", () => {
+    expect(
+      constraintText({
+        default: 5,
+        minimum: 1,
+        maximum: 9,
+        minLength: 2,
+        maxLength: 10,
+        pattern: "^[a-z]+$",
+      }),
+    ).toBe("default 5 · min 1 · max 9 · min 2 chars · max 10 chars · pattern: ^[a-z]+$");
+  });
+});

--- a/playground/src/utils/openapi.ts
+++ b/playground/src/utils/openapi.ts
@@ -1,0 +1,104 @@
+import type { OpenAPIDocument, OpenAPISchema } from "@/types/openapi";
+
+const REF_PREFIX = "#/components/schemas/";
+
+/** Resolves a local component-schema reference, leaving unsupported references unchanged. */
+export function resolveRef(root: OpenAPIDocument, value: OpenAPISchema): OpenAPISchema {
+  if (!value.$ref?.startsWith(REF_PREFIX)) return value;
+  return root.components?.schemas?.[value.$ref.slice(REF_PREFIX.length)] ?? value;
+}
+
+/** Resolves local references and unwraps a nullable `anyOf` with one non-null branch. */
+export function effectiveSchema(root: OpenAPIDocument, value: OpenAPISchema): OpenAPISchema {
+  let schema = resolveRef(root, value);
+  if (!schema.anyOf) return schema;
+  const nonNull = schema.anyOf
+    .map((item) => resolveRef(root, item))
+    .filter((item) => item.type !== "null");
+  if (nonNull.length !== 1) return schema;
+  const merged: OpenAPISchema = { ...schema, ...nonNull[0] };
+  delete merged.anyOf;
+  return merged;
+}
+
+/** Finds enum choices declared directly or through a referenced `allOf` branch. */
+export function enumValues(root: OpenAPIDocument, value: OpenAPISchema): unknown[] | undefined {
+  const schema = effectiveSchema(root, value);
+  if (schema.enum) return schema.enum;
+  for (const item of schema.allOf ?? []) {
+    const resolved = resolveRef(root, item);
+    if (resolved.enum) return resolved.enum;
+  }
+  return undefined;
+}
+
+/** Builds initial input from explicit defaults and required enum or Boolean properties. */
+export function defaultInput(
+  root: OpenAPIDocument,
+  schema: OpenAPISchema,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  const required = new Set(schema.required ?? []);
+  for (const [name, raw] of orderedProperties(schema)) {
+    const property = effectiveSchema(root, raw);
+    if (Object.hasOwn(property, "default")) {
+      result[name] = property.default;
+      continue;
+    }
+    if (!required.has(name)) continue;
+    const choices = enumValues(root, property);
+    if (choices?.length) result[name] = choices[0];
+    else if (property.type === "boolean") result[name] = false;
+  }
+  return result;
+}
+
+/** Orders object properties by Cog's `x-order` extension, with unspecified entries last. */
+export function orderedProperties(schema: OpenAPISchema): [string, OpenAPISchema][] {
+  return Object.entries(schema.properties ?? {}).sort(([, left], [, right]) => {
+    const leftOrder = typeof left["x-order"] === "number" ? left["x-order"] : 999;
+    const rightOrder = typeof right["x-order"] === "number" ? right["x-order"] : 999;
+    return leftOrder - rightOrder;
+  });
+}
+
+/** Formats an explicit default and supported constraints as field guidance. */
+export function constraintText(schema: OpenAPISchema): string {
+  const parts: string[] = [];
+  if (Object.hasOwn(schema, "default")) parts.push(`default ${formatSchemaValue(schema.default)}`);
+  if (schema.minimum !== undefined) parts.push(`min ${schema.minimum}`);
+  if (schema.maximum !== undefined) parts.push(`max ${schema.maximum}`);
+  if (schema.minLength !== undefined) parts.push(`min ${schema.minLength} chars`);
+  if (schema.maxLength !== undefined) parts.push(`max ${schema.maxLength} chars`);
+  if (schema.pattern) parts.push(`pattern: ${schema.pattern}`);
+  return parts.join(" · ");
+}
+
+function formatSchemaValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+export type PlaygroundCapabilities = {
+  endpoint: "/predictions" | "/trainings";
+  input: OpenAPISchema;
+  streaming: boolean;
+  async: boolean;
+};
+
+/** Derives the model endpoint, input schema, streaming support, and cancellation capability. */
+export function playgroundCapabilities(document: OpenAPIDocument): PlaygroundCapabilities {
+  const schemas = document.components?.schemas ?? {};
+  const training = Boolean(document.paths?.["/trainings"]);
+  const endpoint = training ? "/trainings" : "/predictions";
+  const input = resolveRef(document, schemas[training ? "TrainingInput" : "Input"] ?? {});
+  const operation = document.paths?.[endpoint]?.post;
+  return {
+    endpoint,
+    input,
+    streaming: operation?.["x-cog-streaming"] === true,
+    async: Boolean(
+      document.paths?.[`${endpoint}/{${training ? "training" : "prediction"}_id}/cancel`],
+    ),
+  };
+}

--- a/playground/src/utils/terminal.test.ts
+++ b/playground/src/utils/terminal.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { renderTerminalText } from "@/utils/terminal";
+
+describe("renderTerminalText", () => {
+  it("renders carriage-return progress updates as separate lines", () => {
+    expect(renderTerminalText("starting\n\r  0%| | 0/28\r 50%|#| 14/28\r100%|#| 28/28\n")).toBe(
+      "starting\n\n  0%| | 0/28\n 50%|#| 14/28\n100%|#| 28/28\n",
+    );
+  });
+
+  it("normalizes CRLF without adding an extra line", () => {
+    expect(renderTerminalText("first\rsecond\r\nthird")).toBe("first\nsecond\nthird");
+  });
+});

--- a/playground/src/utils/terminal.ts
+++ b/playground/src/utils/terminal.ts
@@ -1,0 +1,4 @@
+/** Displays terminal carriage-return updates as separate lines without changing captured text. */
+export function renderTerminalText(value: string): string {
+  return value.replaceAll("\r\n", "\n").replaceAll("\r", "\n");
+}


### PR DESCRIPTION
- shared playground types, theme config, test setup, and openapi/terminal utilities
- includes colocated utility unit tests
- cog-playground stack: #3109, #3108, #3114, #3110/#3106, #3105/#3111/#3107, #3113, #3112