### PR TITLE
mise: fix deprecated experimental_monorepo_root warning

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -25,7 +25,7 @@
 #
 # =============================================================================
 
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["."]


### PR DESCRIPTION
`mise` warns on every run:

```
mise WARN  deprecated [config.experimental_monorepo_root]: `experimental_monorepo_root` in ~/src/replicate/cog/mise.toml is deprecated. Use `monorepo_root` instead. This will be removed in mise 2027.12.0.
```

Renamed the key to `monorepo_root`.