### PR TITLE
ci: un-bonk bonk

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -38,7 +38,7 @@ jobs:
           OPENCODE_PRINT_LOGS: '1'
           OPENCODE_LOG_LEVEL: INFO
         with:
-          model: 'cf-gateway/nemotron-3-120b'
+          model: 'cf-gateway/kimi-k2.7-code'
           mentions: '/bonk,@ask-bonk'
           forks: 'false'
           permissions: write

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -33,15 +33,8 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_GATEWAY_BASE_URL: https://gateway.ai.cloudflare.com/v1/${{ vars.CLOUDFLARE_ACCOUNT_ID }}/${{ vars.CLOUDFLARE_GATEWAY_ID }}/compat
-          # Must stay below the job's timeout-minutes. The harness defaults to
-          # 45m, so on a 30m job opencode's own timeout and retry handling never
-          # fires and the runner kills it with no diagnostic.
+          # Must stay below the job's timeout-minutes. The harness defaults to 45m, so 25m gives opencode enough time to retry
           OPENCODE_TIMEOUT: 25m
-          # The equivalent of --print-logs and --log-level, which we cannot pass
-          # as flags because the harness spawns `opencode github run` directly.
-          # Without these, opencode only writes to its log file inside the
-          # runner, so a provider error looks like a silent stall: a deprecated
-          # model returning 429 cost us a week of timeouts with an empty log.
           OPENCODE_PRINT_LOGS: '1'
           OPENCODE_LOG_LEVEL: INFO
         with:

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -37,11 +37,18 @@ jobs:
           # 45m, so on a 30m job opencode's own timeout and retry handling never
           # fires and the runner kills it with no diagnostic.
           OPENCODE_TIMEOUT: 25m
+          # The equivalent of --print-logs and --log-level, which we cannot pass
+          # as flags because the harness spawns `opencode github run` directly.
+          # Without these, opencode only writes to its log file inside the
+          # runner, so a provider error looks like a silent stall: a deprecated
+          # model returning 429 cost us a week of timeouts with an empty log.
+          OPENCODE_PRINT_LOGS: '1'
+          OPENCODE_LOG_LEVEL: DEBUG
         with:
           model: 'cf-gateway/nemotron-3-120b'
           mentions: '/bonk,@ask-bonk'
           forks: 'false'
           permissions: write
-          opencode_version: '1.2.27'
+          opencode_version: '1.18.13'
           # token_permissions defaults to WRITE so bonk can push commits
           # when asked via /bonk.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -43,7 +43,7 @@ jobs:
           # runner, so a provider error looks like a silent stall: a deprecated
           # model returning 429 cost us a week of timeouts with an empty log.
           OPENCODE_PRINT_LOGS: '1'
-          OPENCODE_LOG_LEVEL: DEBUG
+          OPENCODE_LOG_LEVEL: INFO
         with:
           model: 'cf-gateway/nemotron-3-120b'
           mentions: '/bonk,@ask-bonk'

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -33,8 +33,12 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_GATEWAY_BASE_URL: https://gateway.ai.cloudflare.com/v1/${{ vars.CLOUDFLARE_ACCOUNT_ID }}/${{ vars.CLOUDFLARE_GATEWAY_ID }}/compat
+          # Must stay below the job's timeout-minutes. The harness defaults to
+          # 45m, so on a 30m job opencode's own timeout and retry handling never
+          # fires and the runner kills it with no diagnostic.
+          OPENCODE_TIMEOUT: 25m
         with:
-          model: 'cf-gateway/kimi-k2.5'
+          model: 'cf-gateway/nemotron-3-120b'
           mentions: '/bonk,@ask-bonk'
           forks: 'false'
           permissions: write

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -49,7 +49,7 @@ jobs:
           # runner, so a provider error looks like a silent stall: a deprecated
           # model returning 429 cost us a week of timeouts with an empty log.
           OPENCODE_PRINT_LOGS: '1'
-          OPENCODE_LOG_LEVEL: DEBUG
+          OPENCODE_LOG_LEVEL: INFO
         with:
           model: 'cf-gateway/nemotron-3-120b'
           forks: 'false'

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -34,60 +34,6 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
 
-      # TEMPORARY (debug/bonk-reviewer-hang): every reviewer run since
-      # 2026-07-28 has hung at "Sending message to opencode..." and been killed
-      # at the 30 minute job timeout with zero output. This probe hits the
-      # gateway directly so the job log shows the status code, latency, the
-      # model the gateway actually resolves to, and the raw shape of the
-      # stream. Delete this step once the cause is known.
-      - name: Probe AI Gateway
-        continue-on-error: true
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CF_GATEWAY_BASE_URL: https://gateway.ai.cloudflare.com/v1/${{ vars.CLOUDFLARE_ACCOUNT_ID }}/${{ vars.CLOUDFLARE_GATEWAY_ID }}/compat
-        run: |
-          # Diagnostics must never fail the job, and a hung or erroring probe is
-          # itself the signal we want, so drop the default -e / pipefail.
-          set +e +o pipefail
-
-          probe() {
-            local model="$1"
-            local stream="$2"
-            local prompt="$3"
-            local body hdr stats
-            echo "::group::model=${model} stream=${stream}"
-            body="$(mktemp)"
-            hdr="$(mktemp)"
-            stats="$(
-              curl -sS -X POST "${CF_GATEWAY_BASE_URL}/chat/completions" \
-                -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-                -H 'Content-Type: application/json' \
-                --max-time 120 \
-                -D "${hdr}" -o "${body}" \
-                -w 'http=%{http_code} ttfb=%{time_starttransfer}s total=%{time_total}s bytes=%{size_download}' \
-                -d "{\"model\":\"${model}\",\"stream\":${stream},\"max_tokens\":256,\"messages\":[{\"role\":\"user\",\"content\":\"${prompt}\"}]}"
-            )" || echo "curl failed with exit code $?"
-            echo "${stats}"
-            echo "-- response headers --"
-            grep -iv '^set-cookie' "${hdr}" | head -n 40 || true
-            echo "-- body (first 3000 bytes) --"
-            head -c 3000 "${body}"
-            echo
-            echo "::endgroup::"
-          }
-
-          # Non-streaming. The "model" field in the response reveals whether the
-          # gateway silently aliases deprecated kimi-k2.5 to kimi-k2.6.
-          probe 'workers-ai/@cf/moonshotai/kimi-k2.5' false 'Reply with the single word: pong'
-          probe 'workers-ai/@cf/nvidia/nemotron-3-120b-a12b' false 'Reply with the single word: pong'
-
-          # Streaming with a prompt that forces reasoning. Shows whether tokens
-          # arrive as content, reasoning, or reasoning_content. If they land in
-          # a field the openai-compatible provider ignores, opencode would print
-          # nothing while the model runs, which matches the observed hang.
-          probe 'workers-ai/@cf/moonshotai/kimi-k2.5' true 'What is 17 times 23? Think step by step.'
-          probe 'workers-ai/@cf/nvidia/nemotron-3-120b-a12b' true 'What is 17 times 23? Think step by step.'
-
       - name: Run Bonk
         uses: ask-bonk/ask-bonk/github@main
         env:
@@ -97,11 +43,18 @@ jobs:
           # 45m, so on a 30m job opencode's own timeout and retry handling never
           # fires and the runner kills it with no diagnostic.
           OPENCODE_TIMEOUT: 25m
+          # The equivalent of --print-logs and --log-level, which we cannot pass
+          # as flags because the harness spawns `opencode github run` directly.
+          # Without these, opencode only writes to its log file inside the
+          # runner, so a provider error looks like a silent stall: a deprecated
+          # model returning 429 cost us a week of timeouts with an empty log.
+          OPENCODE_PRINT_LOGS: '1'
+          OPENCODE_LOG_LEVEL: DEBUG
         with:
           model: 'cf-gateway/nemotron-3-120b'
           forks: 'false'
           permissions: write
-          opencode_version: '1.2.27'
+          opencode_version: '1.18.13'
           # The auto-reviewer must never push to PR branches. NO_PUSH
           # enforces that at the token level.
           token_permissions: 'NO_PUSH'

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -34,13 +34,71 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
 
+      # TEMPORARY (debug/bonk-reviewer-hang): every reviewer run since
+      # 2026-07-28 has hung at "Sending message to opencode..." and been killed
+      # at the 30 minute job timeout with zero output. This probe hits the
+      # gateway directly so the job log shows the status code, latency, the
+      # model the gateway actually resolves to, and the raw shape of the
+      # stream. Delete this step once the cause is known.
+      - name: Probe AI Gateway
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_GATEWAY_BASE_URL: https://gateway.ai.cloudflare.com/v1/${{ vars.CLOUDFLARE_ACCOUNT_ID }}/${{ vars.CLOUDFLARE_GATEWAY_ID }}/compat
+        run: |
+          # Diagnostics must never fail the job, and a hung or erroring probe is
+          # itself the signal we want, so drop the default -e / pipefail.
+          set +e +o pipefail
+
+          probe() {
+            local model="$1"
+            local stream="$2"
+            local prompt="$3"
+            local body hdr stats
+            echo "::group::model=${model} stream=${stream}"
+            body="$(mktemp)"
+            hdr="$(mktemp)"
+            stats="$(
+              curl -sS -X POST "${CF_GATEWAY_BASE_URL}/chat/completions" \
+                -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+                -H 'Content-Type: application/json' \
+                --max-time 120 \
+                -D "${hdr}" -o "${body}" \
+                -w 'http=%{http_code} ttfb=%{time_starttransfer}s total=%{time_total}s bytes=%{size_download}' \
+                -d "{\"model\":\"${model}\",\"stream\":${stream},\"max_tokens\":256,\"messages\":[{\"role\":\"user\",\"content\":\"${prompt}\"}]}"
+            )" || echo "curl failed with exit code $?"
+            echo "${stats}"
+            echo "-- response headers --"
+            grep -iv '^set-cookie' "${hdr}" | head -n 40 || true
+            echo "-- body (first 3000 bytes) --"
+            head -c 3000 "${body}"
+            echo
+            echo "::endgroup::"
+          }
+
+          # Non-streaming. The "model" field in the response reveals whether the
+          # gateway silently aliases deprecated kimi-k2.5 to kimi-k2.6.
+          probe 'workers-ai/@cf/moonshotai/kimi-k2.5' false 'Reply with the single word: pong'
+          probe 'workers-ai/@cf/nvidia/nemotron-3-120b-a12b' false 'Reply with the single word: pong'
+
+          # Streaming with a prompt that forces reasoning. Shows whether tokens
+          # arrive as content, reasoning, or reasoning_content. If they land in
+          # a field the openai-compatible provider ignores, opencode would print
+          # nothing while the model runs, which matches the observed hang.
+          probe 'workers-ai/@cf/moonshotai/kimi-k2.5' true 'What is 17 times 23? Think step by step.'
+          probe 'workers-ai/@cf/nvidia/nemotron-3-120b-a12b' true 'What is 17 times 23? Think step by step.'
+
       - name: Run Bonk
         uses: ask-bonk/ask-bonk/github@main
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_GATEWAY_BASE_URL: https://gateway.ai.cloudflare.com/v1/${{ vars.CLOUDFLARE_ACCOUNT_ID }}/${{ vars.CLOUDFLARE_GATEWAY_ID }}/compat
+          # Must stay below the job's timeout-minutes. The harness defaults to
+          # 45m, so on a 30m job opencode's own timeout and retry handling never
+          # fires and the runner kills it with no diagnostic.
+          OPENCODE_TIMEOUT: 25m
         with:
-          model: 'cf-gateway/kimi-k2.5'
+          model: 'cf-gateway/nemotron-3-120b'
           forks: 'false'
           permissions: write
           opencode_version: '1.2.27'

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -44,7 +44,7 @@ jobs:
           OPENCODE_PRINT_LOGS: '1'
           OPENCODE_LOG_LEVEL: INFO
         with:
-          model: 'cf-gateway/nemotron-3-120b'
+          model: 'cf-gateway/kimi-k2.7-code'
           forks: 'false'
           permissions: write
           opencode_version: '1.18.13'

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -39,15 +39,8 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_GATEWAY_BASE_URL: https://gateway.ai.cloudflare.com/v1/${{ vars.CLOUDFLARE_ACCOUNT_ID }}/${{ vars.CLOUDFLARE_GATEWAY_ID }}/compat
-          # Must stay below the job's timeout-minutes. The harness defaults to
-          # 45m, so on a 30m job opencode's own timeout and retry handling never
-          # fires and the runner kills it with no diagnostic.
+          # Must stay below the job's timeout-minutes. The harness defaults to 45m, so 25m gives opencode enough time to retry
           OPENCODE_TIMEOUT: 25m
-          # The equivalent of --print-logs and --log-level, which we cannot pass
-          # as flags because the harness spawns `opencode github run` directly.
-          # Without these, opencode only writes to its log file inside the
-          # runner, so a provider error looks like a silent stall: a deprecated
-          # model returning 429 cost us a week of timeouts with an empty log.
           OPENCODE_PRINT_LOGS: '1'
           OPENCODE_LOG_LEVEL: INFO
         with:

--- a/.opencode/agents/reviewer.md
+++ b/.opencode/agents/reviewer.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only code reviewer for pull requests
 mode: primary
-model: cf-gateway/nemotron-3-120b
+model: cf-gateway/kimi-k2.7-code
 temperature: 0.1
 permission:
   edit: deny

--- a/.opencode/agents/reviewer.md
+++ b/.opencode/agents/reviewer.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only code reviewer for pull requests
 mode: primary
-model: cf-gateway/kimi-k2.5
+model: cf-gateway/nemotron-3-120b
 temperature: 0.1
 permission:
   edit: deny

--- a/opencode.json
+++ b/opencode.json
@@ -16,14 +16,6 @@
             "context": 256000,
             "output": 32000
           }
-        },
-        "kimi-k2.5": {
-          "id": "workers-ai/@cf/moonshotai/kimi-k2.5",
-          "name": "Kimi K2.5 (Workers AI via Gateway, deprecated)",
-          "limit": {
-            "context": 256000,
-            "output": 64000
-          }
         }
       }
     }

--- a/opencode.json
+++ b/opencode.json
@@ -9,9 +9,17 @@
         "apiKey": "{env:CLOUDFLARE_API_TOKEN}"
       },
       "models": {
+        "nemotron-3-120b": {
+          "id": "workers-ai/@cf/nvidia/nemotron-3-120b-a12b",
+          "name": "Nemotron 3 120B (Workers AI via Gateway)",
+          "limit": {
+            "context": 256000,
+            "output": 32000
+          }
+        },
         "kimi-k2.5": {
           "id": "workers-ai/@cf/moonshotai/kimi-k2.5",
-          "name": "Kimi K2.5 (Workers AI via Gateway)",
+          "name": "Kimi K2.5 (Workers AI via Gateway, deprecated)",
           "limit": {
             "context": 256000,
             "output": 64000

--- a/opencode.json
+++ b/opencode.json
@@ -9,12 +9,12 @@
         "apiKey": "{env:CLOUDFLARE_API_TOKEN}"
       },
       "models": {
-        "nemotron-3-120b": {
-          "id": "workers-ai/@cf/nvidia/nemotron-3-120b-a12b",
-          "name": "Nemotron 3 120B (Workers AI via Gateway)",
+        "kimi-k2.7-code": {
+          "id": "workers-ai/@cf/moonshotai/kimi-k2.7-code",
+          "name": "Kimi K2.7 Code (Workers AI via Gateway)",
           "limit": {
-            "context": 256000,
-            "output": 32000
+            "context": 262144,
+            "output": 64000
           }
         }
       }


### PR DESCRIPTION
- Switch Bonk from the deprecated, rate-limited `kimi-k2.5` to paid `kimi-k2.7-code`.
- Update opencode to `1.18.13` and set its timeout below the 30-minute job limit.
- Print opencode's INFO logs in the Actions output so provider errors are visible.
