### PR TITLE
ci: switch Bonk and PR review to Kimi K2.7

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -39,7 +39,7 @@ jobs:
           OPENCODE_LOG_LEVEL: INFO
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cf-gateway/nemotron-3-120b-a12b'
+          model: 'cf-gateway/kimi-k2.7-code'
           mentions: '/bonk,@ask-bonk'
           forks: 'false'
           permissions: write

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -45,7 +45,7 @@ jobs:
           OPENCODE_LOG_LEVEL: INFO
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cf-gateway/nemotron-3-120b-a12b'
+          model: 'cf-gateway/kimi-k2.7-code'
           forks: 'false'
           permissions: write
           opencode_version: '1.18.13'

--- a/.opencode/agents/reviewer.md
+++ b/.opencode/agents/reviewer.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only code reviewer for pull requests
 mode: primary
-model: cf-gateway/nemotron-3-120b-a12b
+model: cf-gateway/kimi-k2.7-code
 temperature: 0.1
 permission:
   edit: deny

--- a/opencode.json
+++ b/opencode.json
@@ -9,9 +9,9 @@
         "apiKey": "{env:CLOUDFLARE_API_TOKEN}"
       },
       "models": {
-        "nemotron-3-120b-a12b": {
-          "id": "workers-ai/@cf/nvidia/nemotron-3-120b-a12b",
-          "name": "NVIDIA Nemotron 3 Super (Workers AI via Gateway)",
+        "kimi-k2.7-code": {
+          "id": "workers-ai/@cf/moonshotai/kimi-k2.7-code",
+          "name": "Kimi K2.7 Code (Workers AI via Gateway)",
           "limit": {
             "context": 262144,
             "output": 64000


### PR DESCRIPTION
Switch the Bonk and new-PR-review workflows from Nemotron to the Kimi K2.7 code model.