### PR TITLE
coglet wheel build breaks locally when uv registers a mismatched python

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -245,9 +245,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "email_address"
@@ -503,7 +503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1054,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -1245,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "maplit"
@@ -1672,9 +1672,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-float"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0218004a4aae742209bee9c3cef05672f6b2708be36a50add8eb613b1f2a4008"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -1914,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen"
-version = "0.20.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e2b9e475ac67c249ef794033ac3cf25a3216fbe5fe4b80cd82ab5a84d88485"
+checksum = "a267ea4da9a831f534def7f1d8e14f581d5640d3e5af6527072724f216f4dbbf"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1940,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen-derive"
-version = "0.20.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11633044267957aeda9569863a3a57b3aa2aeebc7144439423c1ddde3d00d887"
+checksum = "6573423a5e8cc43ec7565eccccbc2dd35e1fc9032d9ca404afab875429eb8cf0"
 dependencies = [
  "heck",
  "indexmap",
@@ -2234,7 +2234,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2291,7 +2291,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2584,9 +2584,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -2724,10 +2724,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2882,9 +2882,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2897,27 +2897,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -3433,7 +3433,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -46,7 +46,7 @@ anyhow = "1"
 # Python bindings
 pyo3 = { version = "0.27", features = ["abi3-py310"] }
 pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }
-pyo3-stub-gen = "0.20"
+pyo3-stub-gen = "0.23"
 
 # Testing
 insta = { version = "1", features = ["json"] }

--- a/crates/coglet-python/coglet/_impl.pyi
+++ b/crates/coglet-python/coglet/_impl.pyi
@@ -3,7 +3,6 @@
 
 import builtins
 import typing
-from . import _sdk
 
 __all__ = [
     "BuildInfo",

--- a/mise.toml
+++ b/mise.toml
@@ -174,7 +174,7 @@ run = "cargo build --manifest-path crates/Cargo.toml --workspace --release"
 description = "Build coglet Python wheel (development, local install)"
 run = [
   { task = "_setup_venv" },
-  "maturin develop --manifest-path crates/coglet-python/Cargo.toml",
+  "maturin develop --manifest-path crates/coglet-python/Cargo.toml -i .venv/bin/python",
 ]
 
 [tasks."build:coglet:wheel"]
@@ -187,7 +187,7 @@ run = [
     "_setup_dist",
     "_setup_venv",
   ] },
-  "maturin build --release --out dist --manifest-path crates/coglet-python/Cargo.toml",
+  "maturin build --release --out dist --manifest-path crates/coglet-python/Cargo.toml -i .venv/bin/python",
 ]
 
 [tasks."build:coglet:wheel:linux-x64"]
@@ -199,7 +199,7 @@ run = [
     "_setup_dist",
     "_setup_venv",
   ] },
-  "maturin build --release --out dist --manifest-path crates/coglet-python/Cargo.toml --target x86_64-unknown-linux-gnu --zig",
+  "maturin build --release --out dist --manifest-path crates/coglet-python/Cargo.toml --target x86_64-unknown-linux-gnu --zig -i .venv/bin/python",
 ]
 
 [tasks."build:coglet:wheel:linux-arm64"]
@@ -211,7 +211,7 @@ run = [
     "_setup_dist",
     "_setup_venv",
   ] },
-  "maturin build --release --out dist --manifest-path crates/coglet-python/Cargo.toml --target aarch64-unknown-linux-gnu --zig",
+  "maturin build --release --out dist --manifest-path crates/coglet-python/Cargo.toml --target aarch64-unknown-linux-gnu --zig -i .venv/bin/python",
 ]
 
 [tasks."build:coglet:wheel:darwin-arm64"]
@@ -223,7 +223,7 @@ run = [
     "_setup_dist",
     "_setup_venv",
   ] },
-  "maturin build --release --out dist --manifest-path crates/coglet-python/Cargo.toml --target aarch64-apple-darwin",
+  "maturin build --release --out dist --manifest-path crates/coglet-python/Cargo.toml --target aarch64-apple-darwin -i .venv/bin/python",
 ]
 
 [tasks."build:coglet:wheel:darwin-x64"]
@@ -235,7 +235,7 @@ run = [
     "_setup_dist",
     "_setup_venv",
   ] },
-  "maturin build --release --out dist --manifest-path crates/coglet-python/Cargo.toml --target x86_64-apple-darwin",
+  "maturin build --release --out dist --manifest-path crates/coglet-python/Cargo.toml --target x86_64-apple-darwin -i .venv/bin/python",
 ]
 
 [tasks."build:coglet:wheel:all"]


### PR DESCRIPTION
`mise run build:coglet:wheel*` fails on some machines with:

```
error[E0599]: no function or associated item named `initialize` found for struct `Python<'py>` in the current scope
```

The task creates a `.venv` (`_setup_venv`) but never tells `maturin` to use it. Without an active venv, maturin's interpreter discovery scans `uv`'s Python registry -- installed *and* downloadable pythons -- to pick an interpreter for each Python version it decides to target. On a machine with both a real `cpython-3.11` installed and an uninstalled `pypy-3.11` registered, it picked the PyPy one, wrote a `PYO3_CONFIG_FILE` with `implementation=PyPy`, and the build broke on `pyo3::Python::initialize()`, which pyo3 only defines for CPython/GraalPy.

CI never sees this: `PyO3/maturin-action` builds in a clean manylinux container with no ambient interpreter noise to confuse. Locally it's one bad version match away, and it'll keep coming back for anyone whose machine has a Python version manager (uv, pyenv, etc.) that happens to register more than one thing matching a given minor version.

Fix: pass `-i .venv/bin/python` to every `maturin build`/`maturin develop` invocation so the interpreter is deterministic instead of environment-dependent.

Also in this PR: bump `pyo3-stub-gen` 0.20 -> 0.23. Not required to fix the build above -- I verified the venv pin alone is sufficient -- but 0.20 predates the crate's `pyo3 = "0.27"` pin and doesn't declare a compatibility range against it, where 0.23 explicitly declares `pyo3 >=0.27.0, <0.30.0`. Worth doing while I'm in here so the next `pyo3` bump doesn't quietly break stub generation again.

Verified with `mise run build`, `mise run test:rust`, and `mise run fmt:rust` on a clean worktree off `main`.
