### PR TITLE
feat: add --playground flag to cog serve

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -334,6 +334,9 @@ cog serve [flags]
   # Start on a custom port
   cog serve -p 5000
 
+  # Start the playground alongside the model
+  cog serve --playground
+
   # Listen on all interfaces (e.g. to expose to the network)
   cog serve --host 0.0.0.0
 
@@ -351,6 +354,8 @@ cog serve [flags]
       --gpus docker run --gpus       GPU devices to add to the container, in the same format as docker run --gpus.
   -h, --help                         help for serve
       --host string                  Host IP to publish the container port on. Use 0.0.0.0 to allow connections from other machines. (default "127.0.0.1")
+      --playground                   Start the playground alongside the model
+      --playground-port int          Port for the playground (0 picks a free port) (default 9000)
   -p, --port int                     Port on which to listen (default 8393)
       --progress string              Set type of build progress output, 'auto' (default), 'tty', 'plain', or 'quiet' (default "auto")
       --upload-url string            Upload URL for file outputs (e.g. https://example.com/upload/)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -655,6 +655,9 @@ cog serve [flags]
   # Start on a custom port
   cog serve -p 5000
 
+  # Start the playground alongside the model
+  cog serve --playground
+
   # Listen on all interfaces (e.g. to expose to the network)
   cog serve --host 0.0.0.0
 
@@ -672,6 +675,8 @@ cog serve [flags]
       --gpus docker run --gpus       GPU devices to add to the container, in the same format as docker run --gpus.
   -h, --help                         help for serve
       --host string                  Host IP to publish the container port on. Use 0.0.0.0 to allow connections from other machines. (default "127.0.0.1")
+      --playground                   Start the playground alongside the model
+      --playground-port int          Port for the playground (0 picks a free port) (default 9000)
   -p, --port int                     Port on which to listen (default 8393)
       --progress string              Set type of build progress output, 'auto' (default), 'tty', 'plain', or 'quiet' (default "auto")
       --upload-url string            Upload URL for file outputs (e.g. https://example.com/upload/)

--- a/pkg/cli/playground.go
+++ b/pkg/cli/playground.go
@@ -103,38 +103,62 @@ func newPlaygroundServer(webhookBase, defaultTarget string) *playgroundServer {
 	}
 }
 
+// playgroundConfig holds the runtime settings for a playground instance.
+type playgroundConfig struct {
+	host        string
+	port        int
+	target      string
+	webhookHost string
+}
+
 func cmdPlayground(cmd *cobra.Command, _ []string) error {
 	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	uiFS, err := fs.Sub(playgroundUI, "playground")
-	if err != nil {
-		return fmt.Errorf("loading playground assets: %w", err)
+	cfg := playgroundConfig{
+		host:        playgroundHost,
+		port:        playgroundPort,
+		target:      playgroundTarget,
+		webhookHost: playgroundWebhookHost,
 	}
 
-	ln, err := net.Listen("tcp", playgroundAddress(playgroundHost, playgroundPort))
+	uiURL, srv, ln, err := startPlayground(ctx, cfg)
 	if err != nil {
-		return fmt.Errorf("starting playground server: %w", err)
+		return err
 	}
-	port := ln.Addr().(*net.TCPAddr).Port
 
-	srvState := newPlaygroundServer(
-		"http://"+playgroundAddress(playgroundWebhookHost, port),
-		playgroundTarget,
-	)
-
-	mux := srvState.routes(uiFS)
-
-	browserHost := playgroundBrowserHost(playgroundHost)
-	uiURL := "http://" + playgroundAddress(browserHost, port) + "/"
 	console.Infof("Cog playground running at %s", uiURL)
 	console.Info("Press Ctrl+C to stop.")
 	if !playgroundNoOpen {
 		maybeOpenBrowser(uiURL)
 	}
 
+	return servePlayground(ctx, srv, ln, 5*time.Second)
+}
+
+// startPlayground binds and configures a playground server, returning its UI
+// URL plus the started server and listener. The caller owns serving via
+// servePlayground; binding happens here so a bind failure surfaces as a return
+// error rather than a background failure.
+func startPlayground(ctx context.Context, cfg playgroundConfig) (string, *http.Server, net.Listener, error) {
+	uiFS, err := fs.Sub(playgroundUI, "playground")
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("loading playground assets: %w", err)
+	}
+
+	ln, err := net.Listen("tcp", playgroundAddress(cfg.host, cfg.port))
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("starting playground server: %w", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	srvState := newPlaygroundServer(
+		"http://"+playgroundAddress(cfg.webhookHost, port),
+		cfg.target,
+	)
+
 	srv := &http.Server{
-		Handler:           mux,
+		Handler:           srvState.routes(uiFS),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       5 * time.Minute,
 		IdleTimeout:       60 * time.Second,
@@ -142,7 +166,9 @@ func cmdPlayground(cmd *cobra.Command, _ []string) error {
 		BaseContext:       func(net.Listener) context.Context { return ctx },
 	}
 
-	return servePlayground(ctx, srv, ln, 5*time.Second)
+	browserHost := playgroundBrowserHost(cfg.host)
+	uiURL := "http://" + playgroundAddress(browserHost, port) + "/"
+	return uiURL, srv, ln, nil
 }
 
 func servePlayground(ctx context.Context, srv *http.Server, ln net.Listener, timeout time.Duration) error {

--- a/pkg/cli/playground_test.go
+++ b/pkg/cli/playground_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -99,6 +100,35 @@ func TestStartPlayground(t *testing.T) {
 	assert.Contains(t, string(body), "Cog Playground")
 	assert.Equal(t, "127.0.0.1", u.Hostname())
 	assert.NotEqual(t, "8393", u.Port(), "playground should not bind the default model port")
+
+	cancel()
+	require.NoError(t, <-serveDone)
+}
+
+func TestStartPlaygroundForContainerWebhooks(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	uiURL, srv, ln, err := startPlayground(ctx, playgroundConfig{
+		host:        "0.0.0.0",
+		port:        0,
+		target:      "http://127.0.0.1:8393",
+		webhookHost: "host.docker.internal",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- servePlayground(ctx, srv, ln, time.Second) }()
+
+	resp, err := http.Get(uiURL + "config")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var config map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&config))
+	assert.Equal(t, "http://127.0.0.1:8393", config["target"])
+	assert.Equal(t, "http://host.docker.internal:"+strconv.Itoa(ln.Addr().(*net.TCPAddr).Port), config["webhookBase"])
 
 	cancel()
 	require.NoError(t, <-serveDone)

--- a/pkg/cli/playground_test.go
+++ b/pkg/cli/playground_test.go
@@ -72,6 +72,38 @@ func TestPlaygroundServesUI(t *testing.T) {
 	}
 }
 
+func TestStartPlayground(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	uiURL, srv, ln, err := startPlayground(ctx, playgroundConfig{
+		host:        "127.0.0.1",
+		port:        0,
+		target:      "http://localhost:8393",
+		webhookHost: "host.docker.internal",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- servePlayground(ctx, srv, ln, time.Second) }()
+
+	u, err := url.Parse(uiURL)
+	require.NoError(t, err)
+	resp, err := http.Get(uiURL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, string(body), "Cog Playground")
+	assert.Equal(t, "127.0.0.1", u.Hostname())
+	assert.NotEqual(t, "8393", u.Port(), "playground should not bind the default model port")
+
+	cancel()
+	require.NoError(t, <-serveDone)
+}
+
 func TestServePlaygroundWaitsForHandlers(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	ln, err := net.Listen("tcp", "127.0.0.1:0")

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -1,12 +1,17 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -19,9 +24,11 @@ import (
 )
 
 var (
-	serveHost = command.DefaultHostIP
-	port      = 8393
-	uploadURL = ""
+	serveHost           = command.DefaultHostIP
+	port                = 8393
+	uploadURL           = ""
+	servePlaygroundFlag = false
+	servePlaygroundPort = 9000
 )
 
 func newServeCommand() *cobra.Command {
@@ -42,6 +49,9 @@ the Docker port mapping is published on.`,
 
   # Start on a custom port
   cog serve -p 5000
+
+  # Start the playground alongside the model
+  cog serve --playground
 
   # Listen on all interfaces (e.g. to expose to the network)
   cog serve --host 0.0.0.0
@@ -65,6 +75,8 @@ the Docker port mapping is published on.`,
 	cmd.Flags().StringVar(&serveHost, "host", serveHost, "Host IP to publish the container port on. Use 0.0.0.0 to allow connections from other machines.")
 	cmd.Flags().IntVarP(&port, "port", "p", port, "Port on which to listen")
 	cmd.Flags().StringVar(&uploadURL, "upload-url", "", "Upload URL for file outputs (e.g. https://example.com/upload/)")
+	cmd.Flags().BoolVar(&servePlaygroundFlag, "playground", servePlaygroundFlag, "Start the playground alongside the model")
+	cmd.Flags().IntVar(&servePlaygroundPort, "playground-port", servePlaygroundPort, "Port for the playground (0 picks a free port)")
 
 	return cmd
 }
@@ -105,8 +117,42 @@ func formatServeURL(host string, port int) string {
 	return url
 }
 
+// validateServePorts errors when the model and playground would bind the same
+// port on overlapping interfaces. A playground port of 0 asks for a free port,
+// so it never collides.
+func validateServePorts(serveHost string, port, playgroundPort int, playgroundHost string) error {
+	if playgroundPort == 0 {
+		return nil
+	}
+	if playgroundPort == port && hostsOverlap(serveHost, playgroundHost) {
+		return fmt.Errorf("playground port %d must differ from the model port %d", playgroundPort, port)
+	}
+	return nil
+}
+
+// hostsOverlap reports whether two bind hosts share interfaces. An unspecified
+// host (0.0.0.0, ::) binds every interface, so it overlaps any specific host.
+func hostsOverlap(a, b string) bool {
+	if a == b {
+		return true
+	}
+	return isUnspecifiedHost(a) || isUnspecifiedHost(b)
+}
+
+func isUnspecifiedHost(host string) bool {
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsUnspecified()
+}
+
 func cmdServe(cmd *cobra.Command, arg []string) error {
-	ctx := cmd.Context()
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if servePlaygroundFlag {
+		if err := validateServePorts(serveHost, port, servePlaygroundPort, playgroundHost); err != nil {
+			return err
+		}
+	}
 
 	dockerClient, err := docker.NewClient(ctx)
 	if err != nil {
@@ -200,6 +246,24 @@ func cmdServe(cmd *cobra.Command, arg []string) error {
 
 	serveURL := formatServeURL(serveHost, port)
 
+	// Start the playground before the container so a bind failure aborts fast,
+	// before the multi-minute image build and run. It targets a navigable
+	// localhost URL for the model so the UI can reach it from the browser.
+	var playgroundURL string
+	var playgroundSrv *http.Server
+	var playgroundLn net.Listener
+	if servePlaygroundFlag {
+		playgroundURL, playgroundSrv, playgroundLn, err = startPlayground(ctx, playgroundConfig{
+			host:        playgroundHost,
+			port:        servePlaygroundPort,
+			target:      fmt.Sprintf("http://%s", net.JoinHostPort("localhost", strconv.Itoa(port))),
+			webhookHost: playgroundWebhookHost,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
 	if isRemote, dockerHost, err := docker.IsRemoteDockerHost(); err == nil && isRemote {
 		console.Warnf("Using Docker daemon at %s; the server will bind to %s on that host, not this machine.", dockerHost, serveHost)
 	}
@@ -208,7 +272,18 @@ func cmdServe(cmd *cobra.Command, arg []string) error {
 	console.Infof("Running %[1]s in Docker with the current directory mounted as a volume...", console.Bold(strings.Join(args, " ")))
 	console.Info("")
 	console.Infof("Serving at %s", console.Bold(serveURL))
+	if servePlaygroundFlag {
+		console.Infof("Playground at %s", console.Bold(playgroundURL))
+	}
 	console.Info("")
+
+	if servePlaygroundFlag {
+		go func() {
+			if err := servePlayground(ctx, playgroundSrv, playgroundLn, 5*time.Second); err != nil {
+				console.Errorf("playground: %v", err)
+			}
+		}()
+	}
 
 	err = docker.Run(ctx, dockerClient, runOptions)
 	// Only retry if we're using a GPU but the user didn't explicitly select a GPU with --gpus
@@ -218,6 +293,12 @@ func cmdServe(cmd *cobra.Command, arg []string) error {
 
 		runOptions.GPUs = ""
 		err = docker.Run(ctx, dockerClient, runOptions)
+	}
+
+	// A canceled context means the user signaled us to stop; that's a clean
+	// exit, not a failure.
+	if ctx.Err() == context.Canceled {
+		return nil
 	}
 
 	return err

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -144,6 +144,17 @@ func isUnspecifiedHost(host string) bool {
 	return ip != nil && ip.IsUnspecified()
 }
 
+// playgroundTargetURL is the model URL the playground proxies to, built from
+// the model's actual bind host. A wildcard host isn't navigable, so it falls
+// back to loopback.
+func playgroundTargetURL(serveHost string, port int) string {
+	host := serveHost
+	if isUnspecifiedHost(serveHost) {
+		host = "127.0.0.1"
+	}
+	return fmt.Sprintf("http://%s", net.JoinHostPort(host, strconv.Itoa(port)))
+}
+
 func cmdServe(cmd *cobra.Command, arg []string) error {
 	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -247,8 +258,8 @@ func cmdServe(cmd *cobra.Command, arg []string) error {
 	serveURL := formatServeURL(serveHost, port)
 
 	// Start the playground before the container so a bind failure aborts fast,
-	// before the multi-minute image build and run. It targets a navigable
-	// localhost URL for the model so the UI can reach it from the browser.
+	// before the multi-minute image build and run. It targets the model's
+	// actual bind host so the UI reaches the server being served.
 	var playgroundURL string
 	var playgroundSrv *http.Server
 	var playgroundLn net.Listener
@@ -256,7 +267,7 @@ func cmdServe(cmd *cobra.Command, arg []string) error {
 		playgroundURL, playgroundSrv, playgroundLn, err = startPlayground(ctx, playgroundConfig{
 			host:        playgroundHost,
 			port:        servePlaygroundPort,
-			target:      fmt.Sprintf("http://%s", net.JoinHostPort("localhost", strconv.Itoa(port))),
+			target:      playgroundTargetURL(serveHost, port),
 			webhookHost: playgroundWebhookHost,
 		})
 		if err != nil {

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -23,6 +23,8 @@ import (
 	"github.com/replicate/cog/pkg/weights"
 )
 
+const embeddedPlaygroundHost = "0.0.0.0"
+
 var (
 	serveHost           = command.DefaultHostIP
 	port                = 8393
@@ -118,12 +120,16 @@ func formatServeURL(host string, port int) string {
 }
 
 // validateServePorts errors when the model and playground would bind the same
-// port on overlapping interfaces. A playground port of 0 asks for a free port,
-// so it never collides.
+// port on overlapping interfaces. A playground port of 0 is checked after the
+// listener chooses a port.
 func validateServePorts(serveHost string, port, playgroundPort int, playgroundHost string) error {
 	if playgroundPort == 0 {
 		return nil
 	}
+	return validateBoundServePorts(serveHost, port, playgroundPort, playgroundHost)
+}
+
+func validateBoundServePorts(serveHost string, port, playgroundPort int, playgroundHost string) error {
 	if playgroundPort == port && hostsOverlap(serveHost, playgroundHost) {
 		return fmt.Errorf("playground port %d must differ from the model port %d", playgroundPort, port)
 	}
@@ -160,7 +166,7 @@ func cmdServe(cmd *cobra.Command, arg []string) error {
 	defer stop()
 
 	if servePlaygroundFlag {
-		if err := validateServePorts(serveHost, port, servePlaygroundPort, playgroundHost); err != nil {
+		if err := validateServePorts(serveHost, port, servePlaygroundPort, embeddedPlaygroundHost); err != nil {
 			return err
 		}
 	}
@@ -249,7 +255,7 @@ func cmdServe(cmd *cobra.Command, arg []string) error {
 	// On Linux, host.docker.internal is not available by default — add it.
 	// This allows the container to reach services running on the host,
 	// e.g. when --upload-url points to a local upload server.
-	if uploadURL != "" {
+	if uploadURL != "" || servePlaygroundFlag {
 		runOptions.ExtraHosts = []string{"host.docker.internal:host-gateway"}
 	}
 
@@ -265,12 +271,16 @@ func cmdServe(cmd *cobra.Command, arg []string) error {
 	var playgroundLn net.Listener
 	if servePlaygroundFlag {
 		playgroundURL, playgroundSrv, playgroundLn, err = startPlayground(ctx, playgroundConfig{
-			host:        playgroundHost,
+			host:        embeddedPlaygroundHost,
 			port:        servePlaygroundPort,
 			target:      playgroundTargetURL(serveHost, port),
 			webhookHost: playgroundWebhookHost,
 		})
 		if err != nil {
+			return err
+		}
+		if err := validateBoundServePorts(serveHost, port, playgroundLn.Addr().(*net.TCPAddr).Port, embeddedPlaygroundHost); err != nil {
+			_ = playgroundLn.Close()
 			return err
 		}
 	}

--- a/pkg/cli/serve_test.go
+++ b/pkg/cli/serve_test.go
@@ -77,6 +77,31 @@ func TestValidateServePorts(t *testing.T) {
 	}
 }
 
+func TestValidateBoundServePorts(t *testing.T) {
+	tests := []struct {
+		name           string
+		serveHost      string
+		port           int
+		playgroundPort int
+		playgroundHost string
+		wantErr        bool
+	}{
+		{"resolved port differs", command.DefaultHostIP, 8393, 9000, embeddedPlaygroundHost, false},
+		{"resolved port matches", command.DefaultHostIP, 8393, 8393, embeddedPlaygroundHost, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBoundServePorts(tt.serveHost, tt.port, tt.playgroundPort, tt.playgroundHost)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestPlaygroundTargetURL(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/cli/serve_test.go
+++ b/pkg/cli/serve_test.go
@@ -77,6 +77,26 @@ func TestValidateServePorts(t *testing.T) {
 	}
 }
 
+func TestPlaygroundTargetURL(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		port int
+		want string
+	}{
+		{"default loopback", command.DefaultHostIP, 8393, "http://127.0.0.1:8393"},
+		{"custom IP", "192.168.1.1", 5000, "http://192.168.1.1:5000"},
+		{"wildcard falls back to loopback", "0.0.0.0", 8393, "http://127.0.0.1:8393"},
+		{"ipv6 wildcard falls back to loopback", "::", 8393, "http://127.0.0.1:8393"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, playgroundTargetURL(tt.host, tt.port))
+		})
+	}
+}
+
 func TestHostsOverlap(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/cli/serve_test.go
+++ b/pkg/cli/serve_test.go
@@ -47,3 +47,54 @@ func TestFormatServeURL(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateServePorts(t *testing.T) {
+	tests := []struct {
+		name           string
+		serveHost      string
+		port           int
+		playgroundPort int
+		playgroundHost string
+		wantErr        bool
+	}{
+		{"distinct ports", command.DefaultHostIP, 8393, 9000, "127.0.0.1", false},
+		{"playground picks free port", command.DefaultHostIP, 8393, 0, "127.0.0.1", false},
+		{"same port and host", command.DefaultHostIP, 8393, 8393, "127.0.0.1", true},
+		{"same port different host", "0.0.0.0", 8393, 8393, "127.0.0.1", true},
+		{"same port serve loopback playground all", command.DefaultHostIP, 9000, 9000, "0.0.0.0", true},
+		{"same port different specific host", "127.0.0.1", 8393, 8393, "192.168.1.1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateServePorts(tt.serveHost, tt.port, tt.playgroundPort, tt.playgroundHost)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestHostsOverlap(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{"identical specific", "127.0.0.1", "127.0.0.1", true},
+		{"wildcard and specific", "0.0.0.0", "127.0.0.1", true},
+		{"specific and wildcard", "127.0.0.1", "0.0.0.0", true},
+		{"ipv6 wildcard", "::", "192.168.1.1", true},
+		{"two different specific", "127.0.0.1", "192.168.1.1", false},
+		{"wildcard and wildcard", "0.0.0.0", "::", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, hostsOverlap(tt.a, tt.b))
+		})
+	}
+}


### PR DESCRIPTION
Adds `--playground` to `cog serve` so it starts the playground alongside the model and prints both URLs:

```
Serving at http://127.0.0.1:8393
Playground at http://127.0.0.1:9000
```

The playground binds its own port (`--playground-port`, default 9000, `0` = free port) and never collides with the model port.

- `pkg/cli/serve.go`: new `--playground` and `--playground-port` flags; validates the playground port doesn't overlap the model port; binds the playground before the container starts so a bind failure aborts fast; prints the playground URL next to `Serving at`; runs it with graceful shutdown. `cmdServe` now cancels its context on signal, so Ctrl+C exits cleanly instead of erroring.
- `pkg/cli/playground.go`: pulls the standalone command's startup into a reusable `startPlayground(ctx, playgroundConfig)` helper. `cog playground` is unchanged.
- Tests for the port validation, host overlap, the target URL helper, and the new helper.

Only `serve` supports `--playground` for now; `predict`/`run`/`train` run the container headlessly with no public port.